### PR TITLE
Fix switch thread crash nitro windows linux

### DIFF
--- a/extensions/inference-nitro-extension/bin/linux-start.sh
+++ b/extensions/inference-nitro-extension/bin/linux-start.sh
@@ -28,11 +28,12 @@ export CUDA_VISIBLE_DEVICES=$selectedGpuId
 
 # Attempt to run nitro_linux_amd64_cuda
 cd linux-cuda
-if ./nitro "$@"; then
+./nitro "$@" > output.log 2>&1 || (
+    echo "Check output log" && 
+    if grep -q "CUDA error" output.log; then
+        echo "CUDA error detected, attempting to run nitro_linux_amd64..."
+        cd ../linux-cpu && ./nitro "$@"
+        exit $?
+    fi
     exit $?
-else
-    echo "nitro_linux_amd64_cuda encountered an error, attempting to run nitro_linux_amd64..."
-    cd ../linux-cpu
-    ./nitro "$@"
-    exit $?
-fi
+)

--- a/extensions/inference-nitro-extension/bin/win-start.bat
+++ b/extensions/inference-nitro-extension/bin/win-start.bat
@@ -34,12 +34,7 @@ cd win-cuda
 
 nitro.exe %* > output.log
 type output.log | findstr /C:"CUDA error" >nul
-if %errorlevel% equ 0 (
-    goto :RunCpuVersion
-)
-else (
-    goto :End
-)
+if %errorlevel% equ 0 ( goto :RunCpuVersion ) else ( goto :End )
 
 :RunCpuVersion
 rem Run nitro_windows_amd64.exe...

--- a/extensions/inference-nitro-extension/bin/win-start.bat
+++ b/extensions/inference-nitro-extension/bin/win-start.bat
@@ -31,15 +31,15 @@ set CUDA_VISIBLE_DEVICES=!gpuId!
 
 rem Attempt to run nitro_windows_amd64_cuda.exe
 cd win-cuda
-goto RunGPUVersion
 
-:RunGPUVersion
 nitro.exe %* > output.log
-type output.log | findstr /C:"Connection closed or buffer is null" >nul
+type output.log | findstr /C:"CUDA error" >nul
 if %errorlevel% equ 0 (
-    goto :RunGPUVersion
+    goto :RunCpuVersion
 )
-if %errorlevel% neq 0 goto RunCpuVersion
+else (
+    goto :End
+)
 
 :RunCpuVersion
 rem Run nitro_windows_amd64.exe...

--- a/extensions/inference-nitro-extension/bin/win-start.bat
+++ b/extensions/inference-nitro-extension/bin/win-start.bat
@@ -31,9 +31,15 @@ set CUDA_VISIBLE_DEVICES=!gpuId!
 
 rem Attempt to run nitro_windows_amd64_cuda.exe
 cd win-cuda
-nitro.exe %*
+goto RunGPUVersion
+
+:RunGPUVersion
+nitro.exe %* > output.log
+type output.log | findstr /C:"Connection closed or buffer is null" >nul
+if %errorlevel% equ 0 (
+    goto :RunGPUVersion
+)
 if %errorlevel% neq 0 goto RunCpuVersion
-goto End
 
 :RunCpuVersion
 rem Run nitro_windows_amd64.exe...

--- a/extensions/inference-nitro-extension/src/module.ts
+++ b/extensions/inference-nitro-extension/src/module.ts
@@ -67,6 +67,8 @@ async function loadModel(nitroResourceProbe: any | undefined) {
   // Gather system information for CPU physical cores and memory
   if (!nitroResourceProbe) nitroResourceProbe = await getResourcesInfo();
   return killSubprocess()
+    .then(() => tcpPortUsed.waitUntilFree(PORT, 300, 5000))
+    .then(() => new Promise((resolve) => setTimeout(resolve, 5000))) // wait 5 second
     .then(() => spawnNitroProcess(nitroResourceProbe))
     .then(() => loadLLMModel(currentSettings))
     .then(validateModelStatus)

--- a/extensions/inference-nitro-extension/src/module.ts
+++ b/extensions/inference-nitro-extension/src/module.ts
@@ -68,7 +68,6 @@ async function loadModel(nitroResourceProbe: any | undefined) {
   if (!nitroResourceProbe) nitroResourceProbe = await getResourcesInfo();
   return killSubprocess()
     .then(() => tcpPortUsed.waitUntilFree(PORT, 300, 5000))
-    .then(() => new Promise((resolve) => setTimeout(resolve, 5000))) // wait 5 second
     .then(() => spawnNitroProcess(nitroResourceProbe))
     .then(() => loadLLMModel(currentSettings))
     .then(validateModelStatus)


### PR DESCRIPTION
This PR aim to fix bug #1204 
Change:
- Add tcp wait until port is released before starting nitro new process
- Update bat script and bash script to exit if nitro is killed by jan app.