### PR TITLE
fix: #1191 - update message interruption strategy

### DIFF
--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -6,6 +6,8 @@ import {
   ThreadAssistantInfo,
   ThreadState,
   Model,
+  events,
+  EventName,
 } from '@janhq/core'
 import { atom, useAtomValue, useSetAtom } from 'jotai'
 
@@ -55,6 +57,8 @@ export const useCreateNewThread = () => {
     assistant: Assistant,
     model?: Model | undefined
   ) => {
+    // Per #1191 - Stop any on-going inference when creating a new thread
+    events.emit(EventName.OnInferenceStopped, {})
     // loop through threads state and filter if there's any thread that is not finish init
     let unfinishedInitThreadId: string | undefined = undefined
     for (const key in threadStates) {

--- a/web/hooks/useSendChatMessage.ts
+++ b/web/hooks/useSendChatMessage.ts
@@ -174,7 +174,7 @@ export default function useSendChatMessage() {
       updateThreadInitSuccess(activeThread.id)
       updateThread(updatedThread)
 
-      extensionManager
+      await extensionManager
         .get<ConversationalExtension>(ExtensionType.Conversational)
         ?.saveThread(updatedThread)
     }
@@ -249,6 +249,9 @@ export default function useSendChatMessage() {
     const modelId = selectedModel?.id ?? activeThread.assistants[0].model.id
 
     if (activeModel?.id !== modelId) {
+      // Per #1191 - Stop any on-going inference when switching models
+      events.emit(EventName.OnInferenceStopped, {})
+
       setQueuedMessage(true)
       startModel(modelId)
       await WaitForModelStarting(modelId)

--- a/web/hooks/useSetActiveThread.ts
+++ b/web/hooks/useSetActiveThread.ts
@@ -26,8 +26,6 @@ export default function useSetActiveThread() {
       return
     }
 
-    events.emit(EventName.OnInferenceStopped, thread.id)
-
     // load the corresponding messages
     const messages = await extensionManager
       .get<ConversationalExtension>(ExtensionType.Conversational)


### PR DESCRIPTION
## Description
Implemented a fix to ensure streaming messages are not interrupted when switching to another thread. Interruptions will now only occur when creating a new thread or switching models.

fixes #1191