### PR TITLE
feat: put timestamp under thread name in left panel

### DIFF
--- a/web/hooks/useSendChatMessage.ts
+++ b/web/hooks/useSendChatMessage.ts
@@ -332,7 +332,7 @@ export default function useSendChatMessage() {
       updated: timestamp,
     }
 
-    // cheange last update thread when send message
+    // change last update thread when send message
     updateThread(updatedThread)
 
     await extensionManager

--- a/web/hooks/useSendChatMessage.ts
+++ b/web/hooks/useSendChatMessage.ts
@@ -172,7 +172,7 @@ export default function useSendChatMessage() {
       const instructions = activeThread.assistants[0].instructions ?? ''
       const tools = activeThread.assistants[0].tools ?? []
 
-      const updatedThread: Thread = {
+      const initThread: Thread = {
         ...activeThread,
         assistants: [
           {
@@ -189,12 +189,13 @@ export default function useSendChatMessage() {
           },
         ],
       }
+
       updateThreadInitSuccess(activeThread.id)
-      updateThread(updatedThread)
+      updateThread(initThread)
 
       await extensionManager
         .get<ConversationalExtension>(ExtensionTypeEnum.Conversational)
-        ?.saveThread(updatedThread)
+        ?.saveThread(initThread)
     }
 
     updateThreadWaiting(activeThread.id, true)
@@ -325,6 +326,14 @@ export default function useSendChatMessage() {
     if (base64Blob) {
       setFileUpload([])
     }
+
+    const updatedThread: Thread = {
+      ...activeThread,
+      updated: timestamp,
+    }
+
+    // cheange last update thread when send message
+    updateThread(updatedThread)
 
     await extensionManager
       .get<ConversationalExtension>(ExtensionTypeEnum.Conversational)

--- a/web/screens/Chat/ThreadList/index.tsx
+++ b/web/screens/Chat/ThreadList/index.tsx
@@ -84,7 +84,6 @@ export default function ThreadList() {
         threads.map((thread, i) => {
           const lastMessage =
             threadStates[thread.id]?.lastMessage ?? 'No new message'
-
           return (
             <div
               key={i}
@@ -96,13 +95,10 @@ export default function ThreadList() {
               }}
             >
               <div className="relative z-10 p-4 py-4">
-                <div className="flex justify-between">
-                  <h2 className="line-clamp-1 font-bold">{thread.title}</h2>
-                  <p className="mb-1 line-clamp-1 text-xs leading-5 text-muted-foreground">
-                    {thread.updated &&
-                      displayDate(new Date(thread.updated).getTime())}
-                  </p>
-                </div>
+                <p className="line-clamp-1 text-xs leading-5 text-muted-foreground">
+                  {thread.updated && displayDate(thread.updated)}
+                </p>
+                <h2 className="line-clamp-1 font-bold">{thread.title}</h2>
                 <p className="mt-1 line-clamp-1 text-xs text-gray-700 group-hover/message:max-w-[160px] dark:text-gray-300">
                   {lastMessage || 'No new message'}
                 </p>
@@ -161,9 +157,9 @@ export default function ThreadList() {
                       <div className="flex cursor-pointer items-center space-x-2 px-4 py-2 hover:bg-secondary">
                         <Trash2Icon
                           size={16}
-                          className="text-muted-foreground"
+                          className="text-red-600 dark:text-red-300"
                         />
-                        <span className="text-bold text-black dark:text-muted-foreground">
+                        <span className="text-bold text-red-600 dark:text-red-300">
                           Delete thread
                         </span>
                       </div>


### PR DESCRIPTION
## Describe Your Changes

- [x]  To put timestamp above the thread name
- [x] "Delete thread" should be in red
- [x]  The time should be the last use time (not the time the thread was created)

<img width="1505" alt="Screenshot 2024-01-28 at 12 56 07" src="https://github.com/janhq/jan/assets/10354610/b33d2ff5-185a-4b9a-8087-d858c1d870a2">


## Fixes Issues

- #1472

## Self Checklist
- [x] Updated docs (for bug fixes / features)

