### PR TITLE
chore: read engine.json for openai chat_completion

### DIFF
--- a/extensions/model-extension/src/index.ts
+++ b/extensions/model-extension/src/index.ts
@@ -172,8 +172,8 @@ export default class JanModelExtension implements ModelExtension {
 
       const allDirectories: string[] = []
       for (const file of files) {
-        //TODO: add back directory check
-        if (!file.includes('.')) allDirectories.push(file)
+        if (file === '.DS_Store') continue
+        allDirectories.push(file)
       }
 
       const readJsonPromises = allDirectories.map((dirName) => {


### PR DESCRIPTION
- [x] Read API configuration from `engine.json` instead of sending it over API call.
- [x] Fix an issue that can't read model which has `.` in its name.