### PR TITLE
fix: #1559 Inference Parameters displayed on new thread with Openai GPT Model

### DIFF
--- a/web/containers/DropdownListSidebar/index.tsx
+++ b/web/containers/DropdownListSidebar/index.tsx
@@ -96,9 +96,16 @@ export default function DropdownListSidebar() {
       const modelParams: ModelParams = {
         ...recommendedModel?.parameters,
         ...recommendedModel?.settings,
-        // This is to set default value for these settings instead of maximum value
-        max_tokens: defaultValue(recommendedModel?.parameters.max_tokens),
-        ctx_len: defaultValue(recommendedModel?.settings.ctx_len),
+        /**
+         * This is to set default value for these settings instead of maximum value
+         * Should only apply when model.json has these settings
+         */
+        ...(recommendedModel?.parameters.max_tokens && {
+          max_tokens: defaultValue(recommendedModel?.parameters.max_tokens),
+        }),
+        ...(recommendedModel?.settings.ctx_len && {
+          ctx_len: defaultValue(recommendedModel?.settings.ctx_len),
+        }),
       }
       setThreadModelParams(activeThread.id, modelParams)
     }


### PR DESCRIPTION
## Describe Your Changes
Fixed an issue where Inference Parameters displayed on new thread with Openai GPT Model, this issue occurred since we set default of the max_tokens and ctx_len <= 4096 <= max value. It should check whether model.json does have these settings before applying the default value.

## Fixes Issues
- #1559

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
