### PR TITLE
chore: attempt to kill Nitro subprocesses

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -43,6 +43,11 @@ app.on("window-all-closed", () => {
   app.quit();
 });
 
+app.on("quit", () => {
+  dispose(requiredModules);
+  app.quit();
+});
+
 ipcMain.handle("setNativeThemeLight", () => {
   nativeTheme.themeSource = "light";
 });

--- a/plugins/inference-plugin/index.ts
+++ b/plugins/inference-plugin/index.ts
@@ -183,7 +183,14 @@ const registerListener = () => {
   events.on(EventName.OnNewMessageRequest, handleMessageRequest);
 };
 
+const killSubprocess = () => {
+  invokePluginFunc(MODULE_PATH, "killSubprocess");
+};
+
 const onStart = async () => {
+  // Try killing any existing subprocesses related to Nitro
+  killSubprocess();
+
   registerListener();
 };
 // Register all the above functions and objects with the relevant extension points


### PR DESCRIPTION
## Problem
- App will just attempt to kill Nitro subprocess on window-close event fires.
- Somehow nitro subprocess is still alive (after update / force quit)

## Solution
- Attempt to kill Nitro process (if any) when inference plugin is booted up
- Attempt to kill Nitro process when the app "quit" event fires 