### PR TITLE
fix: model active indicator only show when model activated

### DIFF
--- a/web/containers/Layout/BottomBar/index.tsx
+++ b/web/containers/Layout/BottomBar/index.tsx
@@ -46,12 +46,12 @@ const BottomBar = () => {
         )}
         {!stateModel.loading && downloadedModels.length !== 0 && (
           <SystemItem
-            name="Active model:"
+            name={activeModel?.id ? 'Active model:' : ''}
             value={
               activeModel?.id || (
                 <Badge themes="outline" className="pl-1">
                   <ShortCut menu="E" />
-                  &nbsp; to show your model
+                  &nbsp; to view models
                 </Badge>
               )
             }


### PR DESCRIPTION
fixes #1083

<img width="1567" alt="Screenshot 2023-12-20 at 14 29 39" src="https://github.com/janhq/jan/assets/10354610/77cfea2b-2f7b-4f1a-bfc1-e698ac7c41f2">

