### PR TITLE
feat: add swagger /docs to localhost:1337

### DIFF
--- a/docs/docs/guides/05-using-server/01-server.md
+++ b/docs/docs/guides/05-using-server/01-server.md
@@ -27,6 +27,6 @@ Jan runs on port `1337` by default, but this can be changed in Settings.
 Check out the [API Reference](/api-reference) for more information on the API endpoints.
 
 ```
-curl https://localhost:1337/v1/chat/completions
+curl http://localhost:1337/v1/chat/completions
 
 ```

--- a/docs/openapi/jan.yaml
+++ b/docs/openapi/jan.yaml
@@ -14,7 +14,7 @@ license:
   name: AGPLv3
   url: "https://github.com/janhq/nitro/blob/main/LICENSE"
 servers:
-  - url: "https://localhost:1337/v1/"
+  - url: "http://localhost:1337/v1/"
 tags:
   - name: Models
     description: List and describe the various models available in the API.
@@ -100,7 +100,7 @@ paths:
       x-codeSamples:
         - lang: cURL
           source: |
-            curl https://localhost:1337/v1/models
+            curl http://localhost:1337/v1/models
     post:
       operationId: downloadModel
       tags:
@@ -118,7 +118,7 @@ paths:
       x-codeSamples:
         - lang: cURL
           source: |
-            curl -X POST https://localhost:1337/v1/models
+            curl -X POST http://localhost:1337/v1/models
   "/models/{model_id}":
     get:
       operationId: retrieveModel
@@ -149,7 +149,7 @@ paths:
       x-codeSamples:
         - lang: cURL
           source: |
-            curl https://localhost:1337/v1/models/{model_id}
+            curl http://localhost:1337/v1/models/{model_id}
     delete:
       operationId: deleteModel
       tags:
@@ -178,7 +178,7 @@ paths:
       x-codeSamples:
         - lang: cURL
           source: |
-            curl -X DELETE https://localhost:1337/v1/models/{model_id}
+            curl -X DELETE http://localhost:1337/v1/models/{model_id}
   "/models/{model_id}/start":
     put:
       operationId: startModel
@@ -206,7 +206,7 @@ paths:
       x-codeSamples:
         - lang: cURL
           source: |
-            curl -X PUT https://localhost:1337/v1/models/{model_id}/start
+            curl -X PUT http://localhost:1337/v1/models/{model_id}/start
   "/models/{model_id}/stop":
     put:
       operationId: stopModel
@@ -233,7 +233,7 @@ paths:
       x-codeSamples:
         - lang: cURL
           source: |
-            curl -X PUT https://localhost:1337/v1/models/{model_id}/stop
+            curl -X PUT http://localhost:1337/v1/models/{model_id}/stop
   /threads:
     post:
       operationId: createThread

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,6 +10,23 @@ const JAN_API_PORT = Number.parseInt(process.env.JAN_API_PORT || "1337");
 
 const server = fastify();
 server.register(require("@fastify/cors"), {});
+server.register(require("@fastify/swagger"), {
+  mode: "static",
+  specification: {
+    path: "./../docs/openapi/jan.yaml",
+    baseDir: "./../docs/openapi",
+  },
+});
+server.register(require("@fastify/swagger-ui"), {
+  routePrefix: "/docs",
+  baseDir: path.join(__dirname, "../..", "./docs/openapi"),
+  uiConfig: {
+    docExpansion: "full",
+    deepLinking: false,
+  },
+  staticCSP: true,
+  transformSpecificationClone: true,
+});
 server.register(
   (childContext, _, done) => {
     childContext.register(require("@fastify/static"), {

--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,8 @@
   "dependencies": {
     "@fastify/cors": "^8.4.2",
     "@fastify/static": "^6.12.0",
+    "@fastify/swagger": "^8.13.0",
+    "@fastify/swagger-ui": "^2.0.1",
     "@janhq/core": "link:./core",
     "dotenv": "^16.3.1",
     "fastify": "^4.24.3",


### PR DESCRIPTION
## Description
As a user, I would like to see all supported APIs and test them out. Local swagger hosted at /docs would be helpful.

<img width="1512" alt="Screenshot 2023-12-31 at 12 58 42" src="https://github.com/janhq/jan/assets/133622055/2612a363-3af8-4394-a3da-64e761fc9ae4">
