### PR TITLE
leave the app window active in the dock when closing on mac

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -39,7 +39,7 @@ app
   })
 
 app.once('window-all-closed', () => {
-  cleanUpAndQuit()
+  if (process.platform !== 'darwin') app.quit()
 })
 
 app.once('quit', () => {


### PR DESCRIPTION
fixes #584 

If its macOS, if the close button on the window is pressed we close all windows but we leave the app active in the dock otherwise we quit the app, this quit functionality using cmd + q shortcut on macOS still quits the app completely.

Should still be tested on other OSs.

quick demo:

https://github.com/janhq/jan/assets/82527700/8ac29ac3-e530-4460-883b-a33a95df3f2b

