### PR TITLE
Hotfix CI pre-release not trigger 

### DIFF
--- a/.github/workflows/jan-electron-build-pre-release.yml
+++ b/.github/workflows/jan-electron-build-pre-release.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "!README.md"
 
 jobs:
 


### PR DESCRIPTION
## Describe Your Changes

Remove paths trigger for pre-release ci to let it trigger on-push to main branch

