### PR TITLE
bug: fix anchor link sidebar openapi

### DIFF
--- a/docs/src/styles/base.scss
+++ b/docs/src/styles/base.scss
@@ -1,7 +1,4 @@
 @layer base {
-  html {
-    @apply scroll-smooth;
-  }
   html[data-theme="light"] {
     --ifm-background-color: white;
     --ifm-color-primary: #2563eb; /* New Primary Blue */


### PR DESCRIPTION
Fix same issue with Nitro https://github.com/janhq/nitro/issues/152

Result:
When clicking on any sidebar, it should move to the section.

<img width="797" alt="Screenshot 2023-11-21 at 09 38 03" src="https://github.com/janhq/jan/assets/10354610/6f8b3dc7-bb07-491c-b7d2-9efd9117e613">
