### PR TITLE
fix: generating response loader always show up during message response

### DIFF
--- a/web/containers/Providers/EventHandler.tsx
+++ b/web/containers/Providers/EventHandler.tsx
@@ -50,9 +50,10 @@ export default function EventHandler({ children }: { children: ReactNode }) {
 
   const onNewMessageResponse = useCallback(
     (message: ThreadMessage) => {
+      updateThreadWaiting(message.thread_id, false)
       addNewMessage(message)
     },
-    [addNewMessage]
+    [addNewMessage, updateThreadWaiting]
   )
 
   const onModelReady = useCallback(


### PR DESCRIPTION
## Describe Your Changes
Update threads state when onMessageResponse event handler

## Fixes Issues
#1861 

Uploading Screen Recording 2024-01-30 at 10.58.34.mov…

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [x] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
