### PR TITLE
feat: explore plugins from the npm repository and install them remotely

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -5,8 +5,8 @@ import { rmdir, unlink, createWriteStream } from "fs";
 import { init } from "./core/plugin-manager/pluginMgr";
 import { setupMenu } from "./utils/menu";
 import { dispose } from "./utils/disposable";
-const pacote = require("pacote");
 
+const pacote = require("pacote");
 const request = require("request");
 const progress = require("request-progress");
 const { autoUpdater } = require("electron-updater");

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,10 +1,11 @@
 import { app, BrowserWindow, ipcMain, dialog, shell } from "electron";
-import { readdirSync } from "fs";
+import { readdirSync, writeFileSync } from "fs";
 import { resolve, join, extname } from "path";
 import { rmdir, unlink, createWriteStream } from "fs";
 import { init } from "./core/plugin-manager/pluginMgr";
 import { setupMenu } from "./utils/menu";
 import { dispose } from "./utils/disposable";
+const pacote = require("pacote");
 
 const request = require("request");
 const progress = require("request-progress");
@@ -224,6 +225,24 @@ function handleIPCs() {
         });
       })
       .pipe(createWriteStream(destination));
+  });
+
+  /**
+   * Installs a remote plugin by downloading its tarball and writing it to a tgz file.
+   * @param _event - The IPC event object.
+   * @param pluginName - The name of the remote plugin to install.
+   * @returns A Promise that resolves to the path of the installed plugin file.
+   */
+  ipcMain.handle("installRemotePlugin", async (_event, pluginName) => {
+    const destination = join(app.getPath("userData"), pluginName.replace(/^@.*\//, "") + ".tgz");
+    return pacote
+      .manifest(pluginName)
+      .then(async (manifest: any) => {
+        await pacote.tarball(manifest._resolved).then((data: Buffer) => {
+          writeFileSync(destination, data);
+        });
+      })
+      .then(() => destination);
   });
 }
 

--- a/electron/package.json
+++ b/electron/package.json
@@ -37,7 +37,9 @@
       "icon": "icons/icon.png"
     },
     "linux": {
-      "target": ["deb"],
+      "target": [
+        "deb"
+      ],
       "category": "Utility",
       "icon": "icons/"
     },

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -23,24 +23,19 @@ contextBridge.exposeInMainWorld("electronAPI", {
 
   deleteFile: (filePath: string) => ipcRenderer.invoke("deleteFile", filePath),
 
-  downloadFile: (url: string, path: string) =>
-    ipcRenderer.invoke("downloadFile", url, path),
+  installRemotePlugin: (pluginName: string) => ipcRenderer.invoke("installRemotePlugin", pluginName),
 
-  onFileDownloadUpdate: (callback: any) =>
-    ipcRenderer.on("FILE_DOWNLOAD_UPDATE", callback),
+  downloadFile: (url: string, path: string) => ipcRenderer.invoke("downloadFile", url, path),
 
-  onFileDownloadError: (callback: any) =>
-    ipcRenderer.on("FILE_DOWNLOAD_ERROR", callback),
+  onFileDownloadUpdate: (callback: any) => ipcRenderer.on("FILE_DOWNLOAD_UPDATE", callback),
 
-  onFileDownloadSuccess: (callback: any) =>
-    ipcRenderer.on("FILE_DOWNLOAD_COMPLETE", callback),
+  onFileDownloadError: (callback: any) => ipcRenderer.on("FILE_DOWNLOAD_ERROR", callback),
 
-  onAppUpdateDownloadUpdate: (callback: any) =>
-    ipcRenderer.on("APP_UPDATE_PROGRESS", callback),
+  onFileDownloadSuccess: (callback: any) => ipcRenderer.on("FILE_DOWNLOAD_COMPLETE", callback),
 
-  onAppUpdateDownloadError: (callback: any) =>
-    ipcRenderer.on("APP_UPDATE_ERROR", callback),
+  onAppUpdateDownloadUpdate: (callback: any) => ipcRenderer.on("APP_UPDATE_PROGRESS", callback),
 
-  onAppUpdateDownloadSuccess: (callback: any) =>
-    ipcRenderer.on("APP_UPDATE_COMPLETE", callback),
+  onAppUpdateDownloadError: (callback: any) => ipcRenderer.on("APP_UPDATE_ERROR", callback),
+
+  onAppUpdateDownloadSuccess: (callback: any) => ipcRenderer.on("APP_UPDATE_COMPLETE", callback),
 });

--- a/web/app/_components/Preferences.tsx
+++ b/web/app/_components/Preferences.tsx
@@ -7,6 +7,7 @@ import { MagnifyingGlassIcon } from "@heroicons/react/20/solid";
 import classNames from "classnames";
 import { PluginService, preferences } from "@janhq/core";
 import { execute } from "../../../electron/core/plugin-manager/execution/extension-manager";
