### PR TITLE
bug: chatbox doesn't resize back down

### DIFF
--- a/web/screens/Chat/index.tsx
+++ b/web/screens/Chat/index.tsx
@@ -75,19 +75,14 @@ const ChatScreen = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [waitingToSendMessage, activeThreadId])
 
-  useEffect(() => {
-    if (textareaRef.current !== null) {
-      const scrollHeight = textareaRef.current.scrollHeight
-      if (currentPrompt.length === 0) {
-        textareaRef.current.style.height = '40px'
-      } else {
-        textareaRef.current.style.height = `${
-          scrollHeight < 40 ? 40 : scrollHeight
-        }px`
-      }
+  const resizeTextArea = () => {
+    if (textareaRef.current) {
+      textareaRef.current.style.height = '40px'
+      textareaRef.current.style.height = textareaRef.current.scrollHeight + 'px'
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentPrompt])
+  }
+
+  useEffect(resizeTextArea, [currentPrompt])
 
   const onKeyDown = async (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter') {
@@ -155,7 +150,8 @@ const ChatScreen = () => {
           )}
           <div className="mx-auto flex w-full flex-shrink-0 items-end justify-center space-x-4 px-8 py-4">
             <Textarea
-              className="min-h-10 h-10 max-h-[400px] resize-none pr-20"
+              className="max-h-[400px] resize-none overflow-y-hidden pr-20"
+              style={{ height: '40px' }}
               ref={textareaRef}
               onKeyDown={(e: KeyboardEvent<HTMLTextAreaElement>) =>
                 onKeyDown(e)

--- a/web/screens/Settings/Models/Row.tsx
+++ b/web/screens/Settings/Models/Row.tsx
@@ -47,7 +47,9 @@ export default function RowModel(props: RowModelProps) {
       <td className="px-6 py-4 font-bold">{props.data.id}</td>
       <td className="px-6 py-4">
         <Badge themes="secondary">
-          {toGigabytes(props.data.metadata.size)}
+          {props.data.metadata.size
+            ? toGigabytes(props.data.metadata.size)
+            : '-'}
         </Badge>
       </td>
       <td className="px-6 py-4">


### PR DESCRIPTION
#1045 

### Testing scenario
- Create new thread
- Type long message on `chatbox` / `textarea`
- Remove several word, make sure the box should be auto resize perfectly

### Screenshots
<img width="1456" alt="Screenshot 2023-12-19 at 10 38 14" src="https://github.com/janhq/jan/assets/10354610/b2b53405-d278-4052-af9b-1fbfb8793629">
<img width="1456" alt="Screenshot 2023-12-19 at 10 38 07" src="https://github.com/janhq/jan/assets/10354610/dcd90c8a-2cf0-4f77-a5d3-126c7c252652">
