### PR TITLE
chore: update core services and module export

### DIFF
--- a/.github/workflows/publish-plugin-core.yml
+++ b/.github/workflows/publish-plugin-core.yml
@@ -8,7 +8,7 @@ on:
       - ".github/workflows/publish-core.yml"
       - "!core/package.json"
 jobs:
-  build:
+  build-and-publish-plugins:
     runs-on: ubuntu-latest
     environment: production
     steps:

--- a/core/README.md
+++ b/core/README.md
@@ -11,7 +11,7 @@
 const core = require("@janhq/core");
 
 // typescript
-import { core } from "@janhq/core";
+import * as core from "@janhq/core";
 ```
 
 ### Register Plugin Extensions

--- a/core/README.md
+++ b/core/README.md
@@ -186,7 +186,7 @@ In your main entry code (e.g., `index.ts`), start by importing the necessary mod
 
 ```js
 // index.ts
-import { core } from "@janhq/core";
+import * as core from "@janhq/core";
 ```
 
 #### Perform File Operations
@@ -223,7 +223,7 @@ In your main process code (e.g., `index.ts`), start by importing the `core` obje
 
 ```js
 // index.ts
-import { core } from "@janhq/core";
+import * as core from "@janhq/core";
 ```
 
 ##### Define the Module Path

--- a/core/core.ts
+++ b/core/core.ts
@@ -37,11 +37,18 @@ export type RegisterExtensionPoint = (
   method: Function,
   priority?: number
 ) => void;
+
 /**
- * Core exports
+ * @deprecated This object is deprecated and should not be used.
+ * Use individual functions instead.
  */
 export const core = {
   invokePluginFunc,
   downloadFile,
   deleteFile,
 };
+
+/**
+ * Functions exports
+ */
+export { invokePluginFunc, downloadFile, deleteFile };

--- a/core/index.ts
+++ b/core/index.ts
@@ -117,6 +117,11 @@ export enum InferenceService {
    * Stops a running inference model.
    */
   StopModel = "stopModel",
+
+  /**
+   * Single inference response.
+   */
+  InferenceRequest = "inferenceRequest",
 }
 
 /**
@@ -124,16 +129,6 @@ export enum InferenceService {
  * @enum {string}
  */
 export enum ModelManagementService {
-  /**
-   * Gets a list of downloaded models.
-   */
-  GetDownloadedModels = "getDownloadedModels",
-
-  /**
-   * Gets a list of available models from the server.
-   */
-  GetAvailableModels = "getAvailableModels",
-
   /**
    * Deletes a downloaded model.
    */
@@ -143,11 +138,6 @@ export enum ModelManagementService {
    * Downloads a model from the server.
    */
   DownloadModel = "downloadModel",
-
-  /**
-   * Searches for models on the server.
-   */
-  SearchModels = "searchModels",
 
   /**
    * Gets configued models from the database.
@@ -163,11 +153,6 @@ export enum ModelManagementService {
    * Updates the finished download time for a model in the database.
    */
   UpdateFinishedDownloadAt = "updateFinishedDownloadAt",
-
-  /**
-   * Gets a list of unfinished download models from the database.
-   */
-  GetUnfinishedDownloadModels = "getUnfinishedDownloadModels",
 
   /**
    * Gets a list of finished download models from the database.
@@ -245,10 +230,16 @@ export enum PluginService {
 export { store } from "./store";
 
 /**
+ * @deprecated This object is deprecated and should not be used.
+ * Use individual functions instead.
+ */
+export { core } from "./core";
+
+/**
  * Core module exports.
  * @module
  */
-export { core, RegisterExtensionPoint } from "./core";
+export { RegisterExtensionPoint, deleteFile, downloadFile, invokePluginFunc } from "./core";
 
 /**
  * Events module exports.

--- a/plugins/data-plugin/package-lock.json
+++ b/plugins/data-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@janhq/data-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@janhq/data-plugin",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "bundleDependencies": [
         "pouchdb-node",
         "pouchdb-find"

--- a/plugins/data-plugin/package.json
+++ b/plugins/data-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janhq/data-plugin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "The Data Connector provides easy access to a data API using the PouchDB engine. It offers accessible data management capabilities.",
   "icon": "https://raw.githubusercontent.com/tailwindlabs/heroicons/88e98b0c2b458553fbadccddc2d2f878edc0387b/src/20/solid/circle-stack.svg",
   "main": "dist/esm/index.js",

--- a/plugins/data-plugin/package.json
+++ b/plugins/data-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janhq/data-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The Data Connector provides easy access to a data API using the PouchDB engine. It offers accessible data management capabilities.",
   "icon": "https://raw.githubusercontent.com/tailwindlabs/heroicons/88e98b0c2b458553fbadccddc2d2f878edc0387b/src/20/solid/circle-stack.svg",
   "main": "dist/esm/index.js",

--- a/plugins/inference-plugin/package-lock.json
+++ b/plugins/inference-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@janhq/inference-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@janhq/inference-plugin",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "bundleDependencies": [
         "tcp-port-used",
         "kill-port-process"

--- a/plugins/inference-plugin/package.json
+++ b/plugins/inference-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janhq/inference-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Inference Plugin, powered by @janhq/nitro, bring a high-performance Llama model inference in pure C++.",
   "icon": "https://raw.githubusercontent.com/tailwindlabs/heroicons/88e98b0c2b458553fbadccddc2d2f878edc0387b/src/20/solid/command-line.svg",
   "main": "dist/index.js",

--- a/plugins/inference-plugin/package.json
+++ b/plugins/inference-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janhq/inference-plugin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Inference Plugin, powered by @janhq/nitro, bring a high-performance Llama model inference in pure C++.",
   "icon": "https://raw.githubusercontent.com/tailwindlabs/heroicons/88e98b0c2b458553fbadccddc2d2f878edc0387b/src/20/solid/command-line.svg",
   "main": "dist/index.js",

--- a/plugins/model-management-plugin/package-lock.json
+++ b/plugins/model-management-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@janhq/model-management-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@janhq/model-management-plugin",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "bundleDependencies": [
         "@huggingface/hub"
       ],

--- a/plugins/model-management-plugin/package.json
+++ b/plugins/model-management-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janhq/model-management-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Model Management Plugin provides model exploration and seamless downloads",
   "icon": "https://raw.githubusercontent.com/tailwindlabs/heroicons/88e98b0c2b458553fbadccddc2d2f878edc0387b/src/20/solid/queue-list.svg",
   "main": "dist/index.js",

--- a/plugins/model-management-plugin/package.json
+++ b/plugins/model-management-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janhq/model-management-plugin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Model Management Plugin provides model exploration and seamless downloads",
   "icon": "https://raw.githubusercontent.com/tailwindlabs/heroicons/88e98b0c2b458553fbadccddc2d2f878edc0387b/src/20/solid/queue-list.svg",
   "main": "dist/index.js",

--- a/plugins/monitoring-plugin/package-lock.json
+++ b/plugins/monitoring-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@janhq/monitoring-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@janhq/monitoring-plugin",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "bundleDependencies": [
         "systeminformation"
       ],

--- a/plugins/monitoring-plugin/package.json
+++ b/plugins/monitoring-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janhq/monitoring-plugin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Utilizing systeminformation, it provides essential System and OS information retrieval",
   "icon": "https://raw.githubusercontent.com/tailwindlabs/heroicons/88e98b0c2b458553fbadccddc2d2f878edc0387b/src/20/solid/cpu-chip.svg",
   "main": "dist/index.js",

--- a/plugins/monitoring-plugin/package.json
+++ b/plugins/monitoring-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janhq/monitoring-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Utilizing systeminformation, it provides essential System and OS information retrieval",
   "icon": "https://raw.githubusercontent.com/tailwindlabs/heroicons/88e98b0c2b458553fbadccddc2d2f878edc0387b/src/20/solid/cpu-chip.svg",
   "main": "dist/index.js",

--- a/plugins/openai-plugin/package.json
+++ b/plugins/openai-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janhq/azure-openai-plugin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Inference plugin for Azure OpenAI",
   "icon": "https://static-assets.jan.ai/openai-icon.jpg",
   "main": "dist/index.js",

--- a/plugins/openai-plugin/package.json
+++ b/plugins/openai-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janhq/azure-openai-plugin",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Inference plugin for Azure OpenAI",
   "icon": "https://static-assets.jan.ai/openai-icon.jpg",
   "main": "dist/index.js",

--- a/web/app/_components/HistoryItem/index.tsx
+++ b/web/app/_components/HistoryItem/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { useAtomValue, useSetAtom } from "jotai";
 import Image from "next/image";
 import { Conversation } from "@/_models/Conversation";
-import { ModelManagementService } from "@janhq/plugin-core";
+import { ModelManagementService } from "@janhq/core";
 import { executeSerial } from "../../../../electron/core/plugin-manager/execution/extension-manager";
 import {
   conversationStatesAtom,

--- a/web/app/_components/Preferences.tsx
+++ b/web/app/_components/Preferences.tsx
@@ -10,7 +10,7 @@ import { ChartPieIcon, CommandLineIcon, PlayIcon } from "@heroicons/react/24/out
 
 import { MagnifyingGlassIcon } from "@heroicons/react/20/solid";
 import classNames from "classnames";
-import { PluginService, preferences } from "@janhq/plugin-core";
+import { PluginService, preferences } from "@janhq/core";
 import { execute } from "../../../electron/core/plugin-manager/execution/extension-manager";
 
 export const Preferences = () => {

--- a/web/app/_helpers/EventHandler.tsx
+++ b/web/app/_helpers/EventHandler.tsx
@@ -1,6 +1,6 @@
 import { addNewMessageAtom, updateMessageAtom } from "@/_helpers/atoms/ChatMessage.atom";
 import { toChatMessage } from "@/_models/ChatMessage";
-import { events, EventName, NewMessageResponse } from "@janhq/plugin-core";
+import { events, EventName, NewMessageResponse } from "@janhq/core";
 import { useSetAtom } from "jotai";
 import { ReactNode, useEffect } from "react";
 

--- a/web/app/_helpers/EventListenerWrapper.tsx
+++ b/web/app/_helpers/EventListenerWrapper.tsx
@@ -5,7 +5,7 @@ import { ReactNode, useEffect } from "react";
 import { appDownloadProgress } from "./JotaiWrapper";
 import { DownloadState } from "@/_models/DownloadState";
 import { executeSerial } from "../../../electron/core/plugin-manager/execution/extension-manager";
-import { ModelManagementService } from "@janhq/plugin-core";
+import { ModelManagementService } from "@janhq/core";
 import { setDownloadStateAtom, setDownloadStateSuccessAtom } from "./atoms/DownloadState.atom";
 import { getDownloadedModels } from "@/_hooks/useGetDownloadedModels";
 import { downloadedModelAtom } from "./atoms/DownloadedModel.atom";

--- a/web/app/_hooks/useChatMessages.ts
+++ b/web/app/_hooks/useChatMessages.ts
@@ -2,7 +2,7 @@ import { ChatMessage, RawMessage, toChatMessage } from "@/_models/ChatMessage";
 import { executeSerial } from "@/_services/pluginService";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useEffect, useState } from "react";
-import { DataService } from "@janhq/plugin-core";
+import { DataService } from "@janhq/core";
 import { addOldMessagesAtom } from "@/_helpers/atoms/ChatMessage.atom";
 import {
   currentConversationAtom,

--- a/web/app/_hooks/useCreateConversation.ts
+++ b/web/app/_hooks/useCreateConversation.ts
@@ -1,7 +1,7 @@
 import { useAtom, useSetAtom } from "jotai";
 import { Conversation } from "@/_models/Conversation";
 import { executeSerial } from "@/_services/pluginService";
-import { DataService } from "@janhq/plugin-core";
+import { DataService } from "@janhq/core";
 import {
   userConversationsAtom,
   setActiveConvoIdAtom,

--- a/web/app/_hooks/useDeleteConversation.ts
+++ b/web/app/_hooks/useDeleteConversation.ts
@@ -1,7 +1,7 @@
 import { currentPromptAtom } from "@/_helpers/JotaiWrapper";
 import { execute } from "@/_services/pluginService";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import { DataService } from "@janhq/plugin-core";
+import { DataService } from "@janhq/core";
 import { deleteConversationMessage } from "@/_helpers/atoms/ChatMessage.atom";
 import {
   userConversationsAtom,

--- a/web/app/_hooks/useDeleteModel.ts
+++ b/web/app/_hooks/useDeleteModel.ts
@@ -1,5 +1,5 @@
 import { execute, executeSerial } from "@/_services/pluginService";
-import { ModelManagementService } from "@janhq/plugin-core";
+import { ModelManagementService } from "@janhq/core";
 import { useSetAtom } from "jotai";
 import { downloadedModelAtom } from "@/_helpers/atoms/DownloadedModel.atom";
 import { getDownloadedModels } from "./useGetDownloadedModels";

--- a/web/app/_hooks/useDownloadModel.ts
+++ b/web/app/_hooks/useDownloadModel.ts
@@ -1,5 +1,5 @@
 import { executeSerial } from "@/_services/pluginService";
-import { DataService, ModelManagementService } from "@janhq/plugin-core";
+import { DataService, ModelManagementService } from "@janhq/core";
 import { ModelVersion } from "@/_models/ModelVersion";
 import { Product } from "@/_models/Product";
 import { AssistantModel } from "@/_models/AssistantModel";

--- a/web/app/_hooks/useGetDownloadedModels.ts
+++ b/web/app/_hooks/useGetDownloadedModels.ts
@@ -1,7 +1,7 @@
 import { Product } from "@/_models/Product";
 import { useEffect } from "react";
 import { executeSerial } from "../../../electron/core/plugin-manager/execution/extension-manager";
-import { ModelManagementService } from "@janhq/plugin-core";
+import { ModelManagementService } from "@janhq/core";
 import { useAtom } from "jotai";
 import { downloadedModelAtom } from "@/_helpers/atoms/DownloadedModel.atom";
 import { AssistantModel } from "@/_models/AssistantModel";

--- a/web/app/_hooks/useGetMostSuitableModelVersion.ts
+++ b/web/app/_hooks/useGetMostSuitableModelVersion.ts
@@ -1,5 +1,5 @@
 import { executeSerial } from "@/_services/pluginService";
-import { SystemMonitoringService } from "@janhq/plugin-core";
+import { SystemMonitoringService } from "@janhq/core";
 import { ModelVersion } from "@/_models/ModelVersion";
 import { useState } from "react";
 

--- a/web/app/_hooks/useGetPerformanceTag.ts
+++ b/web/app/_hooks/useGetPerformanceTag.ts
@@ -1,5 +1,5 @@
 import { executeSerial } from "../../../electron/core/plugin-manager/execution/extension-manager";
-import { SystemMonitoringService } from "@janhq/plugin-core";
+import { SystemMonitoringService } from "@janhq/core";
 import { useState } from "react";
 import { ModelVersion } from "@/_models/ModelVersion";
 import { ModelPerformance, TagType } from "@/_components/SimpleTag/TagType";

--- a/web/app/_hooks/useGetSystemResources.ts
+++ b/web/app/_hooks/useGetSystemResources.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { executeSerial } from "../../../electron/core/plugin-manager/execution/extension-manager";
-import { SystemMonitoringService } from "@janhq/plugin-core";
+import { SystemMonitoringService } from "@janhq/core";
 
 export default function useGetSystemResources() {
   const [ram, setRam] = useState<number>(0);

--- a/web/app/_hooks/useGetUserConversations.ts
+++ b/web/app/_hooks/useGetUserConversations.ts
@@ -1,7 +1,7 @@
 import { Conversation, ConversationState } from "@/_models/Conversation";
 import { useSetAtom } from "jotai";
 import { executeSerial } from "@/_services/pluginService";
-import { DataService } from "@janhq/plugin-core";
+import { DataService } from "@janhq/core";
 import {
   conversationStatesAtom,
   userConversationsAtom,

--- a/web/app/_hooks/useInitModel.ts
+++ b/web/app/_hooks/useInitModel.ts
@@ -1,5 +1,5 @@
 import { executeSerial } from "@/_services/pluginService";
-import { InferenceService } from "@janhq/plugin-core";
+import { InferenceService } from "@janhq/core";
 import { useAtom } from "jotai";
 import { activeAssistantModelAtom } from "@/_helpers/atoms/Model.atom";
 import { AssistantModel } from "@/_models/AssistantModel";

--- a/web/app/_hooks/useSendChatMessage.ts
+++ b/web/app/_hooks/useSendChatMessage.ts
@@ -1,6 +1,6 @@
 import { currentPromptAtom } from "@/_helpers/JotaiWrapper";
 import { useAtom, useAtomValue, useSetAtom } from "jotai";
-import { DataService, EventName, events } from "@janhq/plugin-core";
+import { DataService, EventName, events } from "@janhq/core";
 import { RawMessage, toChatMessage } from "@/_models/ChatMessage";
 import { executeSerial } from "@/_services/pluginService";
 import { addNewMessageAtom } from "@/_helpers/atoms/ChatMessage.atom";

--- a/web/app/_hooks/useStartStopModel.ts
+++ b/web/app/_hooks/useStartStopModel.ts
@@ -1,5 +1,5 @@
 import { executeSerial } from "@/_services/pluginService";
-import { ModelManagementService, InferenceService } from "@janhq/plugin-core";
+import { ModelManagementService, InferenceService } from "@janhq/core";
 import useInitModel from "./useInitModel";
 import { useSetAtom } from "jotai";
 import { activeAssistantModelAtom } from "@/_helpers/atoms/Model.atom";

--- a/web/app/_models/ChatMessage.ts
+++ b/web/app/_models/ChatMessage.ts
@@ -1,4 +1,4 @@
-import { NewMessageResponse } from "@janhq/plugin-core";
+import { NewMessageResponse } from "@janhq/core";
 export enum MessageType {
   Text = "Text",
   Image = "Image",

--- a/web/app/_services/pluginService.ts
+++ b/web/app/_services/pluginService.ts
@@ -1,6 +1,6 @@
 "use client";
 import { extensionPoints, plugins } from "../../../electron/core/plugin-manager/execution/index";
-import { CoreService, DataService, InferenceService, ModelManagementService } from "@janhq/plugin-core";
+import { CoreService, DataService, InferenceService, ModelManagementService } from "@janhq/core";
 
 export const isCorePluginInstalled = () => {
   if (!extensionPoints.get(DataService.GetConversations)) {

--- a/web/app/_services/storeService.ts
+++ b/web/app/_services/storeService.ts
@@ -1,4 +1,4 @@
-import { StoreService } from "@janhq/plugin-core";
+import { StoreService } from "@janhq/core";
 import { executeSerial } from "./pluginService";
 
 /**

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { PluginService } from "@janhq/plugin-core";
+import { PluginService } from "@janhq/core";
 import { ThemeWrapper } from "./_helpers/ThemeWrapper";
 import JotaiWrapper from "./_helpers/JotaiWrapper";
 import { ModalWrapper } from "./_helpers/ModalWrapper";

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@headlessui/react": "^1.7.15",
     "@heroicons/react": "^2.0.18",
-    "@janhq/plugin-core": "^0.1.8",
+    "@janhq/core": "^0.1.1",
     "@tailwindcss/typography": "^0.5.9",
     "@types/react": "18.2.15",
     "@types/react-dom": "18.2.7",


### PR DESCRIPTION
## Problem
Since we renamed @janhq/plugin-core to @janhq/core, its not so reasonable to 
``` typescript
import { core } from "@janhq/core" ;
core.downloadFile("");
```
// OR

``` typescript
import * as core from "@janhq/core"
core.core.downloadFile("")
```

## Solution
Core module should export all functions so:

``` typescript
import { downloadFile } from "@janhq/core" ;
downloadFile("");
```

// OR

``` typescript
import * as core from "@janhq/core"
core.downloadFile("")
```
