### PR TITLE
refactor: shared server module

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2,7 +2,6 @@ import { app, BrowserWindow } from 'electron'
 import { join } from 'path'
 import { setupMenu } from './utils/menu'
 import { createUserSpace } from './utils/path'
-import Fastify from 'fastify'
 
 /**
  * Managers
@@ -20,22 +19,11 @@ import { handleAppIPCs } from './handlers/app'
 import { handleAppUpdates } from './handlers/update'
 import { handleFsIPCs } from './handlers/fs'
 import { migrateExtensions } from './utils/migration'
-import { v1Router } from '@janhq/core/node'
 
-const fastify = Fastify({
-  logger: true,
-})
-
-fastify.listen({ port: 1337 }, function (err, address) {
-  if (err) {
-    fastify.log.error(err)
-    process.exit(1)
-  }
-})
-
-fastify.register(v1Router, {
-  prefix: '/api/v1',
-})
+/**
+ * Server
+ */
+import { startServer } from '@janhq/server'
 
 app
   .whenReady()
@@ -46,6 +34,7 @@ app
   .then(handleIPCs)
   .then(handleAppUpdates)
   .then(createMainWindow)
+  .then(startServer)
   .then(() => {
     app.on('activate', () => {
       if (!BrowserWindow.getAllWindows().length) {

--- a/electron/package.json
+++ b/electron/package.json
@@ -72,12 +72,12 @@
   "dependencies": {
     "@alumna/reflect": "^1.1.3",
     "@janhq/core": "link:./core",
+    "@janhq/server": "file:../server",
     "@npmcli/arborist": "^7.1.0",
     "@types/request": "^2.48.12",
     "@uiball/loaders": "^1.3.0",
     "electron-store": "^8.1.0",
     "electron-updater": "^6.1.7",
-    "fastify": "^4.25.0",
     "fs-extra": "^11.2.0",
     "node-fetch": "2",
     "pacote": "^17.0.4",

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,43 @@
+import fastify from "fastify";
+import dotenv from "dotenv";
+import { v1Router } from "@janhq/core/node";
+import path from "path";
+
+dotenv.config();
+
+const JAN_API_HOST = process.env.JAN_API_HOST || "0.0.0.0";
+const JAN_API_PORT = Number.parseInt(process.env.JAN_API_PORT || "1337");
+
+const server = fastify();
+server.register(require("@fastify/cors"), {});
+server.register(
+  (childContext, _, done) => {
+    childContext.register(require("@fastify/static"), {
+      root:
+        process.env.EXTENSION_ROOT ||
+        path.join(require("os").homedir(), "jan", "extensions"),
+      wildcard: false,
+    });
+
+    done();
+  },
+  { prefix: "extensions" }
+);
+server.register(v1Router, { prefix: "/api/v1" });
+
+export const startServer = () => {
+  server
+    .listen({
+      port: JAN_API_PORT,
+      host: JAN_API_HOST,
+    })
+    .then(() => {
+      console.log(
+        `JAN API listening at: http://${JAN_API_HOST}:${JAN_API_PORT}`
+      );
+    });
+};
+
+export const stopServer = () => {
+  server.close();
+};

--- a/server/main.ts
+++ b/server/main.ts
@@ -1,32 +1,3 @@
-import fastify from "fastify";
-import dotenv from "dotenv";
-import { v1Router } from '@janhq/core/node'
+import { startServer } from "./index";
 
-dotenv.config();
-
-const JAN_API_HOST = process.env.JAN_API_HOST || "0.0.0.0";
-const JAN_API_PORT = Number.parseInt(process.env.JAN_API_PORT || "1337");
-
-const server = fastify();
-server.register(require("@fastify/cors"), {});
-server.register(
-  (childContext, _, done) => {
-    childContext.register(require("@fastify/static"), {
-      root: process.env.EXTENSION_ROOT,
-      wildcard: false,
-    });
-
-    done();
-  },
-  { prefix: "extensions" }
-);
-server.register(v1Router, { prefix: "/api/v1" });
-
-server
-  .listen({
-    port: JAN_API_PORT,
-    host: JAN_API_HOST,
-  })
-  .then(() => {
-    console.log(`JAN API listening at: http://${JAN_API_HOST}:${JAN_API_PORT}`);
-  });
+startServer();

--- a/server/package.json
+++ b/server/package.json
@@ -1,22 +1,25 @@
 {
-  "name": "jan-server",
+  "name": "@janhq/server",
   "version": "0.1.3",
-  "main": "./build/main.js",
+  "main": "./build/index.js",
   "author": "Jan <service@jan.ai>",
   "license": "AGPL-3.0",
   "homepage": "https://jan.ai",
   "description": "Use offline LLMs with your own data. Run open source models like Llama2 or Falcon on your internal computers/servers.",
-  "build": "",
+  "files": [
+    "build/**"
+  ],
   "scripts": {
     "lint": "eslint . --ext \".js,.jsx,.ts,.tsx\"",
     "test:e2e": "playwright test --workers=1",
-    "dev": "nodemon .",
+    "dev": "tsc --watch & node --watch build/main.js",
     "build": "tsc"
   },
   "dependencies": {
     "@fastify/cors": "^8.4.2",
     "@fastify/static": "^6.12.0",
     "core": "link:./core",
+    "fastify": "^4.24.3",
     "request": "^2.88.2",
     "request-progress": "^3.0.0"
   },
@@ -27,12 +30,7 @@
     "@typescript-eslint/parser": "^6.7.3",
     "dotenv": "^16.3.1",
     "eslint-plugin-react": "^7.33.2",
-    "fastify": "^4.24.3",
-    "nodemon": "^3.0.1",
     "run-script-os": "^1.1.6",
     "typescript": "^5.2.2"
-  },
-  "installConfig": {
-    "hoistingLimits": "workspaces"
   }
 }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -14,7 +14,8 @@
     "skipLibCheck": true,
     "paths": { "*": ["node_modules/*"] },
     "typeRoots": ["node_modules/@types"],
-    "ignoreDeprecations": "5.0"
+    "ignoreDeprecations": "5.0",
+    "declaration": true
   },
   // "sourceMap": true,
 

--- a/web/services/restService.ts
+++ b/web/services/restService.ts
@@ -1,11 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { safeJsonParse } from '@/utils/json'
 import {
   AppRoute,
   DownloadRoute,
   ExtensionRoute,
   FileSystemRoute,
 } from '@janhq/core'
+
+import { safeJsonParse } from '@/utils/json'
 
 // Function to open an external URL in a new browser window
 export function openExternalUrl(url: string) {


### PR DESCRIPTION
## Description
Jan, localhost is now coupled with electron targets. The server should be exported as an ES module and used by the electron app. It could also be deployed separately. This is to remove the duplicated server settings for both electron and server target.

![Screenshot 2023-12-26 at 16 39 21 (2)](https://github.com/janhq/jan/assets/133622055/c001e732-6178-45ee-887e-5b0a0919719c)

fixes: #1050