### PR TITLE
fix: update copy setting page

### DIFF
--- a/web/screens/Settings/Appearance/index.tsx
+++ b/web/screens/Settings/Appearance/index.tsx
@@ -6,15 +6,19 @@ export default function AppearanceOptions() {
     <div className="block w-full">
       <div className="flex w-full items-center justify-between border-b border-border py-3 first:pt-0 last:border-none">
         <div className="flex-shrink-0 space-y-1">
-          <h6 className="text-sm font-semibold capitalize">Themes</h6>
-          <p className="leading-relaxed ">Choose your default theme.</p>
+          <h6 className="text-sm font-semibold capitalize">
+            Base color scheme
+          </h6>
+          <p className="leading-relaxed ">Choose Jan default color scheme.</p>
         </div>
         <ToggleTheme />
       </div>
       <div className="flex w-full items-center justify-between border-b border-border py-3 first:pt-0 last:border-none">
         <div className="flex-shrink-0 space-y-1">
-          <h6 className="text-sm font-semibold capitalize">Primary color</h6>
-          <p className="leading-relaxed ">Choose your primary color.</p>
+          <h6 className="text-sm font-semibold capitalize">Accent Color</h6>
+          <p className="leading-relaxed ">
+            Choose the accent color used throughout the app.
+          </p>
         </div>
         <ToggleAccent />
       </div>


### PR DESCRIPTION
fixes #1082 

### Test scenario 
- Go to Setting page - Appearance
- Make sure copy already update

### Screenshots
- Before
<img width="740" alt="Screenshot 2023-12-19 at 20 51 08" src="https://github.com/janhq/jan/assets/10354610/43809ba7-4f91-4466-92df-e71d7b6d7575">

- After
<img width="1396" alt="Screenshot 2023-12-19 at 20 51 15" src="https://github.com/janhq/jan/assets/10354610/12bb5c31-edaf-4877-b0c4-b736f103c6c8">
