### PR TITLE
bug: fix broken banner position hub screen

### DIFF
--- a/web/screens/ExploreModels/index.tsx
+++ b/web/screens/ExploreModels/index.tsx
@@ -78,8 +78,9 @@ const ExploreModelsScreen = () => {
               </div>
             </div>
             <div className="mx-auto w-4/5 py-6">
-              <div className="flex items-center justify-between">
-                <div className="inline-flex overflow-hidden rounded-lg border border-border">
+              <div className="flex items-center justify-end">
+                {/* Temporary hide tabs */}
+                {/* <div className="inline-flex overflow-hidden rounded-lg border border-border">
                   <div
                     className={twMerge(
                       'flex cursor-pointer items-center space-x-2 border-r border-border px-3 py-2',
@@ -108,7 +109,7 @@ const ExploreModelsScreen = () => {
                       <TooltipArrow />
                     </TooltipContent>
                   </Tooltip>
-                </div>
+                </div> */}
 
                 <Select
                   value={sortSelected}

--- a/web/screens/ExploreModels/index.tsx
+++ b/web/screens/ExploreModels/index.tsx
@@ -58,7 +58,11 @@ const ExploreModelsScreen = () => {
         <div className="h-full" data-test-id="testid-explore-models">
           <ScrollArea>
             <div className="relative">
-              <img src="./images/hub-banner.png" alt="Hub Banner" />
+              <img
+                src="./images/hub-banner.png"
+                alt="Hub Banner"
+                className="w-full object-cover"
+              />
               <div className="absolute left-1/2 top-1/2 w-1/3 -translate-x-1/2 -translate-y-1/2">
                 <SearchIcon
                   size={20}


### PR DESCRIPTION
Fix #844 

- Fix banner position 
- Temporary hide tabs element

Before
![287906229-ec6ccb0e-c5ce-47fc-9479-311d32a538dd](https://github.com/janhq/jan/assets/10354610/f66215eb-4347-4542-883f-e453b46d71bf)


Result
<img width="1912" alt="Screenshot 2023-12-05 at 10 26 05" src="https://github.com/janhq/jan/assets/10354610/5cf4576d-d0d3-47ee-bbdb-6ebe1267ac0f">
