### PR TITLE
fix: enable enter command on dialog confirmation delete thread

### DIFF
--- a/web/screens/Chat/ThreadList/index.tsx
+++ b/web/screens/Chat/ThreadList/index.tsx
@@ -169,6 +169,7 @@ export default function ThreadList() {
                           </ModalClose>
                           <ModalClose asChild>
                             <Button
+                              autoFocus
                               themes="danger"
                               onClick={() => deleteThread(thread.id)}
                             >

--- a/web/screens/Chat/ThreadList/index.tsx
+++ b/web/screens/Chat/ThreadList/index.tsx
@@ -161,7 +161,10 @@ export default function ThreadList() {
                       <ModalHeader>
                         <ModalTitle>Delete Thread</ModalTitle>
                       </ModalHeader>
-                      <p>Are you sure you want to delete this thread?</p>
+                      <p>
+                        Are you sure you want to delete this thread? This action
+                        cannot be undone.
+                      </p>
                       <ModalFooter>
                         <div className="flex gap-x-2">
                           <ModalClose asChild>


### PR DESCRIPTION
fixes #1188 

### Test
- Create thread and try delete thread, when dialog confirmation shown hit enter, thread should be deleted

https://github.com/janhq/jan/assets/10354610/cc16151f-3065-4a37-9b4e-9d5d22e70c62

