### PR TITLE
Fix CI Test run failed on ubuntu and change release file app name

### DIFF
--- a/.github/workflows/linter-and-test.yml
+++ b/.github/workflows/linter-and-test.yml
@@ -78,11 +78,12 @@ jobs:
 
       - name: Linter and test
         run: |
+          w_output=$(w)
+          export DISPLAY=$(echo "$w_output" | awk '$3 ~ /:[0-9]+/ {print $3}')
+          echo -e "Display ID: $DISPLAY"
           yarn config set network-timeout 300000
           yarn install
           yarn lint
           yarn build:plugins
           yarn build:linux
           yarn test
-        env:
-            DISPLAY: ":0"

--- a/electron/package.json
+++ b/electron/package.json
@@ -34,7 +34,7 @@
         "teamId": "YT49P7GXG4"
       }
     },
-    "artifactName": "${name}-${os}-${arch}-${version}.${ext}"
+    "artifactName": "jan-${os}-${arch}-${version}.${ext}"
   },
   "scripts": {
     "lint": "eslint . --ext \".js,.jsx,.ts,.tsx\"",


### PR DESCRIPTION
This PR aims at:
- Fixing test pipeline run failed on ubuntu
- Change release file name from `jan-electron` to `jan`