### PR TITLE
fix: messages sync is not threadsafe

### DIFF
--- a/electron/handlers/fs.ts
+++ b/electron/handlers/fs.ts
@@ -60,15 +60,11 @@ export function handleFsIPCs() {
   ipcMain.handle(
     'writeFile',
     async (event, path: string, data: string): Promise<void> => {
-      return new Promise((resolve, reject) => {
-        fs.writeFile(join(userSpacePath, path), data, 'utf8', (err) => {
-          if (err) {
-            reject(err)
-          } else {
-            resolve()
-          }
-        })
-      })
+      try {
+        await fs.writeFileSync(join(userSpacePath, path), data, 'utf8')
+      } catch (err) {
+        console.error(`writeFile ${path} result: ${err}`)
+      }
     }
   )
 
@@ -79,15 +75,11 @@ export function handleFsIPCs() {
    * @returns A promise that resolves when the directory has been created.
    */
   ipcMain.handle('mkdir', async (event, path: string): Promise<void> => {
-    return new Promise((resolve, reject) => {
-      fs.mkdir(join(userSpacePath, path), { recursive: true }, (err) => {
-        if (err) {
-          reject(err)
-        } else {
-          resolve()
-        }
-      })
-    })
+    try {
+      fs.mkdirSync(join(userSpacePath, path), { recursive: true })
+    } catch (err) {
+      console.error(`mkdir ${path} result: ${err}`)
+    }
   })
 
   /**
@@ -97,15 +89,11 @@ export function handleFsIPCs() {
    * @returns A promise that resolves when the directory is removed successfully.
    */
   ipcMain.handle('rmdir', async (event, path: string): Promise<void> => {
-    return new Promise((resolve, reject) => {
-      fs.rm(join(userSpacePath, path), { recursive: true }, (err) => {
-        if (err) {
-          reject(err)
-        } else {
-          resolve()
-        }
-      })
-    })
+    try {
+      await fs.rmSync(join(userSpacePath, path), { recursive: true })
+    } catch (err) {
+      console.error(`rmdir ${path} result: ${err}`)
+    }
   })
 
   /**
@@ -136,23 +124,11 @@ export function handleFsIPCs() {
    * @returns A string indicating the result of the operation.
    */
   ipcMain.handle('deleteFile', async (_event, filePath) => {
-    const fullPath = join(userSpacePath, filePath)
-
-    let result = 'NULL'
-    fs.unlink(fullPath, function (err) {
-      if (err && err.code == 'ENOENT') {
-        result = `File not exist: ${err}`
-      } else if (err) {
-        result = `File delete error: ${err}`
-      } else {
-        result = 'File deleted successfully'
-      }
-      console.debug(
-        `Delete file ${filePath} from ${fullPath} result: ${result}`
-      )
-    })
-
-    return result
+    try {
+      await fs.unlinkSync(join(userSpacePath, filePath))
+    } catch (err) {
+      console.error(`unlink ${filePath} result: ${err}`)
+    }
   })
 
   /**
@@ -163,17 +139,19 @@ export function handleFsIPCs() {
    * @returns A promise that resolves when the file has been written.
    */
   ipcMain.handle('appendFile', async (_event, path: string, data: string) => {
-    return new Promise((resolve, reject) => {
-      fs.appendFile(join(userSpacePath, path), data, 'utf8', (err) => {
-        if (err) {
-          reject(err)
-        } else {
-          resolve(data)
-        }
-      })
-    })
+    try {
+      await fs.appendFileSync(join(userSpacePath, path), data, 'utf8')
+    } catch (err) {
+      console.error(`appendFile ${path} result: ${err}`)
+    }
   })
 
+  /**
+   * Reads a file line by line.
+   * @param event - The event object.
+   * @param path - The path of the file to read.
+   * @returns A promise that resolves with the contents of the file.
+   */
   ipcMain.handle('readLineByLine', async (_event, path: string) => {
     const fullPath = join(userSpacePath, path)
 

--- a/electron/package.json
+++ b/electron/package.json
@@ -13,8 +13,7 @@
       "renderer/**/*",
       "build/*.{js,map}",
       "build/**/*.{js,map}",
-      "core/pre-install",
-      "core/plugin-manager/facade"
+      "core/pre-install"
     ],
     "asarUnpack": [
       "core/pre-install"

--- a/web/services/coreService.ts
+++ b/web/services/coreService.ts
@@ -1,4 +1,4 @@
-import * as cn from './cloudNativeService'
+import * as restAPI from './cloudNativeService'
 import { EventEmitter } from './eventsService'
 export const setupCoreServices = () => {
   if (typeof window === 'undefined') {
@@ -13,11 +13,7 @@ export const setupCoreServices = () => {
     }
     window.coreAPI = {}
     window.coreAPI = window.electronAPI ?? {
-      invokePluginFunc: cn.invokePluginFunc,
-      downloadFile: cn.downloadFile,
-      deleteFile: cn.deleteFile,
-      appVersion: cn.appVersion,
-      openExternalUrl: cn.openExternalUrl,
+      ...restAPI,
     }
   }
 }


### PR DESCRIPTION
**Describe the bug**
Since https://github.com/janhq/jan/issues/731, Jan appends a new message as a new line onto messages.jsonl this lead to an issue where there may be many concurrent `fs` operations on messages.jsonl. 
e.g:
- multiple responses, before an fs writing operation is done, another responses may come from other assistants / extensions
- edit/delete message: this operation will delete a single line in messages.jsonl
- clean thread messages: this operation will wipe out all messages in the thread

To Reproduce
1. Start a thread and send a message
2. While message is streaming, delete another message
3. Reload the app. Thread is broken, and no messages are loaded (failed to parse)
4. Expected behavior

After reloading, the thread messages should be fully loaded.
ref
https://nodejs.org/api/fs.html#synchronous-example