### PR TITLE
fix: suppress all main node JS error message dialog

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2,7 +2,6 @@ import { app, BrowserWindow } from 'electron'
 import { join } from 'path'
 import { setupMenu } from './utils/menu'
 import { createUserSpace } from './utils/path'
-
 /**
  * Managers
  **/
@@ -19,7 +18,7 @@ import { handleAppIPCs } from './handlers/app'
 import { handleAppUpdates } from './handlers/update'
 import { handleFsIPCs } from './handlers/fs'
 import { migrateExtensions } from './utils/migration'
-import { dispose } from './utils/disposable'
+import { cleanUpAndQuit } from './utils/clean'
 
 app
   .whenReady()
@@ -89,12 +88,10 @@ function handleIPCs() {
   handleFileMangerIPCs()
 }
 
-function cleanUpAndQuit() {
-  if (!ModuleManager.instance.cleaningResource) {
-    ModuleManager.instance.cleaningResource = true
-    WindowManager.instance.currentWindow?.destroy()
-    dispose(ModuleManager.instance.requiredModules)
-    ModuleManager.instance.clearImportedModules()
-    app.quit()
-  }
-}
+/*
+** Suppress Node error messages
+*/
+process.on('uncaughtException', function (err) {
+  // TODO: Write error to log file in #1447
+  console.error(err)
+})

--- a/electron/utils/clean.ts
+++ b/electron/utils/clean.ts
@@ -1,0 +1,14 @@
+import { ModuleManager } from '@janhq/core/node'
+import { WindowManager } from './../managers/window'
+import { dispose } from './disposable'
+import { app } from 'electron'
+
+export function cleanUpAndQuit() {
+  if (!ModuleManager.instance.cleaningResource) {
+    ModuleManager.instance.cleaningResource = true
+    WindowManager.instance.currentWindow?.destroy()
+    dispose(ModuleManager.instance.requiredModules)
+    ModuleManager.instance.clearImportedModules()
+    app.quit()
+  }
+}


### PR DESCRIPTION
## Describe Your Changes
As per user reports, there is still a case where the app could show a 'JavaScript error occurred in the main process' on quit. This pull request is intended to handle unhandled exceptions so that we can log them to the error log accordingly in #1430

![jan ai_2](https://github.com/janhq/jan/assets/133622055/f62e9de2-31e4-4d6f-b1af-b60ee07b440f)


## Fixes Issues
fixes #1264

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

## Next Actions
Write unhandled error message into log file in #1430 for further user problem report.
