### PR TITLE
refactor: exported modules from core with types

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -22,6 +22,27 @@
   "engines": {
     "node": ">=6.0.0"
   },
+  "exports": {
+    ".": "./dist/core.umd.js",
+    "./sdk": "./dist/core.umd.js",
+    "./node": "./dist/node/index.cjs.js"
+  },
+  "typesVersions": {
+    "*": {
+      ".": [
+        "./dist/core.es5.js.map",
+        "./dist/types/index.d.ts"
+      ],
+      "sdk": [
+        "./dist/core.es5.js.map",
+        "./dist/types/index.d.ts"
+      ],
+      "node": [
+        "./dist/node/index.cjs.js.map",
+        "./dist/types/node/index.d.ts"
+      ]
+    }
+  },
   "scripts": {
     "lint": "tslint  --project tsconfig.json -t codeFrame 'src/**/*.ts' 'test/**/*.ts'",
     "prebuild": "rimraf dist",

--- a/core/rollup.config.ts
+++ b/core/rollup.config.ts
@@ -38,7 +38,7 @@ export default [
   },
   {
     input: `src/node/index.ts`,
-    output: [{ file: 'dist/node/index.cjs', format: 'cjs', sourcemap: true }],
+    output: [{ file: 'dist/node/index.cjs.js', format: 'cjs', sourcemap: true }],
     // Indicate here external modules you don't wanna include in your bundle (i.e.: 'lodash')
     external: [
       'fs/promises',
@@ -52,7 +52,7 @@ export default [
       'request',
       'crypto',
       'url',
-      'http'
+      'http',
     ],
     watch: {
       include: 'src/node/**',

--- a/core/src/node/api/common/builder.ts
+++ b/core/src/node/api/common/builder.ts
@@ -330,6 +330,6 @@ const getEngineConfiguration = async (engineId: string) => {
   }
   const directoryPath = join(path, 'engines')
   const filePath = join(directoryPath, `${engineId}.json`)
-  const data = await fs.readFileSync(filePath, 'utf8')
+  const data = await fs.readFileSync(filePath, 'utf-8')
   return JSON.parse(data)
 }

--- a/core/src/node/api/routes/extension.ts
+++ b/core/src/node/api/routes/extension.ts
@@ -34,7 +34,7 @@ export const extensionRouter = async (app: HttpServer) => {
   app.post(`/${ExtensionRoute.invokeExtensionFunc}`, async (req, res) => {
     const args = JSON.parse(req.body as any)
     console.debug(args)
-    const module = require(join(userSpacePath, 'extensions', args[0]))
+    const module = await import(join(userSpacePath, 'extensions', args[0]))
 
     ModuleManager.instance.setModule(args[0], module)
     const method = args[1]

--- a/core/src/node/api/routes/fs.ts
+++ b/core/src/node/api/routes/fs.ts
@@ -1,19 +1,20 @@
 import { FileSystemRoute } from '../../../api'
 import { join } from 'path'
 import { HttpServer, userSpacePath } from '../../index'
-const fs = require('fs')
 
 export const fsRouter = async (app: HttpServer) => {
+  const moduleName = "fs"
   // Generate handlers for each fs route
   Object.values(FileSystemRoute).forEach((route) => {
     app.post(`/${route}`, async (req, res) => {
       const body = JSON.parse(req.body as any)
       try {
-        const result = await fs[route](
+        const result = await import(moduleName).then(mdl => { return mdl[route](
           ...body.map((arg: any) =>
             arg.includes('file:/') ? join(userSpacePath, arg.replace('file:/', '')) : arg,
           ),
         )
+        })
         res.status(200).send(result)
       } catch (ex) {
         console.log(ex)

--- a/core/src/node/api/routes/v1.ts
+++ b/core/src/node/api/routes/v1.ts
@@ -1,7 +1,7 @@
 import { HttpServer } from '../HttpServer'
 import { commonRouter, threadRouter, fsRouter, extensionRouter, downloadRouter } from './index'
 
-const v1Router = async (app: HttpServer) => {
+export const v1Router = async (app: HttpServer) => {
   // MARK: External Routes
   app.register(commonRouter)
   app.register(threadRouter, {
@@ -19,4 +19,3 @@ const v1Router = async (app: HttpServer) => {
     prefix: '/download',
   })
 }
-export default v1Router

--- a/core/src/node/extension/index.ts
+++ b/core/src/node/extension/index.ts
@@ -1,13 +1,5 @@
 import { readFileSync } from 'fs'
 
-let electron: any = undefined
-
-try {
-  electron = require('electron')
-} catch (err) {
-  console.error('Electron is not available')
-}
-
 import { normalize } from 'path'
 
 import Extension from './extension'
@@ -39,7 +31,16 @@ export function init(options: any) {
  * @private
  * @returns {boolean} Whether the protocol registration was successful
  */
-function registerExtensionProtocol() {
+async function registerExtensionProtocol() {
+  let electron: any = undefined
+
+  try {
+    const moduleName = "electron"
+    electron = await import(moduleName)
+  } catch (err) {
+    console.error('Electron is not available')
+  }
+  
   if (electron) {
     return electron.protocol.registerFileProtocol('extension', (request: any, callback: any) => {
       const entry = request.url.substr('extension://'.length - 1)

--- a/core/src/node/extension/manager.ts
+++ b/core/src/node/extension/manager.ts
@@ -2,11 +2,12 @@ import { join, resolve } from "path";
 
 import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { init } from "./index";
+import { homedir } from "os"
 /**
  * Manages extension installation and migration.
  */
 
-export const userSpacePath = join(require("os").homedir(), "jan");
+export const userSpacePath = join(homedir(), "jan");
 
 export class ExtensionManager {
   public static instance: ExtensionManager = new ExtensionManager();

--- a/core/tsconfig.json
+++ b/core/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "moduleResolution": "node",
     "target": "es5",
-    "module": "es2015",
+    "module": "ES2020",
     "lib": ["es2015", "es2016", "es2017", "dom"],
     "strict": true,
     "sourceMap": true,

--- a/electron/handlers/app.ts
+++ b/electron/handlers/app.ts
@@ -4,10 +4,10 @@ import { WindowManager } from './../managers/window'
 import { userSpacePath } from './../utils/path'
 import { AppRoute } from '@janhq/core'
 import { getResourcePath } from './../utils/path'
-const {
+import {
   ExtensionManager,
   ModuleManager,
-} = require('@janhq/core/dist/node/index.cjs')
+} from '@janhq/core/node'
 
 export function handleAppIPCs() {
   /**

--- a/electron/handlers/download.ts
+++ b/electron/handlers/download.ts
@@ -46,6 +46,9 @@ export function handleDownloaderIPCs() {
    */
   ipcMain.handle(DownloadRoute.downloadFile, async (_event, url, fileName) => {
     const userDataPath = join(app.getPath('home'), 'jan')
+    if (typeof fileName === 'string' && fileName.includes('file:/')) {
+      fileName = fileName.replace('file:/', '')
+    }
     const destination = resolve(userDataPath, fileName)
     const rq = request(url)
 

--- a/electron/handlers/download.ts
+++ b/electron/handlers/download.ts
@@ -5,7 +5,7 @@ import request from 'request'
 import { createWriteStream } from 'fs'
 import { DownloadEvent, DownloadRoute } from '@janhq/core'
 const progress = require('request-progress')
-const { DownloadManager } = require('@janhq/core/dist/node/index.cjs')
+import { DownloadManager } from '@janhq/core/node'
 
 export function handleDownloaderIPCs() {
   /**

--- a/electron/handlers/extension.ts
+++ b/electron/handlers/extension.ts
@@ -1,14 +1,14 @@
 import { ipcMain, webContents } from 'electron'
 import { readdirSync } from 'fs'
 import { join, extname } from 'path'
-const { ModuleManager } = require('@janhq/core/dist/node/index.cjs')
 
-const {
+import {
   installExtensions,
   getExtension,
   removeExtension,
   getActiveExtensions,
-} = require('@janhq/core/dist/node/index.cjs')
+  ModuleManager
+} from '@janhq/core/node'
 
 import { getResourcePath, userSpacePath } from './../utils/path'
 import { ExtensionRoute } from '@janhq/core'

--- a/electron/handlers/fs.ts
+++ b/electron/handlers/fs.ts
@@ -3,19 +3,20 @@ import { ipcMain } from 'electron'
 import { FileSystemRoute } from '@janhq/core'
 import { userSpacePath } from '../utils/path'
 import { join } from 'path'
-const fs = require('fs')
 /**
  * Handles file system operations.
  */
 export function handleFsIPCs() {
   Object.values(FileSystemRoute).forEach((route) => {
+    const moduleName = "fs"
     ipcMain.handle(route, async (event, ...args) => {
-      return fs[route](
+      return import(moduleName).then(mdl => 
+         { return mdl[route](
         ...args.map((arg) =>
           arg.includes('file:/')
             ? join(userSpacePath, arg.replace('file:/', ''))
             : arg
-        )
+        ))}
       )
     })
   })

--- a/electron/handlers/fs.ts
+++ b/electron/handlers/fs.ts
@@ -7,16 +7,16 @@ import { join } from 'path'
  * Handles file system operations.
  */
 export function handleFsIPCs() {
+  const moduleName = "fs"
   Object.values(FileSystemRoute).forEach((route) => {
-    const moduleName = "fs"
     ipcMain.handle(route, async (event, ...args) => {
       return import(moduleName).then(mdl => 
-         { return mdl[route](
+          mdl[route](
         ...args.map((arg) =>
           arg.includes('file:/')
             ? join(userSpacePath, arg.replace('file:/', ''))
             : arg
-        ))}
+        ))
       )
     })
   })

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -8,11 +8,7 @@ import Fastify from 'fastify'
  * Managers
  **/
 import { WindowManager } from './managers/window'
-const {
-  ExtensionManager,
-  ModuleManager,
-  threadRouter,
-} = require('@janhq/core/dist/node/index.cjs')
+import { ExtensionManager, ModuleManager } from '@janhq/core/node'
 
 /**
  * IPC Handlers
@@ -22,7 +18,8 @@ import { handleExtensionIPCs } from './handlers/extension'
 import { handleAppIPCs } from './handlers/app'
 import { handleAppUpdates } from './handlers/update'
 import { handleFsIPCs } from './handlers/fs'
-const { v1Router } = require('@janhq/core/dist/node/index.cjs')
+import { migrateExtensions } from './utils/migration'
+import { v1Router } from '@janhq/core/node'
 
 const fastify = Fastify({
   logger: true,
@@ -42,7 +39,7 @@ fastify.register(v1Router, {
 app
   .whenReady()
   .then(createUserSpace)
-  .then(ExtensionManager.instance.migrateExtensions)
+  .then(migrateExtensions)
   .then(ExtensionManager.instance.setupExtensions)
   .then(setupMenu)
   .then(handleIPCs)

--- a/electron/tsconfig.json
+++ b/electron/tsconfig.json
@@ -15,6 +15,9 @@
     "paths": { "*": ["node_modules/*"] },
     "typeRoots": ["node_modules/@types"]
   },
+  "ts-node": {
+    "esm": true
+  },
   "include": ["./**/*.ts"],
   "exclude": ["core", "build", "dist", "tests", "node_modules"]
 }

--- a/electron/utils/menu.ts
+++ b/electron/utils/menu.ts
@@ -1,5 +1,5 @@
 // @ts-nocheck
-const { app, Menu, dialog } = require("electron");
+import { app, Menu, dialog, shell } from "electron";
 const isMac = process.platform === "darwin";
 const { autoUpdater } = require("electron-updater");
 import { compareSemanticVersions } from "./versionDiff";
@@ -97,7 +97,6 @@ const template: (Electron.MenuItemConstructorOptions | Electron.MenuItem)[] = [
       {
         label: "Learn More",
         click: async () => {
-          const { shell } = require("electron");
           await shell.openExternal("https://jan.ai/");
         },
       },

--- a/extensions/assistant-extension/src/index.ts
+++ b/extensions/assistant-extension/src/index.ts
@@ -20,7 +20,7 @@ export default class JanAssistantExtension implements AssistantExtension {
   /**
    * Called when the extension is unloaded.
    */
-  onUnload(): void {}
+  onUnload(): void { }
 
   async createAssistant(assistant: Assistant): Promise<void> {
     // assuming that assistants/ directory is already created in the onLoad above
@@ -61,7 +61,7 @@ export default class JanAssistantExtension implements AssistantExtension {
         continue;
       }
 
-      const content = await fs.readFileSync(join(filePath, jsonFiles[0]));
+      const content = await fs.readFileSync(join(filePath, jsonFiles[0]), 'utf-8');
       const assistant: Assistant =
         typeof content === "object" ? content : JSON.parse(content);
 

--- a/extensions/conversational-extension/src/index.ts
+++ b/extensions/conversational-extension/src/index.ts
@@ -8,8 +8,7 @@ import { join } from 'path'
  * functionality for managing threads.
  */
 export default class JSONConversationalExtension
-  implements ConversationalExtension
-{
+  implements ConversationalExtension {
   private static readonly _homeDir = 'file://threads'
   private static readonly _threadInfoFileName = 'thread.json'
   private static readonly _threadMessagesFileName = 'messages.jsonl'
@@ -202,7 +201,7 @@ export default class JSONConversationalExtension
         JSONConversationalExtension._threadMessagesFileName
       )
 
-      const result = await fs.readFileSync(messageFilePath).then((content) =>
+      const result = await fs.readFileSync(messageFilePath, 'utf-8').then((content) =>
         content
           .toString()
           .split('\n')

--- a/extensions/model-extension/src/index.ts
+++ b/extensions/model-extension/src/index.ts
@@ -37,7 +37,7 @@ export default class JanModelExtension implements ModelExtension {
    * Called when the extension is unloaded.
    * @override
    */
-  onUnload(): void {}
+  onUnload(): void { }
 
   private async copyModelsToHomeDir() {
     try {
@@ -113,7 +113,7 @@ export default class JanModelExtension implements ModelExtension {
         dirPath,
         JanModelExtension._modelMetadataFileName
       )
-      const json = await fs.readFileSync(jsonFilePath)
+      const json = await fs.readFileSync(jsonFilePath, 'utf-8')
       const model = JSON.parse(json) as Model
       delete model.state
 
@@ -208,7 +208,7 @@ export default class JanModelExtension implements ModelExtension {
   }
 
   private readModelMetadata(path: string) {
-    return fs.readFileSync(join(path))
+    return fs.readFileSync(join(path), 'utf-8')
   }
 
   /**

--- a/server/main.ts
+++ b/server/main.ts
@@ -1,6 +1,6 @@
 import fastify from "fastify";
 import dotenv from "dotenv";
-const { v1Router } = require("@janhq/core/dist/node/index.cjs");
+import { v1Router } from '@janhq/core/node'
 
 dotenv.config();
 


### PR DESCRIPTION
**Description**
In PR #948, we encountered an issue where we could not import node modules exported by @janhq/core but were only able to require them since modules were not exported accordingly.

In this PR, we refactored to have three exported modules:

- @janhq/core: default UMD module root, serving as its core SDK, can be imported from both browsers and Node.
- @janhq/core/sdk: ES5 core SDK module, importable from browser projects.
- @janhq/core/node: CommonJS Node module, importable from Node projects.

**Success Criteria**
Refactored modules import
```ts
// from 
const node = require('@janhq/core/dist/node/index.cjs')
// to
import  { ... } from '@janhq/core/node'
```

**Additional context**
Include any other relevant context or screenshots about the feature request here.