### PR TITLE
feat: move stop inference button into the send button

### DIFF
--- a/extensions/inference-nitro-extension/src/index.ts
+++ b/extensions/inference-nitro-extension/src/index.ts
@@ -227,6 +227,11 @@ export default class JanInferenceNitroExtension implements InferenceExtension {
         events.emit(EventName.OnMessageUpdate, message);
       },
       error: async (err) => {
+        if (instance.isCancelled) {
+          message.status = MessageStatus.Ready;
+          events.emit(EventName.OnMessageUpdate, message);
+          return;
+        }
         const messageContent: ThreadContent = {
           type: ContentType.Text,
           text: {

--- a/extensions/inference-openai-extension/src/index.ts
+++ b/extensions/inference-openai-extension/src/index.ts
@@ -217,6 +217,11 @@ export default class JanInferenceOpenAIExtension implements InferenceExtension {
         events.emit(EventName.OnMessageUpdate, message);
       },
       error: async (err) => {
+        if (instance.isCancelled) {
+          message.status = MessageStatus.Ready;
+          events.emit(EventName.OnMessageUpdate, message);
+          return;
+        }
         const messageContent: ThreadContent = {
           type: ContentType.Text,
           text: {

--- a/web/screens/Chat/MessageToolbar/index.tsx
+++ b/web/screens/Chat/MessageToolbar/index.tsx
@@ -1,14 +1,12 @@
 import {
-  EventName,
   MessageStatus,
   ExtensionType,
   ThreadMessage,
-  events,
   ChatCompletionRole,
 } from '@janhq/core'
-import { ConversationalExtension, InferenceExtension } from '@janhq/core'
+import { ConversationalExtension } from '@janhq/core'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { RefreshCcw, Copy, Trash2Icon, StopCircle } from 'lucide-react'
+import { RefreshCcw, Copy, Trash2Icon } from 'lucide-react'
 
 import { twMerge } from 'tailwind-merge'
 
@@ -28,17 +26,6 @@ const MessageToolbar = ({ message }: { message: ThreadMessage }) => {
   const thread = useAtomValue(activeThreadAtom)
   const messages = useAtomValue(getCurrentChatMessagesAtom)
   const { resendChatMessage } = useSendChatMessage()
-
-  const onStopInferenceClick = async () => {
-    events.emit(EventName.OnInferenceStopped, {})
-
-    setTimeout(() => {
-      events.emit(EventName.OnMessageUpdate, {
-        ...message,
-        status: MessageStatus.Ready,
-      })
-    }, 300)
-  }
 
   const onDeleteClick = async () => {
     deleteMessage(message.id ?? '')
@@ -60,26 +47,19 @@ const MessageToolbar = ({ message }: { message: ThreadMessage }) => {
     resendChatMessage(message)
   }
 
+  if (message.status !== MessageStatus.Ready) return null
+
   return (
     <div className={twMerge('flex flex-row items-center')}>
       <div className="flex overflow-hidden rounded-md border border-border bg-background/20">
-        {message.status === MessageStatus.Pending && (
+        {message.id === messages[messages.length - 1]?.id && (
           <div
             className="cursor-pointer border-r border-border px-2 py-2 hover:bg-background/80"
-            onClick={onStopInferenceClick}
+            onClick={onRegenerateClick}
           >
-            <StopCircle size={14} />
+            <RefreshCcw size={14} />
           </div>
         )}
-        {message.status !== MessageStatus.Pending &&
-          message.id === messages[messages.length - 1]?.id && (
-            <div
-              className="cursor-pointer border-r border-border px-2 py-2 hover:bg-background/80"
-              onClick={onRegenerateClick}
-            >
-              <RefreshCcw size={14} />
-            </div>
-          )}
         <div
           className="cursor-pointer border-r border-border px-2 py-2 hover:bg-background/80"
           onClick={() => {
@@ -91,14 +71,12 @@ const MessageToolbar = ({ message }: { message: ThreadMessage }) => {
         >
           <Copy size={14} />
         </div>
-        {message.status === MessageStatus.Ready && (
-          <div
-            className="cursor-pointer px-2 py-2 hover:bg-background/80"
-            onClick={onDeleteClick}
-          >
-            <Trash2Icon size={14} />
-          </div>
-        )}
+        <div
+          className="cursor-pointer px-2 py-2 hover:bg-background/80"
+          onClick={onDeleteClick}
+        >
+          <Trash2Icon size={14} />
+        </div>
       </div>
     </div>
   )

--- a/web/screens/Chat/index.tsx
+++ b/web/screens/Chat/index.tsx
@@ -1,9 +1,11 @@
 import { ChangeEvent, Fragment, KeyboardEvent, useEffect, useRef } from 'react'
 
+import { EventName, MessageStatus, events } from '@janhq/core'
 import { Button, Textarea } from '@janhq/uikit'
 
 import { useAtom, useAtomValue } from 'jotai'
 
+import { StopCircle } from 'lucide-react'
 import { twMerge } from 'tailwind-merge'
 
 import LogoMark from '@/containers/Brand/Logo/Mark'
@@ -26,6 +28,7 @@ import ThreadList from '@/screens/Chat/ThreadList'
 
 import Sidebar, { showRightSideBarAtom } from './Sidebar'
 
+import { getCurrentChatMessagesAtom } from '@/helpers/atoms/ChatMessage.atom'
 import {
   activeThreadAtom,
   getActiveThreadIdAtom,
@@ -40,6 +43,7 @@ const ChatScreen = () => {
 
   const { activeModel, stateModel } = useActiveModel()
   const { setMainViewState } = useMainViewState()
+  const messages = useAtomValue(getCurrentChatMessagesAtom)
 
   const [currentPrompt, setCurrentPrompt] = useAtom(currentPromptAtom)
   const activeThreadState = useAtomValue(activeThreadStateAtom)
@@ -92,6 +96,10 @@ const ChatScreen = () => {
         sendChatMessage()
       }
     }
+  }
+
+  const onStopInferenceClick = async () => {
+    events.emit(EventName.OnInferenceStopped, {})
   }
 
   return (
@@ -159,14 +167,26 @@ const ChatScreen = () => {
                 onPromptChange(e)
               }
             />
-            <Button
-              size="lg"
-              disabled={disabled || stateModel.loading || !activeThread}
-              themes={'primary'}
-              onClick={sendChatMessage}
-            >
-              Send
-            </Button>
+            {messages[messages.length - 1]?.status !== MessageStatus.Pending ? (
+              <Button
+                size="lg"
+                disabled={disabled || stateModel.loading || !activeThread}
+                themes="primary"
+                className="min-w-[100px]"
+                onClick={sendChatMessage}
+              >
+                Send
+              </Button>
+            ) : (
+              <Button
+                size="lg"
+                themes="danger"
+                onClick={onStopInferenceClick}
+                className="min-w-[100px]"
+              >
+                <StopCircle size={24} />
+              </Button>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
#925 

Testing scenario:

- Retry, copy, delete button show after response is complete.
- Send button become into Stop inference when response incomplete

Result:

<img width="687" alt="Screenshot 2023-12-14 at 16 30 15" src="https://github.com/janhq/jan/assets/10354610/880e1c86-9c2e-42e2-9a3d-11f17ce8c2d4">


https://github.com/janhq/jan/assets/10354610/80e73310-391d-4313-9bfb-7743e1f62d0a

