### PR TITLE
bug: fix padding quotations and numbering list

### DIFF
--- a/docs/src/styles/tweaks.scss
+++ b/docs/src/styles/tweaks.scss
@@ -97,6 +97,9 @@
       @apply leading-loose;
       line-height: 1.5;
     }
+    + div {
+      margin-top: 12px;
+    }
   }
 }
 
@@ -116,4 +119,8 @@
 
 .task-list-item {
   list-style: none;
+}
+
+blockquote {
+  margin-bottom: 12px;
 }


### PR DESCRIPTION
Fixed #665 

Cleanup padding quotations
Result
<img width="673" alt="Screenshot 2023-11-22 at 22 40 40" src="https://github.com/janhq/jan/assets/10354610/1816f5d2-5c61-4e97-8ec1-2f01be1d8513">

Cleanup padding numbering

Before:
<img width="920" alt="Screenshot 2023-11-22 at 22 37 40" src="https://github.com/janhq/jan/assets/10354610/740d2008-2d0f-46ff-be29-5e92f573ed20">

After:
<img width="988" alt="Screenshot 2023-11-22 at 22 37 03" src="https://github.com/janhq/jan/assets/10354610/d357f7f3-bf29-40f0-a761-6c890b0d66b2">

