### PR TITLE
#360 plugin preferences

### DIFF
--- a/electron/core/plugins/data-plugin/index.ts
+++ b/electron/core/plugins/data-plugin/index.ts
@@ -12,7 +12,6 @@ const MODULE_PATH = "data-plugin/dist/cjs/module.js";
  *
  */
 function createCollection({ name, schema }: { name: string; schema?: { [key: string]: any } }): Promise<void> {
-  console.log("renderer: creating collection:", name, schema);
   return core.invokePluginFunc(MODULE_PATH, "createCollection", name, schema);
 }
 

--- a/electron/core/plugins/data-plugin/index.ts
+++ b/electron/core/plugins/data-plugin/index.ts
@@ -1,6 +1,6 @@
-import { core, store, RegisterExtensionPoint, StoreService, DataService } from "@janhq/plugin-core";
+import { core, store, RegisterExtensionPoint, StoreService, DataService, PluginService } from "@janhq/plugin-core";
 
-// Provide an async method to manipulate the price provided by the extension point
+const PluginName = "data-plugin";
 const MODULE_PATH = "data-plugin/dist/cjs/module.js";
 
 /**
@@ -136,8 +136,7 @@ function onStart() {
 
 // Register all the above functions and objects with the relevant extension points
 export function init({ register }: { register: RegisterExtensionPoint }) {
-  onStart();
-
+  register(PluginService.OnStart, PluginName, onStart);
   register(StoreService.CreateCollection, createCollection.name, createCollection);
   register(StoreService.DeleteCollection, deleteCollection.name, deleteCollection);
   register(StoreService.InsertOne, insertOne.name, insertOne);

--- a/electron/core/plugins/inference-plugin/index.ts
+++ b/electron/core/plugins/inference-plugin/index.ts
@@ -1,6 +1,6 @@
 import { EventName, InferenceService, NewMessageRequest, PluginService, core, events, store } from "@janhq/plugin-core";
 
-const PluginName = "inference-plugin"
+const PluginName = "inference-plugin";
 const MODULE_PATH = `${PluginName}/dist/module.js`;
 const inferenceUrl = "http://localhost:3928/llama/chat_completion";
 
@@ -12,13 +12,17 @@ const stopModel = () => {
 
 async function handleMessageRequest(data: NewMessageRequest) {
   // TODO: Common collections should be able to access via core functions instead of store
-  const messageHistory = (await store.findMany("messages", { conversationId: data.conversationId })) ?? [];
-  const recentMessages = messageHistory.slice(-10).map((message) => {
-    return {
-      content: message.message,
-      role: message.user === "user" ? "user" : "assistant",
-    };
-  });
+  const messageHistory =
+    (await store.findMany("messages", { conversationId: data.conversationId }, [{ createdAt: "asc" }])) ?? [];
+  const recentMessages = messageHistory
+    .filter((e) => e.message !== "" && (e.user === "user" || e.user === "assistant"))
+    .slice(-10)
+    .map((message) => {
+      return {
+        content: message.message,
+        role: message.user === "user" ? "user" : "assistant",
+      };
+    });
 
   const message = {
     ...data,
@@ -82,8 +86,8 @@ const registerListener = () => {
 };
 
 const onStart = async () => {
-  registerListener()
-}
+  registerListener();
+};
 // Register all the above functions and objects with the relevant extension points
 export function init({ register }) {
   register(PluginService.OnStart, PluginName, onStart);

--- a/electron/core/plugins/model-management-plugin/index.ts
+++ b/electron/core/plugins/model-management-plugin/index.ts
@@ -1,4 +1,6 @@
-import { ModelManagementService, RegisterExtensionPoint, core, store } from "@janhq/plugin-core";
+import { ModelManagementService, PluginService, RegisterExtensionPoint, core, store } from "@janhq/plugin-core";
+
+const PluginName = "model-management-plugin";
 const MODULE_PATH = "model-management-plugin/dist/module.js";
 
 const getDownloadedModels = () => core.invokePluginFunc(MODULE_PATH, "getDownloadedModels");
@@ -81,7 +83,7 @@ function onStart() {
 
 // Register all the above functions and objects with the relevant extension points
 export function init({ register }: { register: RegisterExtensionPoint }) {
-  onStart();
+  register(PluginService.OnStart, PluginName, onStart);
 
   register(ModelManagementService.GetDownloadedModels, getDownloadedModels.name, getDownloadedModels);
   register(ModelManagementService.GetAvailableModels, getAvailableModels.name, getAvailableModels);

--- a/electron/core/plugins/openai-plugin/index.ts
+++ b/electron/core/plugins/openai-plugin/index.ts
@@ -50,7 +50,7 @@ async function handleMessageRequest(data: NewMessageRequest) {
       ...data,
       message: "Your API key is not set. Please set it in the plugin preferences.",
       user: "GPT-3",
-      avatar: "",
+      avatar: "https://static-assets.jan.ai/openai-icon.jpg",
       createdAt: new Date().toISOString(),
       _id: undefined,
     };
@@ -64,7 +64,7 @@ async function handleMessageRequest(data: NewMessageRequest) {
     ...data,
     message: "",
     user: "GPT-3",
-    avatar: "",
+    avatar: "https://static-assets.jan.ai/openai-icon.jpg",
     createdAt: new Date().toISOString(),
     _id: undefined,
   };

--- a/electron/core/plugins/openai-plugin/index.ts
+++ b/electron/core/plugins/openai-plugin/index.ts
@@ -1,5 +1,16 @@
-import { EventName, NewMessageRequest, events, store } from "@janhq/plugin-core";
+import {
+  PluginService,
+  EventName,
+  NewMessageRequest,
+  events,
+  store,
+  preferences,
+  InferenceService,
+  RegisterExtensionPoint,
+} from "@janhq/plugin-core";
 import { Configuration, OpenAIApi } from "azure-openai";
+
+const PluginName = "openai-plugin";
 
 const setRequestHeader = XMLHttpRequest.prototype.setRequestHeader;
 XMLHttpRequest.prototype.setRequestHeader = function newSetRequestHeader(key: string, val: string) {
@@ -9,17 +20,47 @@ XMLHttpRequest.prototype.setRequestHeader = function newSetRequestHeader(key: st
   setRequestHeader.apply(this, [key, val]);
 };
 
-const openai = new OpenAIApi(
-  new Configuration({
-    azure: {
-      apiKey: "", //Your API key goes here
-      endpoint: "", //Your endpoint goes here. It is like: "https://endpointname.openai.azure.com/"
-      deploymentName: "", //Your deployment name goes here. It is like "chatgpt"
-    },
-  })
-);
+var openai: OpenAIApi | undefined = undefined;
+
+const setup = async () => {
+  const apiKey: string = (await preferences.get(PluginName, "apiKey")) ?? "";
+  const endpoint: string = (await preferences.get(PluginName, "endpoint")) ?? "";
+  const deploymentName: string = (await preferences.get(PluginName, "deploymentName")) ?? "";
+  if (apiKey === "") {
+    return;
+  }
+  openai = new OpenAIApi(
+    new Configuration({
+      azure: {
+        apiKey, //Your API key goes here
+        endpoint, //Your endpoint goes here. It is like: "https://endpointname.openai.azure.com/"
+        deploymentName, //Your deployment name goes here. It is like "chatgpt"
+      },
+    })
+  );
+};
+
+async function onStart() {
+  setup();
+  registerListener();
+}
 
 async function handleMessageRequest(data: NewMessageRequest) {
+  if (!openai) {
+    const message = {
+      ...data,
+      message: "Your API key is not set. Please set it in the plugin preferences.",
+      user: "GPT-3",
+      avatar: "",
+      createdAt: new Date().toISOString(),
+      _id: undefined,
+    };
+    const id = await store.insertOne("messages", message);
+    message._id = id;
+    events.emit(EventName.OnNewMessageResponse, message);
+    return;
+  }
+
   const message = {
     ...data,
     message: "",
@@ -44,7 +85,16 @@ async function handleMessageRequest(data: NewMessageRequest) {
 const registerListener = () => {
   events.on(EventName.OnNewMessageRequest, handleMessageRequest);
 };
+
+const onPreferencesUpdate = () => {
+  setup();
+};
 // Register all the above functions and objects with the relevant extension points
-export function init({ register }) {
-  registerListener();
+export function init({ register }: { register: RegisterExtensionPoint }) {
+  register(PluginService.OnStart, PluginName, onStart);
+  register(PluginService.OnPreferencesUpdate, PluginName, onPreferencesUpdate);
+
+  preferences.registerPreferences<string>(register, PluginName, "apiKey", "");
+  preferences.registerPreferences<string>(register, PluginName, "endpoint", "");
+  preferences.registerPreferences<string>(register, PluginName, "deploymentName", "");
 }

--- a/electron/core/plugins/openai-plugin/index.ts
+++ b/electron/core/plugins/openai-plugin/index.ts
@@ -93,7 +93,21 @@ export function init({ register }: { register: RegisterExtensionPoint }) {
   register(PluginService.OnStart, PluginName, onStart);
   register(PluginService.OnPreferencesUpdate, PluginName, onPreferencesUpdate);
 
-  preferences.registerPreferences<string>(register, PluginName, "apiKey", "");
-  preferences.registerPreferences<string>(register, PluginName, "endpoint", "");
-  preferences.registerPreferences<string>(register, PluginName, "deploymentName", "");
+  preferences.registerPreferences<string>(register, PluginName, "apiKey", "API Key", "Azure Project API Key", "");
+  preferences.registerPreferences<string>(
+    register,
+    PluginName,
+    "endpoint",
+    "API Endpoint",
+    "Azure Deployment Endpoint API",
+    ""
+  );
+  preferences.registerPreferences<string>(
+    register,
+    PluginName,
+    "deploymentName",
+    "Deployment Name",
+    "The deployment name you chose when you deployed the model",
+    ""
+  );
 }

--- a/electron/core/plugins/openai-plugin/index.ts
+++ b/electron/core/plugins/openai-plugin/index.ts
@@ -5,7 +5,6 @@ import {
   events,
   store,
   preferences,
-  InferenceService,
   RegisterExtensionPoint,
 } from "@janhq/plugin-core";
 import { Configuration, OpenAIApi } from "azure-openai";

--- a/electron/core/plugins/openai-plugin/package.json
+++ b/electron/core/plugins/openai-plugin/package.json
@@ -2,7 +2,7 @@
   "name": "azure-openai-plugin",
   "version": "1.0.0",
   "description": "Inference plugin for Azure OpenAI",
-  "icon": "https://raw.githubusercontent.com/tailwindlabs/heroicons/88e98b0c2b458553fbadccddc2d2f878edc0387b/src/20/solid/command-line.svg",
+  "icon": "https://static-assets.jan.ai/openai-icon.jpg",
   "main": "dist/index.js",
   "author": "Jan",
   "license": "MIT",

--- a/plugin-core/README.md
+++ b/plugin-core/README.md
@@ -34,20 +34,7 @@ export function init({ register }: { register: RegisterExtensionPoint }) {
 }
 ```
 
-### Access Core API
-
-To access the Core API in your plugin, you can follow the code examples and explanations provided below.
-
-##### Import Core API and Store Module
-
-In your main entry code (e.g., `index.ts`), start by importing the necessary modules and functions from the `@janhq/plugin-core` library.
-
-```js
-// index.ts
-import { store, core } from "@janhq/plugin-core";
-```
-
-#### Interact with Local Data Storage
+### Interact with Local Data Storage
 
 The Core API allows you to interact with local data storage. Here are a couple of examples of how you can use it:
 
@@ -56,6 +43,8 @@ The Core API allows you to interact with local data storage. Here are a couple o
 You can use the store.insertOne function to insert data into a specific collection in the local data store.
 
 ```js
+import { store } from "@janhq/plugin-core";
+
 function insertData() {
   store.insertOne("conversations", { name: "meow" });
   // Insert a new document with { name: "meow" } into the "conversations" collection.
@@ -70,6 +59,8 @@ store.getOne(collectionName, key) retrieves a single document that matches the p
 store.getMany(collectionName, selector, sort) retrieves multiple documents that match the provided selector in the specified collection.
 
 ```js
+import { store } from "@janhq/plugin-core";
+
 function getData() {
   const selector = { name: "meow" };
   const data = store.findMany("conversations", selector);
@@ -108,7 +99,7 @@ function deleteData() {
 }
 ```
 
-#### Events
+### Events
 
 You can subscribe to NewMessageRequest events by defining a function to handle the event and registering it with the events object:
 
@@ -145,6 +136,56 @@ function handleMessageRequest(data: NewMessageRequest) {
 }
 ```
 
+### Preferences
+
+To register plugin preferences, you can use the preferences object from the @janhq/plugin-core package. Here's an example of how to register and retrieve plugin preferences:
+
+```js
+import { PluginService, preferences } from "@janhq/plugin-core";
+
+const PluginName = "your-first-plugin";
+
+export function init({ register }: { register: RegisterExtensionPoint }) {
+  // Register preference update handlers. E.g. update plugin instance with new configuration
+  register(PluginService.OnPreferencesUpdate, PluginName, onPreferencesUpdate);
+
+  // Register plugin preferences. E.g. Plugin need apiKey and endpoint to connect to your service
+  preferences.registerPreferences<string>(register, PluginName, "apiKey", "");
+  preferences.registerPreferences<string>(register, PluginName, "endpoint", "");
+}
+```
+
+In this example, we're registering preference update handlers and plugin preferences using the preferences object. We're also defining a PluginName constant to use as the name of the plugin.
+
+To retrieve the values of the registered preferences, we're using the get method of the preferences object and passing in the name of the plugin and the name of the preference.
+
+```js
+import { preferences } from "@janhq/plugin-core";
+
+const PluginName = "your-first-plugin";
+
+const setup = async () => {
+  // Retrieve apiKey
+  const apiKey: string = (await preferences.get(PluginName, "apiKey")) ?? "";
+
+  // Retrieve endpoint
+  const endpoint: string = (await preferences.get(PluginName, "endpoint")) ?? "";
+}
+```
+
+### Access Core API
+
+To access the Core API in your plugin, you can follow the code examples and explanations provided below.
+
+##### Import Core API and Store Module
+
+In your main entry code (e.g., `index.ts`), start by importing the necessary modules and functions from the `@janhq/plugin-core` library.
+
+```js
+// index.ts
+import { core } from "@janhq/plugin-core";
+```
+
 #### Perform File Operations
 
 The Core API also provides functions to perform file operations. Here are a couple of examples:
@@ -169,7 +210,7 @@ function deleteModel(filePath: string) {
 }
 ```
 
-### Execute plugin module in main process
+#### Execute plugin module in main process
 
 To execute a plugin module in the main process of your application, you can follow the steps outlined below.
 

--- a/plugin-core/README.md
+++ b/plugin-core/README.md
@@ -294,4 +294,11 @@ The `SystemMonitoringService` enum includes methods for monitoring system resour
 - `GetResourcesInfo`: Gets information about system resources.
 - `GetCurrentLoad`: Gets the current system load.
 
+## PluginService
+
+The `PluginService` enum includes plugin cycle handlers:
+
+- `OnStart`: Handler for starting. E.g. Create a collection.
+- `OnPreferencesUpdate`: Handler for preferences update. E.g. Update instances with new configurations.
+
 For more detailed information on each of these components, please refer to the source code.

--- a/plugin-core/index.ts
+++ b/plugin-core/index.ts
@@ -212,6 +212,32 @@ export enum SystemMonitoringService {
 }
 
 /**
+ * PluginService exports.
+ * @enum {string}
+ */
+export enum PluginService {
+  /**
+   * The plugin is being started.
+   */
+  OnStart = "pluginOnStart",
+
+  /**
+   * The plugin is being started.
+   */
+  OnPreferencesUpdate = "pluginPreferencesUpdate",
+
+  /**
+   * The plugin is being stopped.
+   */
+  OnStop = "pluginOnStop",
+
+  /**
+   * The plugin is being destroyed.
+   */
+  OnDestroy = "pluginOnDestroy",
+}
+
+/**
  * Store module exports.
  * @module
  */
