### PR TITLE
fix: hot-fix algolia search

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -155,8 +155,8 @@ const config = {
     algolia: {
       appId: process.env.ALGOLIA_APP_ID || "XXX",
       apiKey: process.env.ALGOLIA_API_KEY || "XXX",
-      indexName: "jan",
-      contextualSearch: false,
+      indexName: "jan_docs",
+      contextualSearch: true,
       insights: true,
     },
     // SEO Docusarus


### PR DESCRIPTION
## Describe Your Changes

- Following issue https://github.com/facebook/docusaurus/issues/6693, the reason is crawler search data doesn't have a data type for the docusaurus tag. Thus, if turn on `contextualSearch` search, result will be not found and turn off `contextualSearch`, only modal search works well, full page search e.g jan.ai/search will not working. 

- Solution: 
+ Re-implement the crawler code and added the docusaurus tag. 
+ Created new indices `jan_docs` for crawling data based on this new implementation
+ Modify docusaurus.config.js with `indexName: "jan_docs",` and `contextualSearch: true,`


## Fixes Issues

- Closes #1675 

## Preview
![image](https://github.com/janhq/jan/assets/150573299/61b1c111-5a99-44ef-9f18-c7709c3c609f)


## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [x] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
