### PR TITLE
fix: incorrect update progress bar visibility check

### DIFF
--- a/web/containers/Layout/BottomBar/index.tsx
+++ b/web/containers/Layout/BottomBar/index.tsx
@@ -31,7 +31,7 @@ const BottomBar = () => {
     <div className="fixed bottom-0 left-16 z-20 flex h-12 w-[calc(100%-64px)] items-center justify-between border-t border-border bg-background/50 px-3">
       <div className="flex flex-shrink-0 items-center gap-x-2">
         <div className="flex items-center space-x-2">
-          {!progress && progress === 0 ? (
+          {progress && progress > 0 ? (
             <ProgressBar total={100} used={progress} />
           ) : null}
         </div>


### PR DESCRIPTION
## Problem
The app fails to display the update progress again due to an incorrect conditional check for visibility

Fixed #710 

<img width="1312" alt="Screenshot 2023-11-24 at 11 52 41" src="https://github.com/janhq/jan/assets/133622055/fffe613f-c247-4fc9-aecb-a10251244870">
<img width="1312" alt="Screenshot 2023-11-24 at 11 52 47" src="https://github.com/janhq/jan/assets/133622055/41be463a-6dc1-44ab-b2ef-d455b8d2e8b4">
