### PR TITLE
feat: Hotfit for Nitro loading on CPU with hyper-threading support

### DIFF
--- a/core/src/types/index.ts
+++ b/core/src/types/index.ts
@@ -275,7 +275,7 @@ export type ModelSettingParams = {
   ngl?: number;
   embedding?: boolean;
   n_parallel?: number;
-  cpu_threads: number;
+  cpu_threads?: number;
   system_prompt?: string;
   user_prompt?: string;
   ai_prompt?: string;

--- a/core/src/types/index.ts
+++ b/core/src/types/index.ts
@@ -275,6 +275,7 @@ export type ModelSettingParams = {
   ngl?: number;
   embedding?: boolean;
   n_parallel?: number;
+  cpu_threads: number;
   system_prompt?: string;
   user_prompt?: string;
   ai_prompt?: string;

--- a/extensions/inference-nitro-extension/package.json
+++ b/extensions/inference-nitro-extension/package.json
@@ -36,6 +36,7 @@
     "kill-port": "^2.0.1",
     "path-browserify": "^1.0.1",
     "rxjs": "^7.8.1",
+    "systeminformation": "^5.21.20",
     "tcp-port-used": "^1.0.2",
     "ts-loader": "^9.5.0",
     "ulid": "^2.3.0"
@@ -52,6 +53,7 @@
     "tcp-port-used",
     "kill-port",
     "fetch-retry",
-    "electron-log"
+    "electron-log",
+    "systeminformation"
   ]
 }

--- a/extensions/inference-nitro-extension/src/@types/global.d.ts
+++ b/extensions/inference-nitro-extension/src/@types/global.d.ts
@@ -24,3 +24,8 @@ interface ModelOperationResponse {
   error?: any;
   modelFile?: string;
 }
+
+interface ResourcesInfo {
+  numCpuPhysicalCore: number;
+  memAvailable: number;
+}

--- a/extensions/inference-nitro-extension/src/@types/global.d.ts
+++ b/extensions/inference-nitro-extension/src/@types/global.d.ts
@@ -12,6 +12,7 @@ declare const INFERENCE_URL: string;
 interface EngineSettings {
   ctx_len: number;
   ngl: number;
+  cpu_threads: number;
   cont_batching: boolean;
   embedding: boolean;
 }

--- a/extensions/inference-nitro-extension/src/index.ts
+++ b/extensions/inference-nitro-extension/src/index.ts
@@ -12,7 +12,6 @@ import {
   EventName,
   MessageRequest,
   MessageStatus,
-  ModelSettingParams,
   ExtensionType,
   ThreadContent,
   ThreadMessage,
@@ -41,6 +40,7 @@ export default class JanInferenceNitroExtension implements InferenceExtension {
   private static _engineSettings: EngineSettings = {
     ctx_len: 2048,
     ngl: 100,
+    cpu_threads: 1,
     cont_batching: false,
     embedding: false,
   };

--- a/extensions/inference-nitro-extension/src/module.ts
+++ b/extensions/inference-nitro-extension/src/module.ts
@@ -298,6 +298,7 @@ async function getResourcesInfo(): Promise<ResourcesInfo> {
 
 module.exports = {
   initModel,
+  stopModel,
   killSubprocess,
   dispose,
 };

--- a/extensions/inference-nitro-extension/src/module.ts
+++ b/extensions/inference-nitro-extension/src/module.ts
@@ -179,10 +179,8 @@ async function spawnNitroProcess(nitroResourceProbe: any): Promise<any> {
     let binaryName;
 
     if (process.platform === "win32") {
-      // Todo: Need to check for CUDA support to switch between CUDA and non-CUDA binaries
       binaryName = "win-start.bat";
     } else if (process.platform === "darwin") {
-      // Mac OS platform
       if (process.arch === "arm64") {
         binaryFolder = path.join(binaryFolder, "mac-arm64");
       } else {
@@ -190,21 +188,15 @@ async function spawnNitroProcess(nitroResourceProbe: any): Promise<any> {
       }
       binaryName = "nitro";
     } else {
-      // Linux
-      // Todo: Need to check for CUDA support to switch between CUDA and non-CUDA binaries
-      binaryName = "linux-start.sh"; // For other platforms
+      binaryName = "linux-start.sh";
     }
 
     const binaryPath = path.join(binaryFolder, binaryName);
 
     // Execute the binary
-    subprocess = spawn(
-      binaryPath,
-      [nitroResourceProbe.numCpuPhysicalCore, "127.0.0.1", PORT],
-      {
-        cwd: binaryFolder,
-      }
-    );
+    subprocess = spawn(binaryPath, [1, LOCAL_HOST, PORT], {
+      cwd: binaryFolder,
+    });
 
     // Handle subprocess output
     subprocess.stdout.on("data", (data) => {
@@ -273,7 +265,6 @@ function validateModelVersion(): Promise<void> {
     });
   });
 }
-
 
 function dispose() {
   // clean other registered resources here

--- a/extensions/inference-nitro-extension/src/module.ts
+++ b/extensions/inference-nitro-extension/src/module.ts
@@ -53,7 +53,7 @@ async function initModel(wrapper: any): Promise<ModelOperationResponse> {
       llama_model_path: currentModelFile,
       ...wrapper.model.settings,
       // This is critical and requires real system information
-      n_threads: nitroResourceProbe.numCpuPhysicalCore,
+      cpu_threads: nitroResourceProbe.numCpuPhysicalCore,
     };
     log.info(`Load model settings: ${JSON.stringify(settings, null, 2)}`);
     return (

--- a/extensions/inference-openai-extension/src/index.ts
+++ b/extensions/inference-openai-extension/src/index.ts
@@ -12,7 +12,6 @@ import {
   EventName,
   MessageRequest,
   MessageStatus,
-  ModelSettingParams,
   ExtensionType,
   ThreadContent,
   ThreadMessage,


### PR DESCRIPTION
Problem statement:
- Nitro needs to know exactly the number of physical core and can combine it to run with `numactl` on linux

Solution:
- Add `systeminformation` to get cpu.physicalCores as INT an pass to `nitro`

- [x] Mac M
- [x] Windows
- [x] Linux 

References:
- Based on https://github.com/sebhildebrandt/systeminformation?tab=readme-ov-file#3-cpu
![CleanShot 2023-12-11 at 22 02 29@2x](https://github.com/janhq/jan/assets/22463238/c00fda96-68c4-4e1e-9244-00445048e7e7)
