### PR TITLE
bug: update convo state when user change model

### DIFF
--- a/uikit/src/button/styles.scss
+++ b/uikit/src/button/styles.scss
@@ -12,7 +12,7 @@
   }
 
   &-outline {
-    @apply border-input hover:bg-accent hover:text-accent-foreground border bg-transparent;
+    @apply border-input hover:bg-primary hover:text-primary-foreground border bg-transparent;
   }
 
   &-secondary {
@@ -20,7 +20,7 @@
   }
 
   &-ghost {
-    @apply hover:bg-accent hover:text-accent-foreground;
+    @apply hover:bg-primary hover:text-primary-foreground;
   }
 
   &-sm {

--- a/uikit/src/command/styles.scss
+++ b/uikit/src/command/styles.scss
@@ -25,7 +25,7 @@
   }
 
   &-list-item {
-    @apply text-foreground aria-selected:bg-accent relative flex cursor-pointer select-none items-center rounded-md px-2 py-2 text-sm outline-none;
+    @apply text-foreground aria-selected:bg-primary relative flex cursor-pointer select-none items-center rounded-md px-2 py-2 text-sm outline-none;
   }
 
   &-empty {

--- a/uikit/src/main.scss
+++ b/uikit/src/main.scss
@@ -27,16 +27,12 @@
   }
 }
 
-
 :root {
   --background: 0 0% 100%;
   --foreground: 20 14.3% 4.1%;
 
   --muted: 60 4.8% 95.9%;
   --muted-foreground: 240 3.8% 46.1%;
-
-  --accent: 60 4.8% 95.9%;
-  --accent-foreground: 24 9.8% 10%;
 
   --danger: 346.8 77.2% 49.8%;
   --danger-foreground: 355.7 100% 97.3%;
@@ -76,9 +72,6 @@
 
   --muted: 12 6.5% 15.1%;
   --muted-foreground: 24 5.4% 63.9%;
-
-  --accent: 12 6.5% 15.1%;
-  --accent-foreground: 60 9.1% 97.8%;
 
   --danger: 346.8 77.2% 49.8%;
   --danger-foreground: 355.7 100% 97.3%;

--- a/web/containers/Layout/TopBar/CommandListDownloadedModel/index.tsx
+++ b/web/containers/Layout/TopBar/CommandListDownloadedModel/index.tsx
@@ -73,7 +73,7 @@ export default function CommandListDownloadedModel() {
                     <div className="flex w-full items-center justify-between">
                       <span>{model.name}</span>
                       {activeModel && activeModel._id === model._id && (
-                        <Badge>Active</Badge>
+                        <Badge themes="secondary">Active</Badge>
                       )}
                     </div>
                   </CommandItem>

--- a/web/hooks/useGetConfiguredModels.ts
+++ b/web/hooks/useGetConfiguredModels.ts
@@ -40,6 +40,7 @@ export function useGetConfiguredModels() {
   // TODO allow user for filter
   useEffect(() => {
     fetchModels()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   return { loading, models }

--- a/web/screens/Chat/HistoryList/index.tsx
+++ b/web/screens/Chat/HistoryList/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react'
 
 import { Conversation, Model } from '@janhq/core/lib/types'
-import { Button } from '@janhq/uikit'
+import { Badge, Button } from '@janhq/uikit'
 import { motion as m } from 'framer-motion'
 import { useAtomValue, useSetAtom } from 'jotai'
 
@@ -64,7 +64,7 @@ export default function HistoryList() {
       <div className="sticky top-0 z-20 flex flex-col border-b border-border bg-background px-4 py-3">
         <Button
           size="sm"
-          themes="outline"
+          themes="secondary"
           onClick={handleClickConversation}
           disabled={!activeModel}
         >

--- a/web/screens/ExploreModels/ExploreModelList/index.tsx
+++ b/web/screens/ExploreModels/ExploreModelList/index.tsx
@@ -10,7 +10,7 @@ export default function ExploreModelList(props: Props) {
   const { models } = props
   return (
     <div className="relative h-full w-full flex-shrink-0">
-      {models?.map((item) => <ExploreModelItem key={item._id} model={item} />)}
+      {models?.map((item, i) => <ExploreModelItem key={i} model={item} />)}
     </div>
   )
 }

--- a/web/screens/MyModels/index.tsx
+++ b/web/screens/MyModels/index.tsx
@@ -113,7 +113,8 @@ const MyModelsScreen = () => {
                                 <Button
                                   themes="danger"
                                   onClick={() =>
-                                    setTimeout(() => {
+                                    setTimeout(async () => {
+                                      await stopModel(model._id)
                                       deleteModel(model)
                                     }, 500)
                                   }


### PR DESCRIPTION
Issue: #564 

Solution
Disabled input when active model and current convo id is different

New Improvement 

Handle convo if model is deleted 
- still show history of convo on chat body, disabled input and show button re download again the model 

<img width="1215" alt="Screenshot 2023-11-09 at 12 35 47" src="https://github.com/janhq/jan/assets/10354610/ebd09dcc-9f79-41f8-a4fa-dc2b3b91f6e2">
