### PR TITLE
fix: should not hide empty message away

### DIFF
--- a/web/screens/Chat/ChatBody/index.tsx
+++ b/web/screens/Chat/ChatBody/index.tsx
@@ -117,11 +117,8 @@ const ChatBody: React.FC = () => {
         <ScrollToBottom className="flex h-full w-full flex-col">
           {messages.map((message, index) => (
             <>
-              {message.content.length ? (
-                <ChatItem {...message} key={message.id} />
-              ) : (
-                <></>
-              )}
+              <ChatItem {...message} key={message.id} />
+
               {message.status === MessageStatus.Error &&
                 index === messages.length - 1 && (
                   <div


### PR DESCRIPTION
## Description
The previous fix of hiding empty message is not a good approach, where the thread should reflect the entire message array even it is an empty message, so user can delete it.