### PR TITLE
fix: server API reference

### DIFF
--- a/web/screens/LocalServer/index.tsx
+++ b/web/screens/LocalServer/index.tsx
@@ -127,7 +127,7 @@ const LocalServerScreen = () => {
             </Button>
             {serverEnabled && (
               <Button block themes="secondaryBlue" asChild>
-                <a href={`http://127.0.0.1:${port}`} target="_blank">
+                <a href={`http://${host}:${port}`} target="_blank">
                   API Reference <ExternalLinkIcon size={20} className="ml-2" />
                 </a>
               </Button>


### PR DESCRIPTION
## Describe Your Changes
- `API Reference` local should point to local swagger instead of `jan.ai` remote documentation which is not interactive.
- Only render `API reference` button is `serverEnabled` is `true`

## Fixes Issues
Context: https://discord.com/channels/1107178041848909847/1187243133386375208/1197768679631372329

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [x] Updated docs (for bug fixes / features)
- [x] Created issues for follow-up changes or refactoring needed