### PR TITLE
[WIP] feat: Thread titles should auto-summarize Topic

### DIFF
--- a/core/src/events.ts
+++ b/core/src/events.ts
@@ -21,6 +21,10 @@ export enum EventName {
   OnModelStopped = 'OnModelStopped',
   /** The `OnInferenceStopped` event is emitted when a inference is stopped. */
   OnInferenceStopped = 'OnInferenceStopped',
+  /** The `OnFirstPrompt` event is emitted when the first prompt is entered in a thread. */
+  OnFirstPrompt = 'OnFirstPrompt',
+/** The `OnFirstPrompt` event is emitted when the first prompt is updated. */
+  OnFirstPromptUpdate = 'OnFirstPromptUpdate',
 }
 
 /**

--- a/extensions/inference-nitro-extension/src/helpers/sse.ts
+++ b/extensions/inference-nitro-extension/src/helpers/sse.ts
@@ -30,6 +30,8 @@ export function requestInference(
       signal: controller?.signal,
     })
       .then(async (response) => {
+        console.log("--------- HELPER SSE --------");
+        console.log(response);
         if (model.parameters.stream === false) {
           const data = await response.json();
           subscriber.next(data.choices[0]?.message?.content ?? "");

--- a/extensions/inference-nitro-extension/src/index.ts
+++ b/extensions/inference-nitro-extension/src/index.ts
@@ -89,6 +89,7 @@ export default class JanInferenceNitroExtension implements InferenceExtension {
     this.writeDefaultEngineSettings();
 
     // Events subscription
+    console.log("------ EVENT SUBSCRIPTION ---------");
     events.on(EventName.OnMessageSent, (data) => this.onMessageRequest(data));
 
     events.on(EventName.OnModelInit, (model: Model) => this.onModelInit(model));
@@ -96,6 +97,8 @@ export default class JanInferenceNitroExtension implements InferenceExtension {
     events.on(EventName.OnModelStop, (model: Model) => this.onModelStop(model));
 
     events.on(EventName.OnInferenceStopped, () => this.onInferenceStopped());
+
+    events.on(EventName.OnFirstPrompt, (firstPrompt) => this.onFirstPrompt(firstPrompt));
 
     // Attempt to fetch nvidia info
     await executeOnMain(MODULE, "updateNvidiaInfo", {});
@@ -215,6 +218,58 @@ export default class JanInferenceNitroExtension implements InferenceExtension {
     });
   }
 
+  private async onFirstPrompt(firstPrompt: string) {
+    console.log("------ ON FIRST PROMPT NITRO ------");
+    console.log(firstPrompt);
+
+    // const timestamp = Date.now();
+    // const message: ThreadMessage = {
+    //   id: ulid(),
+    //   thread_id: 0,
+    //   assistant_id: 0,
+    //   role: ChatCompletionRole.Assistant,
+    //   content: [],
+    //   status: MessageStatus.Pending,
+    //   created: timestamp,
+    //   updated: timestamp,
+    //   object: "thread.message",
+    // };
+
+    // requestInference(
+    //   data.messages ?? [],
+    //   { ...this._currentModel, ...data.model },
+    //   this.controller
+    // ).subscribe({
+    //   next: (content) => {
+    //     const messageContent: ThreadContent = {
+    //       type: ContentType.Text,
+    //       text: {
+    //         value: content.trim(),
+    //         annotations: [],
+    //       },
+    //     };
+    //     message.content = [messageContent];
+    //     events.emit(EventName.OnFirstPromptUpdate, message);
+    //   },
+    //   complete: async () => {
+    //     message.status = message.content.length
+    //       ? MessageStatus.Ready
+    //       : MessageStatus.Error;
+    //     events.emit(EventName.OnFirstPromptUpdate, message);
+    //   },
+    //   error: async (err) => {
+    //     if (this.isCancelled || message.content.length) {
+    //       message.status = MessageStatus.Stopped;
+    //       events.emit(EventName.OnFirstPromptUpdate, message);
+    //       return;
+    //     }
+    //     message.status = MessageStatus.Error;
+    //     events.emit(EventName.OnFirstPromptUpdate, message);
+    //     log(`[APP]::Error: ${err.message}`);
+    //   },
+    // });
+  }
+
   /**
    * Handles a new message request by making an inference request and emitting events.
    * Function registered in event manager, should be static to avoid binding issues.
@@ -222,6 +277,9 @@ export default class JanInferenceNitroExtension implements InferenceExtension {
    * @param {MessageRequest} data - The data for the new message request.
    */
   private async onMessageRequest(data: MessageRequest) {
+    console.log("----- ON MESSAGE REQUEST -----");
+    console.log(data);
+    
     if (data.model.engine !== "nitro") return;
 
     const timestamp = Date.now();

--- a/extensions/inference-openai-extension/src/index.ts
+++ b/extensions/inference-openai-extension/src/index.ts
@@ -74,9 +74,14 @@ export default class JanInferenceOpenAIExtension implements InferenceExtension {
     events.on(EventName.OnModelStop, (model: OpenAIModel) => {
       JanInferenceOpenAIExtension.handleModelStop(model);
     });
+
     events.on(EventName.OnInferenceStopped, () => {
       JanInferenceOpenAIExtension.handleInferenceStopped(this);
     });
+
+    events.on(EventName.OnFirstPrompt, (firstPrompt) =>
+      JanInferenceOpenAIExtension.onFirstPrompt(firstPrompt)
+    );
   }
 
   /**
@@ -164,6 +169,11 @@ export default class JanInferenceOpenAIExtension implements InferenceExtension {
   ) {
     instance.isCancelled = true;
     instance.controller?.abort();
+  }
+
+  private static async onFirstPrompt(firstPrompt: string) {
+    console.log("------ ON FIRST PROMPT OPENAI ------");
+    console.log(firstPrompt);
   }
 
   /**

--- a/web/helpers/atoms/Thread.atom.ts
+++ b/web/helpers/atoms/Thread.atom.ts
@@ -49,6 +49,7 @@ export const deleteThreadStateAtom = atom(
 export const updateThreadInitSuccessAtom = atom(
   null,
   (get, set, threadId: string) => {
+    console.log("------ INIT THREAD ATOM -------");
     const currentState = { ...get(threadStatesAtom) }
     currentState[threadId] = {
       ...currentState[threadId],

--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -22,6 +22,8 @@ import {
 } from '@/helpers/atoms/Thread.atom'
 
 const createNewThreadAtom = atom(null, (get, set, newThread: Thread) => {
+  console.log("----- REQUEST CREATE NEW THREAD ATOM ----");
+  console.log(newThread);
   // create thread state for this new thread
   const currentState = { ...get(threadStatesAtom) }
 
@@ -40,6 +42,7 @@ const createNewThreadAtom = atom(null, (get, set, newThread: Thread) => {
 })
 
 export const useCreateNewThread = () => {
+  // console.log("----- USE CREATE NEW THREAD ----");
   const threadStates = useAtomValue(threadStatesAtom)
   const createNewThread = useSetAtom(createNewThreadAtom)
   const setActiveThreadId = useSetAtom(setActiveThreadIdAtom)
@@ -50,6 +53,7 @@ export const useCreateNewThread = () => {
     assistant: Assistant,
     model?: Model | undefined
   ) => {
+    console.log("----- REQUEST CREATE NEW THREAD ----");
     // loop through threads state and filter if there's any thread that is not finish init
     let unfinishedInitThreadId: string | undefined = undefined
     for (const key in threadStates) {

--- a/web/hooks/useSendChatMessage.ts
+++ b/web/hooks/useSendChatMessage.ts
@@ -27,6 +27,8 @@ import { toRuntimeParams, toSettingParams } from '@/utils/modelParam'
 
 import { useActiveModel } from './useActiveModel'
 
+import { requestInference } from "../helpers/sse";
+
 import { extensionManager } from '@/extension/ExtensionManager'
 import {
   addNewMessageAtom,
@@ -135,9 +137,11 @@ export default function useSendChatMessage() {
   }
 
   const sendChatMessage = async () => {
+    console.log("----- SEND CHAT MESSAGE -----");
     if (!currentPrompt || currentPrompt.trim().length === 0) return
 
     if (!activeThread) {
+      console.log("----- SEND CHAT MESSAGE NO ACTIVE -----");
       console.error('No active thread')
       return
     }
@@ -148,11 +152,14 @@ export default function useSendChatMessage() {
     const runtimeParams = toRuntimeParams(activeModelParams)
     const settingParams = toSettingParams(activeModelParams)
 
+    const modelRequest = selectedModel ?? activeThread.assistants[0].model
+
     // if the thread is not initialized, we need to initialize it first
     if (
       !activeThreadState.isFinishInit ||
       activeThread.assistants[0].model.id !== selectedModel?.id
     ) {
+      console.log("---- INIT THREAD ---");
       if (!selectedModel) {
         toaster({ title: 'Please select a model' })
         return
@@ -177,8 +184,40 @@ export default function useSendChatMessage() {
           },
         ],
       }
+
       updateThreadInitSuccess(activeThread.id)
       updateThread(updatedThread)
+
+      console.log("---- UPDATE INIT SUCCESS ---");
+      console.log("---- ACTIVE THREAD ---");
+      console.log(activeThread);
+      console.log("---- UPDATED THREAD ---");
+      console.log(updatedThread);
+
+      // This is the first time message comes in on a new thread
+      // 1. Get the summary of the first prompt using whatever engine user is currently using
+      const firstPrompt = currentPrompt.trim();
+
+      // Prompt: Given this query from user {query}, return to me the summary in 5 words as the title
+      // const msgId = ulid()
+      // const messages: ChatCompletionMessage[] = [
+      //   "Summarize '" + firstPrompt + "' in 5 words as a title",
+      // ]
+      // const messageRequest: MessageRequest = {
+      //   id: msgId,
+      //   threadId: activeThread.id,
+      //   messages,
+      //   model: {
+      //     ...modelRequest,
+      //     settings: settingParams,
+      //     parameters: runtimeParams,
+      //   },
+      // }
+
+      events.emit(EventName.OnFirstPrompt, firstPrompt);
+
+      // 2. Update the title with the result of the inference
+      updatedThread.title = "Hello World!";
 
       await extensionManager
         .get<ConversationalExtension>(ExtensionType.Conversational)
@@ -189,7 +228,14 @@ export default function useSendChatMessage() {
 
     const prompt = currentPrompt.trim()
     setCurrentPrompt('')
+    console.log("----- PROMPT ---");
+    console.log(prompt);
+    console.log("----- CURRENT MESSAGES -----");
+    console.log(currentMessages);
 
+    console.log("----- ACTIVE THREAD INSTRUCTIONS -----");
+    console.log(activeThread.assistants[0]?.instructions);
+    
     const messages: ChatCompletionMessage[] = [
       activeThread.assistants[0]?.instructions,
     ]
@@ -215,8 +261,9 @@ export default function useSendChatMessage() {
           ])
       )
     const msgId = ulid()
+    console.log("------ MESSAGES ------");
+    console.log(messages);
 
-    const modelRequest = selectedModel ?? activeThread.assistants[0].model
     if (runtimeParams.stream == null) {
       runtimeParams.stream = true
     }
@@ -250,6 +297,9 @@ export default function useSendChatMessage() {
       ],
     }
 
+    console.log("----- THREAD MESSAGE -----");
+    console.log(threadMessage.content);
+
     addNewMessage(threadMessage)
 
     await extensionManager
@@ -265,7 +315,7 @@ export default function useSendChatMessage() {
       setQueuedMessage(false)
     }
 
-    events.emit(EventName.OnMessageSent, messageRequest)
+    events.emit(EventName.OnMessageSent, messageRequest);
 
     setReloadModel(false)
     setEngineParamsUpdate(false)


### PR DESCRIPTION
Issue https://github.com/janhq/jan/issues/979

The core logic is [here](https://github.com/janhq/jan/pull/1554/files#diff-4bcabf86358832bf98408dfb9dc4ef66ba0d94bd74dc5281e8ba8a2586668860R197)

I made changes on the following files so that I can capture [the event emitted on the first prompt](https://github.com/janhq/jan/pull/1554/files#diff-4bcabf86358832bf98408dfb9dc4ef66ba0d94bd74dc5281e8ba8a2586668860R217)

```bash
        modified:   extensions/inference-nitro-extension/src/index.ts
        modified:   extensions/inference-openai-extension/src/index.ts
```

Then we figured that `make dev` does not update the files in the Jan runtime:

```bash
/Users/gokuz/jan/extensions/@janhq/inference-openai-extension
/Users/gokuz/jan/extensions/@janhq/inference-nitro-extension
```

So I tried to manually copy and paste the following:

```bash
~/jan/extensions/inference-openai-extension/dist
~/jan/extensions/inference-openai-extension/package.json
~/jan/extensions/inference-openai-extension/README.md



~/jan/extensions/inference-nitro-extension/dist
~/jan/extensions/inference-nitro-extension/package.json
~/jan/extensions/inference-nitro-extension/README.md
```

Then I start seeing this error:

```bash
[0] Missing `origin` header from a forwarded Server Actions request.
[0] Missing `origin` header from a forwarded Server Actions request.
[1] Error occurred in handler for 'invokeExtensionFunc': Error: Cannot find module 'tcp-port-used'
[1] Require stack:
[1] - /Users/gokuz/jan/extensions/@janhq/inference-nitro-extension/dist/module.js
[1] - /Users/gokuz/Documents/jan/electron/build/handlers/extension.js
[1] - /Users/gokuz/Documents/jan/electron/build/main.js
[1]     at Module._resolveFilename (node:internal/modules/cjs/loader:1084:15)
[1]     at n._resolveFilename (node:electron/js2c/browser_init:2:114728)
[1]     at Module._load (node:internal/modules/cjs/loader:929:27)
[1]     at l._load (node:electron/js2c/asar_bundle:2:13642)
[1]     at Module.require (node:internal/modules/cjs/loader:1150:19)
[1]     at require (node:internal/modules/cjs/helpers:119:18)
[1]     at Object.<anonymous> (/Users/gokuz/jan/extensions/@janhq/inference-nitro-extension/dist/module.js:13:21)
[1]     at Module._compile (node:internal/modules/cjs/loader:1271:14)
[1]     at Module._extensions..js (node:internal/modules/cjs/loader:1326:10)
[1]     at Module.load (node:internal/modules/cjs/loader:1126:32)
[1]     at Module._load (node:internal/modules/cjs/loader:967:12)
[1]     at l._load (node:electron/js2c/asar_bundle:2:13642)
[1]     at Module.require (node:internal/modules/cjs/loader:1150:19)
[1]     at require (node:internal/modules/cjs/helpers:119:18)
[1]     at /Users/gokuz/Documents/jan/electron/build/handlers/extension.js:65:26
[1]     at step (/Users/gokuz/Documents/jan/electron/build/handlers/extension.js:33:23) {
[1]   code: 'MODULE_NOT_FOUND',
[1]   requireStack: [
[1]     '/Users/gokuz/jan/extensions/@janhq/inference-nitro-extension/dist/module.js',
[1]     '/Users/gokuz/Documents/jan/electron/build/handlers/extension.js',
[1]     '/Users/gokuz/Documents/jan/electron/build/main.js'
[1]   ]
[1] }
```

![Screenshot_2024-01-12_at_15 55 24](https://github.com/janhq/jan/assets/155065525/1ad2bcb4-f9c3-414a-a7f3-21312eedd888)
