### PR TITLE
ui: improve state of welcome screen

### DIFF
--- a/web/screens/Chat/index.tsx
+++ b/web/screens/Chat/index.tsx
@@ -67,6 +67,7 @@ const ChatScreen = () => {
       setIsWaitingToSend(false)
       sendChatMessage()
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [waitingToSendMessage, activeConversationId])
 
   const handleKeyDown = async (

--- a/web/screens/Welcome/index.tsx
+++ b/web/screens/Welcome/index.tsx
@@ -1,6 +1,21 @@
+import { Fragment } from 'react'
+
+import { Badge, Button } from '@janhq/uikit'
+
 import LogoMark from '@/containers/Brand/Logo/Mark'
 
+import { MainViewState } from '@/constants/screens'
+
+import { useActiveModel } from '@/hooks/useActiveModel'
+import { useGetDownloadedModels } from '@/hooks/useGetDownloadedModels'
+
+import { useMainViewState } from '@/hooks/useMainViewState'
+
 const WelcomeScreen = () => {
+  const { downloadedModels } = useGetDownloadedModels()
+  const { activeModel } = useActiveModel()
+  const { setMainViewState } = useMainViewState()
+
   return (
     <div className="flex h-full items-center justify-center px-4">
       <div className="text-center">
@@ -9,10 +24,45 @@ const WelcomeScreen = () => {
           width={56}
           height={56}
         />
-        <h1 data-testid="testid-welcome-title" className="text-2xl font-bold">
-          Welcome to Jan
-        </h1>
-        <p className="">{`let’s download your first model`}</p>
+
+        {downloadedModels.length === 0 && !activeModel && (
+          <Fragment>
+            <h1
+              data-testid="testid-welcome-title"
+              className="text-2xl font-bold"
+            >
+              Welcome to Jan
+            </h1>
+            <p className="mt-1">{`let’s download your first model`}</p>
+            <Button
+              className="mt-4"
+              onClick={() => setMainViewState(MainViewState.ExploreModels)}
+            >
+              Explore Models
+            </Button>
+          </Fragment>
+        )}
+        {downloadedModels.length >= 1 && !activeModel && (
+          <Fragment>
+            <h1 className="mt-2 text-lg font-medium">{`You don’t have any actively running models`}</h1>
+            <p className="mt-1">{`Please start a downloaded model in My Models page to use this feature.`}</p>
+            <Badge className="mt-4" themes="secondary">
+              ⌘e to show your model
+            </Badge>
+          </Fragment>
+        )}
+        {downloadedModels.length >= 1 && activeModel && (
+          <Fragment>
+            <h1 className="mt-2 text-lg font-medium">{`Your Model is Active`}</h1>
+            <p className="mt-1">{`You are ready to start conversations.`}</p>
+            <Button
+              className="mt-4"
+              onClick={() => setMainViewState(MainViewState.Chat)}
+            >
+              Start a conversation
+            </Button>
+          </Fragment>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
- State user first download Jan and doesn't have download model yet
<img width="1201" alt="Screenshot 2023-11-08 at 00 11 30" src="https://github.com/janhq/jan/assets/10354610/89a5a37e-eb6c-4fee-b64d-6f142ad8bec6">

- State user have a downloaded model but doesn't have active model yet
<img width="1204" alt="Screenshot 2023-11-08 at 00 11 05" src="https://github.com/janhq/jan/assets/10354610/ed3f0e17-9821-4637-92ec-1b0563f4e245">

- State user have a downloaded model and have active model
<img width="1211" alt="Screenshot 2023-11-08 at 00 10 03" src="https://github.com/janhq/jan/assets/10354610/32f01666-0cb2-4348-a22d-33a0c2c39c8e">
