### PR TITLE
feat: Deprecate model.json ready state in favor of .download ext

### DIFF
--- a/core/src/types/model/modelEntity.ts
+++ b/core/src/types/model/modelEntity.ts
@@ -68,13 +68,6 @@ export type Model = {
   description: string
 
   /**
-   * The model state.
-   * Default: "to_download"
-   * Enum: "to_download" "downloading" "ready" "running"
-   */
-  state?: ModelState
-
-  /**
    * The model settings.
    */
   settings: ModelSettingParams
@@ -99,15 +92,6 @@ export type ModelMetadata = {
   tags: string[]
   size: number
   cover?: string
-}
-
-/**
- * The Model transition states.
- */
-export enum ModelState {
-  Downloading = 'downloading',
-  Ready = 'ready',
-  Running = 'running',
 }
 
 /**

--- a/electron/handlers/download.ts
+++ b/electron/handlers/download.ts
@@ -3,7 +3,7 @@ import { DownloadManager } from './../managers/download'
 import { resolve, join } from 'path'
 import { WindowManager } from './../managers/window'
 import request from 'request'
-import { createWriteStream } from 'fs'
+import { createWriteStream, renameSync } from 'fs'
 import { DownloadEvent, DownloadRoute } from '@janhq/core'
 const progress = require('request-progress')
 
@@ -48,6 +48,8 @@ export function handleDownloaderIPCs() {
     const userDataPath = join(app.getPath('home'), 'jan')
     const destination = resolve(userDataPath, fileName)
     const rq = request(url)
+    // downloading file to a temp file first
+    const downloadingTempFile = `${destination}.download`
 
     progress(rq, {})
       .on('progress', function (state: any) {
@@ -70,6 +72,9 @@ export function handleDownloaderIPCs() {
       })
       .on('end', function () {
         if (DownloadManager.instance.networkRequests[fileName]) {
+          // Finished downloading, rename temp file to actual file
+          renameSync(downloadingTempFile, destination)
+
           WindowManager?.instance.currentWindow?.webContents.send(
             DownloadEvent.onFileDownloadSuccess,
             {
@@ -87,7 +92,7 @@ export function handleDownloaderIPCs() {
           )
         }
       })
-      .pipe(createWriteStream(destination))
+      .pipe(createWriteStream(downloadingTempFile))
 
     DownloadManager.instance.setRequest(fileName, rq)
   })

--- a/extensions/conversational-extension/src/index.ts
+++ b/extensions/conversational-extension/src/index.ts
@@ -1,7 +1,6 @@
-import { ExtensionType, fs } from '@janhq/core'
+import { ExtensionType, fs, joinPath } from '@janhq/core'
 import { ConversationalExtension } from '@janhq/core'
 import { Thread, ThreadMessage } from '@janhq/core'
-import { join } from 'path'
 
 /**
  * JSONConversationalExtension is a ConversationalExtension implementation that provides
@@ -69,14 +68,14 @@ export default class JSONConversationalExtension
    */
   async saveThread(thread: Thread): Promise<void> {
     try {
-      const threadDirPath = join(
+      const threadDirPath = await joinPath([
         JSONConversationalExtension._homeDir,
-        thread.id
-      )
-      const threadJsonPath = join(
+        thread.id,
+      ])
+      const threadJsonPath = await joinPath([
         threadDirPath,
-        JSONConversationalExtension._threadInfoFileName
-      )
+        JSONConversationalExtension._threadInfoFileName,
+      ])
       await fs.mkdir(threadDirPath)
       await fs.writeFile(threadJsonPath, JSON.stringify(thread, null, 2))
       Promise.resolve()
@@ -89,20 +88,22 @@ export default class JSONConversationalExtension
    * Delete a thread with the specified ID.
    * @param threadId The ID of the thread to delete.
    */
-  deleteThread(threadId: string): Promise<void> {
-    return fs.rmdir(join(JSONConversationalExtension._homeDir, `${threadId}`))
+  async deleteThread(threadId: string): Promise<void> {
+    return fs.rmdir(
+      await joinPath([JSONConversationalExtension._homeDir, `${threadId}`])
+    )
   }
 
   async addNewMessage(message: ThreadMessage): Promise<void> {
     try {
-      const threadDirPath = join(
+      const threadDirPath = await joinPath([
         JSONConversationalExtension._homeDir,
-        message.thread_id
-      )
-      const threadMessagePath = join(
+        message.thread_id,
+      ])
+      const threadMessagePath = await joinPath([
         threadDirPath,
-        JSONConversationalExtension._threadMessagesFileName
-      )
+        JSONConversationalExtension._threadMessagesFileName,
+      ])
       await fs.mkdir(threadDirPath)
       await fs.appendFile(threadMessagePath, JSON.stringify(message) + '\n')
       Promise.resolve()
@@ -116,11 +117,14 @@ export default class JSONConversationalExtension
     messages: ThreadMessage[]
   ): Promise<void> {
     try {
-      const threadDirPath = join(JSONConversationalExtension._homeDir, threadId)
-      const threadMessagePath = join(
+      const threadDirPath = await joinPath([
+        JSONConversationalExtension._homeDir,
+        threadId,
+      ])
+      const threadMessagePath = await joinPath([
         threadDirPath,
-        JSONConversationalExtension._threadMessagesFileName
-      )
+        JSONConversationalExtension._threadMessagesFileName,
+      ])
       await fs.mkdir(threadDirPath)
       await fs.writeFile(
         threadMessagePath,
@@ -140,11 +144,11 @@ export default class JSONConversationalExtension
    */
   private async readThread(threadDirName: string): Promise<any> {
     return fs.readFile(
-      join(
+      await joinPath([
         JSONConversationalExtension._homeDir,
         threadDirName,
-        JSONConversationalExtension._threadInfoFileName
-      )
+        JSONConversationalExtension._threadInfoFileName,
+      ])
     )
   }
 
@@ -159,10 +163,10 @@ export default class JSONConversationalExtension
 
     const threadDirs: string[] = []
     for (let i = 0; i < fileInsideThread.length; i++) {
-      const path = join(
+      const path = await joinPath([
         JSONConversationalExtension._homeDir,
-        fileInsideThread[i]
-      )
+        fileInsideThread[i],
+      ])
       const isDirectory = await fs.isDirectory(path)
       if (!isDirectory) {
         console.debug(`Ignore ${path} because it is not a directory`)
@@ -184,7 +188,10 @@ export default class JSONConversationalExtension
 
   async getAllMessages(threadId: string): Promise<ThreadMessage[]> {
     try {
-      const threadDirPath = join(JSONConversationalExtension._homeDir, threadId)
+      const threadDirPath = await joinPath([
+        JSONConversationalExtension._homeDir,
+        threadId,
+      ])
       const isDir = await fs.isDirectory(threadDirPath)
       if (!isDir) {
         throw Error(`${threadDirPath} is not directory`)
@@ -197,10 +204,10 @@ export default class JSONConversationalExtension
         throw Error(`${threadDirPath} not contains message file`)
       }
 
-      const messageFilePath = join(
+      const messageFilePath = await joinPath([
         threadDirPath,
-        JSONConversationalExtension._threadMessagesFileName
-      )
+        JSONConversationalExtension._threadMessagesFileName,
+      ])
 
       const result = await fs.readLineByLine(messageFilePath)
 

--- a/extensions/inference-nitro-extension/src/index.ts
+++ b/extensions/inference-nitro-extension/src/index.ts
@@ -111,7 +111,7 @@ export default class JanInferenceNitroExtension implements InferenceExtension {
       return;
     }
     const userSpacePath = await getUserSpace();
-    const modelFullPath = join(userSpacePath, "models", model.id, model.id);
+    const modelFullPath = join(userSpacePath, "models", model.id);
 
     const nitroInitResult = await executeOnMain(MODULE, "initModel", {
       modelFullPath: modelFullPath,

--- a/extensions/inference-nitro-extension/src/module.ts
+++ b/extensions/inference-nitro-extension/src/module.ts
@@ -43,7 +43,7 @@ async function initModel(wrapper: any): Promise<ModelOperationResponse> {
   // Look for GGUF model file
   const ggufBinFile = files.find(
     (file) =>
-      file === currentModelFile.split(path.sep).pop() ||
+      file === path.basename(currentModelFile) ||
       file.toLowerCase().includes(SUPPORTED_MODEL_FORMAT)
   );
 

--- a/extensions/inference-nitro-extension/src/module.ts
+++ b/extensions/inference-nitro-extension/src/module.ts
@@ -13,10 +13,11 @@ const NITRO_HTTP_LOAD_MODEL_URL = `${NITRO_HTTP_SERVER_URL}/inferences/llamacpp/
 const NITRO_HTTP_UNLOAD_MODEL_URL = `${NITRO_HTTP_SERVER_URL}/inferences/llamacpp/unloadModel`;
 const NITRO_HTTP_VALIDATE_MODEL_URL = `${NITRO_HTTP_SERVER_URL}/inferences/llamacpp/modelstatus`;
 const NITRO_HTTP_KILL_URL = `${NITRO_HTTP_SERVER_URL}/processmanager/destroy`;
+const SUPPORTED_MODEL_FORMAT = ".gguf";
 
 // The subprocess instance for Nitro
 let subprocess = undefined;
-let currentModelFile = undefined;
+let currentModelFile: string = undefined;
 let currentSettings = undefined;
 
 /**
@@ -37,6 +38,17 @@ function stopModel(): Promise<void> {
  */
 async function initModel(wrapper: any): Promise<ModelOperationResponse> {
   currentModelFile = wrapper.modelFullPath;
+  const files: string[] = fs.readdirSync(currentModelFile);
+
+  // Look for GGUF model file
+  const ggufBinFile = files.find(
+    (file) =>
+      file === currentModelFile.split(path.sep).pop() ||
+      file.toLowerCase().includes(SUPPORTED_MODEL_FORMAT)
+  );
+
+  currentModelFile = path.join(currentModelFile, ggufBinFile);
+
   if (wrapper.model.engine !== "nitro") {
     return Promise.resolve({ error: "Not a nitro model" });
   } else {
@@ -66,25 +78,26 @@ async function initModel(wrapper: any): Promise<ModelOperationResponse> {
 async function loadModel(nitroResourceProbe: any | undefined) {
   // Gather system information for CPU physical cores and memory
   if (!nitroResourceProbe) nitroResourceProbe = await getResourcesInfo();
-  return killSubprocess()
-    .then(() => tcpPortUsed.waitUntilFree(PORT, 300, 5000))
-    // wait for 500ms to make sure the port is free for windows platform
-    .then(() => {
-      if (process.platform === "win32") {
-        return sleep(500);
-      }
-      else {
-        return sleep(0);
-      }
-    })
-    .then(() => spawnNitroProcess(nitroResourceProbe))
-    .then(() => loadLLMModel(currentSettings))
-    .then(validateModelStatus)
-    .catch((err) => {
-      console.error("error: ", err);
-      // TODO: Broadcast error so app could display proper error message
-      return { error: err, currentModelFile };
-    });
+  return (
+    killSubprocess()
+      .then(() => tcpPortUsed.waitUntilFree(PORT, 300, 5000))
+      // wait for 500ms to make sure the port is free for windows platform
+      .then(() => {
+        if (process.platform === "win32") {
+          return sleep(500);
+        } else {
+          return sleep(0);
+        }
+      })
+      .then(() => spawnNitroProcess(nitroResourceProbe))
+      .then(() => loadLLMModel(currentSettings))
+      .then(validateModelStatus)
+      .catch((err) => {
+        console.error("error: ", err);
+        // TODO: Broadcast error so app could display proper error message
+        return { error: err, currentModelFile };
+      })
+  );
 }
 
 // Add function sleep

--- a/web/containers/Layout/BottomBar/DownloadingState/index.tsx
+++ b/web/containers/Layout/BottomBar/DownloadingState/index.tsx
@@ -1,7 +1,5 @@
 import { Fragment } from 'react'
 
-import { ExtensionType } from '@janhq/core'
-import { ModelExtension } from '@janhq/core'
 import {
   Progress,
   Modal,
@@ -12,14 +10,19 @@ import {
   ModalTrigger,
 } from '@janhq/uikit'
 
+import { useAtomValue } from 'jotai'
+
+import useDownloadModel from '@/hooks/useDownloadModel'
 import { useDownloadState } from '@/hooks/useDownloadState'
 
 import { formatDownloadPercentage } from '@/utils/converter'
 
-import { extensionManager } from '@/extension'
+import { downloadingModelsAtom } from '@/helpers/atoms/Model.atom'
 
 export default function DownloadingState() {
   const { downloadStates } = useDownloadState()
+  const downloadingModels = useAtomValue(downloadingModelsAtom)
+  const { abortModelDownload } = useDownloadModel()
 
   const totalCurrentProgress = downloadStates
     .map((a) => a.size.transferred + a.size.transferred)
@@ -73,9 +76,10 @@ export default function DownloadingState() {
                       size="sm"
                       onClick={() => {
                         if (item?.modelId) {
-                          extensionManager
-                            .get<ModelExtension>(ExtensionType.Model)
-                            ?.cancelModelDownload(item.modelId)
+                          const model = downloadingModels.find(
+                            (model) => model.id === item.modelId
+                          )
+                          if (model) abortModelDownload(model)
                         }
                       }}
                     >

--- a/web/containers/Providers/EventListener.tsx
+++ b/web/containers/Providers/EventListener.tsx
@@ -2,33 +2,32 @@
 
 import { PropsWithChildren, useEffect, useRef } from 'react'
 
-import { ExtensionType } from '@janhq/core'
-import { ModelExtension } from '@janhq/core'
-
 import { useAtomValue, useSetAtom } from 'jotai'
 
 import { useDownloadState } from '@/hooks/useDownloadState'
 import { useGetDownloadedModels } from '@/hooks/useGetDownloadedModels'
 
+import { modelBinFileName } from '@/utils/model'
+
 import EventHandler from './EventHandler'
 
 import { appDownloadProgress } from './Jotai'
 
-import { extensionManager } from '@/extension/ExtensionManager'
 import { downloadingModelsAtom } from '@/helpers/atoms/Model.atom'
 
 export default function EventListenerWrapper({ children }: PropsWithChildren) {
   const setProgress = useSetAtom(appDownloadProgress)
   const models = useAtomValue(downloadingModelsAtom)
   const modelsRef = useRef(models)
-  useEffect(() => {
-    modelsRef.current = models
-  }, [models])
+
   const { setDownloadedModels, downloadedModels } = useGetDownloadedModels()
   const { setDownloadState, setDownloadStateSuccess, setDownloadStateFailed } =
     useDownloadState()
   const downloadedModelRef = useRef(downloadedModels)
 
+  useEffect(() => {
+    modelsRef.current = models
+  }, [models])
   useEffect(() => {
     downloadedModelRef.current = downloadedModels
   }, [downloadedModels])
@@ -38,40 +37,38 @@ export default function EventListenerWrapper({ children }: PropsWithChildren) {
       window.electronAPI.onFileDownloadUpdate(
         (_event: string, state: any | undefined) => {
           if (!state) return
-          setDownloadState({
-            ...state,
-            modelId: state.fileName.split('/').pop() ?? '',
-          })
+          const model = modelsRef.current.find(
+            (model) =>
+              modelBinFileName(model) === state.fileName.split('/').pop()
+          )
+          if (model)
+            setDownloadState({
+              ...state,
+              modelId: model.id,
+            })
         }
       )
 
-      window.electronAPI.onFileDownloadError(
-        (_event: string, callback: any) => {
-          console.error('Download error', callback)
-          const modelId = callback.fileName.split('/').pop() ?? ''
-          setDownloadStateFailed(modelId)
-        }
-      )
+      window.electronAPI.onFileDownloadError((_event: string, state: any) => {
+        console.error('Download error', state)
+        const model = modelsRef.current.find(
+          (model) => modelBinFileName(model) === state.fileName.split('/').pop()
+        )
+        if (model) setDownloadStateFailed(model.id)
+      })
 
-      window.electronAPI.onFileDownloadSuccess(
-        (_event: string, callback: any) => {
-          if (callback && callback.fileName) {
-            const modelId = callback.fileName.split('/').pop() ?? ''
-
-            const model = modelsRef.current.find((e) => e.id === modelId)
-
-            setDownloadStateSuccess(modelId)
-
-            if (model)
-              extensionManager
-                .get<ModelExtension>(ExtensionType.Model)
-                ?.saveModel(model)
-                .then(() => {
-                  setDownloadedModels([...downloadedModelRef.current, model])
-                })
+      window.electronAPI.onFileDownloadSuccess((_event: string, state: any) => {
+        if (state && state.fileName) {
+          const model = modelsRef.current.find(
+            (model) =>
+              modelBinFileName(model) === state.fileName.split('/').pop()
+          )
+          if (model) {
+            setDownloadStateSuccess(model.id)
+            setDownloadedModels([...downloadedModelRef.current, model])
           }
         }
-      )
+      })
 
       window.electronAPI.onAppUpdateDownloadUpdate(
         (_event: string, progress: any) => {

--- a/web/containers/Providers/EventListener.tsx
+++ b/web/containers/Providers/EventListener.tsx
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { basename } from 'path'
+
 import { PropsWithChildren, useEffect, useRef } from 'react'
 
 import { useAtomValue, useSetAtom } from 'jotai'
@@ -38,8 +40,7 @@ export default function EventListenerWrapper({ children }: PropsWithChildren) {
         (_event: string, state: any | undefined) => {
           if (!state) return
           const model = modelsRef.current.find(
-            (model) =>
-              modelBinFileName(model) === state.fileName.split('/').pop()
+            (model) => modelBinFileName(model) === basename(state.fileName)
           )
           if (model)
             setDownloadState({
@@ -52,7 +53,7 @@ export default function EventListenerWrapper({ children }: PropsWithChildren) {
       window.electronAPI.onFileDownloadError((_event: string, state: any) => {
         console.error('Download error', state)
         const model = modelsRef.current.find(
-          (model) => modelBinFileName(model) === state.fileName.split('/').pop()
+          (model) => modelBinFileName(model) === basename(state.fileName)
         )
         if (model) setDownloadStateFailed(model.id)
       })
@@ -60,8 +61,7 @@ export default function EventListenerWrapper({ children }: PropsWithChildren) {
       window.electronAPI.onFileDownloadSuccess((_event: string, state: any) => {
         if (state && state.fileName) {
           const model = modelsRef.current.find(
-            (model) =>
-              modelBinFileName(model) === state.fileName.split('/').pop()
+            (model) => modelBinFileName(model) === basename(state.fileName)
           )
           if (model) {
             setDownloadStateSuccess(model.id)

--- a/web/hooks/useDownloadModel.ts
+++ b/web/hooks/useDownloadModel.ts
@@ -1,10 +1,9 @@
-import { join } from 'path'
-
 import {
   Model,
   ExtensionType,
   ModelExtension,
   abortDownload,
+  joinPath,
 } from '@janhq/core'
 
 import { useSetAtom } from 'jotai'
@@ -43,7 +42,9 @@ export default function useDownloadModel() {
       ?.downloadModel(model)
   }
   const abortModelDownload = async (model: Model) => {
-    await abortDownload(join('models', model.id, modelBinFileName(model)))
+    await abortDownload(
+      await joinPath(['models', model.id, modelBinFileName(model)])
+    )
   }
 
   return {

--- a/web/hooks/useDownloadModel.ts
+++ b/web/hooks/useDownloadModel.ts
@@ -1,6 +1,15 @@
-import { Model, ExtensionType, ModelExtension } from '@janhq/core'
+import { join } from 'path'
+
+import {
+  Model,
+  ExtensionType,
+  ModelExtension,
+  abortDownload,
+} from '@janhq/core'
 
 import { useSetAtom } from 'jotai'
+
+import { modelBinFileName } from '@/utils/model'
 
 import { useDownloadState } from './useDownloadState'
 
@@ -33,8 +42,12 @@ export default function useDownloadModel() {
       .get<ModelExtension>(ExtensionType.Model)
       ?.downloadModel(model)
   }
+  const abortModelDownload = async (model: Model) => {
+    await abortDownload(join('models', model.id, modelBinFileName(model)))
+  }
 
   return {
     downloadModel,
+    abortModelDownload,
   }
 }

--- a/web/hooks/useEngineSettings.ts
+++ b/web/hooks/useEngineSettings.ts
@@ -1,10 +1,10 @@
-import { join } from 'path'
-
-import { fs } from '@janhq/core'
+import { fs, joinPath } from '@janhq/core'
 
 export const useEngineSettings = () => {
   const readOpenAISettings = async () => {
-    const settings = await fs.readFile(join('engines', 'openai.json'))
+    const settings = await fs.readFile(
+      await joinPath(['engines', 'openai.json'])
+    )
     if (settings) {
       return JSON.parse(settings)
     }
@@ -17,7 +17,10 @@ export const useEngineSettings = () => {
   }) => {
     const settings = await readOpenAISettings()
     settings.api_key = apiKey
-    await fs.writeFile(join('engines', 'openai.json'), JSON.stringify(settings))
+    await fs.writeFile(
+      await joinPath(['engines', 'openai.json']),
+      JSON.stringify(settings)
+    )
   }
   return { readOpenAISettings, saveOpenAISettings }
 }

--- a/web/screens/Chat/ChatBody/index.tsx
+++ b/web/screens/Chat/ChatBody/index.tsx
@@ -116,7 +116,7 @@ const ChatBody: React.FC = () => {
       ) : (
         <ScrollToBottom className="flex h-full w-full flex-col">
           {messages.map((message, index) => (
-            <>
+            <div key={message.id}>
               <ChatItem {...message} key={message.id} />
 
               {message.status === MessageStatus.Error &&
@@ -126,8 +126,8 @@ const ChatBody: React.FC = () => {
                     className="mt-10 flex flex-col items-center"
                   >
                     <span className="mb-3 text-center text-sm font-medium text-gray-500">
-                      Oops! The generation was interrupted. Let&apos;s
-                      give it another go!
+                      Oops! The generation was interrupted. Let&apos;s give it
+                      another go!
                     </span>
                     <Button
                       className="w-min"
@@ -140,7 +140,7 @@ const ChatBody: React.FC = () => {
                     </Button>
                   </div>
                 )}
-            </>
+            </div>
           ))}
         </ScrollToBottom>
       )}

--- a/web/utils/model.ts
+++ b/web/utils/model.ts
@@ -1,0 +1,10 @@
+import { Model } from '@janhq/core'
+
+export const modelBinFileName = (model: Model) => {
+  const modelFormatExt = '.gguf'
+  const extractedFileName = model.source_url.split('/').pop() ?? model.id
+  const fileName = extractedFileName.toLowerCase().endsWith(modelFormatExt)
+    ? extractedFileName
+    : model.id
+  return fileName
+}

--- a/web/utils/model.ts
+++ b/web/utils/model.ts
@@ -1,8 +1,10 @@
+import { basename } from 'path'
+
 import { Model } from '@janhq/core'
 
 export const modelBinFileName = (model: Model) => {
   const modelFormatExt = '.gguf'
-  const extractedFileName = model.source_url.split('/').pop() ?? model.id
+  const extractedFileName = basename(model.source_url) ?? model.id
   const fileName = extractedFileName.toLowerCase().endsWith(modelFormatExt)
     ? extractedFileName
     : model.id

--- a/web/utils/model_param.ts
+++ b/web/utils/model_param.ts
@@ -22,8 +22,7 @@ export const toRuntimeParams = (
 
   for (const [key, value] of Object.entries(modelParams)) {
     if (key in defaultModelParams) {
-      // @ts-ignore
-      runtimeParams[key] = value
+      runtimeParams[key as keyof ModelRuntimeParams] = value
     }
   }
 
@@ -46,8 +45,7 @@ export const toSettingParams = (
 
   for (const [key, value] of Object.entries(modelParams)) {
     if (key in defaultSettingParams) {
-      // @ts-ignore
-      settingParams[key] = value
+      settingParams[key as keyof ModelSettingParams] = value
     }
   }
 


### PR DESCRIPTION
## Description


1. GGUF model with `.download` ext while downloading
![Screenshot 2023-12-28 at 00 50 34](https://github.com/janhq/jan/assets/133622055/9f3dfafd-0f71-4046-a98d-89aa7c6e7576)

2. GGUF model with origin filename instead of model id
![Screenshot 2023-12-28 at 00 27 35](https://github.com/janhq/jan/assets/133622055/5a6f449d-3ae8-43f5-8ba5-c6e0a5f2050a)

fixes #1231 
fixes #1039
fixes #1072