### PR TITLE
chore: set default theme to light

### DIFF
--- a/web-client/app/_helpers/ThemeWrapper.tsx
+++ b/web-client/app/_helpers/ThemeWrapper.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 export const ThemeWrapper: React.FC<Props> = ({ children }) => {
   return (
-    <ThemeProvider enableSystem={true} attribute="class">
+    <ThemeProvider enableSystem={false} attribute="class">
       {children}
     </ThemeProvider>
   );


### PR DESCRIPTION
As #43 , default theme should be `light`.

fixes #43 