### PR TITLE
fix: enable command enter on dialog confirmation clean thread

### DIFF
--- a/web/screens/Chat/ThreadList/index.tsx
+++ b/web/screens/Chat/ThreadList/index.tsx
@@ -136,6 +136,7 @@ export default function ThreadList() {
                             <Button
                               themes="danger"
                               onClick={() => cleanThread(thread.id)}
+                              autoFocus
                             >
                               Yes
                             </Button>


### PR DESCRIPTION
fixes: #1260 

### solution
- add auto focus on button `yes` when user hit enter on dialog confirmation clean thread

### screenshot
<img width="1509" alt="Screenshot 2023-12-30 at 13 38 26" src="https://github.com/janhq/jan/assets/10354610/e4d2f45e-fd4e-48e6-b209-25d4ad46ff82">
