### PR TITLE
fix: avoid users to create so many threads at the same time

### DIFF
--- a/web/containers/Providers/EventHandler.tsx
+++ b/web/containers/Providers/EventHandler.tsx
@@ -33,6 +33,7 @@ import {
   updateThreadWaitingForResponseAtom,
   threadsAtom,
   isGeneratingResponseAtom,
+  updateThreadAtom,
 } from '@/helpers/atoms/Thread.atom'
 
 export default function EventHandler({ children }: { children: ReactNode }) {
@@ -49,6 +50,7 @@ export default function EventHandler({ children }: { children: ReactNode }) {
   const modelsRef = useRef(downloadedModels)
   const threadsRef = useRef(threads)
   const setIsGeneratingResponse = useSetAtom(isGeneratingResponseAtom)
+  const updateThread = useSetAtom(updateThreadAtom)
 
   useEffect(() => {
     threadsRef.current = threads
@@ -131,6 +133,12 @@ export default function EventHandler({ children }: { children: ReactNode }) {
           ...thread.metadata,
           lastMessage: messageContent,
         }
+
+        updateThread({
+          ...thread,
+          metadata,
+        })
+
         extensionManager
           .get<ConversationalExtension>(ExtensionTypeEnum.Conversational)
           ?.saveThread({

--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -54,7 +54,7 @@ export const useCreateNewThread = () => {
 
   const { recommendedModel, downloadedModels } = useRecommendedModel()
 
-  const threadStates = useAtomValue(threadStatesAtom)
+  const threads = useAtomValue(threadsAtom)
 
   const requestCreateNewThread = async (
     assistant: Assistant,
@@ -62,12 +62,11 @@ export const useCreateNewThread = () => {
   ) => {
     const defaultModel = model ?? recommendedModel ?? downloadedModels[0]
 
-    // check threads last message, if there empty last message use can not create thread
-    for (const key in threadStates) {
-      const lastMessage = threadStates[key].lastMessage
-      if (!lastMessage) {
-        return
-      }
+    // check last thread message, if there empty last message use can not create thread
+    const lastMessage = threads[0]?.metadata?.lastMessage
+
+    if (!lastMessage && threads.length !== 0) {
+      return null
     }
 
     const createdAt = Date.now()

--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -65,7 +65,7 @@ export const useCreateNewThread = () => {
     // check last thread message, if there empty last message use can not create thread
     const lastMessage = threads[0]?.metadata?.lastMessage
 
-    if (!lastMessage && threads.length !== 0) {
+    if (!lastMessage && threads.length) {
       return null
     }
 

--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -7,7 +7,7 @@ import {
   ThreadState,
   Model,
 } from '@janhq/core'
-import { atom, useSetAtom } from 'jotai'
+import { atom, useAtomValue, useSetAtom } from 'jotai'
 
 import { selectedModelAtom } from '@/containers/DropdownListSidebar'
 import { fileUploadAtom } from '@/containers/Providers/Jotai'
@@ -19,6 +19,7 @@ import useRecommendedModel from './useRecommendedModel'
 import useSetActiveThread from './useSetActiveThread'
 
 import { extensionManager } from '@/extension'
+
 import {
   threadsAtom,
   threadStatesAtom,
@@ -53,11 +54,21 @@ export const useCreateNewThread = () => {
 
   const { recommendedModel, downloadedModels } = useRecommendedModel()
 
+  const threadStates = useAtomValue(threadStatesAtom)
+
   const requestCreateNewThread = async (
     assistant: Assistant,
     model?: Model | undefined
   ) => {
     const defaultModel = model ?? recommendedModel ?? downloadedModels[0]
+
+    // check threads last message, if there empty last message use can not create thread
+    for (const key in threadStates) {
+      const lastMessage = threadStates[key].lastMessage
+      if (!lastMessage) {
+        return
+      }
+    }
 
     const createdAt = Date.now()
     const assistantInfo: ThreadAssistantInfo = {

--- a/web/screens/Chat/ThreadList/index.tsx
+++ b/web/screens/Chat/ThreadList/index.tsx
@@ -35,8 +35,6 @@ export default function ThreadList() {
     [setActiveThread]
   )
 
-  console.log(threadStates)
-
   return (
     <div className="px-3 py-4">
       {threads.length === 0 ? (

--- a/web/screens/Chat/ThreadList/index.tsx
+++ b/web/screens/Chat/ThreadList/index.tsx
@@ -35,6 +35,8 @@ export default function ThreadList() {
     [setActiveThread]
   )
 
+  console.log(threadStates)
+
   return (
     <div className="px-3 py-4">
       {threads.length === 0 ? (
@@ -62,7 +64,9 @@ export default function ThreadList() {
               </p>
               <h2 className="line-clamp-1 font-bold">{thread.title}</h2>
               <p className="mt-1 line-clamp-1 text-xs text-gray-700 group-hover/message:max-w-[160px] dark:text-gray-300">
-                {threadStates[thread.id]?.lastMessage ?? 'No new message'}
+                {threadStates[thread.id]?.lastMessage
+                  ? threadStates[thread.id]?.lastMessage
+                  : 'No new message'}
               </p>
             </div>
             <div


### PR DESCRIPTION
## Describe Your Changes
checking last message threads if there are empty last message we prevent create new thread

## Fixes Issues

#1887 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [x] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
