### PR TITLE
Switch from systeminformation to os-utils to resolve Bitdefender false positive and memory leak issue

### DIFF
--- a/extensions/inference-nitro-extension/package.json
+++ b/extensions/inference-nitro-extension/package.json
@@ -32,9 +32,9 @@
     "@janhq/core": "file:../../core",
     "download-cli": "^1.1.1",
     "fetch-retry": "^5.0.6",
+    "os-utils": "^0.0.14",
     "path-browserify": "^1.0.1",
     "rxjs": "^7.8.1",
-    "systeminformation": "^5.21.20",
     "tcp-port-used": "^1.0.2",
     "ts-loader": "^9.5.0",
     "ulid": "^2.3.0"
@@ -50,6 +50,6 @@
   "bundleDependencies": [
     "tcp-port-used",
     "fetch-retry",
-    "systeminformation"
+    "os-utils"
   ]
 }

--- a/extensions/inference-nitro-extension/src/module.ts
+++ b/extensions/inference-nitro-extension/src/module.ts
@@ -4,7 +4,7 @@ const path = require("path");
 const { exec, spawn } = require("child_process");
 const tcpPortUsed = require("tcp-port-used");
 const fetchRetry = require("fetch-retry")(global.fetch);
-const si = require("systeminformation");
+const osUtils = require("os-utils");
 const { readFileSync, writeFileSync, existsSync } = require("fs");
 
 // The PORT to use for the Nitro subprocess
@@ -440,11 +440,10 @@ function spawnNitroProcess(nitroResourceProbe: any): Promise<any> {
  */
 function getResourcesInfo(): Promise<ResourcesInfo> {
   return new Promise(async (resolve) => {
-    const cpu = await si.cpu();
-    // const mem = await si.mem();
-
+    const cpu = await osUtils.cpuCount();
+    console.log("cpu: ", cpu);
     const response: ResourcesInfo = {
-      numCpuPhysicalCore: cpu.physicalCores,
+      numCpuPhysicalCore: cpu,
       memAvailable: 0,
     };
     resolve(response);

--- a/extensions/monitoring-extension/package.json
+++ b/extensions/monitoring-extension/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@janhq/core": "file:../../core",
-    "systeminformation": "^5.21.8",
+    "os-utils": "^0.0.14",
     "ts-loader": "^9.5.0"
   },
   "files": [
@@ -26,6 +26,6 @@
     "README.md"
   ],
   "bundleDependencies": [
-    "systeminformation"
+    "os-utils"
   ]
 }

--- a/extensions/monitoring-extension/src/module.ts
+++ b/extensions/monitoring-extension/src/module.ts
@@ -1,22 +1,32 @@
-const si = require("systeminformation");
+const os = require("os");
+const osUtils = require("os-utils");
 
-const getResourcesInfo = async () =>
-  new Promise(async (resolve) => {
-    const cpu = await si.cpu();
-    const mem = await si.mem();
-    // const gpu = await si.graphics();
+const getResourcesInfo = () =>
+  new Promise((resolve) => {
+    const totalMemory = os.totalmem();
+    const freeMemory = os.freemem();
+    const usedMemory = totalMemory - freeMemory;
+
     const response = {
-      cpu,
-      mem,
-      // gpu,
+      mem: {
+        totalMemory,
+        usedMemory,
+      },
     };
     resolve(response);
   });
 
-const getCurrentLoad = async () =>
-  new Promise(async (resolve) => {
-    const currentLoad = await si.currentLoad();
-    resolve(currentLoad);
+const getCurrentLoad = () =>
+  new Promise((resolve) => {
+    osUtils.cpuUsage(function(v){
+      const cpuPercentage = v * 100;
+      const response = {
+        cpu: {
+          usage: cpuPercentage,
+        },
+      };
+      resolve(response);
+    });
   });
 
 module.exports = {

--- a/web/hooks/useGetSystemResources.ts
+++ b/web/hooks/useGetSystemResources.ts
@@ -32,24 +32,26 @@ export default function useGetSystemResources() {
     const currentLoadInfor = await monitoring?.getCurrentLoad()
 
     const ram =
-      (resourceInfor?.mem?.active ?? 0) / (resourceInfor?.mem?.total ?? 1)
-    if (resourceInfor?.mem?.active) setUsedRam(resourceInfor.mem.active)
-    if (resourceInfor?.mem?.total) setTotalRam(resourceInfor.mem.total)
+      (resourceInfor?.mem?.usedMemory ?? 0) /
+      (resourceInfor?.mem?.totalMemory ?? 1)
+    if (resourceInfor?.mem?.usedMemory) setUsedRam(resourceInfor.mem.usedMemory)
+    if (resourceInfor?.mem?.totalMemory)
+      setTotalRam(resourceInfor.mem.totalMemory)
 
     setRam(Math.round(ram * 100))
-    setCPU(Math.round(currentLoadInfor?.currentLoad ?? 0))
-    setCpuUsage(Math.round(currentLoadInfor?.currentLoad ?? 0))
+    setCPU(Math.round(currentLoadInfor?.cpu?.usage ?? 0))
+    setCpuUsage(Math.round(currentLoadInfor?.cpu?.usage ?? 0))
   }
 
   useEffect(() => {
     getSystemResources()
 
-    // Fetch interval - every 5s
+    // Fetch interval - every 2s
     // TODO: Will we really need this?
     // There is a possibility that this will be removed and replaced by the process event hook?
     const intervalId = setInterval(() => {
       getSystemResources()
-    }, 5000)
+    }, 2000)
 
     // clean up interval
     return () => clearInterval(intervalId)


### PR DESCRIPTION
This PR introduces a significant change in our system monitoring approach. We have switched from the `systeminformation` library to `os-utils` to address two critical issues:

1. Bitdefender was incorrectly flagging our monitor extension as a virus. This false positive was causing unnecessary alarm and confusion among our users. By switching to `os-utils`, we have resolved this issue.

2. We have also addressed a memory leak issue that was affecting our Windows users. The `os-utils` library provides more efficient memory management, which has helped us eliminate this problem.

These changes will improve the overall performance and reliability of our application, providing a better user experience. We look forward to your feedback on these improvements.