### PR TITLE
fix: Update stop token for models

### DIFF
--- a/extensions/model-extension/package.json
+++ b/extensions/model-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janhq/model-extension",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Model Management Extension provides model exploration and seamless downloads",
   "main": "dist/index.js",
   "module": "dist/module.js",

--- a/models/mistral-ins-7b-q4/model.json
+++ b/models/mistral-ins-7b-q4/model.json
@@ -1,24 +1,24 @@
 {
-    "source_url": "https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF/resolve/main/mistral-7b-instruct-v0.2.Q4_K_M.gguf",
-    "id": "mistral-ins-7b-q4",
-    "object": "model",
-    "name": "Mistral Instruct 7B Q4",
-    "version": "1.0",
-    "description": "This is a 4-bit quantized iteration of MistralAI's Mistral Instruct 7b model, specifically designed for a comprehensive understanding through training on extensive internet data.",
-    "format": "gguf",
-    "settings": {
-      "ctx_len": 4096,
-      "prompt_template": "<s>[INST]{prompt}\n[/INST]"
-    },
-    "parameters": {
-      "max_tokens": 4096
-    },
-    "metadata": {
-      "author": "MistralAI, The Bloke",
-      "tags": ["Featured", "7B", "Foundational Model"],
-      "size": 4370000000,
-      "cover": "https://raw.githubusercontent.com/janhq/jan/main/models/mistral-ins-7b-q4/cover.png"
-    },
-    "engine": "nitro"
-  }
-  
+  "source_url": "https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.2-GGUF/resolve/main/mistral-7b-instruct-v0.2.Q4_K_M.gguf",
+  "id": "mistral-ins-7b-q4",
+  "object": "model",
+  "name": "Mistral Instruct 7B Q4",
+  "version": "1.1",
+  "description": "This is a 4-bit quantized iteration of MistralAI's Mistral Instruct 7b model, specifically designed for a comprehensive understanding through training on extensive internet data.",
+  "format": "gguf",
+  "settings": {
+    "ctx_len": 4096,
+    "prompt_template": "<s>[INST]{prompt}\n[/INST]",
+    "stop_word": "<s>"
+  },
+  "parameters": {
+    "max_tokens": 4096
+  },
+  "metadata": {
+    "author": "MistralAI, The Bloke",
+    "tags": ["Featured", "7B", "Foundational Model"],
+    "size": 4370000000,
+    "cover": "https://raw.githubusercontent.com/janhq/jan/main/models/mistral-ins-7b-q4/cover.png"
+  },
+  "engine": "nitro"
+}


### PR DESCRIPTION
## Describe Your Changes
- There are some reported case for instruction-based models that has strikethrough. This is because of the stop word parameters are not well-defined and pass to nitro in loadModel stage properly

## Fixes Issues
- TBU

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [x] Updated docs (for bug fixes / features)
- [x] Created issues for follow-up changes or refactoring needed
