### PR TITLE
chore: add required app version to edge release plugin

### DIFF
--- a/plugins/openai-plugin/index.ts
+++ b/plugins/openai-plugin/index.ts
@@ -85,6 +85,7 @@ const registerListener = () => {
   events.on(EventName.OnNewMessageRequest, handleMessageRequest);
 };
 
+// Preference update - reconfigure OpenAI 
 const onPreferencesUpdate = () => {
   setup();
 };

--- a/plugins/openai-plugin/package.json
+++ b/plugins/openai-plugin/package.json
@@ -6,6 +6,7 @@
   "main": "dist/index.js",
   "module": "dist/module.js",
   "author": "Jan <service@jan.ai>",
+  "requiredVersion": "^0.3.1",
   "license": "MIT",
   "activationPoints": [
     "init"


### PR DESCRIPTION
Its to mark experimental openai plugin as edge release plugin