### PR TITLE
fix: render external links

### DIFF
--- a/web/styles/components/message.scss
+++ b/web/styles/components/message.scss
@@ -6,6 +6,14 @@
   ol {
     list-style: auto;
     padding-left: 24px;
+    white-space: normal;
+  }
+
+  a {
+    @apply text-blue-600 dark:text-blue-300;
+    &:hover {
+      @apply underline;
+    }
   }
 }
 


### PR DESCRIPTION
@namchuai already fix this as a functionality i just enhance better UX/UI for readability user

## Describe Your Changes
- make sure render external link correctly and open new tab
- give a blue color and hover underline for better UX

## Fixes Issues
fixes #1368 

<img width="1472" alt="Screenshot 2024-01-08 at 14 10 34" src="https://github.com/janhq/jan/assets/10354610/3f547210-d1ea-4509-8464-532d426eecd0">
<img width="1472" alt="Screenshot 2024-01-08 at 14 10 27" src="https://github.com/janhq/jan/assets/10354610/b5595ae6-c323-4e1a-ae6a-f95a6e4f2622">
