### PR TITLE
fix: clean last message when user clean thread message

### DIFF
--- a/web/hooks/useDeleteThread.ts
+++ b/web/hooks/useDeleteThread.ts
@@ -49,6 +49,14 @@ export default function useDeleteThread() {
             threadId,
             messages.filter((msg) => msg.role === ChatCompletionRole.System)
           )
+
+        thread.metadata = {
+          ...thread.metadata,
+          lastMessage: undefined,
+        }
+        await extensionManager
+          .get<ConversationalExtension>(ExtensionTypeEnum.Conversational)
+          ?.saveThread(thread)
         updateThreadLastMessage(threadId, undefined)
       }
     }


### PR DESCRIPTION
## Describe Your Changes

- Clean last message when user clean up the thread

## Fixes Issues

- #1501 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
