### PR TITLE
fix: system monitor broken layout when responsive

### DIFF
--- a/web/screens/SystemMonitor/index.tsx
+++ b/web/screens/SystemMonitor/index.tsx
@@ -25,13 +25,13 @@ export default function SystemMonitorScreen() {
       <ScrollArea className="h-full w-full">
         <div className="h-full p-8" data-test-id="testid-system-monitor">
           <div className="grid grid-cols-2 gap-8 lg:grid-cols-3">
-            <div className="rounded-xl border border-border px-8 py-6">
+            <div className="rounded-xl border border-border p-4">
               <div className="flex items-center justify-between">
                 <h4 className="text-base font-bold uppercase">
                   ram ({Math.round((usedRam / totalRam) * 100)}%)
                 </h4>
                 <span className="text-xs text-muted-foreground">
-                  {toGigabytes(usedRam)} GB of {toGigabytes(totalRam)} GB used
+                  {toGigabytes(usedRam)} of {toGigabytes(totalRam)} used
                 </span>
               </div>
               <div className="mt-2">
@@ -41,7 +41,7 @@ export default function SystemMonitorScreen() {
                 />
               </div>
             </div>
-            <div className="rounded-xl border border-border px-8 py-6">
+            <div className="rounded-xl border border-border p-4">
               <div className="flex items-center justify-between">
                 <h4 className="text-base font-bold uppercase">
                   cpu ({cpuUsage}%)


### PR DESCRIPTION
fixes #177

### Issue
<img width="739" alt="Screenshot 2023-12-19 at 11 09 16" src="https://github.com/janhq/jan/assets/10354610/b9af3c3c-0971-4fd5-b7da-20508580a5d2">

### Solution
- Decrease padding
- Remove multiple `GB` on the title

### Screenshot
<img width="1312" alt="Screenshot_2023-12-19_at_11 05 04" src="https://github.com/janhq/jan/assets/10354610/819d6fd9-6a83-44cc-b960-bb220ef4d979">
