### PR TITLE
fix: Cleared thread last message is not updated

### DIFF
--- a/web/hooks/useDeleteThread.ts
+++ b/web/hooks/useDeleteThread.ts
@@ -22,6 +22,7 @@ import {
   setActiveThreadIdAtom,
   deleteThreadStateAtom,
   threadStatesAtom,
+  updateThreadStateLastMessageAtom,
 } from '@/helpers/atoms/Thread.atom'
 
 export default function useDeleteThread() {
@@ -33,21 +34,23 @@ export default function useDeleteThread() {
   const deleteMessages = useSetAtom(deleteChatMessagesAtom)
   const cleanMessages = useSetAtom(cleanChatMessagesAtom)
   const deleteThreadState = useSetAtom(deleteThreadStateAtom)
-
   const threadStates = useAtomValue(threadStatesAtom)
+  const updateThreadLastMessage = useSetAtom(updateThreadStateLastMessageAtom)
 
   const cleanThread = async (threadId: string) => {
     if (threadId) {
       const thread = threads.filter((c) => c.id === threadId)[0]
       cleanMessages(threadId)
 
-      if (thread)
+      if (thread) {
         await extensionManager
           .get<ConversationalExtension>(ExtensionType.Conversational)
           ?.writeMessages(
             threadId,
             messages.filter((msg) => msg.role === ChatCompletionRole.System)
           )
+        updateThreadLastMessage(threadId, undefined)
+      }
     }
   }
 


### PR DESCRIPTION
## Description 
When a user clears the conversation in a thread, the last message displayed was still the old one. This led to confusion about whether or not the user had successfully cleared the conversation.

<img width="1312" alt="Screenshot 2023-12-27 at 08 37 17" src="https://github.com/janhq/jan/assets/133622055/75657366-930f-4011-97e5-69fe700acf4f">

fixes #1200