### PR TITLE
Fix Makefile Indentation Issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,15 +45,15 @@ clean:
 ifeq ($(OS),Windows_NT)
 	powershell -Command "Get-ChildItem -Path . -Include node_modules, .next, dist -Recurse -Directory | Remove-Item -Recurse -Force"
 	rmdir /s /q "%USERPROFILE%\AppData\Roaming\jan"
-    rmdir /s /q "%USERPROFILE%\AppData\Roaming\jan-electron"
-    rmdir /s /q "%USERPROFILE%\AppData\Local\jan*"
+	rmdir /s /q "%USERPROFILE%\AppData\Roaming\jan-electron"
+	rmdir /s /q "%USERPROFILE%\AppData\Local\jan*"
 else ifeq ($(shell uname -s),Linux)
 	find . -name "node_modules" -type d -prune -exec rm -rf '{}' +
 	find . -name ".next" -type d -exec rm -rf '{}' +
 	find . -name "dist" -type d -exec rm -rf '{}' +
-    rm -rf "~/.config/jan"
+	rm -rf "~/.config/jan"
 	rm -rf "~/.config/jan-electron"
-    rm -rf "~/.cache/jan*"
+	rm -rf "~/.cache/jan*"
 else
 	find . -name "node_modules" -type d -prune -exec rm -rf '{}' +
 	find . -name ".next" -type d -exec rm -rf '{}' +


### PR DESCRIPTION
This PR addresses an issue in the Makefile where 4 spaces were used instead of a tab for indentation. This caused errors when running make commands. The spaces have been replaced with tabs to adhere to Makefile syntax standards and ensure proper execution.