### PR TITLE
bug: cancelling a model download should be delete the model file on user data

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -396,7 +396,20 @@ function handleIPCs() {
   ipcMain.handle("abortDownload", async (_event, fileName) => {
     const rq = networkRequests[fileName];
     networkRequests[fileName] = undefined;
+    const userDataPath = app.getPath("userData");
+    const fullPath = join(userDataPath, fileName);
     rq?.abort();
+    let result = "NULL";
+    unlink(fullPath, function (err) {
+      if (err && err.code == "ENOENT") {
+        result = `File not exist: ${err}`;
+      } else if (err) {
+        result = `File delete error: ${err}`;
+      } else {
+        result = "File deleted successfully";
+      }
+      console.log(`Delete file ${fileName} from ${fullPath} result: ${result}`);
+    });
   });
 
   /**


### PR DESCRIPTION
Fix #605 

Test scenario:

1. Download a model -> go to user data `models` you should see the file name current download
2. Cancel download --> go to user data `models` you should not see the file name anymore

<img width="267" alt="Screenshot 2023-11-13 at 23 06 11" src="https://github.com/janhq/jan/assets/10354610/674108de-3735-4680-b9c0-80ba2164b0a8">

