### PR TITLE
fix: add loader when user change folder

### DIFF
--- a/web/containers/Layout/index.tsx
+++ b/web/containers/Layout/index.tsx
@@ -27,7 +27,6 @@ const BaseLayout = (props: PropsWithChildren) => {
   useEffect(() => {
     if (localStorage.getItem(SUCCESS_SET_NEW_DESTINATION) === 'true') {
       setMainViewState(MainViewState.Settings)
-      localStorage.removeItem(SUCCESS_SET_NEW_DESTINATION)
     }
   }, [setMainViewState])
 

--- a/web/screens/Settings/Advanced/DataFolder/index.tsx
+++ b/web/screens/Settings/Advanced/DataFolder/index.tsx
@@ -5,6 +5,8 @@ import { Button, Input } from '@janhq/uikit'
 import { useSetAtom } from 'jotai'
 import { PencilIcon, FolderOpenIcon } from 'lucide-react'
 
+import Loader from '@/containers/Loader'
+
 import { SUCCESS_SET_NEW_DESTINATION } from '@/hooks/useVaultDirectory'
 
 import ModalChangeDirectory, {
@@ -13,10 +15,12 @@ import ModalChangeDirectory, {
 import ModalErrorSetDestGlobal, {
   showChangeFolderErrorAtom,
 } from './ModalErrorSetDestGlobal'
+
 import ModalSameDirectory, { showSamePathModalAtom } from './ModalSameDirectory'
 
 const DataFolder = () => {
   const [janDataFolderPath, setJanDataFolderPath] = useState('')
+  const [showLoader, setShowLoader] = useState(false)
   const setShowDirectoryConfirm = useSetAtom(showDirectoryConfirmModalAtom)
   const setShowSameDirectory = useSetAtom(showSamePathModalAtom)
   const setShowChangeFolderError = useSetAtom(showChangeFolderErrorAtom)
@@ -46,18 +50,20 @@ const DataFolder = () => {
   const onUserConfirmed = useCallback(async () => {
     if (!destinationPath) return
     try {
+      setShowLoader(true)
       const appConfiguration: AppConfiguration =
         await window.core?.api?.getAppConfigurations()
       const currentJanDataFolder = appConfiguration.data_folder
       appConfiguration.data_folder = destinationPath
       await fs.syncFile(currentJanDataFolder, destinationPath)
       await window.core?.api?.updateAppConfiguration(appConfiguration)
-
       console.debug(
         `File sync finished from ${currentJanDataFolder} to ${destinationPath}`
       )
-
       localStorage.setItem(SUCCESS_SET_NEW_DESTINATION, 'true')
+      setTimeout(() => {
+        setShowLoader(false)
+      }, 1200)
       await window.core?.api?.relaunch()
     } catch (e) {
       console.error(`Error: ${e}`)
@@ -107,6 +113,7 @@ const DataFolder = () => {
         onUserConfirmed={onUserConfirmed}
       />
       <ModalErrorSetDestGlobal />
+      {showLoader && <Loader description="Relocating Jan Data Folder..." />}
     </Fragment>
   )
 }

--- a/web/screens/Settings/index.tsx
+++ b/web/screens/Settings/index.tsx
@@ -49,6 +49,7 @@ const SettingsScreen = () => {
   useEffect(() => {
     if (localStorage.getItem(SUCCESS_SET_NEW_DESTINATION) === 'true') {
       setActiveStaticMenu('Advanced Settings')
+      localStorage.removeItem(SUCCESS_SET_NEW_DESTINATION)
     }
   }, [])
 


### PR DESCRIPTION
## Describe Your Changes
add loader for block user from doing anything while the folder is moving

## Fixes Issues
#1618 

<img width="1483" alt="Screenshot_2024-01-29_at_16 48 25" src="https://github.com/janhq/jan/assets/10354610/f516c685-cf5c-4df3-aea6-a7bef7afddee">


## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [x] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
