### PR TITLE
fix: dest.end is not a function

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -19,7 +19,7 @@ const progress = require("request-progress");
 const { autoUpdater } = require("electron-updater");
 const Store = require("electron-store");
 
-const requiredModules: Record<string, any> = {};
+let requiredModules: Record<string, any> = {};
 let mainWindow: BrowserWindow | undefined = undefined;
 
 app
@@ -39,12 +39,12 @@ app
   });
 
 app.on("window-all-closed", () => {
-  dispose(requiredModules);
+  clearImportedModules();
   app.quit();
 });
 
 app.on("quit", () => {
-  dispose(requiredModules);
+  clearImportedModules();
   app.quit();
 });
 
@@ -226,7 +226,7 @@ function handleIPCs() {
    * @param url - The URL to reload.
    */
   ipcMain.handle("relaunch", async (_event, url) => {
-    dispose(requiredModules);
+    clearImportedModules();
 
     if (app.isPackaged) {
       app.relaunch();
@@ -255,7 +255,7 @@ function handleIPCs() {
 
     rmdir(fullPath, { recursive: true }, function (err) {
       if (err) console.log(err);
-      dispose(requiredModules);
+      clearImportedModules();
 
       // just relaunch if packaged, should launch manually in development mode
       if (app.isPackaged) {
@@ -393,4 +393,9 @@ function setupPlugins() {
     // Path to install plugin to
     pluginsPath: join(app.getPath("userData"), "plugins"),
   });
+}
+
+function clearImportedModules() {
+  dispose(requiredModules);
+  requiredModules = {};
 }

--- a/plugins/inference-plugin/module.ts
+++ b/plugins/inference-plugin/module.ts
@@ -3,7 +3,7 @@ const { app } = require("electron");
 const { spawn } = require("child_process");
 const fs = require("fs");
 const tcpPortUsed = require("tcp-port-used");
-const { killPortProcess } = require("kill-port-process");
+const kill = require("kill-port");
 
 const PORT = 3928;
 let subprocess = null;
@@ -99,7 +99,7 @@ function killSubprocess() {
     subprocess = null;
     console.log("Subprocess terminated.");
   } else {
-    killPortProcess(PORT);
+    kill(PORT, "tcp").then(console.log).catch(console.log);
     console.error("No subprocess is currently running.");
   }
 }

--- a/plugins/inference-plugin/package.json
+++ b/plugins/inference-plugin/package.json
@@ -29,15 +29,11 @@
   },
   "dependencies": {
     "@janhq/core": "^0.1.6",
-    "kill-port-process": "^3.2.0",
+    "kill-port": "^2.0.1",
     "rxjs": "^7.8.1",
     "tcp-port-used": "^1.0.2",
     "ts-loader": "^9.5.0"
   },
-  "bundledDependencies": [
-    "tcp-port-used",
-    "kill-port-process"
-  ],
   "engines": {
     "node": ">=18.0.0"
   },
@@ -45,5 +41,9 @@
     "dist/*",
     "package.json",
     "README.md"
+  ],
+  "bundleDependencies": [
+    "tcp-port-used",
+    "kill-port"
   ]
 }

--- a/plugins/inference-plugin/webpack.config.js
+++ b/plugins/inference-plugin/webpack.config.js
@@ -30,5 +30,8 @@ module.exports = {
   resolve: {
     extensions: [".ts", ".js"],
   },
+  optimization: {
+    minimize: false,
+  },
   // Add loaders and other configuration as needed for your project
 };

--- a/plugins/monitoring-plugin/webpack.config.js
+++ b/plugins/monitoring-plugin/webpack.config.js
@@ -29,5 +29,8 @@ module.exports = {
   resolve: {
     extensions: [".ts", ".js"],
   },
+  optimization: {
+    minimize: false,
+  },
   // Add loaders and other configuration as needed for your project
 };


### PR DESCRIPTION
## Problem
- `kill-port-process` raises this error when attempting to kill a non-existing process
## Solution
- use `kill-port` instead

fixes: #405 