+import LoadingIndicator from "./LoadingIndicator";
 
 export const Preferences = () => {
   const [search, setSearch] = useState<string>("");
@@ -15,9 +16,10 @@ export const Preferences = () => {
   const [preferenceValues, setPreferenceValues] = useState<any[]>([]);
   const [isTestAvailable, setIsTestAvailable] = useState(false);
   const [fileName, setFileName] = useState("");
+  const [pluginCatalog, setPluginCatalog] = useState<any[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
   const experimentRef = useRef(null);
   const preferenceRef = useRef(null);
-  const [pluginCatalog, setPluginCatalog] = useState<any[]>([]);
 
   /**
    * Loads the plugin catalog module from a CDN and sets it as the plugin catalog state.
@@ -119,8 +121,10 @@ export const Preferences = () => {
    * @param pluginName - The name of the remote plugin to download and install.
    */
   const downloadTarball = async (pluginName: string) => {
+    setIsLoading(true);
     const pluginPath = await window.coreAPI?.installRemotePlugin(pluginName);
     const installed = await plugins.install([pluginPath]);
+    setIsLoading(false);
     if (installed) window.coreAPI.relaunch();
   };
   /**
@@ -311,18 +315,20 @@ export const Preferences = () => {
                   </p>
 
                   <div className="flex flex-row space-x-5">
-                    <button
-                      type="submit"
-                      onClick={() => downloadTarball(e.name)}
-                      className={classNames(
-                        "mt-5 rounded-md px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600",
-                        activePlugins.some((p) => p.name === e.name)
-                          ? "bg-blue-500 hover:bg-blue-600"
-                          : "bg-red-500 hover:bg-red-600"
-                      )}
-                    >
-                      {activePlugins.some((p) => p.name === e.name) ? "Update" : "Install"}
-                    </button>
+                    {e.version !== activePlugins.filter((p) => p.name === e.name)[0]?.version && (
+                      <button
+                        type="submit"
+                        onClick={() => downloadTarball(e.name)}
+                        className={classNames(
+                          "mt-5 rounded-md px-3.5 py-2.5 text-sm font-semibold text-white shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600",
+                          activePlugins.some((p) => p.name === e.name)
+                            ? "bg-blue-500 hover:bg-blue-600"
+                            : "bg-red-500 hover:bg-red-600"
+                        )}
+                      >
+                        {activePlugins.some((p) => p.name === e.name) ? "Update" : "Install"}
+                      </button>
+                    )}
                   </div>
                 </div>
               ))}
@@ -363,6 +369,12 @@ export const Preferences = () => {
           </div>
         </div>
       </main>
+      {isLoading && (
+        <div className="z-50 absolute inset-0 bg-gray-900/90 flex justify-center items-center text-white">
+          <LoadingIndicator />
+          Installing...
+        </div>
+      )}
     </div>
   );
 };

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
+const webpack = require("webpack");
+
 const nextConfig = {
   output: "export",
   assetPrefix: ".",
@@ -18,6 +20,12 @@ const nextConfig = {
     // do some stuff here
     config.optimization.minimize = false;
     config.optimization.minimizer = [];
+    config.plugins = [
+      ...config.plugins,
+      new webpack.DefinePlugin({
+        PLUGIN_CATALOGS: JSON.stringify("https://cdn.jsdelivr.net/npm/@janhq/plugin-catalog@latest/dist/index.js"),
+      }),
+    ];
     return config;
   },
 };

--- a/web/types/index.d.ts
+++ b/web/types/index.d.ts
@@ -1,5 +1,6 @@
 export {};
 
+declare const PLUGIN_CATALOGS: string[];
 declare global {
   interface Window {
     electronAPI?: any | undefined;


### PR DESCRIPTION
Explore plugins: use exported module from CDN for published plugins retrieval
Install a plugin: use `pacote` to retrieve npm manifest and install tarball package (thanks to @hiento09 ) 
( No app update required )

<img width="1571" alt="Screenshot 2023-10-19 at 15 54 08" src="https://github.com/janhq/jan/assets/133622055/6e474049-a393-475d-9352-05cad5995255">

<img width="1312" alt="Screenshot 2023-10-19 at 17 12 48" src="https://github.com/janhq/jan/assets/133622055/07989864-57c8-4c62-9a6b-e2e0fef37dbc">

Action items: 
- [x] Explore Plugins from NPM @janhq/plugin-catalog via CDN
- [x] Download and install using pacote
- [x] Loading spinner
- [x] Compare between versions for the update button appearance
- [ ] Address cross-compile module issue (data-plugin)
