### PR TITLE
bug: chat UI is not consistent 

### DIFF
--- a/web/app/_components/InputToolbar/index.tsx
+++ b/web/app/_components/InputToolbar/index.tsx
@@ -78,7 +78,7 @@ const InputToolbar: React.FC = () => {
 
   if (conversations.length > 0)
     return (
-      <div className="sticky bottom-0 w-full bg-background/90 px-5 py-0">
+      <div className="sticky bottom-0 w-full bg-background/90 px-5 pb-0 pt-2">
         {currentConvoState?.error && (
           <div className="flex flex-row justify-center">
             <span className="mx-5 my-2 text-sm text-red-500">

--- a/web/app/_components/SimpleTextMessage/index.tsx
+++ b/web/app/_components/SimpleTextMessage/index.tsx
@@ -51,7 +51,7 @@ const SimpleTextMessage: React.FC<Props> = ({
 
   return (
     <div
-      className={`flex items-start gap-x-4 gap-y-2 border-b border-border/50 px-4 py-5 last:border-none`}
+      className={`flex items-start gap-x-4 gap-y-2 border-b border-border/50 px-4 py-5`}
     >
       <Image
         className="rounded-full"


### PR DESCRIPTION
Fixing #506 

Issue
- No border bottom on first chat 
- No space last message and box message

Solution 
- Add border bottom on first convo to make consistent
- Increase padding box message since we remove button `new conversation` above a box message

<img width="787" alt="Screenshot 2023-11-01 at 12 12 54" src="https://github.com/janhq/jan/assets/10354610/461fd550-16a2-4143-89bc-b096348f0537">
<img width="756" alt="Screenshot 2023-11-01 at 12 17 26" src="https://github.com/janhq/jan/assets/10354610/fd060ab0-487c-4160-bf84-0326db8d70ca">