@@ -228,3 +254,9 @@ export { core, RegisterExtensionPoint } from "./core";
  * @module
  */
 export { events, EventName, NewMessageRequest, NewMessageResponse } from "./events";
+
+/**
+ * Preferences module exports.
+ * @module
+ */
+export { preferences } from "./preferences";

--- a/plugin-core/preferences.ts
+++ b/plugin-core/preferences.ts
@@ -1,0 +1,117 @@
+import { store } from "./store";
+
+/**
+ * Returns the value of the specified preference for the specified plugin.
+ *
+ * @param pluginName The name of the plugin.
+ * @param preferenceName The name of the preference.
+ * @returns A promise that resolves to the value of the preference.
+ */
+function get(pluginName: string, preferenceName: string): Promise<any> {
+  return store
+    .createCollection("preferences", {})
+    .then(() => store.findOne("preferences", `${pluginName}.${preferenceName}`))
+    .then((doc) => doc?.value ?? "");
+}
+
+/**
+ * Sets the value of the specified preference for the specified plugin.
+ *
+ * @param pluginName The name of the plugin.
+ * @param preferenceName The name of the preference.
+ * @param value The value of the preference.
+ * @returns A promise that resolves when the preference has been set.
+ */
+function set(pluginName: string, preferenceName: string, value: any): Promise<any> {
+  return store
+    .createCollection("preferences", {})
+    .then(() =>
+      store
+        .findOne("preferences", `${pluginName}.${preferenceName}`)
+        .then((doc) =>
+          doc
+            ? store.updateOne("preferences", `${pluginName}.${preferenceName}`, { value })
+            : store.insertOne("preferences", { _id: `${pluginName}.${preferenceName}`, value })
+        )
+    );
+}
+
+/**
+ * Clears all preferences for the specified plugin.
+ *
+ * @param pluginName The name of the plugin.
+ * @returns A promise that resolves when the preferences have been cleared.
+ */
+function clear(pluginName: string): Promise<void> {
+  return Promise.resolve();
+}
+
+/**
+ * Registers a preference with the specified default value.
+ *
+ * @param register The function to use for registering the preference.
+ * @param pluginName The name of the plugin.
+ * @param preferenceName The name of the preference.
+ * @param defaultValue The default value of the preference.
+ */
+function registerPreferences<T>(register: Function, pluginName: string, preferenceName: string, defaultValue: T) {
+  register("PluginPreferences", `${pluginName}.${preferenceName}`, () =>
+    experimentComponent(pluginName, preferenceName, defaultValue)
+  );
+}
+
+/**
+ * An object that provides methods for getting, setting, and clearing preferences.
+ */
+export const preferences = {
+  get,
+  set,
+  clear,
+  registerPreferences,
+};
+
+// TODO: Better CSS styling
+const experimentComponent = async (pluginName: string, preferenceName: string, defaultValue: any) => {
+  var parent = document.createElement("div");
+  parent.style.marginTop = "16px";
+  const label = document.createElement("p");
+  label.style.marginTop = "5px";
+  label.style.fontSize = "16px";
+  label.innerText = `Setting ${preferenceName}:`;
+  parent.appendChild(label);
+
+  const form = document.createElement("form");
+  form.id = "Set key value";
+  form.addEventListener("submit", (e: any) => {
+    e.preventDefault();
+    const value = new FormData(e.target).get("value");
+    set(pluginName, preferenceName, value);
+  });
+  const input = document.createElement("input");
+  input.name = "value";
+  input.defaultValue = (await preferences.get(pluginName, preferenceName)) || defaultValue;
+  input.style.marginTop = "3px";
+  input.style.padding = "5px";
+  input.style.paddingLeft = "12px";
+  input.style.borderRadius = "5px";
+  input.style.borderColor = "#CBD5E0";
+  input.style.borderWidth = "1px";
+  input.style.marginRight = "10px";
+  input.style.width = "40%";
+  input.style.fontSize = "14px";
+  input.style.color = "#9ca3af";
+
+  form.appendChild(input);
+  const button = document.createElement("button");
+  button.type = "submit";
+  button.innerText = "Save";
+  button.style.backgroundColor = "#3b82f6";
+  button.style.color = "white";
+  button.style.padding = "5px 10px";
+  button.style.border = "none";
+  button.style.borderRadius = "5px";
+  form.appendChild(button);
+
+  parent.appendChild(form);
+  return parent;
+};

