### PR TITLE
fix: #1545 long thread title

### DIFF
--- a/web/containers/Layout/TopBar/index.tsx
+++ b/web/containers/Layout/TopBar/index.tsx
@@ -125,9 +125,14 @@ const TopBar = () => {
               </div>
             </div>
           </div>
-          <div className="absolute left-80 h-full">
+          <div
+            className={twMerge(
+              'absolute left-80 right-10 h-full',
+              showing && 'right-80'
+            )}
+          >
             <div className="flex h-full items-center">
-              <span className="text-sm font-bold">
+              <span className="truncate text-ellipsis text-sm font-bold">
                 {titleScreen(mainViewState)}
               </span>
             </div>


### PR DESCRIPTION
## Describe Your Changes

Changed the CSS to truncate the text if it overflows.

Before:
<img width="1312" alt="Before" src="https://github.com/janhq/jan/assets/47147996/dbb5d196-4ccd-40a0-8305-4bedbd4465ba">

After:
<img width="1312" alt="After" src="https://github.com/janhq/jan/assets/47147996/49ae1c55-ab35-49e7-a840-2dc4ba305f95">

## Fixes Issues

- Closes #1545 

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [x] Updated docs (for bug fixes / features)
- [x] Created issues for follow-up changes or refactoring needed
