### PR TITLE
fix: app toolbar is gone on windows

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -64,7 +64,6 @@ function createMainWindow() {
   mainWindow = new BrowserWindow({
     width: 1200,
     height: 800,
-    frame: false,
     show: false,
     trafficLightPosition: {
       x: 16,


### PR DESCRIPTION
## Problem
There is no toolbar which include close / minimize / maximize buttons on windows (frameless), user has no option to close / maximize without right clicking on taskbar app icon

## Solution
Disable frameless (same behavior on macOS)

fixes #494 