### PR TITLE
[bug] fix markdown todo items shifted to the left and remove the dots

### DIFF
--- a/docs/src/styles/tweaks.scss
+++ b/docs/src/styles/tweaks.scss
@@ -113,3 +113,7 @@
 .table-of-contents {
   font-size: 14px;
 }
+
+.task-list-item {
+  list-style: none;
+}


### PR DESCRIPTION
Fixed #676 

Before: 
<img width="696" alt="Screenshot 2023-11-22 at 22 23 20" src="https://github.com/janhq/jan/assets/10354610/d9acbb41-1f58-4730-95d7-08fc8c1e131d">

After:
<img width="673" alt="Screenshot 2023-11-22 at 22 22 57" src="https://github.com/janhq/jan/assets/10354610/94c2c5ae-1dbb-4882-b669-12a1a11afaf6">
