### PR TITLE
fix: API chat/completion is blocked by CORS

### DIFF
--- a/core/src/node/api/common/builder.ts
+++ b/core/src/node/api/common/builder.ts
@@ -317,6 +317,7 @@ export const chatCompletions = async (request: any, reply: any) => {
     'Content-Type': 'text/event-stream',
     'Cache-Control': 'no-cache',
     'Connection': 'keep-alive',
+    "Access-Control-Allow-Origin": "*"
   })
 
   const headers: Record<string, any> = {


### PR DESCRIPTION
## Describe Your Changes
- Fixed an issue where users could not test chat/completion request from localhost:1337 Swagger page due to CORS.
<img width="1436" alt="Screenshot 2024-01-22 at 19 29 16" src="https://github.com/janhq/jan/assets/133622055/0793ffbf-846b-49c8-9211-9f8610516ed2">

## Fixes Issues
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
