### PR TITLE
fix: #479 - Toggle plugin is now experimental feature

### DIFF
--- a/web/screens/Settings/CorePlugins/PluginsCatalog.tsx
+++ b/web/screens/Settings/CorePlugins/PluginsCatalog.tsx
@@ -169,16 +169,18 @@ const PluginCatalog = () => {
                   </Button>
                 )}
               </div>
-              <Switch
-                checked={isActivePlugin}
-                onCheckedChange={(e) => {
-                  if (e === true) {
-                    downloadTarball(item.name)
-                  } else {
-                    uninstall(item.name)
-                  }
-                }}
-              />
+              {experimentalFeatureEnabed && (
+                <Switch
+                  checked={isActivePlugin}
+                  onCheckedChange={(e) => {
+                    if (e === true) {
+                      downloadTarball(item.name)
+                    } else {
+                      uninstall(item.name)
+                    }
+                  }}
+                />
+              )}
             </div>
           )
         })}


### PR DESCRIPTION
## Problem
- User should not toggle off core plugins, only for development purpose.

## Solution
- Mark Plugin Toggle on/off as an experimental feature

<img width="1312" alt="Screenshot 2023-11-02 at 16 04 44" src="https://github.com/janhq/jan/assets/133622055/4f4d1495-e53d-46ea-a1d2-e93ab60737ef">


fixes #479 