### PR TITLE
experimental: message actions tooltip

### DIFF
--- a/web/context/FeatureToggle.tsx
+++ b/web/context/FeatureToggle.tsx
@@ -22,12 +22,9 @@ export default function FeatureToggleWrapper({
   const [experimentalEnabed, setExperimentalEnabled] = useState<boolean>(false)
 
   useEffect(() => {
-    // Global experimental feature is disabled
-    let globalFeatureEnabled = false
-    if (localStorage.getItem(EXPERIMENTAL_FEATURE_ENABLED) !== 'true') {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      globalFeatureEnabled = true
-    }
+    setExperimentalEnabled(
+      localStorage.getItem(EXPERIMENTAL_FEATURE_ENABLED) === 'true'
+    )
   }, [])
 
   const setExperimentalFeature = (on: boolean) => {

--- a/web/helpers/atoms/ChatMessage.atom.ts
+++ b/web/helpers/atoms/ChatMessage.atom.ts
@@ -3,6 +3,7 @@ import { atom } from 'jotai'
 
 import {
   conversationStatesAtom,
+  currentConversationAtom,
   getActiveConvoIdAtom,
   updateThreadStateLastMessageAtom,
 } from './Conversation.atom'
@@ -100,6 +101,17 @@ export const cleanConversationMessages = atom(null, (get, set, id: string) => {
   }
   newData[id] = newData[id].filter((e) => e.role === ChatCompletionRole.System)
   set(chatMessages, newData)
+})
+
+export const deleteMessage = atom(null, (get, set, id: string) => {
+  const newData: Record<string, ThreadMessage[]> = {
+    ...get(chatMessages),
+  }
+  const threadId = get(currentConversationAtom)?.id
+  if (threadId) {
+    newData[threadId] = newData[threadId].filter((e) => e.id !== id)
+    set(chatMessages, newData)
+  }
 })
 
 export const updateMessageAtom = atom(

--- a/web/hooks/useSendChatMessage.ts
+++ b/web/hooks/useSendChatMessage.ts
@@ -41,7 +41,7 @@ export default function useSendChatMessage() {
     if (
       currentConvo &&
       newMessage.messages &&
-      newMessage.messages.length > 2 &&
+      newMessage.messages.length >= 2 &&
       (!currentConvo.summary ||
         currentConvo.summary === '' ||
         currentConvo.summary === activeModel?.name)

--- a/web/screens/Chat/MessageToolbar/index.tsx
+++ b/web/screens/Chat/MessageToolbar/index.tsx
@@ -1,0 +1,85 @@
+import {
+  ChatCompletionRole,
+  EventName,
+  MessageStatus,
+  PluginType,
+  ThreadMessage,
+  events,
+} from '@janhq/core'
+import { ConversationalPlugin, InferencePlugin } from '@janhq/core/lib/plugins'
+import { useAtomValue, useSetAtom } from 'jotai'
+import { RefreshCcw, ClipboardCopy, Trash2Icon, StopCircle } from 'lucide-react'
+
+import { toaster } from '@/containers/Toast'
+
+import {
+  deleteMessage,
+  getCurrentChatMessagesAtom,
+} from '@/helpers/atoms/ChatMessage.atom'
+import { currentConversationAtom } from '@/helpers/atoms/Conversation.atom'
+import { pluginManager } from '@/plugin'
+
+const MessageToolbar = ({ message }: { message: ThreadMessage }) => {
+  const deleteAMessage = useSetAtom(deleteMessage)
+  const thread = useAtomValue(currentConversationAtom)
+  const messages = useAtomValue(getCurrentChatMessagesAtom)
+  const stopInference = async () => {
+    await pluginManager
+      .get<InferencePlugin>(PluginType.Inference)
+      ?.stopInference()
+    setTimeout(() => {
+      events.emit(EventName.OnMessageResponseFinished, message)
+    }, 300)
+  }
+  return (
+    <div className="flex flex-row items-center">
+      {message.status === MessageStatus.Pending && (
+        <StopCircle
+          className="mx-1 cursor-pointer rounded-sm bg-gray-800 px-[3px]"
+          size={20}
+          onClick={() => stopInference()}
+        />
+      )}
+      {message.status !== MessageStatus.Pending &&
+        message.id === messages[0]?.id && (
+          <RefreshCcw
+            className="mx-1 cursor-pointer rounded-sm bg-gray-800 px-[3px]"
+            size={20}
+            onClick={() => {
+              const messageRequest = messages[1]
+              if (message.role === ChatCompletionRole.Assistant) {
+                deleteAMessage(message.id ?? '')
+              }
+              events.emit(EventName.OnNewMessageRequest, messageRequest)
+            }}
+          />
+        )}
+      <ClipboardCopy
+        className="mx-1 cursor-pointer rounded-sm bg-gray-800 px-[3px]"
+        size={20}
+        onClick={() => {
+          navigator.clipboard.writeText(message.content ?? '')
+          toaster({
+            title: 'Copied to clipboard',
+          })
+        }}
+      />
+      <Trash2Icon
+        className="mx-1 cursor-pointer rounded-sm bg-gray-800 px-[3px]"
+        size={20}
+        onClick={async () => {
+          deleteAMessage(message.id ?? '')
+          if (thread)
+            await pluginManager
+              .get<ConversationalPlugin>(PluginType.Conversational)
+              ?.saveConversation({
+                ...thread,
+                messages: messages.filter((e) => e.id !== message.id),
+              })
+        }}
+      />
+    </div>
+  )
+}
+
+export default MessageToolbar

--- a/web/screens/Chat/MessageToolbar/index.tsx
+++ b/web/screens/Chat/MessageToolbar/index.tsx
@@ -1,6 +1,8 @@
 import {
   ChatCompletionRole,
+  ChatCompletionMessage,
   EventName,
+  MessageRequest,
   MessageStatus,
   PluginType,
   ThreadMessage,
@@ -46,7 +48,19 @@ const MessageToolbar = ({ message }: { message: ThreadMessage }) => {
             className="mx-1 cursor-pointer rounded-sm bg-gray-800 px-[3px]"
             size={20}
             onClick={() => {
-              const messageRequest = messages[1]
+              const messageRequest: MessageRequest = {
+                id: message.id ?? '',
+                messages: messages
+                  .slice(1, messages.length)
+                  .reverse()
+                  .map((e) => {
+                    return {
+                      content: e.content,
+                      role: e.role,
+                    } as ChatCompletionMessage
+                  }),
+                threadId: message.threadId ?? '',
+              }
               if (message.role === ChatCompletionRole.Assistant) {
                 deleteAMessage(message.id ?? '')
               }

--- a/web/screens/Chat/SimpleTextMessage/index.tsx
+++ b/web/screens/Chat/SimpleTextMessage/index.tsx
@@ -5,7 +5,6 @@ import { ChatCompletionRole, MessageStatus, ThreadMessage } from '@janhq/core'
 
 import hljs from 'highlight.js'
 
-import { MoreVertical } from 'lucide-react'
 import { Marked } from 'marked'
 
 import { markedHighlight } from 'marked-highlight'

--- a/web/screens/Chat/SimpleTextMessage/index.tsx
+++ b/web/screens/Chat/SimpleTextMessage/index.tsx
@@ -113,7 +113,7 @@ const SimpleTextMessage: React.FC<ThreadMessage> = (props) => {
       </div>
       {experimentalFeatureEnabed &&
         (props.status === MessageStatus.Pending || tokenSpeed > 0) && (
-          <p className="text-xs font-medium text-white">
+          <p className="mt-1 text-xs font-medium text-white">
             Token Speed: {Number(tokenSpeed).toFixed(2)}/s
           </p>
         )}

--- a/web/screens/Chat/SimpleTextMessage/index.tsx
+++ b/web/screens/Chat/SimpleTextMessage/index.tsx
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import React from 'react'
+import React, { useContext } from 'react'
 
-import { ChatCompletionRole, ThreadMessage } from '@janhq/core'
+import { ChatCompletionRole, MessageStatus, ThreadMessage } from '@janhq/core'
+
 import hljs from 'highlight.js'
 
+import { MoreVertical } from 'lucide-react'
 import { Marked } from 'marked'
 
 import { markedHighlight } from 'marked-highlight'
@@ -14,7 +16,11 @@ import LogoMark from '@/containers/Brand/Logo/Mark'
 
 import BubbleLoader from '@/containers/Loader/Bubble'
 
+import { FeatureToggleContext } from '@/context/FeatureToggle'
+
 import { displayDate } from '@/utils/datetime'
+
+import MessageToolbar from '../MessageToolbar'
 
 const marked = new Marked(
   markedHighlight({
@@ -42,12 +48,13 @@ const marked = new Marked(
 )
 
 const SimpleTextMessage: React.FC<ThreadMessage> = (props) => {
+  const { experimentalFeatureEnabed } = useContext(FeatureToggleContext)
   const parsedText = marked.parse(props.content ?? '')
   const isUser = props.role === ChatCompletionRole.User
   const isSystem = props.role === ChatCompletionRole.System
 
   return (
-    <div className="mx-auto rounded-xl px-4 lg:w-3/4">
+    <div className="group mx-auto rounded-xl px-4 lg:w-3/4">
       <div
         className={twMerge(
           'mb-1 flex items-center justify-start gap-2',
@@ -57,10 +64,17 @@ const SimpleTextMessage: React.FC<ThreadMessage> = (props) => {
         {!isUser && !isSystem && <LogoMark width={20} />}
         <div className="text-sm font-extrabold capitalize">{props.role}</div>
         <p className="text-xs font-medium">{displayDate(props.createdAt)}</p>
+
+        {experimentalFeatureEnabed && (
+          <div className="hidden cursor-pointer group-hover:flex">
+            <MessageToolbar message={props} />
+          </div>
+        )}
       </div>
 
       <div className={twMerge('w-full')}>
-        {!props.content || props.content === '' ? (
+        {props.status === MessageStatus.Pending &&
+        (!props.content || props.content === '') ? (
           <BubbleLoader />
         ) : (
           <>


### PR DESCRIPTION
## Problem
As a user I would like to have these features:
- Stop current streaming message (#385)
- Re-prompt the latest response
- Copy message
- Delete message
- See token speed

Stop requesting inference
<img width="1269" alt="Screenshot 2023-11-24 at 15 02 21" src="https://github.com/janhq/jan/assets/133622055/5d5bae2f-160f-44c9-9571-cb43eede1585">

Stop streaming inference
<img width="1269" alt="Screenshot 2023-11-24 at 15 02 55" src="https://github.com/janhq/jan/assets/133622055/c3d0353f-df1f-4ac6-86dd-fabb0032fbc4">

Request a new response
<img width="1269" alt="Screenshot 2023-11-24 at 15 02 58" src="https://github.com/janhq/jan/assets/133622055/a9c2eaec-9384-4271-a6b2-d83ab3f67027">

Copy to clipboard 
<img width="1269" alt="Screenshot 2023-11-24 at 15 03 35" src="https://github.com/janhq/jan/assets/133622055/237cff40-f6b6-42ca-8496-05d39687cac4">

Token speed
<img width="1312" alt="Screenshot 2023-11-24 at 22 55 06" src="https://github.com/janhq/jan/assets/133622055/415d542b-0295-4053-b551-b1d35b8afe5e">

Fixes #385 