### PR TITLE
fix: adjust calculation hub labels using total RAM instead remaining RAM

### DIFF
--- a/web/screens/ExploreModels/ExploreModelItemHeader/index.tsx
+++ b/web/screens/ExploreModels/ExploreModelItemHeader/index.tsx
@@ -14,7 +14,6 @@ import ModalCancelDownload from '@/containers/ModalCancelDownload'
 
 import { MainViewState } from '@/constants/screens'
 
-import { useActiveModel } from '@/hooks/useActiveModel'
 import { useCreateNewThread } from '@/hooks/useCreateNewThread'
 import useDownloadModel from '@/hooks/useDownloadModel'
 import { useDownloadState } from '@/hooks/useDownloadState'
@@ -24,7 +23,7 @@ import { useMainViewState } from '@/hooks/useMainViewState'
 
 import { toGibibytes } from '@/utils/converter'
 
-import { totalRamAtom, usedRamAtom } from '@/helpers/atoms/SystemBar.atom'
+import { totalRamAtom } from '@/helpers/atoms/SystemBar.atom'
 
 type Props = {
   model: Model
@@ -38,7 +37,6 @@ const ExploreModelItemHeader: React.FC<Props> = ({ model, onClick, open }) => {
   const { modelDownloadStateAtom, downloadStates } = useDownloadState()
   const { requestCreateNewThread } = useCreateNewThread()
   const totalRam = useAtomValue(totalRamAtom)
-  const usedRam = useAtomValue(usedRamAtom)
 
   const downloadAtom = useMemo(
     () => atom((get) => get(modelDownloadStateAtom)[model.id]),
@@ -84,30 +82,17 @@ const ExploreModelItemHeader: React.FC<Props> = ({ model, onClick, open }) => {
     downloadButton = <ModalCancelDownload model={model} />
   }
 
-  const { activeModel } = useActiveModel()
-
   const getLabel = (size: number) => {
-    const minimumRamModel = size * 1.25
-    const availableRam = totalRam - usedRam + (activeModel?.metadata.size ?? 0)
-
-    if (minimumRamModel > totalRam) {
+    if (size * 1.25 >= totalRam) {
       return (
         <Badge className="rounded-md" themes="danger">
           Not enough RAM
         </Badge>
       )
-    }
-    if (minimumRamModel < availableRam) {
+    } else {
       return (
         <Badge className="rounded-md" themes="success">
           Recommended
-        </Badge>
-      )
-    }
-    if (minimumRamModel < totalRam && minimumRamModel > availableRam) {
-      return (
-        <Badge className="rounded-md" themes="warning">
-          Slow on your device
         </Badge>
       )
     }


### PR DESCRIPTION
## Describe Your Changes

calculation hub labels using total RAM instead remaining RAM

## Fixes Issues
#1521 

<img width="1312" alt="Screenshot 2024-01-11 at 16 28 29" src="https://github.com/janhq/jan/assets/10354610/14cd3579-ef66-41c7-8245-972a124c6b46">
<img width="1312" alt="Screenshot 2024-01-11 at 16 28 13" src="https://github.com/janhq/jan/assets/10354610/544300c7-dd00-45e4-b2a5-c48612fe1e03">


## Self Checklist
- [x] Updated docs (for bug fixes / features)

