### PR TITLE
fix: toaster success deleted thread showing id instead of active model

### DIFF
--- a/web/hooks/useDeleteThread.ts
+++ b/web/hooks/useDeleteThread.ts
@@ -10,8 +10,6 @@ import { currentPromptAtom } from '@/containers/Providers/Jotai'
 
 import { toaster } from '@/containers/Toast'
 
-import { useActiveModel } from './useActiveModel'
-
 import { extensionManager } from '@/extension/ExtensionManager'
 
 import {
@@ -27,7 +25,6 @@ import {
 } from '@/helpers/atoms/Thread.atom'
 
 export default function useDeleteThread() {
-  const { activeModel } = useActiveModel()
   const [threads, setThreads] = useAtom(threadsAtom)
   const setCurrentPrompt = useSetAtom(currentPromptAtom)
   const messages = useAtomValue(getCurrentChatMessagesAtom)
@@ -77,7 +74,7 @@ export default function useDeleteThread() {
         setCurrentPrompt('')
         toaster({
           title: 'Thread successfully deleted.',
-          description: `Thread with ${activeModel?.name} has been successfully deleted.`,
+          description: `Thread ${threadId} has been successfully deleted.`,
         })
       }
 


### PR DESCRIPTION
fixes #1107 

<img width="450" alt="Screenshot 2023-12-20 at 14 39 55" src="https://github.com/janhq/jan/assets/10354610/7df336dc-a9fc-4257-a3f8-aa4ecc29a8ae">
