### PR TITLE
fix: Inference engine Nitro with Windows with/ without CUDA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ core/lib/**
 
 # Nitro binary files
 extensions/inference-nitro-extension/bin/*/nitro
+extensions/inference-nitro-extension/bin/*/*.metal
 extensions/inference-nitro-extension/bin/*/*.exe
 extensions/inference-nitro-extension/bin/*/*.dll
-extensions/inference-nitro-extension/bin/*/*.metal
+extensions/inference-nitro-extension/bin/*/*.exp
+extensions/inference-nitro-extension/bin/*/*.lib


### PR DESCRIPTION
Windows has serious problem with only CPU and also it cannot use NVIDIA GPU properly

See comments for the test result