### PR TITLE
chore: open app data should lead user to jan root

### DIFF
--- a/electron/handlers/app.ts
+++ b/electron/handlers/app.ts
@@ -29,7 +29,8 @@ export function handleAppIPCs() {
    * @param _event - The IPC event object.
    */
   ipcMain.handle("openAppDirectory", async (_event) => {
-    shell.openPath(app.getPath("userData"));
+    const userSpacePath = join(app.getPath('home'), 'jan')
+    shell.openPath(userSpacePath);
   });
 
   /**


### PR DESCRIPTION
## Description
- The button still lead user to system app data directory instead of jan root dir