### PR TITLE
fix: handle chat completion state with enter button

### DIFF
--- a/web/screens/Chat/index.tsx
+++ b/web/screens/Chat/index.tsx
@@ -86,7 +86,9 @@ const ChatScreen = () => {
     if (e.key === 'Enter') {
       if (!e.shiftKey) {
         e.preventDefault()
-        sendChatMessage()
+        if (messages[messages.length - 1]?.status !== MessageStatus.Pending)
+          sendChatMessage()
+        else onStopInferenceClick()
       }
     }
   }


### PR DESCRIPTION
## Description
As mentioned in #1112, user can press Enter to send messages continuously, despite the current chat completion state. The Send button is changed to stop when generating, but the Enter button does not handle it. It just sends a message anyway.

## Changes
Check current state of the thread, if message is generating, press Enter will stop the stream, the same behavior as the send button. Otherwise send as a new message

## Issues
fixes #1112 