### PR TITLE
fix: user should be able to access Swagger docs from localhost:1337

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -45,7 +45,7 @@ export const startServer = async (schemaPath?: string, baseDir?: string) => {
     });
 
     await server.register(require("@fastify/swagger-ui"), {
-      routePrefix: "/docs",
+      routePrefix: "/",
       baseDir: baseDir ?? path.join(__dirname, "../..", "./docs/openapi"),
       uiConfig: {
         docExpansion: "full",


### PR DESCRIPTION
## Problem
- Users could not know there is a /docs endpoint (Swagger), should redirect by default when accessing localhost:1337