### PR TITLE
chore: fs module should not cover app logic

### DIFF
--- a/core/src/core.ts
+++ b/core/src/core.ts
@@ -41,9 +41,8 @@ const downloadFile: (url: string, fileName: string) => Promise<any> = (
   window.electronAPI?.downloadFile(url, fileName);
 
 /**
- * Deletes a file from the local file system.
- * @param {string} path - The path of the file to delete.
- * @returns {Promise<any>} A promise that resolves when the file is deleted.
+ * @deprecated This object is deprecated and should not be used.
+ * Use fs module instead.
  */
 const deleteFile: (path: string) => Promise<any> = (path) =>
   window.coreAPI?.deleteFile(path) ?? window.electronAPI?.deleteFile(path);
@@ -54,6 +53,13 @@ const deleteFile: (path: string) => Promise<any> = (path) =>
  * @returns A Promise that resolves with the path to the app data directory, or `undefined` if the `coreAPI` object is not available.
  */
 const appDataPath: () => Promise<any> = () => window.coreAPI?.appDataPath();
+
+/**
+ * Gets the user space path.
+ * @returns {Promise<any>} A Promise that resolves with the user space path.
+ */
+const getUserSpace = (): Promise<string> =>
+  window.coreAPI?.getUserSpace() ?? window.electronAPI?.getUserSpace();
 
 /** Register extension point function type definition
  *
@@ -75,6 +81,7 @@ export const core = {
   downloadFile,
   deleteFile,
   appDataPath,
+  getUserSpace,
 };
 
 /**
@@ -86,4 +93,5 @@ export {
   downloadFile,
   deleteFile,
   appDataPath,
+  getUserSpace,
 };

--- a/core/src/fs.ts
+++ b/core/src/fs.ts
@@ -9,13 +9,6 @@ const writeFile: (path: string, data: string) => Promise<any> = (path, data) =>
   window.electronAPI?.writeFile(path, data);
 
 /**
- * Gets the user space path.
- * @returns {Promise<any>} A Promise that resolves with the user space path.
- */
-const getUserSpace = (): Promise<string> =>
-  window.coreAPI?.getUserSpace() ?? window.electronAPI?.getUserSpace();
-
-/**
  * Checks whether the path is a directory.
  * @param path - The path to check.
  * @returns {boolean} A boolean indicating whether the path is a directory.
@@ -64,7 +57,6 @@ const deleteFile: (path: string) => Promise<any> = (path) =>
 
 export const fs = {
   isDirectory,
-  getUserSpace,
   writeFile,
   readFile,
   listFiles,

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -8,7 +8,7 @@ export { core, deleteFile, invokePluginFunc } from "./core";
  * Core module exports.
  * @module
  */
-export { downloadFile, executeOnMain, appDataPath } from "./core";
+export { downloadFile, executeOnMain, appDataPath, getUserSpace } from "./core";
 
 /**
  * Events module exports.

--- a/plugins/inference-plugin/src/index.ts
+++ b/plugins/inference-plugin/src/index.ts
@@ -20,7 +20,7 @@ import { InferencePlugin } from "@janhq/core/lib/plugins";
 import { requestInference } from "./helpers/sse";
 import { ulid } from "ulid";
 import { join } from "path";
-import { fs } from "@janhq/core";
+import { getUserSpace } from "@janhq/core";
 
 /**
  * A class that implements the InferencePlugin interface from the @janhq/core package.
@@ -60,7 +60,7 @@ export default class JanInferencePlugin implements InferencePlugin {
    * @returns {Promise<void>} A promise that resolves when the model is initialized.
    */
   async initModel(modelFileName: string): Promise<void> {
-    const userSpacePath = await fs.getUserSpace();
+    const userSpacePath = await getUserSpace();
     const modelFullPath = join(userSpacePath, modelFileName);
 
     return executeOnMain(MODULE, "initModel", modelFullPath);


### PR DESCRIPTION
## Problem
- `getUserSpace` is part of both the app / core logic, so it shouldn't reside in the `fs` module.
- `deleteFile` is deprecated, it should be in 'fs' module instead of `core` module.
