### PR TITLE
fix: darkmode broken color

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className="bg-white font-sans text-sm antialiased dark:bg-background/50">
+      <body className="bg-white font-sans text-sm antialiased dark:bg-background">
         <div className="title-bar" />
         <Providers>{children}</Providers>
       </body>

--- a/web/containers/Layout/index.tsx
+++ b/web/containers/Layout/index.tsx
@@ -24,7 +24,7 @@ const BaseLayout = (props: PropsWithChildren) => {
   return (
     <div className="flex h-screen w-screen flex-1 overflow-hidden">
       <RibbonNav />
-      <div className=" relative top-12 flex h-[calc(100vh-96px)] w-full overflow-hidden bg-background/50">
+      <div className=" relative top-12 flex h-[calc(100vh-96px)] w-full overflow-hidden bg-background">
         <div className="w-full">
           <TopBar />
           <m.div

--- a/web/screens/Chat/index.tsx
+++ b/web/screens/Chat/index.tsx
@@ -99,7 +99,7 @@ const ChatScreen = () => {
 
   return (
     <div className="flex h-full w-full">
-      <div className="flex h-full w-60 flex-shrink-0 flex-col overflow-y-auto border-r border-border bg-background dark:bg-background/50">
+      <div className="flex h-full w-60 flex-shrink-0 flex-col overflow-y-auto border-r border-border bg-background">
         <ThreadList />
       </div>
       <div

--- a/web/screens/ExploreModels/ExploreModelItemHeader/index.tsx
+++ b/web/screens/ExploreModels/ExploreModelItemHeader/index.tsx
@@ -81,7 +81,7 @@ const ExploreModelItemHeader: React.FC<Props> = ({ model, onClick, open }) => {
 
   return (
     <div
-      className="cursor-pointer rounded-t-md bg-background/50"
+      className="cursor-pointer rounded-t-md bg-background"
       onClick={onClick}
     >
       {model.metadata.cover && (

--- a/web/screens/Settings/index.tsx
+++ b/web/screens/Settings/index.tsx
@@ -176,7 +176,7 @@ const SettingsScreen = () => {
         </ScrollArea>
       </div>
 
-      <div className="h-full w-full bg-background/50">
+      <div className="h-full w-full bg-background">
         <ScrollArea className="h-full w-full">
           <div className="p-4">
             {handleShowOptions(activeStaticMenu || activePreferenceExtension)}

--- a/web/screens/SystemMonitor/index.tsx
+++ b/web/screens/SystemMonitor/index.tsx
@@ -21,7 +21,7 @@ export default function SystemMonitorScreen() {
   const { activeModel, stateModel, stopModel } = useActiveModel()
 
   return (
-    <div className="flex h-full w-full bg-background dark:bg-background/50">
+    <div className="flex h-full w-full bg-background dark:bg-background">
       <ScrollArea className="h-full w-full">
         <div className="h-full p-8" data-test-id="testid-system-monitor">
           <div className="grid grid-cols-2 gap-8 lg:grid-cols-3">
@@ -59,7 +59,9 @@ export default function SystemMonitorScreen() {
           {activeModel && (
             <div className="mt-8 overflow-hidden rounded-xl border border-border shadow-sm">
               <div className="px-6 py-5">
-                <h4 className="text-base font-medium">Actively Running Models</h4>
+                <h4 className="text-base font-medium">
+                  Actively Running Models
+                </h4>
               </div>
               <div className="relative overflow-x-auto shadow-md">
                 <table className="w-full px-8">


### PR DESCRIPTION
fixes #1170 

### Description
Broken schema color when dark mode
<img width="1312" alt="Screenshot 2023-12-25 at 11 01 18" src="https://github.com/janhq/jan/assets/10354610/2df33867-cad0-480c-88ff-15aec0985f19">


### Scenario test
- Set your device to light mode by setting
- Go to app and make sure color schema dark mode works well
- Try switch to light or dark via app, user should be smoothly change color schema

### Screenshot
<img width="1312" alt="Screenshot 2023-12-25 at 11 02 26" src="https://github.com/janhq/jan/assets/10354610/aa059f6b-1e32-471f-8b2b-24714bd66657">

https://github.com/janhq/jan/assets/10354610/84dd4697-81d7-47f2-b073-27a5814a3cc9



