### PR TITLE
fix: added dialog confirmation when delete thread

### DIFF
--- a/uikit/src/button/styles.scss
+++ b/uikit/src/button/styles.scss
@@ -1,6 +1,6 @@
 .btn {
   @apply inline-flex items-center justify-center whitespace-nowrap rounded-lg font-semibold transition-colors;
-  @apply focus-visible:ring-ring cursor-pointer focus-visible:outline-none focus-visible:ring-1;
+  @apply cursor-pointer focus:outline-none focus-visible:outline-none focus-visible:ring-0;
   @apply disabled:pointer-events-none disabled:opacity-50;
 
   &-primary {
@@ -28,7 +28,7 @@
   }
 
   &-ghost {
-    @apply hover:bg-primary hover:text-primary-foreground;
+    @apply hover:bg-secondary hover:text-secondary-foreground;
   }
 
   &-sm {

--- a/web/screens/Chat/ThreadList/index.tsx
+++ b/web/screens/Chat/ThreadList/index.tsx
@@ -1,5 +1,16 @@
 import { useEffect } from 'react'
 
+import {
+  Modal,
+  ModalTrigger,
+  ModalClose,
+  ModalFooter,
+  ModalContent,
+  ModalHeader,
+  ModalTitle,
+  Button,
+} from '@janhq/uikit'
+
 import { motion as m } from 'framer-motion'
 import { useAtomValue } from 'jotai'
 import {
@@ -107,15 +118,40 @@ export default function ThreadList() {
                       Clean thread
                     </span>
                   </div>
-                  <div
-                    className="flex cursor-pointer items-center space-x-2 px-4 py-2 hover:bg-secondary"
-                    onClick={() => deleteThread(thread.id)}
-                  >
-                    <Trash2Icon size={16} className="text-muted-foreground" />
-                    <span className="text-bold text-black dark:text-muted-foreground">
-                      Delete thread
-                    </span>
-                  </div>
+                  <Modal>
+                    <ModalTrigger asChild>
+                      <div className="flex cursor-pointer items-center space-x-2 px-4 py-2 hover:bg-secondary">
+                        <Trash2Icon
+                          size={16}
+                          className="text-muted-foreground"
+                        />
+                        <span className="text-bold text-black dark:text-muted-foreground">
+                          Delete thread
+                        </span>
+                      </div>
+                    </ModalTrigger>
+                    <ModalContent>
+                      <ModalHeader>
+                        <ModalTitle>Delete Thread</ModalTitle>
+                      </ModalHeader>
+                      <p>Are you sure you want to delete Thread?</p>
+                      <ModalFooter>
+                        <div className="flex gap-x-2">
+                          <ModalClose asChild>
+                            <Button themes="ghost">No</Button>
+                          </ModalClose>
+                          <ModalClose asChild>
+                            <Button
+                              themes="danger"
+                              onClick={() => deleteThread(thread.id)}
+                            >
+                              Yes
+                            </Button>
+                          </ModalClose>
+                        </div>
+                      </ModalFooter>
+                    </ModalContent>
+                  </Modal>
                 </div>
               </div>
               {/* {messages.length > 0 && (

--- a/web/screens/Chat/ThreadList/index.tsx
+++ b/web/screens/Chat/ThreadList/index.tsx
@@ -134,7 +134,7 @@ export default function ThreadList() {
                       <ModalHeader>
                         <ModalTitle>Delete Thread</ModalTitle>
                       </ModalHeader>
-                      <p>Are you sure you want to delete Thread?</p>
+                      <p>Are you sure you want to delete this thread?</p>
                       <ModalFooter>
                         <div className="flex gap-x-2">
                           <ModalClose asChild>


### PR DESCRIPTION
#1087 

### Testing scenario
- Create some of threads
- Click on the '...' to see delete option then delete
- Make sure wow we have dialog confirmation for user and action `yes` or `no`
- Yes --> delete Thread , No ---> Close dialog

### Screenshots
<img width="1518" alt="Screenshot 2023-12-19 at 13 28 59" src="https://github.com/janhq/jan/assets/10354610/8b92e955-1f49-4dd1-9791-05e93c74f8d7">
<img width="1518" alt="Screenshot 2023-12-19 at 13 24 22" src="https://github.com/janhq/jan/assets/10354610/971d713a-fc0d-4c18-af21-7c8d65da5eda">
