### PR TITLE
fix: download button text color is blending into the background

### DIFF
--- a/docs/src/containers/DownloadApp/index.js
+++ b/docs/src/containers/DownloadApp/index.js
@@ -110,14 +110,14 @@ export default function DownloadApp() {
           <a
             key={i}
             href={system.href}
-            className={`inline-flex m-2 px-4 py-2 rounded-lg text-lg font-semibold cursor-pointer justify-center items-center space-x-2 border border-gray-400 dark:border-gray-700 text-black dark:text-white bg-neutral-50 min-w-[150px] dark:bg-[#18181B], ${
+            className={`inline-flex m-2 px-4 py-2 rounded-lg text-lg font-semibold cursor-pointer justify-center items-center space-x-2 border border-gray-400 dark:border-gray-700 text-black dark:text-black bg-neutral-50 min-w-[150px] dark:bg-[#18181B], ${
               system.comingSoon && "pointer-events-none	"
             }`}
           >
             <system.logo />
             <span>{system.name}</span>
             {system.comingSoon && (
-              <span className="bg-gray-300 dark:bg-gray-700 py-0.5 px-2 inline-block ml-2 rounded-md text-sm mt-1">
+              <span className="bg-gray-300 py-0.5 px-2 inline-block ml-2 rounded-md text-sm mt-1">
                 Coming Soon
               </span>
             )}


### PR DESCRIPTION
## Problem
- User could not see the text of download options
![Screenshot 2023-12-06 at 20 07 44](https://github.com/janhq/jan/assets/133622055/47c6548d-1dad-49b8-884e-63137dbfa68f)

Fixed
<img width="509" alt="Screenshot 2023-12-06 at 20 19 38" src="https://github.com/janhq/jan/assets/133622055/dfb8f04d-9455-472e-86db-9517bc4b121e">
