### PR TITLE
fix(trinity): update cover  path for trinity v1.2

### DIFF
--- a/models/stealth-v1.2-7b/model.json
+++ b/models/stealth-v1.2-7b/model.json
@@ -17,7 +17,8 @@
       "author": "Jan",
       "tags": [
         "7B",
-        "Merged"
+        "Finetuned",
+        "Featured"
       ],
       "size": 4370000000
     },

--- a/models/trinity-v1.2-7b/model.json
+++ b/models/trinity-v1.2-7b/model.json
@@ -17,7 +17,7 @@
       "author": "Jan",
       "tags": ["7B", "Merged", "Featured"],
       "size": 4370000000,
-      "cover": "https://raw.githubusercontent.com/janhq/jan/main/models/trinity-v1-7b/cover.png"
+      "cover": "https://raw.githubusercontent.com/janhq/jan/main/models/trinity-v1.2-7b/cover.png"
     },
     "engine": "nitro"
   }  


### PR DESCRIPTION
Correct the path for the cover image of `trinity v1.2`