### PR TITLE
Feat: Add Dolphin 2.6 Phi-2 🐬

### DIFF
--- a/models/dolphin-2.6-phi-2/model.json
+++ b/models/dolphin-2.6-phi-2/model.json
@@ -14,7 +14,8 @@
     "prompt_template": "<|im_start|>system\n{system_message}<|im_end|>\n<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n"
   },
   "parameters": {
-    "max_tokens": 4096
+    "max_tokens": 4096,
+    "stop": ["<|im_end|>"]
   },
   "metadata": {
     "author": "Cognitive Computations, Microsoft, TheBloke",

--- a/models/dolphin-2.6-phi-2/model.json
+++ b/models/dolphin-2.6-phi-2/model.json
@@ -1,0 +1,29 @@
+{
+  "source_url": "https://huggingface.co/TheBloke/dolphin-2_6-phi-2-GGUF/resolve/main/dolphin-2_6-phi-2.Q4_K_M.gguf",
+  "id": "dolphin-2.6-phi-2",
+  "object": "model",
+  "name": "Dolphin 2.6 Phi-2 2.7B Q4",
+  "version": "1.0",
+  "description": "Dolphin 2.6 Phi-2 is a 2.7B model, fine-tuned for chat, excelling in common sense and logical reasoning benchmarks.",
+  "format": "gguf",
+  "settings": {
+    "ctx_len": 4096,
+    "system_prompt": "<|im_start|>system\nYou are Dolphin, a helpful AI assistant.<|im_end|>\n",
+    "user_prompt": "<|im_start|>user\n",
+    "ai_prompt": "<|im_end|>\n<|im_start|>assistant\n",
+    "prompt_template": "<|im_start|>system\n{system_message}<|im_end|>\n<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n"
+  },
+  "parameters": {
+    "max_tokens": 4096
+  },
+  "metadata": {
+    "author": "Cognitive Computations, Microsoft, TheBloke",
+    "tags": [
+      "2.7B",
+      "Chat Model"
+    ],
+    "size": 1790000000
+  },
+  "engine": "nitro",
+  "state": "ready"
+}

--- a/models/dolphin-2.6-phi-2/model.json
+++ b/models/dolphin-2.6-phi-2/model.json
@@ -25,6 +25,5 @@
     ],
     "size": 1790000000
   },
-  "engine": "nitro",
-  "state": "ready"
+  "engine": "nitro"
 }

--- a/models/dolphin-2.6-phi-2/model.json
+++ b/models/dolphin-2.6-phi-2/model.json
@@ -8,9 +8,6 @@
   "format": "gguf",
   "settings": {
     "ctx_len": 4096,
-    "system_prompt": "<|im_start|>system\nYou are Dolphin, a helpful AI assistant.<|im_end|>\n",
-    "user_prompt": "<|im_start|>user\n",
-    "ai_prompt": "<|im_end|>\n<|im_start|>assistant\n",
     "prompt_template": "<|im_start|>system\n{system_message}<|im_end|>\n<|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n"
   },
   "parameters": {


### PR DESCRIPTION
## Describe Your Changes

- This PR adds support for Dolphin 2.6 Phi-2 (https://huggingface.co/cognitivecomputations/dolphin-2_6-phi-2) in Jan. This model is a finetuned version of Phi-2 with much better results for chat. It's is a great little model (2.7B) to run locally as a personal assistant.

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [x] Updated docs (for bug fixes / features)
- [x] Created issues for follow-up changes or refactoring needed