--- a/plugin-core/preferences.ts
+++ b/plugin-core/preferences.ts
@@ -55,9 +55,11 @@ function clear(pluginName: string): Promise<void> {
  * @param defaultValue The default value of the preference.
  */
 function registerPreferences<T>(register: Function, pluginName: string, preferenceName: string, defaultValue: T) {
-  register("PluginPreferences", `${pluginName}.${preferenceName}`, () =>
-    experimentComponent(pluginName, preferenceName, defaultValue)
-  );
+  register("PluginPreferences", `${pluginName}.${preferenceName}`, () => ({
+    pluginName,
+    preferenceName,
+    defaultValue,
+  }));
 }
 
 /**
@@ -68,50 +70,4 @@ export const preferences = {
   set,
   clear,
   registerPreferences,
-};
-
-// TODO: Better CSS styling
-const experimentComponent = async (pluginName: string, preferenceName: string, defaultValue: any) => {
-  var parent = document.createElement("div");
-  parent.style.marginTop = "16px";
-  const label = document.createElement("p");
-  label.style.marginTop = "5px";
-  label.style.fontSize = "16px";
-  label.innerText = `Setting ${preferenceName}:`;
-  parent.appendChild(label);
-
-  const form = document.createElement("form");
-  form.id = "Set key value";
-  form.addEventListener("submit", (e: any) => {
-    e.preventDefault();
-    const value = new FormData(e.target).get("value");
-    set(pluginName, preferenceName, value);
-  });
-  const input = document.createElement("input");
-  input.name = "value";
-  input.defaultValue = (await preferences.get(pluginName, preferenceName)) || defaultValue;
-  input.style.marginTop = "3px";
-  input.style.padding = "5px";
-  input.style.paddingLeft = "12px";
-  input.style.borderRadius = "5px";
-  input.style.borderColor = "#CBD5E0";
-  input.style.borderWidth = "1px";
-  input.style.marginRight = "10px";
-  input.style.width = "40%";
-  input.style.fontSize = "14px";
-  input.style.color = "#9ca3af";
-
-  form.appendChild(input);
-  const button = document.createElement("button");
-  button.type = "submit";
-  button.innerText = "Save";
-  button.style.backgroundColor = "#3b82f6";
-  button.style.color = "white";
-  button.style.padding = "5px 10px";
-  button.style.border = "none";
-  button.style.borderRadius = "5px";
-  form.appendChild(button);
-
-  parent.appendChild(form);
-  return parent;
 };

--- a/plugin-core/preferences.ts
+++ b/plugin-core/preferences.ts
@@ -54,10 +54,19 @@ function clear(pluginName: string): Promise<void> {
  * @param preferenceName The name of the preference.
  * @param defaultValue The default value of the preference.
  */
-function registerPreferences<T>(register: Function, pluginName: string, preferenceName: string, defaultValue: T) {
-  register("PluginPreferences", `${pluginName}.${preferenceName}`, () => ({
+function registerPreferences<T>(
+  register: Function,
+  pluginName: string,
+  preferenceKey: string,
+  preferenceName: string,
+  preferenceDescription: string,
+  defaultValue: T
+) {
+  register("PluginPreferences", `${pluginName}.${preferenceKey}`, () => ({
     pluginName,
+    preferenceKey,
     preferenceName,
+    preferenceDescription,
     defaultValue,
   }));
 }

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-
+import { PluginService } from "@janhq/plugin-core";
 import { ThemeWrapper } from "./_helpers/ThemeWrapper";
 import JotaiWrapper from "./_helpers/JotaiWrapper";
 import { ModalWrapper } from "./_helpers/ModalWrapper";
@@ -17,6 +17,7 @@ import {
 import EventListenerWrapper from "./_helpers/EventListenerWrapper";
 import { setupCoreServices } from "./_services/coreService";
 import MainContainer from "./_components/MainContainer";
+import { executeSerial } from "../../electron/core/plugin-manager/execution/extension-manager";
 
 const Page: React.FC = () => {
   const [setupCore, setSetupCore] = useState(false);
@@ -40,6 +41,7 @@ const Page: React.FC = () => {
         setupBasePlugins();
         return;
       }
+      await executeSerial(PluginService.OnStart);
       setActivated(true);
     }, 500);
   }
@@ -49,6 +51,7 @@ const Page: React.FC = () => {
     setupCoreServices();
     setSetupCore(true);
   }, []);
+
   useEffect(() => {
     if (setupCore) {
       // Electron

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -5,15 +5,8 @@ import JotaiWrapper from "./_helpers/JotaiWrapper";
 import { ModalWrapper } from "./_helpers/ModalWrapper";
 import { useEffect, useState } from "react";
 import Image from "next/image";
-import {
-  setup,
-  plugins,
-  activationPoints,
-} from "../../electron/core/plugin-manager/execution/index";
-import {
-  isCorePluginInstalled,
-  setupBasePlugins,
-} from "./_services/pluginService";
+import { setup, plugins, activationPoints, extensionPoints } from "../../electron/core/plugin-manager/execution/index";
+import { isCorePluginInstalled, setupBasePlugins } from "./_services/pluginService";
 import EventListenerWrapper from "./_helpers/EventListenerWrapper";
 import { setupCoreServices } from "./_services/coreService";
 import MainContainer from "./_components/MainContainer";
@@ -41,7 +34,9 @@ const Page: React.FC = () => {
         setupBasePlugins();
         return;
       }
-      await executeSerial(PluginService.OnStart);
+      if (extensionPoints.get(PluginService.OnStart)) {
+        await executeSerial(PluginService.OnStart);
+      }
       setActivated(true);
     }, 500);
   }
@@ -67,19 +62,19 @@ const Page: React.FC = () => {
   return (
     <JotaiWrapper>
       {setupCore && (
-      <EventListenerWrapper>
-        <ThemeWrapper>
-          <ModalWrapper>
-            {activated ? (
-              <MainContainer />
-            ) : (
-              <div className="bg-white w-screen h-screen items-center justify-center flex">
-                <Image width={50} height={50} src="icons/app_icon.svg" alt="" />
-              </div>
-            )}
-          </ModalWrapper>
-        </ThemeWrapper>
-      </EventListenerWrapper>
+        <EventListenerWrapper>
+          <ThemeWrapper>
+            <ModalWrapper>
+              {activated ? (
+                <MainContainer />
+              ) : (
+                <div className="bg-white w-screen h-screen items-center justify-center flex">
+                  <Image width={50} height={50} src="icons/app_icon.svg" alt="" />
+                </div>
+              )}
+            </ModalWrapper>
+          </ThemeWrapper>
+        </EventListenerWrapper>
       )}
     </JotaiWrapper>
   );


### PR DESCRIPTION
### Problem
- User can't configure Plugin settings

### Solution
- The Core module supports preferences APIs, and plugins can register available preferences along with their value types
- Plugin registers available preferences (with preference value type)

```ts
import { preferences } from "@janhq/plugin-core";

export function init({ register }: { register: RegisterExtensionPoint }) {
  preferences.registerPreferences<string>(register, PluginName, PreferenceName, DefaultValue);
}
```

- Plugin retrieve preference value in it entry codes

```ts
import { preferences } from "@janhq/plugin-core";

const setup = async () => {
  const preferenceValue: string = (await preferences.get(PluginName, PreferenceName)) ?? DefaultValue;
}
```

- Preferences page execute to retrieve all available preferences then list out (and allow user to set value)

<img width="1312" alt="Screenshot 2023-10-16 at 15 08 32" src="https://github.com/janhq/jan/assets/133622055/aa0f21c2-3ee4-4710-89b2-253ee50ac4b9">


- Plugin checks for preference settings and function:

No settings available:

![Image](https://github.com/janhq/jan/assets/133622055/d049a06e-5e35-42f3-97fc-7508d631905e)


Valid settings:

![Image](https://github.com/janhq/jan/assets/133622055/675dec86-df1c-4131-a110-03ca9bb2ca02)

### Preferences

To register plugin preferences, you can use the preferences object from the @janhq/plugin-core package. Here's an example of how to register and retrieve plugin preferences:

```js
import { PluginService, preferences } from "@janhq/plugin-core";

const PluginName = "your-first-plugin";

export function init({ register }: { register: RegisterExtensionPoint }) {
  // Register preference update handlers. E.g. update plugin instance with new configuration
  register(PluginService.OnPreferencesUpdate, PluginName, onPreferencesUpdate);

  // Register plugin preferences. E.g. Plugin need apiKey and endpoint to connect to your service
  preferences.registerPreferences<string>(register, PluginName, "apiKey", "");
  preferences.registerPreferences<string>(register, PluginName, "endpoint", "");
}
```

In this example, we're registering preference update handlers and plugin preferences using the preferences object. We're also defining a PluginName constant to use as the name of the plugin.

To retrieve the values of the registered preferences, we're using the get method of the preferences object and passing in the name of the plugin and the name of the preference.

```js
import { preferences } from "@janhq/plugin-core";

const PluginName = "your-first-plugin";

const setup = async () => {
  // Retrieve apiKey
  const apiKey: string = (await preferences.get(PluginName, "apiKey")) ?? "";

  // Retrieve endpoint
  const endpoint: string = (await preferences.get(PluginName, "endpoint")) ?? "";
}
```

fixes #360 

Action Items: 

- [x] `preferences` module in `@janhq/plugin-core`
- [x] register preference type & handler in Plugin
- [x] preferences allow get/set using `store` module
- [ ] app handles preference UI with better CSS (registerPreferences should return json instead of DOM component)
- [ ] clear values
- [ ] grouped settings