### PR TITLE
bug: fix compatibility content not fully display

### DIFF
--- a/web/screens/ExploreModels/ExploreModelItem/index.tsx
+++ b/web/screens/ExploreModels/ExploreModelItem/index.tsx
@@ -58,10 +58,18 @@ const ExploreModelItem = forwardRef<HTMLDivElement, Props>(({ model }, ref) => {
           <div>
             <span className="mb-1 font-semibold">Compatibility</span>
             <div className="mt-1 flex gap-2">
-              <Badge themes="secondary" className="line-clamp-1 max-w-[400px]">
+              <Badge
+                themes="secondary"
+                className="line-clamp-1 max-w-[400px] lg:line-clamp-none lg:max-w-none"
+                title={usecase}
+              >
                 {usecase}
               </Badge>
-              <Badge themes="secondary" className="line-clamp-1">
+              <Badge
+                themes="secondary"
+                className="line-clamp-1 lg:line-clamp-none"
+                title={`${toGigabytes(maxRamRequired)} RAM required`}
+              >
                 {toGigabytes(maxRamRequired)} RAM required
               </Badge>
             </div>

--- a/web/screens/ExploreModels/ModelVersionItem/index.tsx
+++ b/web/screens/ExploreModels/ModelVersionItem/index.tsx
@@ -2,8 +2,8 @@
 import React, { useMemo } from 'react'
 
 import { ModelCatalog, ModelVersion } from '@janhq/core/lib/types'
-import { Button } from '@janhq/uikit'
-import { Badge } from '@janhq/uikit'
+import { Button, Badge } from '@janhq/uikit'
+
 import { atom, useAtomValue } from 'jotai'
 
 import ModalCancelDownload from '@/containers/ModalCancelDownload'
@@ -73,16 +73,25 @@ const ModelVersionItem: React.FC<Props> = ({ model, modelVersion }) => {
   return (
     <div className="flex items-center justify-between gap-4 border-t border-border pb-3 pl-3 pr-4 pt-3 first:border-t-0">
       <div className="flex items-center gap-2">
-        <span className="mb-4 line-clamp-1 flex-1">{modelVersion.name}</span>
+        <span className="line-clamp-1 flex-1" title={modelVersion.name}>
+          {modelVersion.name}
+        </span>
       </div>
       <div className="flex items-center gap-4">
         <div className="flex justify-end gap-2">
-          <Badge themes="secondary" className="line-clamp-1 max-w-[240px]">
+          <Badge
+            themes="secondary"
+            className="line-clamp-1 max-w-[240px] lg:line-clamp-none lg:max-w-none"
+            title={usecase}
+          >
             {usecase}
           </Badge>
-          <Badge themes="secondary" className="line-clamp-1 ">{`${toGigabytes(
-            maxRamRequired
-          )} RAM required`}</Badge>
+
+          <Badge
+            themes="secondary"
+            className="line-clamp-1"
+            title={`${toGigabytes(maxRamRequired)} RAM required`}
+          >{`${toGigabytes(maxRamRequired)} RAM required`}</Badge>
           <Badge themes="secondary">{toGigabytes(modelVersion.size)}</Badge>
         </div>
         {downloadButton}


### PR DESCRIPTION
Fix #644 

Result 
<img width="1215" alt="Screenshot 2023-11-18 at 19 46 30" src="https://github.com/janhq/jan/assets/10354610/b203bf7e-5f7e-489f-910a-63e718c50180">

Another case 
When user try to resize window to small we still not showing fully content, but when user hover the content with `xxx...` we show full title using attribute title html

<img width="804" alt="Screenshot 2023-11-18 at 19 46 59" src="https://github.com/janhq/jan/assets/10354610/65d72ccf-cb86-474d-8dfb-e5f220a24a87">

