### PR TITLE
bug: download modal should truncate model name

### DIFF
--- a/web/containers/Layout/BottomBar/DownloadingState/index.tsx
+++ b/web/containers/Layout/BottomBar/DownloadingState/index.tsx
@@ -59,9 +59,9 @@ export default function DownloadingState() {
                       }) as number
                     }
                   />
-                  <div className="flex items-center justify-between">
+                  <div className="flex items-center justify-between gap-x-2">
                     <div className="flex gap-x-2">
-                      <p>{item?.fileName}</p>
+                      <p className="line-clamp-1">{item?.fileName}</p>
                       <span>{formatDownloadPercentage(item?.percent)}</span>
                     </div>
                     <Button


### PR DESCRIPTION
Fix #590 

Result
<img width="556" alt="Screenshot 2023-11-11 at 14 30 59" src="https://github.com/janhq/jan/assets/10354610/bab65566-9196-49e6-a0c1-c4526f0f4415">
