### PR TITLE
experimental: allow user to give instruction for the conversation

### DIFF
--- a/web/context/FeatureToggle.tsx
+++ b/web/context/FeatureToggle.tsx
@@ -22,12 +22,9 @@ export default function FeatureToggleWrapper({
   const [experimentalEnabed, setExperimentalEnabled] = useState<boolean>(false)
 
   useEffect(() => {
-    // Global experimental feature is disabled
-    let globalFeatureEnabled = false
-    if (localStorage.getItem(EXPERIMENTAL_FEATURE_ENABLED) !== 'true') {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      globalFeatureEnabled = true
-    }
+    setExperimentalEnabled(
+      localStorage.getItem(EXPERIMENTAL_FEATURE_ENABLED) === 'true'
+    )
   }, [])
 
   const setExperimentalFeature = (on: boolean) => {

--- a/web/helpers/atoms/ChatMessage.atom.ts
+++ b/web/helpers/atoms/ChatMessage.atom.ts
@@ -1,4 +1,4 @@
-import { MessageStatus, ThreadMessage } from '@janhq/core'
+import { ChatCompletionRole, MessageStatus, ThreadMessage } from '@janhq/core'
 import { atom } from 'jotai'
 
 import {
@@ -91,6 +91,14 @@ export const deleteConversationMessage = atom(null, (get, set, id: string) => {
     ...get(chatMessages),
   }
   newData[id] = []
+  set(chatMessages, newData)
+})
+
+export const cleanConversationMessages = atom(null, (get, set, id: string) => {
+  const newData: Record<string, ThreadMessage[]> = {
+    ...get(chatMessages),
+  }
+  newData[id] = newData[id].filter((e) => e.role === ChatCompletionRole.System)
   set(chatMessages, newData)
 })
 

--- a/web/helpers/atoms/ChatMessage.atom.ts
+++ b/web/helpers/atoms/ChatMessage.atom.ts
@@ -3,6 +3,7 @@ import { atom } from 'jotai'
 
 import {
   conversationStatesAtom,
+  currentConversationAtom,
   getActiveConvoIdAtom,
   updateThreadStateLastMessageAtom,
 } from './Conversation.atom'
@@ -100,6 +101,17 @@ export const cleanConversationMessages = atom(null, (get, set, id: string) => {
   }
   newData[id] = newData[id].filter((e) => e.role === ChatCompletionRole.System)
   set(chatMessages, newData)
+})
+
+export const deleteMessage = atom(null, (get, set, id: string) => {
+  const newData: Record<string, ThreadMessage[]> = {
+    ...get(chatMessages),
+  }
+  const threadId = get(currentConversationAtom)?.id
+  if (threadId) {
+    newData[threadId] = newData[threadId].filter((e) => e.id !== id)
+    set(chatMessages, newData)
+  }
 })
 
 export const updateMessageAtom = atom(

--- a/web/hooks/useSendChatMessage.ts
+++ b/web/hooks/useSendChatMessage.ts
@@ -41,7 +41,7 @@ export default function useSendChatMessage() {
     if (
       currentConvo &&
       newMessage.messages &&
-      newMessage.messages.length > 2 &&
+      newMessage.messages.length >= 2 &&
       (!currentConvo.summary ||
         currentConvo.summary === '' ||
         currentConvo.summary === activeModel?.name)

--- a/web/hooks/useSendChatMessage.ts
+++ b/web/hooks/useSendChatMessage.ts
@@ -49,7 +49,7 @@ export default function useSendChatMessage() {
       const summaryMsg: ChatCompletionMessage = {
         role: ChatCompletionRole.User,
         content:
-          'summary this conversation in a few words, the response should just include the summary',
+          'summary this conversation in less than 5 words, the response should just include the summary',
       }
       // Request convo summary
       setTimeout(async () => {
@@ -64,7 +64,7 @@ export default function useSendChatMessage() {
           currentConvo.id === newMessage.threadId &&
           result?.content &&
           result?.content?.trim().length > 0 &&
-          result.content.split(' ').length <= 10
+          result.content.split(' ').length <= 20
         ) {
           const updatedConv = {
             ...currentConvo,

--- a/web/hooks/useSendChatMessage.ts
+++ b/web/hooks/useSendChatMessage.ts
@@ -5,7 +5,6 @@ import {
   MessageRequest,
   MessageStatus,
   PluginType,
-  Thread,
   ThreadMessage,
   events,
 } from '@janhq/core'

--- a/web/screens/Chat/ChatBody/index.tsx
+++ b/web/screens/Chat/ChatBody/index.tsx
@@ -1,17 +1,25 @@
+import { useContext } from 'react'
+
 import { useAtomValue } from 'jotai'
 
+import { FeatureToggleContext } from '@/context/FeatureToggle'
+
+import ChatInstruction from '../ChatInstruction'
 import ChatItem from '../ChatItem'
 
 import { getCurrentChatMessagesAtom } from '@/helpers/atoms/ChatMessage.atom'
 
 const ChatBody: React.FC = () => {
   const messages = useAtomValue(getCurrentChatMessagesAtom)
-
+  const { experimentalFeatureEnabed } = useContext(FeatureToggleContext)
   return (
     <div className="flex h-full w-full flex-col-reverse overflow-y-auto">
       {messages.map((message) => (
         <ChatItem {...message} key={message.id} />
       ))}
+      {experimentalFeatureEnabed && messages.length === 0 && (
+        <ChatInstruction />
+      )}
     </div>
   )
 }

--- a/web/screens/Chat/ChatInstruction/index.tsx
+++ b/web/screens/Chat/ChatInstruction/index.tsx
@@ -8,7 +8,7 @@ import {
   events,
 } from '@janhq/core'
 
-import { Button, Input } from '@janhq/uikit'
+import { Button, Textarea } from '@janhq/uikit'
 import { useAtomValue } from 'jotai'
 
 import { getActiveConvoIdAtom } from '@/helpers/atoms/Conversation.atom'
@@ -46,11 +46,12 @@ const ChatInstruction = () => {
       )}
       {isSettingInstruction && (
         <div className="space-y-4">
-          <Input
+          <Textarea
             placeholder={`Enter your instructions`}
             onChange={(e) => {
               setInstruction(e.target.value)
             }}
+            className="h-24"
           />
           <Button
             themes={'outline'}

--- a/web/screens/Chat/ChatInstruction/index.tsx
+++ b/web/screens/Chat/ChatInstruction/index.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react'
+
+import {
+  ChatCompletionRole,
+  EventName,
+  MessageStatus,
+  ThreadMessage,
+  events,
+} from '@janhq/core'
+
+import { Button, Input } from '@janhq/uikit'
+import { useAtomValue } from 'jotai'
+
+import { getActiveConvoIdAtom } from '@/helpers/atoms/Conversation.atom'
+
+const ChatInstruction = () => {
+  const activeConvoId = useAtomValue(getActiveConvoIdAtom)
+  const [isSettingInstruction, setIsSettingInstruction] = useState(false)
+  const [instruction, setInstruction] = useState('')
+  const setSystemPrompt = (instruction: string) => {
+    const message: ThreadMessage = {
+      id: 'system-prompt',
+      content: instruction,
+      role: ChatCompletionRole.System,
+      status: MessageStatus.Ready,
+      createdAt: new Date().toISOString(),
+      threadId: activeConvoId,
+    }
+    events.emit(EventName.OnNewMessageResponse, message)
+    events.emit(EventName.OnMessageResponseFinished, message)
+  }
+  return (
+    <div className="mx-auto mb-20 flex flex-col space-y-2">
+      <p>
+        What does this Assistant do? How does it behave? What should it avoid
+        doing?
+      </p>
+      {!isSettingInstruction && (
+        <Button
+          themes={'outline'}
+          className="w-32"
+          onClick={() => setIsSettingInstruction(true)}
+        >
+          Give Instruction
+        </Button>
+      )}
+      {isSettingInstruction && (
+        <div className="space-y-4">
+          <Input
+            placeholder={`Enter your instructions`}
+            onChange={(e) => {
+              setInstruction(e.target.value)
+            }}
+          />
+          <Button
+            themes={'outline'}
+            className="w-32"
+            onClick={() => setSystemPrompt(instruction)}
+          >
+            Set Instruction
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}
+export default ChatInstruction

--- a/web/screens/Chat/MessageToolbar/index.tsx
+++ b/web/screens/Chat/MessageToolbar/index.tsx
@@ -1,0 +1,85 @@
+import {
+  ChatCompletionRole,
+  EventName,
+  MessageStatus,
+  PluginType,
+  ThreadMessage,
+  events,
+} from '@janhq/core'
+import { ConversationalPlugin, InferencePlugin } from '@janhq/core/lib/plugins'
+import { useAtomValue, useSetAtom } from 'jotai'
+import { RefreshCcw, ClipboardCopy, Trash2Icon, StopCircle } from 'lucide-react'
+
+import { toaster } from '@/containers/Toast'
+
+import {
+  deleteMessage,
+  getCurrentChatMessagesAtom,
+} from '@/helpers/atoms/ChatMessage.atom'
+import { currentConversationAtom } from '@/helpers/atoms/Conversation.atom'
+import { pluginManager } from '@/plugin'
+
+const MessageToolbar = ({ message }: { message: ThreadMessage }) => {
+  const deleteAMessage = useSetAtom(deleteMessage)
+  const thread = useAtomValue(currentConversationAtom)
+  const messages = useAtomValue(getCurrentChatMessagesAtom)
+  const stopInference = async () => {
+    await pluginManager
+      .get<InferencePlugin>(PluginType.Inference)
+      ?.stopInference()
+    setTimeout(() => {
+      events.emit(EventName.OnMessageResponseFinished, message)
+    }, 300)
+  }
+  return (
+    <div className="flex flex-row items-center">
+      {message.status === MessageStatus.Pending && (
+        <StopCircle
+          className="mx-1 cursor-pointer rounded-sm bg-gray-800 px-[3px]"
+          size={20}
+          onClick={() => stopInference()}
+        />
+      )}
+      {message.status !== MessageStatus.Pending &&
+        message.id === messages[0]?.id && (
+          <RefreshCcw
+            className="mx-1 cursor-pointer rounded-sm bg-gray-800 px-[3px]"
+            size={20}
+            onClick={() => {
+              const messageRequest = messages[1]
+              if (message.role === ChatCompletionRole.Assistant) {
+                deleteAMessage(message.id ?? '')
+              }
+              events.emit(EventName.OnNewMessageRequest, messageRequest)
+            }}
+          />
+        )}
+      <ClipboardCopy
+        className="mx-1 cursor-pointer rounded-sm bg-gray-800 px-[3px]"
+        size={20}
+        onClick={() => {
+          navigator.clipboard.writeText(message.content ?? '')
+          toaster({
+            title: 'Copied to clipboard',
+          })
+        }}
+      />
+      <Trash2Icon
+        className="mx-1 cursor-pointer rounded-sm bg-gray-800 px-[3px]"
+        size={20}
+        onClick={async () => {
+          deleteAMessage(message.id ?? '')
+          if (thread)
+            await pluginManager
+              .get<ConversationalPlugin>(PluginType.Conversational)
+              ?.saveConversation({
+                ...thread,
+                messages: messages.filter((e) => e.id !== message.id),
+              })
+        }}
+      />
+    </div>
+  )
+}
+
+export default MessageToolbar

--- a/web/screens/Chat/MessageToolbar/index.tsx
+++ b/web/screens/Chat/MessageToolbar/index.tsx
@@ -1,6 +1,8 @@
 import {
   ChatCompletionRole,
+  ChatCompletionMessage,
   EventName,
+  MessageRequest,
   MessageStatus,
   PluginType,
   ThreadMessage,
@@ -46,7 +48,19 @@ const MessageToolbar = ({ message }: { message: ThreadMessage }) => {
             className="mx-1 cursor-pointer rounded-sm bg-gray-800 px-[3px]"
             size={20}
             onClick={() => {
-              const messageRequest = messages[1]
+              const messageRequest: MessageRequest = {
+                id: message.id ?? '',
+                messages: messages
+                  .slice(1, messages.length)
+                  .reverse()
+                  .map((e) => {
+                    return {
+                      content: e.content,
+                      role: e.role,
+                    } as ChatCompletionMessage
+                  }),
+                threadId: message.threadId ?? '',
+              }
               if (message.role === ChatCompletionRole.Assistant) {
                 deleteAMessage(message.id ?? '')
               }

--- a/web/screens/Chat/SimpleTextMessage/index.tsx
+++ b/web/screens/Chat/SimpleTextMessage/index.tsx
@@ -5,7 +5,6 @@ import { ChatCompletionRole, MessageStatus, ThreadMessage } from '@janhq/core'
 
 import hljs from 'highlight.js'
 
-import { MoreVertical } from 'lucide-react'
 import { Marked } from 'marked'
 
 import { markedHighlight } from 'marked-highlight'

--- a/web/screens/Chat/SimpleTextMessage/index.tsx
+++ b/web/screens/Chat/SimpleTextMessage/index.tsx
@@ -113,7 +113,7 @@ const SimpleTextMessage: React.FC<ThreadMessage> = (props) => {
       </div>
       {experimentalFeatureEnabed &&
         (props.status === MessageStatus.Pending || tokenSpeed > 0) && (
-          <p className="text-xs font-medium text-white">
+          <p className="mt-1 text-xs font-medium text-white">
             Token Speed: {Number(tokenSpeed).toFixed(2)}/s
           </p>
         )}

--- a/web/screens/Chat/SimpleTextMessage/index.tsx
+++ b/web/screens/Chat/SimpleTextMessage/index.tsx
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import React from 'react'
+import React, { useContext } from 'react'
 
-import { ChatCompletionRole, ThreadMessage } from '@janhq/core'
+import { ChatCompletionRole, MessageStatus, ThreadMessage } from '@janhq/core'
+
 import hljs from 'highlight.js'
 
+import { MoreVertical } from 'lucide-react'
 import { Marked } from 'marked'
 
 import { markedHighlight } from 'marked-highlight'
@@ -14,7 +16,11 @@ import LogoMark from '@/containers/Brand/Logo/Mark'
 
 import BubbleLoader from '@/containers/Loader/Bubble'
 
+import { FeatureToggleContext } from '@/context/FeatureToggle'
+
 import { displayDate } from '@/utils/datetime'
+
+import MessageToolbar from '../MessageToolbar'
 
 const marked = new Marked(
   markedHighlight({
@@ -42,12 +48,13 @@ const marked = new Marked(
 )
 
 const SimpleTextMessage: React.FC<ThreadMessage> = (props) => {
+  const { experimentalFeatureEnabed } = useContext(FeatureToggleContext)
   const parsedText = marked.parse(props.content ?? '')
   const isUser = props.role === ChatCompletionRole.User
   const isSystem = props.role === ChatCompletionRole.System
 
   return (
-    <div className="mx-auto rounded-xl px-4 lg:w-3/4">
+    <div className="group mx-auto rounded-xl px-4 lg:w-3/4">
       <div
         className={twMerge(
           'mb-1 flex items-center justify-start gap-2',
@@ -57,10 +64,17 @@ const SimpleTextMessage: React.FC<ThreadMessage> = (props) => {
         {!isUser && !isSystem && <LogoMark width={20} />}
         <div className="text-sm font-extrabold capitalize">{props.role}</div>
         <p className="text-xs font-medium">{displayDate(props.createdAt)}</p>
+
+        {experimentalFeatureEnabed && (
+          <div className="hidden cursor-pointer group-hover:flex">
+            <MessageToolbar message={props} />
+          </div>
+        )}
       </div>
 
       <div className={twMerge('w-full')}>
-        {!props.content || props.content === '' ? (
+        {props.status === MessageStatus.Pending &&
+        (!props.content || props.content === '') ? (
           <BubbleLoader />
         ) : (
           <>

--- a/web/screens/Chat/SimpleTextMessage/index.tsx
+++ b/web/screens/Chat/SimpleTextMessage/index.tsx
@@ -44,6 +44,7 @@ const marked = new Marked(
 const SimpleTextMessage: React.FC<ThreadMessage> = (props) => {
   const parsedText = marked.parse(props.content ?? '')
   const isUser = props.role === ChatCompletionRole.User
+  const isSystem = props.role === ChatCompletionRole.System
 
   return (
     <div className="mx-auto rounded-xl px-4 lg:w-3/4">
@@ -53,7 +54,7 @@ const SimpleTextMessage: React.FC<ThreadMessage> = (props) => {
           !isUser && 'mt-2'
         )}
       >
-        {!isUser && <LogoMark width={20} />}
+        {!isUser && !isSystem && <LogoMark width={20} />}
         <div className="text-sm font-extrabold capitalize">{props.role}</div>
         <p className="text-xs font-medium">{displayDate(props.createdAt)}</p>
       </div>

--- a/web/screens/Chat/index.tsx
+++ b/web/screens/Chat/index.tsx
@@ -1,15 +1,16 @@
-import { Fragment, useEffect, useRef, useState } from 'react'
+import { Fragment, useContext, useEffect, useRef, useState } from 'react'
 
 import { Model } from '@janhq/core/lib/types'
 import { Button, Badge, Textarea } from '@janhq/uikit'
 
 import { useAtom, useAtomValue } from 'jotai'
-import { Trash2Icon } from 'lucide-react'
+import { Trash2Icon, Paintbrush } from 'lucide-react'
 
 import { twMerge } from 'tailwind-merge'
 
 import { currentPromptAtom } from '@/containers/Providers/Jotai'
 
+import { FeatureToggleContext } from '@/context/FeatureToggle'
 import ShortCut from '@/containers/Shortcut'
 
 import { MainViewState } from '@/constants/screens'
@@ -42,7 +43,7 @@ import { currentConvoStateAtom } from '@/helpers/atoms/Conversation.atom'
 const ChatScreen = () => {
   const currentConvo = useAtomValue(currentConversationAtom)
   const { downloadedModels } = useGetDownloadedModels()
-  const { deleteConvo } = useDeleteConversation()
+  const { deleteConvo, cleanConvo } = useDeleteConversation()
   const { activeModel, stateModel } = useActiveModel()
   const { setMainViewState } = useMainViewState()
 
@@ -60,6 +61,7 @@ const ChatScreen = () => {
   const [isModelAvailable, setIsModelAvailable] = useState(
     downloadedModels.some((x) => x.id === currentConvo?.modelId)
   )
+  const { experimentalFeatureEnabed } = useContext(FeatureToggleContext)
 
   const textareaRef = useRef<HTMLTextAreaElement>(null)
 
@@ -147,13 +149,20 @@ const ChatScreen = () => {
                       Download Model
                     </Button>
                   )}
-                  {!stateModel.loading && (
+                  {experimentalFeatureEnabed && (
+                    <Paintbrush
+                      size={16}
+                      className="cursor-pointer text-muted-foreground"
+                      onClick={() => cleanConvo()}
+                    />
+                  )}
+                  {
                     <Trash2Icon
                       size={16}
                       className="cursor-pointer text-muted-foreground"
                       onClick={() => deleteConvo()}
                     />
-                  )}
+                  }
                 </div>
               </div>
             </div>


### PR DESCRIPTION
## Problem
- Chat body seems boring after created, blank state is not decorated well 
- As a user I want to give the conversation context (set system prompt)

## Solution
- Before the Assistant settings feature is designed, this could be an experimental feature so users can get how it is working (also to test against models / endpoints)

TODO: 
- Its better to have a toggle for every single dark feature

<img width="1312" alt="Screenshot 2023-11-24 at 13 30 51" src="https://github.com/janhq/jan/assets/133622055/7c04f3e6-4a7e-45f5-8176-a9173a466572">
<img width="1312" alt="Screenshot 2023-11-24 at 13 22 46" src="https://github.com/janhq/jan/assets/133622055/7ad82df8-9eb8-4db6-8001-77c8db04d03c">
