### PR TITLE
bug: fix weird padding vertical snippet code

### DIFF
--- a/web/styles/components/code-block.scss
+++ b/web/styles/components/code-block.scss
@@ -64,11 +64,12 @@
   border-radius: 0.4rem;
   margin-top: 1rem;
   margin-bottom: 1rem;
+  white-space: normal;
 }
 pre > code {
   display: block;
   text-indent: 0;
-  white-space: inherit;
+  white-space: pre;
 }
 
 .hljs-emphasis {


### PR DESCRIPTION
Fix: #606 

Result: 

<img width="824" alt="Screenshot 2023-11-13 at 15 50 21" src="https://github.com/janhq/jan/assets/10354610/a7a07017-dc64-4966-81fa-dff70f44580f">

<img width="715" alt="Screenshot 2023-11-13 at 15 50 32" src="https://github.com/janhq/jan/assets/10354610/75649d76-9902-47ed-bed2-745ada4ae976">
