### PR TITLE
fix: remove delay tooltip and click event

### DIFF
--- a/web/containers/DropdownListSidebar/index.tsx
+++ b/web/containers/DropdownListSidebar/index.tsx
@@ -9,10 +9,6 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-  TooltipArrow,
   Input,
 } from '@janhq/uikit'
 

--- a/web/containers/Providers/index.tsx
+++ b/web/containers/Providers/index.tsx
@@ -73,7 +73,7 @@ const Providers = (props: PropsWithChildren) => {
           {setupCore && activated && (
             <FeatureToggleWrapper>
               <EventListenerWrapper>
-                <TooltipProvider>{children}</TooltipProvider>
+                <TooltipProvider delayDuration={0}>{children}</TooltipProvider>
               </EventListenerWrapper>
               <Toaster position="top-right" />
             </FeatureToggleWrapper>


### PR DESCRIPTION
fixes #1190 

### Test scenario
- Chat with local model 
- Try hovering on model setting with disabled input
- Make sure show a tooltip when hover and no delay, and when you try click the input disabled tooltip should be not disapear

### Screenshot
![Screenshot 2023-12-26 at 21 19 47](https://github.com/janhq/jan/assets/10354610/b8ed55ee-baeb-444c-b4a6-c7ace8acfb1d)
