### PR TITLE
fix: #1594 - Model settings - change thread model - go back does not see according settings

### DIFF
--- a/web/hooks/useSetActiveThread.ts
+++ b/web/hooks/useSetActiveThread.ts
@@ -11,14 +11,17 @@ import { useAtomValue, useSetAtom } from 'jotai'
 import { extensionManager } from '@/extension'
 import { setConvoMessagesAtom } from '@/helpers/atoms/ChatMessage.atom'
 import {
+  ModelParams,
   getActiveThreadIdAtom,
   setActiveThreadIdAtom,
+  setThreadModelParamsAtom,
 } from '@/helpers/atoms/Thread.atom'
 
 export default function useSetActiveThread() {
   const activeThreadId = useAtomValue(getActiveThreadIdAtom)
   const setActiveThreadId = useSetAtom(setActiveThreadIdAtom)
   const setThreadMessage = useSetAtom(setConvoMessagesAtom)
+  const setThreadModelParams = useSetAtom(setThreadModelParamsAtom)
 
   const setActiveThread = async (thread: Thread) => {
     if (activeThreadId === thread.id) {
@@ -35,6 +38,11 @@ export default function useSetActiveThread() {
     setThreadMessage(thread.id, messages ?? [])
 
     setActiveThreadId(thread.id)
+    const modelParams: ModelParams = {
+      ...thread.assistants[0]?.model?.parameters,
+      ...thread.assistants[0]?.model?.settings,
+    }
+    setThreadModelParams(thread.id, modelParams)
   }
 
   return { activeThreadId, setActiveThread }


### PR DESCRIPTION
## Describe Your Changes
Fixed an issue where user revisit thread after changed model without sending message could lead to wrong settings displayed.

Flow: 
- User go to thread A with model B -> change to model Y
- User go to thread X with model Y
- User go back to thread A see model B selected but Y's settings (Wrong)

## Fixes Issues

- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
