### PR TITLE
fix: Jan server - v1/chat/completions is throwing ERR_REQUIRE_ESM

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -81,7 +81,7 @@
     "electron-store": "^8.1.0",
     "electron-updater": "^6.1.7",
     "fs-extra": "^11.2.0",
-    "node-fetch": "^3.3.2",
+    "node-fetch": "2",
     "pacote": "^17.0.4",
     "request": "^2.88.2",
     "request-progress": "^3.0.0",

--- a/server/index.ts
+++ b/server/index.ts
@@ -19,7 +19,7 @@ const JAN_API_PORT = Number.parseInt(process.env.JAN_API_PORT || "1337");
 let server: any | undefined = undefined;
 let hostSetting: string = JAN_API_HOST;
 let portSetting: number = JAN_API_PORT;
-let corsEnbaled: boolean = true;
+let corsEnabled: boolean = true;
 let isVerbose: boolean = true;
 
 /**
@@ -49,7 +49,7 @@ export const startServer = async (configs?: ServerConfig) => {
   isVerbose = configs?.isVerboseEnabled ?? true;
   hostSetting = configs?.host ?? JAN_API_HOST;
   portSetting = configs?.port ?? JAN_API_PORT;
-  corsEnbaled = configs?.isCorsEnabled ?? true;
+  corsEnabled = configs?.isCorsEnabled ?? true;
   const serverLogPath = getServerLogPath();
 
   // Start the server
@@ -66,7 +66,7 @@ export const startServer = async (configs?: ServerConfig) => {
     });
 
     // Register CORS if enabled
-    if (corsEnbaled) await server.register(require("@fastify/cors"), {});
+    if (corsEnabled) await server.register(require("@fastify/cors"), {});
 
     // Register Swagger for API documentation
     await server.register(require("@fastify/swagger"), {


### PR DESCRIPTION
## Describe Your Changes
- node-fetch@^3 is not cjs compatible, it should be node-fetch@2 according to the docs.

TODO:
- Is it possible to configure core/node as ES module?

## Fixes Issues

- Closes #1695

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
