### PR TITLE
fix: app shows wrong performance tag, all say not enough ram on windows

### DIFF
--- a/web/containers/ModalCancelDownload/index.tsx
+++ b/web/containers/ModalCancelDownload/index.tsx
@@ -16,7 +16,6 @@ import {
 import { atom, useAtomValue } from 'jotai'
 
 import { useDownloadState } from '@/hooks/useDownloadState'
-import useGetPerformanceTag from '@/hooks/useGetPerformanceTag'
 
 import { formatDownloadPercentage } from '@/utils/converter'
 
@@ -30,7 +29,6 @@ export default function ModalCancelDownload({
   isFromList,
 }: Props) {
   const { modelDownloadStateAtom } = useDownloadState()
-  useGetPerformanceTag()
   const downloadAtom = useMemo(
     () => atom((get) => get(modelDownloadStateAtom)[suitableModel.name]),
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/web/hooks/useGetPerformanceTag.ts
+++ b/web/hooks/useGetPerformanceTag.ts
@@ -1,11 +1,6 @@
-import { useState } from 'react'
-
 import { ModelVersion } from '@janhq/core/lib/types'
-import { useAtomValue } from 'jotai'
 
 import { ModelPerformance, TagType } from '@/constants/tagType'
-
-import { totalRamAtom } from '@/helpers/atoms/SystemBar.atom'
 
 // Recommendation:
 // `Recommended (green)`: "Max RAM required" is 80% of users max  RAM.
@@ -13,28 +8,30 @@ import { totalRamAtom } from '@/helpers/atoms/SystemBar.atom'
 // `Not enough RAM (red)`: User RAM is below "Max RAM required"
 
 export default function useGetPerformanceTag() {
-  const [performanceTag, setPerformanceTag] = useState<TagType | undefined>()
-  const totalRam = useAtomValue(totalRamAtom)
-
-  const getPerformanceForModel = async (modelVersion: ModelVersion) => {
+  async function getPerformanceForModel(
+    modelVersion: ModelVersion,
+    totalRam: number
+  ): Promise<{ title: string; performanceTag: TagType }> {
     const requiredRam = modelVersion.maxRamRequired
-    setPerformanceTag(calculateRamPerformance(requiredRam, totalRam))
+    const performanceTag = calculateRamPerformance(requiredRam, totalRam)
+
+    let title = ''
+
+    switch (performanceTag) {
+      case ModelPerformance.PerformancePositive:
+        title = 'Recommended'
+        break
+      case ModelPerformance.PerformanceNeutral:
+        title = 'Slow on your device'
+        break
+      case ModelPerformance.PerformanceNegative:
+        title = 'Not enough RAM'
+        break
+    }
+    return { title, performanceTag }
   }
 
-  let title = ''
-  switch (performanceTag) {
-    case ModelPerformance.PerformancePositive:
-      title = 'Recommended'
-      break
-    case ModelPerformance.PerformanceNeutral:
-      title = 'Slow on your device'
-      break
-    case ModelPerformance.PerformanceNegative:
-      title = 'Not enough RAM'
-      break
-  }
-
-  return { performanceTag, title, getPerformanceForModel }
+  return { getPerformanceForModel }
 }
 
 const calculateRamPerformance = (


### PR DESCRIPTION
## Problem 
- As #624 described, Windows users see all models marked as "not enough ram"

## Solution
- It seems like `PerformanceTag` hook would just persist once, it is not updated as soon as app can retrieve the total RAM value.

Address the 1st issue of #624 