### PR TITLE
chore: Update ADR-008 with Jan App Framework

### DIFF
--- a/adr/adr-008-Extensible-Jan-with-Docker.md
+++ b/adr/adr-008-Extensible-Jan-with-Docker.md
@@ -1,0 +1,36 @@
+# ADR 008: Extensible-Jan-with-Docker
+
+## Changelog
+
+- 2023-10-24: Initial draft
+
+## Authors
+
+- @vuonghoainam
+
+## Status
+Proposed
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+- The A.I world is moving fast with multiple runtime/ prebaked environment. We or the builder cannot cover just everything but rather we should adopt it and facillitate it as much as possible within Jan.
+- For `Run your own A.I`: Builder can build app on Jan (NodeJS env) and connect to external endpoint which serves the real A.I
+  - e.g 1: Nitro acting as proxy to `triton-inference-server` running within a Docker container controlled by Jan app
+  - e.g 2: Original models can be in many formats (pytorch, paddlepaddle). In order to run it with the most optimized version locally, there must be a step to transpile the model ([Ollama import model](https://github.com/jmorganca/ollama/blob/main/docs/import.md), Tensorrt). Btw Jan can prebuilt it and let user pull but later
+- For `Build your own A.I`: User can fine tune model locally (of course Jan help it with remote but later)
+
+## Decision
+
+What is the change that we're proposing and/or doing?
+- Add Docker client as Core module - [Docker node](https://github.com/apocas/dockerode)
+- 2 example A.I app (adr-002) to demonstrate it and actually use!
+
+## Consequences
+
+What becomes easier or more difficult to do because of this change?
+- We can extend limitlessly :D 
+
+## Alternatives
+
+## Reference


### PR DESCRIPTION
## Overview

- We discussed an open, portable framework for "AIs" that can run on Jan across platforms
- "Jan Platform" can install "AI Apps" (later on, becomes just "AIs")
    - NPM repo that can be packaged in a `.tar.gz` (similar to VSCode plugins, Obsidian plugins)
    - Include Ollama-like Modelfile (i.e. model selection, system prompt, model settings)
    - Builder writes code for `index.js` (i.e. frontend), and `module.js` (i.e. backend)
- We will standardize this as a common packaging standard across Jan

## Examples

### Llama2 Model

- `chat-app-starter`
- Modelfile = Llama2 with settings

### Janice (i.e. Jan's documentation/support bot)

- `chat-app-starter`
- Modelfile = Codellama with system prompt
- `docs` folder in Janice app, contains the PDFs and RAG source material
- `index.js` indexes the PDFs in `docs` into FAISS
