### PR TITLE
bug: Fix button download detect intel or apple silicon

### DIFF
--- a/docs/src/components/Elements/dropdown.js
+++ b/docs/src/components/Elements/dropdown.js
@@ -71,17 +71,9 @@ export default function Dropdown() {
       arc &&
       arc.architecture === "arm"
     ) {
-      // mac m1, m2
       setDefaultSystem(systems[0]);
-    } else if (
-      userAgent.includes("Mac OS") &&
-      arc &&
-      arc.architecture !== "arm"
-    ) {
-      // mac intel
-      setDefaultSystem(systems[1]);
     } else {
-      setDefaultSystem(systems[0]);
+      setDefaultSystem(systems[1]);
     }
   };
   useEffect(() => {

--- a/docs/src/components/Elements/dropdown.js
+++ b/docs/src/components/Elements/dropdown.js
@@ -53,19 +53,28 @@ export default function Dropdown() {
     return match ? match[1] : null;
   };
 
-  const changeDefaultSystem = (systems) => {
+  const changeDefaultSystem = async (systems) => {
     const userAgent = navigator.userAgent;
+
+    const arc = await navigator?.userAgentData?.getHighEntropyValues([
+      "architecture",
+    ]);
+
     if (userAgent.includes("Windows")) {
       // windows user
       setDefaultSystem(systems[2]);
     } else if (userAgent.includes("Linux")) {
       // linux user
       setDefaultSystem(systems[3]);
-    } else if (userAgent.includes("Mac OS") && userAgent.includes("Intel")) {
-      // mac intel user
-      setDefaultSystem(systems[1]);
+    } else if (userAgent.includes("Mac OS")) {
+      if (arc && arc.architecture === "arm") {
+        // mac m1, m2
+        setDefaultSystem(systems[0]);
+      } else {
+        // mac user intel
+        setDefaultSystem(systems[1]);
+      }
     } else {
-      // mac user and also default
       setDefaultSystem(systems[0]);
     }
   };

--- a/docs/src/components/Elements/dropdown.js
+++ b/docs/src/components/Elements/dropdown.js
@@ -66,14 +66,20 @@ export default function Dropdown() {
     } else if (userAgent.includes("Linux")) {
       // linux user
       setDefaultSystem(systems[3]);
-    } else if (userAgent.includes("Mac OS")) {
-      if (arc && arc.architecture === "arm") {
-        // mac m1, m2
-        setDefaultSystem(systems[0]);
-      } else {
-        // mac user intel
-        setDefaultSystem(systems[1]);
-      }
+    } else if (
+      userAgent.includes("Mac OS") &&
+      arc &&
+      arc.architecture === "arm"
+    ) {
+      // mac m1, m2
+      setDefaultSystem(systems[0]);
+    } else if (
+      userAgent.includes("Mac OS") &&
+      arc &&
+      arc.architecture !== "arm"
+    ) {
+      // mac intel
+      setDefaultSystem(systems[1]);
     } else {
       setDefaultSystem(systems[0]);
     }


### PR DESCRIPTION
Base on this https://stackoverflow.com/questions/65146751/detecting-apple-silicon-mac-in-javascript and https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/getHighEntropyValues we can detect currently only chrome / browser with engine chromium eg : brave then will push default to apple-silicon

Result:

Brave:
<img width="1680" alt="Screenshot 2023-11-13 at 16 32 24" src="https://github.com/janhq/jan/assets/10354610/fa1699af-eb22-4adb-aba4-0c54eaca1bc0">

Chrome:
<img width="1680" alt="Screenshot 2023-11-13 at 16 32 18" src="https://github.com/janhq/jan/assets/10354610/0c21d9c6-b8a4-4eea-8070-4ba1a18afd98">

Firefox:
<img width="1680" alt="Screenshot 2023-11-13 at 16 31 58" src="https://github.com/janhq/jan/assets/10354610/60310dd4-92f5-4a91-b7d7-09b77cae898f">

Safari:
<img width="1680" alt="Screenshot 2023-11-13 at 16 32 56" src="https://github.com/janhq/jan/assets/10354610/7030cc38-4db2-48eb-b5df-f69600878b57">

cc @louis-jan @0xSage @dan-jan 
