### PR TITLE
feat: add New Conversation button on the conversation sidebar

### DIFF
--- a/web/app/_components/HistoryList/index.tsx
+++ b/web/app/_components/HistoryList/index.tsx
@@ -1,46 +1,74 @@
 import HistoryItem from '../HistoryItem'
-import { useEffect } from 'react'
+import { Fragment, useEffect } from 'react'
 import ExpandableHeader from '../ExpandableHeader'
-import { useAtomValue } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 import { searchAtom } from '@helpers/JotaiWrapper'
 import useGetUserConversations from '@hooks/useGetUserConversations'
 import SidebarEmptyHistory from '../SidebarEmptyHistory'
 import { userConversationsAtom } from '@helpers/atoms/Conversation.atom'
 import { twMerge } from 'tailwind-merge'
+import { Button } from '@uikit'
+import { activeAssistantModelAtom, stateModel } from '@helpers/atoms/Model.atom'
+import useCreateConversation from '@hooks/useCreateConversation'
+import { showingModalNoActiveModel } from '@helpers/atoms/Modal.atom'
+import { PlusIcon } from '@heroicons/react/24/outline'
 
 const HistoryList: React.FC = () => {
   const conversations = useAtomValue(userConversationsAtom)
   const searchText = useAtomValue(searchAtom)
   const { getUserConversations } = useGetUserConversations()
+  const activeModel = useAtomValue(activeAssistantModelAtom)
+  const { requestCreateConvo } = useCreateConversation()
+  const setShowModalNoActiveModel = useSetAtom(showingModalNoActiveModel)
+
+  const onNewConversationClick = () => {
+    if (activeModel) {
+      requestCreateConvo(activeModel)
+    } else {
+      setShowModalNoActiveModel(true)
+    }
+  }
 
   useEffect(() => {
     getUserConversations()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   return (
     <div className="flex flex-grow flex-col gap-2">
       <ExpandableHeader title="CHAT HISTORY" />
-      <ul className={twMerge('mt-1 flex flex-col gap-y-3 overflow-y-auto')}>
-        {conversations.length > 0 ? (
-          conversations
-            .filter(
-              (e) =>
-                searchText.trim() === '' ||
-                e.name?.toLowerCase().includes(searchText.toLowerCase().trim())
-            )
-            .map((convo) => (
-              <HistoryItem
-                key={convo._id}
-                conversation={convo}
-                summary={convo.summary}
-                name={convo.name || 'Jan'}
-                updatedAt={convo.updatedAt ?? ''}
-              />
-            ))
-        ) : (
-          <SidebarEmptyHistory />
-        )}
-      </ul>
+      {conversations.length > 0 ? (
+        <Fragment>
+          <ul className={twMerge('mt-1 flex flex-col gap-y-3 overflow-y-auto')}>
+            {conversations
+              .filter(
+                (e) =>
+                  searchText.trim() === '' ||
+                  e.name
+                    ?.toLowerCase()
+                    .includes(searchText.toLowerCase().trim())
+              )
+              .map((convo, i) => (
+                <HistoryItem
+                  key={i}
+                  conversation={convo}
+                  summary={convo.summary}
+                  name={convo.name || 'Jan'}
+                  updatedAt={convo.updatedAt ?? ''}
+                />
+              ))}
+          </ul>
+          <Button
+            onClick={onNewConversationClick}
+            className="mt-2 flex items-center space-x-2"
+          >
+            <PlusIcon width={16} height={16} />
+            <span>New Conversation</span>
+          </Button>
+        </Fragment>
+      ) : (
+        <SidebarEmptyHistory />
+      )}
     </div>
   )
 }

--- a/web/app/_components/HistoryList/index.tsx
+++ b/web/app/_components/HistoryList/index.tsx
@@ -1,33 +1,17 @@
 import HistoryItem from '../HistoryItem'
-import { Fragment, useEffect } from 'react'
+import { useEffect } from 'react'
 import ExpandableHeader from '../ExpandableHeader'
-import { useAtomValue, useSetAtom } from 'jotai'
+import { useAtomValue } from 'jotai'
 import { searchAtom } from '@helpers/JotaiWrapper'
 import useGetUserConversations from '@hooks/useGetUserConversations'
 import SidebarEmptyHistory from '../SidebarEmptyHistory'
 import { userConversationsAtom } from '@helpers/atoms/Conversation.atom'
 import { twMerge } from 'tailwind-merge'
-import { Button } from '@uikit'
-import { activeAssistantModelAtom, stateModel } from '@helpers/atoms/Model.atom'
-import useCreateConversation from '@hooks/useCreateConversation'
-import { showingModalNoActiveModel } from '@helpers/atoms/Modal.atom'
-import { PlusIcon } from '@heroicons/react/24/outline'
 
 const HistoryList: React.FC = () => {
   const conversations = useAtomValue(userConversationsAtom)
   const searchText = useAtomValue(searchAtom)
   const { getUserConversations } = useGetUserConversations()
-  const activeModel = useAtomValue(activeAssistantModelAtom)
-  const { requestCreateConvo } = useCreateConversation()
-  const setShowModalNoActiveModel = useSetAtom(showingModalNoActiveModel)
-
-  const onNewConversationClick = () => {
-    if (activeModel) {
-      requestCreateConvo(activeModel)
-    } else {
-      setShowModalNoActiveModel(true)
-    }
-  }
 
   useEffect(() => {
     getUserConversations()
@@ -35,37 +19,26 @@ const HistoryList: React.FC = () => {
   }, [])
 
   return (
-    <div className="flex flex-grow flex-col gap-2">
+    <div className="flex flex-grow flex-col gap-2 px-4 pb-4">
       <ExpandableHeader title="CHAT HISTORY" />
       {conversations.length > 0 ? (
-        <Fragment>
-          <ul className={twMerge('mt-1 flex flex-col gap-y-3 overflow-y-auto')}>
-            {conversations
-              .filter(
-                (e) =>
-                  searchText.trim() === '' ||
-                  e.name
-                    ?.toLowerCase()
-                    .includes(searchText.toLowerCase().trim())
-              )
-              .map((convo, i) => (
-                <HistoryItem
-                  key={i}
-                  conversation={convo}
-                  summary={convo.summary}
-                  name={convo.name || 'Jan'}
-                  updatedAt={convo.updatedAt ?? ''}
-                />
-              ))}
-          </ul>
-          <Button
-            onClick={onNewConversationClick}
-            className="mt-2 flex items-center space-x-2"
-          >
-            <PlusIcon width={16} height={16} />
-            <span>New Conversation</span>
-          </Button>
-        </Fragment>
+        <ul className={twMerge('mt-1 flex flex-col gap-y-3 overflow-y-auto')}>
+          {conversations
+            .filter(
+              (e) =>
+                searchText.trim() === '' ||
+                e.name?.toLowerCase().includes(searchText.toLowerCase().trim())
+            )
+            .map((convo, i) => (
+              <HistoryItem
+                key={i}
+                conversation={convo}
+                summary={convo.summary}
+                name={convo.name || 'Jan'}
+                updatedAt={convo.updatedAt ?? ''}
+              />
+            ))}
+        </ul>
       ) : (
         <SidebarEmptyHistory />
       )}

--- a/web/app/_components/InputToolbar/index.tsx
+++ b/web/app/_components/InputToolbar/index.tsx
@@ -43,15 +43,7 @@ const InputToolbar: React.FC = () => {
   }
 
   if (!activeConvoId) {
-    return (
-      <div className="my-3 flex justify-center gap-2">
-        <SecondaryButton
-          onClick={onNewConversationClick}
-          title="New Conversation"
-          icon={<PlusIcon width={16} height={16} />}
-        />
-      </div>
-    )
+    return null
   }
   if (
     (activeConvoId && inputState === 'model-mismatch') ||
@@ -94,13 +86,13 @@ const InputToolbar: React.FC = () => {
             </span>
           </div>
         )}
-        <div className="my-3 flex justify-center gap-2">
+        {/* <div className="my-3 flex justify-center gap-2">
           <SecondaryButton
             onClick={onNewConversationClick}
             title="New Conversation"
             icon={<PlusIcon width={16} height={16} />}
           />
-        </div>
+        </div> */}
         {/* My text input */}
         <div className="mb-5 flex items-start space-x-4">
           <div className="relative min-w-0 flex-1">

--- a/web/app/_components/LeftHeaderAction/index.tsx
+++ b/web/app/_components/LeftHeaderAction/index.tsx
@@ -2,20 +2,35 @@
 
 import React from 'react'
 import SecondaryButton from '../SecondaryButton'
-import { useSetAtom } from 'jotai'
+import { useSetAtom, useAtomValue } from 'jotai'
 import {
   MainViewState,
   setMainViewStateAtom,
 } from '@helpers/atoms/MainView.atom'
 import { MagnifyingGlassIcon, PlusIcon } from '@heroicons/react/24/outline'
+import useCreateConversation from '@hooks/useCreateConversation'
 import { useGetDownloadedModels } from '@hooks/useGetDownloadedModels'
+import { Button } from '@uikit'
+import { activeAssistantModelAtom } from '@helpers/atoms/Model.atom'
+import { showingModalNoActiveModel } from '@helpers/atoms/Modal.atom'
 
 const LeftHeaderAction: React.FC = () => {
   const setMainView = useSetAtom(setMainViewStateAtom)
   const { downloadedModels } = useGetDownloadedModels()
+  const activeModel = useAtomValue(activeAssistantModelAtom)
+  const { requestCreateConvo } = useCreateConversation()
+  const setShowModalNoActiveModel = useSetAtom(showingModalNoActiveModel)
 
   const onExploreClick = () => {
     setMainView(MainViewState.ExploreModel)
+  }
+
+  const onNewConversationClick = () => {
+    if (activeModel) {
+      requestCreateConvo(activeModel)
+    } else {
+      setShowModalNoActiveModel(true)
+    }
   }
 
   const onCreateBotClicked = () => {
@@ -27,19 +42,28 @@ const LeftHeaderAction: React.FC = () => {
   }
 
   return (
-    <div className="sticky top-0 mb-4 flex flex-row gap-2">
-      <SecondaryButton
-        title={'Explore'}
-        onClick={onExploreClick}
-        className="flex-1"
-        icon={<MagnifyingGlassIcon width={16} height={16} />}
-      />
-      <SecondaryButton
-        title={'Create bot'}
-        onClick={onCreateBotClicked}
-        className="flex-1"
-        icon={<PlusIcon width={16} height={16} />}
-      />
+    <div className="sticky top-0 mb-4 bg-background/90 p-4">
+      <div className="flex flex-row gap-2">
+        <SecondaryButton
+          title={'Explore'}
+          onClick={onExploreClick}
+          className="w-full flex-1"
+          icon={<MagnifyingGlassIcon width={16} height={16} />}
+        />
+        <SecondaryButton
+          title={'Create bot'}
+          onClick={onCreateBotClicked}
+          className="w-full flex-1"
+          icon={<PlusIcon width={16} height={16} />}
+        />
+      </div>
+      <Button
+        onClick={onNewConversationClick}
+        className="mt-2 flex w-full items-center space-x-2"
+      >
+        <PlusIcon width={16} height={16} />
+        <span>New Conversation</span>
+      </Button>
     </div>
   )
 }

--- a/web/app/_components/SecondaryButton/index.tsx
+++ b/web/app/_components/SecondaryButton/index.tsx
@@ -16,7 +16,13 @@ const SecondaryButton: React.FC<Props> = ({
   className,
   icon,
 }) => (
-  <Button size="sm" disabled={disabled} type="button" onClick={onClick}>
+  <Button
+    size="sm"
+    disabled={disabled}
+    type="button"
+    onClick={onClick}
+    className={className}
+  >
     {icon}&nbsp;
     {title}
   </Button>

--- a/web/screens/Chat/index.tsx
+++ b/web/screens/Chat/index.tsx
@@ -10,10 +10,8 @@ const ChatScreen = () => {
   return (
     <div className="flex h-full">
       <div className="flex h-full w-64 flex-shrink-0 flex-col overflow-y-auto border-r border-border ">
-        <div className="px-4 py-6 pt-4">
-          <LeftHeaderAction />
-          <HistoryList />
-        </div>
+        <LeftHeaderAction />
+        <HistoryList />
       </div>
       <div className="relative flex h-full w-full flex-col bg-background/50">
         <MainHeader />


### PR DESCRIPTION
Fixing #485 

Case scenario

- When user have history list and want to create new conversation, will create new conversation with current active model
<img width="1267" alt="Screenshot 2023-10-30 at 22 40 11" src="https://github.com/janhq/jan/assets/10354610/46d34df9-79af-4205-968c-e3d120f09a43">

- When user create new conversation but model not active, will showing popup and let user go to my model page to active the model
<img width="1209" alt="Screenshot 2023-10-30 at 22 40 43" src="https://github.com/janhq/jan/assets/10354610/28548dc4-4512-46f7-b236-0b5b370c2d55">

NB: @0xSage we move button new conv to top to avoid case when user have a lot of list, and the button will be sticky when user scroll the list 

<img width="269" alt="Screenshot 2023-10-30 at 22 43 45" src="https://github.com/janhq/jan/assets/10354610/8461dc4e-a1de-4801-80ba-323cb07a07c8">
