### PR TITLE
fix(compose): Add host dns resolver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,8 @@ services:
       interval: 10s
       timeout: 10s
       retries: 30
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       jan_community:
         ipv4_address: 172.20.0.12
@@ -84,6 +86,8 @@ services:
       timeout: 10s
       retries: 5
       start_period: 5s
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     networks:
       jan_community:
         ipv4_address: 172.20.0.14
@@ -105,6 +109,7 @@ services:
       NODE_ENV: development
     extra_hosts:
       - "localhost:172.20.0.9"
+      - "host.docker.internal:host-gateway"
     depends_on:
       graphql-engine:
         condition: service_healthy


### PR DESCRIPTION
Fix the problem happens in some Linux version that services inside docker container cannot resolve `host.docker.internal`