### PR TITLE
Add a default system message for every model on Jan

### DIFF
--- a/models/capybara-34b/model.json
+++ b/models/capybara-34b/model.json
@@ -8,7 +8,8 @@
     "format": "gguf",
     "settings": {
       "ctx_len": 4096,
-      "prompt_template": "USER:\n{prompt}\nASSISTANT:"
+      "prompt_template": "USER:\n{prompt}\nASSISTANT:",
+      "pre_prompt": "You are a helpful assistant, developed by Jan Company and utilizing your general knowledge understanding and you answer questions from a user by breaking down the query step by step, ensuring to fulfill the users' needs."
     },
     "parameters": {
       "max_tokens": 4096

--- a/models/deepseek-coder-1.3b/model.json
+++ b/models/deepseek-coder-1.3b/model.json
@@ -9,7 +9,8 @@
     "format": "gguf",
     "settings": {
       "ctx_len": 4096,
-      "prompt_template": "### Instruction:\n{prompt}\n### Response:"
+      "prompt_template": "### Instruction:\n{prompt}\n### Response:",
+      "pre_prompt": "You are a helpful assistant, developed by Jan Company and utilizing your general knowledge understanding and you answer questions from a user by breaking down the query step by step, ensuring to fulfill the users' needs."
     },
     "parameters": {
       "max_tokens": 4096

--- a/models/deepseek-coder-34b/model.json
+++ b/models/deepseek-coder-34b/model.json
@@ -8,7 +8,8 @@
     "format": "gguf",
     "settings": {
       "ctx_len": 4096,
-      "prompt_template": "### Instruction:\n{prompt}\n### Response:"
+      "prompt_template": "### Instruction:\n{prompt}\n### Response:",
+      "pre_prompt": "You are a helpful assistant, developed by Jan Company and utilizing your general knowledge understanding and you answer questions from a user by breaking down the query step by step, ensuring to fulfill the users' needs."
     },
     "parameters": {
       "max_tokens": 4096

--- a/models/llama2-chat-70b-q4/model.json
+++ b/models/llama2-chat-70b-q4/model.json
@@ -8,7 +8,8 @@
     "format": "gguf",
     "settings": {
       "ctx_len": 4096,
-      "prompt_template": "[INST] <<SYS>>\n{system_message}<</SYS>>\n{prompt}[/INST]"
+      "prompt_template": "[INST] <<SYS>>\n{system_message}<</SYS>>\n{prompt}[/INST]",
+      "pre_prompt": "You are a helpful assistant, developed by Jan Company and utilizing your general knowledge understanding and you answer questions from a user by breaking down the query step by step, ensuring to fulfill the users' needs."
     },
     "parameters": {
       "max_tokens": 4096

--- a/models/llama2-chat-7b-q4/model.json
+++ b/models/llama2-chat-7b-q4/model.json
@@ -8,7 +8,8 @@
     "format": "gguf",
     "settings": {
       "ctx_len": 4096,
-      "prompt_template": "[INST] <<SYS>>\n{system_message}<</SYS>>\n{prompt}[/INST]"
+      "prompt_template": "[INST] <<SYS>>\n{system_message}<</SYS>>\n{prompt}[/INST]",
+      "pre_prompt": "You are a helpful assistant, developed by Jan Company and utilizing your general knowledge understanding and you answer questions from a user by breaking down the query step by step, ensuring to fulfill the users' needs."
     },
     "parameters": {
       "max_tokens": 4096

--- a/models/lzlv-70b/model.json
+++ b/models/lzlv-70b/model.json
@@ -8,7 +8,8 @@
     "format": "gguf",
     "settings": {
       "ctx_len": 4096,
-      "prompt_template": "USER:\n{prompt}\nASSISTANT:"
+      "prompt_template": "USER:\n{prompt}\nASSISTANT:",
+      "pre_prompt": "You are a helpful assistant, developed by Jan Company and utilizing your general knowledge understanding and you answer questions from a user by breaking down the query step by step, ensuring to fulfill the users' needs."
     },
     "parameters": {
       "max_tokens": 4096

--- a/models/mistral-ins-7b-q4/model.json
+++ b/models/mistral-ins-7b-q4/model.json
@@ -11,7 +11,8 @@
       "system_prompt": "",
       "user_prompt": "<s>[INST]",
       "ai_prompt": "[/INST]",
-      "prompt_template": "<s>[INST]{prompt}\n[/INST]"
+      "prompt_template": "<s>[INST]{prompt}\n[/INST]",
+      "pre_prompt": "You are a helpful assistant, developed by Jan Company and utilizing your general knowledge understanding and you answer questions from a user by breaking down the query step by step, ensuring to fulfill the users' needs."
     },
     "parameters": {
       "max_tokens": 4096

--- a/models/mixtral-8x7b-instruct/model.json
+++ b/models/mixtral-8x7b-instruct/model.json
@@ -8,7 +8,8 @@
     "format": "gguf",
     "settings": {
       "ctx_len": 4096,
-      "prompt_template": "[INST] {prompt} [/INST]"
+      "prompt_template": "[INST] {prompt} [/INST]",
+      "pre_prompt": "You are a helpful assistant, developed by Jan Company and utilizing your general knowledge understanding and you answer questions from a user by breaking down the query step by step, ensuring to fulfill the users' needs."
     },
     "parameters": {
       "max_tokens": 4096

--- a/models/noromaid-20b/model.json
+++ b/models/noromaid-20b/model.json
@@ -8,7 +8,8 @@
     "format": "gguf",
     "settings": {
       "ctx_len": 4096,
-      "prompt_template": "### Instruction:{prompt}\n### Response:"
+      "prompt_template": "### Instruction:{prompt}\n### Response:",
+      "pre_prompt": "You are a helpful assistant, developed by Jan Company and utilizing your general knowledge understanding and you answer questions from a user by breaking down the query step by step, ensuring to fulfill the users' needs."
     },
     "parameters": {
       "max_tokens": 4096

--- a/models/openhermes-neural-7b/model.json
+++ b/models/openhermes-neural-7b/model.json
@@ -8,7 +8,8 @@
     "format": "gguf",
     "settings": {
       "ctx_len": 4096,
-      "prompt_template": "<|im_start|>system\n{system_message}<|im_end|>\n<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant"
+      "prompt_template": "<|im_start|>system\n{system_message}<|im_end|>\n<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant",
+      "pre_prompt": "You are a helpful assistant, developed by Jan Company and utilizing your general knowledge understanding and you answer questions from a user by breaking down the query step by step, ensuring to fulfill the users' needs."
     },
     "parameters": {
       "max_tokens": 4096

--- a/models/pandora-10.7b-v1/model.json
+++ b/models/pandora-10.7b-v1/model.json
@@ -8,7 +8,8 @@
     "format": "gguf",
     "settings": {
       "ctx_len": 4096,
-      "prompt_template": "<|im_start|>system\n{system_message}<|im_end|>\n<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant"
+      "prompt_template": "<|im_start|>system\n{system_message}<|im_end|>\n<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant",
+      "pre_prompt": "You are a helpful assistant, developed by Jan Company and utilizing your general knowledge understanding and you answer questions from a user by breaking down the query step by step, ensuring to fulfill the users' needs."
     },
     "parameters": {
       "max_tokens": 4096

--- a/models/phind-34b/model.json
+++ b/models/phind-34b/model.json
@@ -8,7 +8,8 @@
     "format": "gguf",
     "settings": {
       "ctx_len": 4096,
-      "prompt_template": "### System Prompt\n{system_message}\n### User Message\n{prompt}\n### Assistant"
+      "prompt_template": "### System Prompt\n{system_message}\n### User Message\n{prompt}\n### Assistant",
+      "pre_prompt": "You are a helpful assistant, developed by Jan Company and utilizing your general knowledge understanding and you answer questions from a user by breaking down the query step by step, ensuring to fulfill the users' needs."
     },
     "parameters": {
       "max_tokens": 4096

--- a/models/solar-10.7b-instruct/model.json
+++ b/models/solar-10.7b-instruct/model.json
@@ -8,7 +8,8 @@
     "format": "gguf",
     "settings": {
       "ctx_len": 4096,
-      "prompt_template": "### User: {prompt}\n### Assistant:"
+      "prompt_template": "### User: {prompt}\n### Assistant:",
+      "pre_prompt": "You are a helpful assistant, developed by Jan Company and utilizing your general knowledge understanding and you answer questions from a user by breaking down the query step by step, ensuring to fulfill the users' needs."
     },
     "parameters": {
       "max_tokens": 4096

--- a/models/solar-10.7b-slerp/model.json
+++ b/models/solar-10.7b-slerp/model.json
@@ -8,7 +8,8 @@
     "format": "gguf",
     "settings": {
       "ctx_len": 4096,
-      "prompt_template": "### User: {prompt}\n### Assistant:"
+      "prompt_template": "### User: {prompt}\n### Assistant:",
+      "pre_prompt": "You are a helpful assistant, developed by Jan Company and utilizing your general knowledge understanding and you answer questions from a user by breaking down the query step by step, ensuring to fulfill the users' needs."
     },
     "parameters": {
       "max_tokens": 4096

--- a/models/starling-7b/model.json
+++ b/models/starling-7b/model.json
@@ -8,7 +8,8 @@
     "format": "gguf",
     "settings": {
       "ctx_len": 4096,
-      "prompt_template": "GPT4 User: {prompt}<|end_of_turn|>GPT4 Assistant:"
+      "prompt_template": "GPT4 User: {prompt}<|end_of_turn|>GPT4 Assistant:",
+      "pre_prompt": "You are a helpful assistant, developed by Jan Company and utilizing your general knowledge understanding and you answer questions from a user by breaking down the query step by step, ensuring to fulfill the users' needs."
     },
     "parameters": {
       "max_tokens": 4096

--- a/models/tinyllama-1.1b/model.json
+++ b/models/tinyllama-1.1b/model.json
@@ -8,7 +8,8 @@
   "format": "gguf",
   "settings": {
       "ctx_len": 2048,
-      "prompt_template": "<|system|>\n{system_message}<|user|>\n{prompt}<|assistant|>"
+      "prompt_template": "<|system|>\n{system_message}<|user|>\n{prompt}<|assistant|>",
+      "pre_prompt": "You are a helpful assistant, developed by Jan Company and utilizing your general knowledge understanding and you answer questions from a user by breaking down the query step by step, ensuring to fulfill the users' needs."
   },
   "parameters": {
       "max_tokens": 2048

--- a/models/trinity-v1-7b/model.json
+++ b/models/trinity-v1-7b/model.json
@@ -8,7 +8,7 @@
     "format": "gguf",
     "settings": {
       "ctx_len": 4096,
-      "prompt_template": "<|im_start|>system\n{system_message}<|im_end|>\n<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant",
+      "prompt_template": "{system_message}\n### Instruction:\n{prompt}\n### Response:\n",
       "pre_prompt": "You are a helpful assistant, developed by Jan Company and utilizing your general knowledge understanding and you answer questions from a user by breaking down the query step by step, ensuring to fulfill the users' needs."
     },
     "parameters": {

--- a/models/trinity-v1-7b/model.json
+++ b/models/trinity-v1-7b/model.json
@@ -8,7 +8,8 @@
     "format": "gguf",
     "settings": {
       "ctx_len": 4096,
-      "prompt_template": "<|im_start|>system\n{system_message}<|im_end|>\n<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant"
+      "prompt_template": "<|im_start|>system\n{system_message}<|im_end|>\n<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant",
+      "pre_prompt": "You are a helpful assistant, developed by Jan Company and utilizing your general knowledge understanding and you answer questions from a user by breaking down the query step by step, ensuring to fulfill the users' needs."
     },
     "parameters": {
       "max_tokens": 4096

--- a/models/wizardcoder-13b/model.json
+++ b/models/wizardcoder-13b/model.json
@@ -8,7 +8,8 @@
     "format": "gguf",
     "settings": {
       "ctx_len": 4096,
-      "prompt_template": "### Instruction:\n{prompt}\n### Response:"
+      "prompt_template": "### Instruction:\n{prompt}\n### Response:",
+      "pre_prompt": "You are a helpful assistant, developed by Jan Company and utilizing your general knowledge understanding and you answer questions from a user by breaking down the query step by step, ensuring to fulfill the users' needs."
     },
     "parameters": {
       "max_tokens": 4096

--- a/models/yi-34b/model.json
+++ b/models/yi-34b/model.json
@@ -8,7 +8,8 @@
     "format": "gguf",
     "settings": {
       "ctx_len": 4096,
-      "prompt_template": "<|im_start|>system\n{system_message}<|im_end|>\n<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant"
+      "prompt_template": "<|im_start|>system\n{system_message}<|im_end|>\n<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant",
+      "pre_prompt": "You are a helpful assistant, developed by Jan Company and utilizing your general knowledge understanding and you answer questions from a user by breaking down the query step by step, ensuring to fulfill the users' needs."
     },
     "parameters": {
       "max_tokens": 4096


### PR DESCRIPTION
**Motivation**
Models can give random symbols due to missing `system_message` or wrong `prompt_template`
See : https://github.com/janhq/jan/issues/1048

**In this PR**
I tested out and proposed 2 ways to fix the problems
- [x] Update the `pre_prompt` for every model
- [x] Update the `prompt_template` for Trinity

**Context**

1. For the template has `{system_message}` The `pre_prompt` will automatically replace `{system_message}` by default whenever the model is loaded. For e.g. ChatML:

- Now:
<|im_start|>system\n{system_message}<|im_end|>\n<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant

- Expected:
<|im_start|>system\nyou are a helpful assistant<|im_end|>\n<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant

2. For the template DOESN'T have `{system_message}` The `pre_prompt` will automatically append as the first message with a newline (\n). For e.g.

- Now: 
### Instruction:\n{prompt}\n### Response:

- Expected:
You are a helpful assistant\n### Instruction:\n{prompt}\n### Response:

- 3. Users want to add a custom `system_prompt`. It will overwrite the `pre_prompt`
(Let's discuss more on this)

Please ping me if you need context and information