### PR TITLE
fix: openAIEmbedding now requires top level API Key configuration

### DIFF
--- a/extensions/assistant-extension/src/node/tools/retrieval/index.ts
+++ b/extensions/assistant-extension/src/node/tools/retrieval/index.ts
@@ -35,21 +35,19 @@ export class Retrieval {
     if (engine === "nitro") {
       this.embeddingModel = new OpenAIEmbeddings(
         { openAIApiKey: "nitro-embedding" },
-        { basePath: "http://127.0.0.1:3928/v1" }
+        { basePath: "http://127.0.0.1:3928/v1" },
       );
     } else {
       // Fallback to OpenAI Settings
       this.embeddingModel = new OpenAIEmbeddings({
-        configuration: {
-          apiKey: settings.api_key,
-        },
+        openAIApiKey: settings.api_key,
       });
     }
   }
 
   public ingestAgentKnowledge = async (
     filePath: string,
-    memoryPath: string
+    memoryPath: string,
   ): Promise<any> => {
     const loader = new PDFLoader(filePath, {
       splitPages: true,

--- a/extensions/inference-nitro-extension/src/index.ts
+++ b/extensions/inference-nitro-extension/src/index.ts
@@ -226,9 +226,6 @@ export default class JanInferenceNitroExtension extends InferenceExtension {
    */
   private async onMessageRequest(data: MessageRequest) {
     if (data.model?.engine !== InferenceEngine.nitro || !this._currentModel) {
-      console.log(
-        `Model is not nitro or no model loaded ${data.model?.engine} ${this._currentModel}`
-      );
       return;
     }
 

--- a/web/screens/Settings/Advanced/index.tsx
+++ b/web/screens/Settings/Advanced/index.tsx
@@ -109,10 +109,10 @@ const Advanced = () => {
         <div className="flex w-full items-start justify-between border-b border-border py-4 first:pt-0 last:border-none">
           <div className="flex-shrink-0 space-y-1.5">
             <div className="flex gap-x-2">
-              <h6 className="text-sm font-semibold capitalize">NVidia GPU</h6>
+              <h6 className="text-sm font-semibold capitalize">Nvidia GPU</h6>
             </div>
             <p className="leading-relaxed">
-              Enable GPU acceleration for NVidia GPUs.
+              Enable GPU acceleration for Nvidia GPUs.
             </p>
           </div>
           <Switch


### PR DESCRIPTION
## Describe Your Changes
The client api key setting is deprecated, now configure on top level

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
