### PR TITLE
feat: copy button for code block

### DIFF
--- a/web/hooks/useClipboard.ts
+++ b/web/hooks/useClipboard.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { useState } from 'react'
+
+export function useClipboard({ timeout = 2000 } = {}) {
+  const [error, setError] = useState<Error | null>(null)
+  const [copied, setCopied] = useState(false)
+  const [copyTimeout, setCopyTimeout] = useState<number | null>(null)
+
+  const handleCopyResult = (value: boolean) => {
+    window.clearTimeout(copyTimeout!)
+    setCopyTimeout(window.setTimeout(() => setCopied(false), timeout))
+    setCopied(value)
+  }
+
+  const copy = (valueToCopy: any) => {
+    if ('clipboard' in navigator) {
+      navigator.clipboard
+        .writeText(valueToCopy)
+        .then(() => handleCopyResult(true))
+        .catch((err) => setError(err))
+    } else {
+      setError(new Error('useClipboard: navigator.clipboard is not supported'))
+    }
+  }
+
+  const reset = () => {
+    setCopied(false)
+    setError(null)
+    window.clearTimeout(copyTimeout!)
+  }
+
+  return { copy, reset, error, copied }
+}

--- a/web/screens/Chat/MessageToolbar/index.tsx
+++ b/web/screens/Chat/MessageToolbar/index.tsx
@@ -6,12 +6,11 @@ import {
 } from '@janhq/core'
 import { ConversationalExtension } from '@janhq/core'
 import { useAtomValue, useSetAtom } from 'jotai'
-import { RefreshCcw, Copy, Trash2Icon } from 'lucide-react'
+import { RefreshCcw, CopyIcon, Trash2Icon, CheckIcon } from 'lucide-react'
 
 import { twMerge } from 'tailwind-merge'
 
-import { toaster } from '@/containers/Toast'
-
+import { useClipboard } from '@/hooks/useClipboard'
 import useSendChatMessage from '@/hooks/useSendChatMessage'
 
 import { extensionManager } from '@/extension'
@@ -26,6 +25,7 @@ const MessageToolbar = ({ message }: { message: ThreadMessage }) => {
   const thread = useAtomValue(activeThreadAtom)
   const messages = useAtomValue(getCurrentChatMessagesAtom)
   const { resendChatMessage } = useSendChatMessage()
+  const clipboard = useClipboard({ timeout: 1000 })
 
   const onDeleteClick = async () => {
     deleteMessage(message.id ?? '')
@@ -63,13 +63,14 @@ const MessageToolbar = ({ message }: { message: ThreadMessage }) => {
         <div
           className="cursor-pointer border-r border-border px-2 py-2 hover:bg-background/80"
           onClick={() => {
-            navigator.clipboard.writeText(message.content[0]?.text?.value ?? '')
-            toaster({
-              title: 'Copied to clipboard',
-            })
+            clipboard.copy(message.content[0]?.text?.value ?? '')
           }}
         >
-          <Copy size={14} />
+          {clipboard.copied ? (
+            <CheckIcon size={14} className="text-green-600" />
+          ) : (
+            <CopyIcon size={14} />
+          )}
         </div>
         <div
           className="cursor-pointer px-2 py-2 hover:bg-background/80"


### PR DESCRIPTION
#908 

### Test scenario
- Chat with any model
- Ask regarding programing
- Make sure the answer including code block, hover the code block you will see the copy button, try copy and paste anywere

### Success Criteria
- User can copy code block easily 

### UI visual

1. When hovering code block
<img width="1567" alt="Screenshot 2023-12-18 at 20 19 05" src="https://github.com/janhq/jan/assets/10354610/d828a78e-092e-41b7-8d86-02fa6015efb2">

2. When copied code block
<img width="1567" alt="Screenshot 2023-12-18 at 20 19 50" src="https://github.com/janhq/jan/assets/10354610/cab174ef-d5b5-4e84-af5e-3c604772cc73">
