### PR TITLE
fix: support markdown break line

### DIFF
--- a/web/styles/components/message.scss
+++ b/web/styles/components/message.scss
@@ -1,5 +1,7 @@
 .message {
   @apply text-black dark:text-gray-300;
+  white-space: pre-line;
+
   ul,
   ol {
     list-style: auto;
@@ -9,4 +11,8 @@
 
 button[class*='react-scroll-to-bottom--'] {
   display: none;
+}
+
+.code-block {
+  white-space: normal;
 }


### PR DESCRIPTION
fixes #1253 

### Test scenario
- Open app chat with any model
- Go to `thread` folder enter to your thread id there are a file `message.jsonl`
- Try edit the answer and add `\n` save and refresh your app

### Screenshots

No `\n`
<img width="733" alt="Screenshot 2023-12-31 at 22 49 01" src="https://github.com/janhq/jan/assets/10354610/63835bbc-9edd-4f43-a12a-b41d20c03771">
<img width="1406" alt="Screenshot 2023-12-31 at 22 49 16" src="https://github.com/janhq/jan/assets/10354610/fe785616-fb05-46ee-b95a-b70a7d799a8b">

with `\n`
<img width="749" alt="Screenshot 2023-12-31 at 22 49 33" src="https://github.com/janhq/jan/assets/10354610/be779ff4-efbc-45ab-9ba7-df2d245cebb8">
<img width="1450" alt="Screenshot 2023-12-31 at 22 49 46" src="https://github.com/janhq/jan/assets/10354610/97673924-81d1-448a-874c-dcb43db53e11">
