### PR TITLE
fix: Nitro interface update to prevent warning

### DIFF
--- a/extensions/inference-extension/src/module.ts
+++ b/extensions/inference-extension/src/module.ts
@@ -191,7 +191,7 @@ async function spawnNitroProcess(): Promise<void> {
     const binaryPath = path.join(binaryFolder, binaryName);
 
     // Execute the binary
-    subprocess = spawn(binaryPath, [1, "0.0.0.0", PORT], {
+    subprocess = spawn(binaryPath, [1, "127.0.0.1", PORT], {
       cwd: binaryFolder,
     });
 


### PR DESCRIPTION
On windows there is a warning show up when I try to chat with new model.
This is related to nitro at IP interface `0.0.0.0`
The solution is to change to `127.0.0.1`