### PR TITLE
chore: app raises error when attempting to start a model that is already starting

### DIFF
--- a/web/hooks/useActiveModel.ts
+++ b/web/hooks/useActiveModel.ts
@@ -23,7 +23,10 @@ export function useActiveModel() {
   const { downloadedModels } = useGetDownloadedModels()
 
   const startModel = async (modelId: string) => {
-    if (activeModel && activeModel.id === modelId) {
+    if (
+      (activeModel && activeModel.id === modelId) ||
+      (stateModel.model === modelId && stateModel.loading)
+    ) {
       console.debug(`Model ${modelId} is already init. Ignore..`)
       return
     }


### PR DESCRIPTION
## Problem
- App raises error when attempting to start a model that is already starting. Should skip that action