### PR TITLE
Fix error Jan app linux crash

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -86,7 +86,7 @@
     "@types/pacote": "^11.1.7",
     "@typescript-eslint/eslint-plugin": "^6.7.3",
     "@typescript-eslint/parser": "^6.7.3",
-    "electron": "26.2.1",
+    "electron": "28.0.0",
     "electron-builder": "^24.6.4",
     "electron-playwright-helpers": "^1.6.0",
     "eslint-plugin-react": "^7.33.2",


### PR DESCRIPTION
Fix error Jan app linux crash
Change:
- Upgrade electron from 26.2.1 to 28.0.0

Resolve issues:
- https://github.com/janhq/jan/issues/875
