### PR TITLE
Bring social media links

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -68,6 +68,12 @@ function createMainWindow() {
     if (process.platform !== 'darwin') app.quit()
   })
 
+  /* Open external links in the default browser */
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    require('electron').shell.openExternal(url)
+    return { action: 'deny' }
+  })
+
   /* Enable dev tools for development */
   if (!app.isPackaged) mainWindow.webContents.openDevTools()
 }

--- a/web/containers/Layout/Ribbon/index.tsx
+++ b/web/containers/Layout/Ribbon/index.tsx
@@ -60,7 +60,7 @@ export default function RibbonNav() {
       icon: (
         <Twitter size={20} className="flex-shrink-0 text-muted-foreground" />
       ),
-      link: 'https://twitter.com/janhq',
+      link: 'https://twitter.com/janhq_',
     },
     {
       name: 'Github',

--- a/web/containers/Layout/Ribbon/index.tsx
+++ b/web/containers/Layout/Ribbon/index.tsx
@@ -11,6 +11,8 @@ import {
   SettingsIcon,
   MonitorIcon,
   LayoutGridIcon,
+  Twitter,
+  Github,
 } from 'lucide-react'
 
 import { twMerge } from 'tailwind-merge'
@@ -49,6 +51,23 @@ export default function RibbonNav() {
         />
       ),
       state: MainViewState.Hub,
+    },
+  ]
+
+  const linksMenu = [
+    {
+      name: 'Twitter',
+      icon: (
+        <Twitter size={20} className="flex-shrink-0 text-muted-foreground" />
+      ),
+      link: 'https://twitter.com/janhq',
+    },
+    {
+      name: 'Github',
+      icon: (
+        <Github size={20} className="flex-shrink-0 text-muted-foreground" />
+      ),
+      link: 'https://github.com/janhq/jan',
     },
   ]
 
@@ -118,6 +137,32 @@ export default function RibbonNav() {
           </div>
 
           <div>
+            <>
+              {linksMenu
+                .filter((link) => !!link)
+                .map((link, i) => {
+                  return (
+                    <div className="relative flex p-2" key={i}>
+                      <Tooltip>
+                        <TooltipTrigger>
+                          <a
+                            href={link.link}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="relative flex w-full flex-shrink-0 cursor-pointer items-center justify-center"
+                          >
+                            {link.icon}
+                          </a>
+                        </TooltipTrigger>
+                        <TooltipContent side="right" sideOffset={10}>
+                          <span>{link.name}</span>
+                          <TooltipArrow />
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  )
+                })}
+            </>
             {secondaryMenus
               .filter((secondary) => !!secondary)
               .map((secondary, i) => {


### PR DESCRIPTION
fixes #1273 

I brought back the GitHub and Twitter link back, as for discord, for some reason lucid doesn't have a dedicated discord icon, so I didn't know which Icon I should replace it with, if the team can tell me I would gladly add the icon mentioned.

as for opening the social media links, it seemed cumbersome to me to login every time the new electron window is open, so I open the link in the default browser of the user, if this is not how it should go, I can revert it back.

here is a quick demo: 

https://github.com/janhq/jan/assets/82527700/475f68ea-f673-46d4-a7ae-74064bbfefba

