### PR TITLE
fix: model downloads broken on nightly

### DIFF
--- a/core/src/node/api/routes/download.ts
+++ b/core/src/node/api/routes/download.ts
@@ -1,5 +1,5 @@
 import { DownloadRoute } from '../../../api'
-import { join } from 'path'
+import { join, sep } from 'path'
 import { DownloadManager } from '../../download'
 import { HttpServer } from '../HttpServer'
 import { createWriteStream } from 'fs'
@@ -38,7 +38,7 @@ export const downloadRouter = async (app: HttpServer) => {
     })
 
     const localPath = normalizedArgs[1]
-    const array = localPath.split('/')
+    const array = localPath.split(sep)
     const fileName = array.pop() ?? ''
     const modelId = array.pop() ?? ''
     console.debug('downloadFile', normalizedArgs, fileName, modelId)
@@ -99,7 +99,7 @@ export const downloadRouter = async (app: HttpServer) => {
     })
 
     const localPath = normalizedArgs[0]
-    const fileName = localPath.split('/').pop() ?? ''
+    const fileName = localPath.split(sep).pop() ?? ''
     const rq = DownloadManager.instance.networkRequests[fileName]
     DownloadManager.instance.networkRequests[fileName] = undefined
     rq?.abort()

--- a/electron/handlers/download.ts
+++ b/electron/handlers/download.ts
@@ -1,5 +1,5 @@
 import { ipcMain } from 'electron'
-import { resolve } from 'path'
+import { resolve, sep } from 'path'
 import { WindowManager } from './../managers/window'
 import request from 'request'
 import { createWriteStream, renameSync } from 'fs'
@@ -68,7 +68,7 @@ export function handleDownloaderIPCs() {
       if (typeof localPath === 'string') {
         localPath = normalizeFilePath(localPath)
       }
-      const array = localPath.split('/')
+      const array = localPath.split(sep)
       const fileName = array.pop() ?? ''
       const modelId = array.pop() ?? ''
 

--- a/electron/handlers/download.ts
+++ b/electron/handlers/download.ts
@@ -46,7 +46,7 @@ export function handleDownloaderIPCs() {
         DownloadEvent.onFileDownloadError,
         {
           fileName,
-          err: { message: 'aborted' },
+          error: 'aborted',
         }
       )
     }
@@ -92,13 +92,13 @@ export function handleDownloaderIPCs() {
             }
           )
         })
-        .on('error', function (err: Error) {
+        .on('error', function (error: Error) {
           WindowManager?.instance.currentWindow?.webContents.send(
             DownloadEvent.onFileDownloadError,
             {
               fileName,
-              err,
               modelId,
+              error,
             }
           )
         })
@@ -121,7 +121,7 @@ export function handleDownloaderIPCs() {
               {
                 fileName,
                 modelId,
-                err: { message: 'aborted' },
+                error: 'aborted',
               }
             )
           }

--- a/web/hooks/useDownloadState.ts
+++ b/web/hooks/useDownloadState.ts
@@ -44,7 +44,10 @@ export const setDownloadStateAtom = atom(
         })
       } else {
         let error = state.error
-        if (state.error?.includes('certificate')) {
+        if (
+          typeof error?.includes === 'function' &&
+          state.error?.includes('certificate')
+        ) {
           error +=
             '. To fix enable "Ignore SSL Certificates" in Advanced settings.'
         }


### PR DESCRIPTION
## Describe Your Changes
Root cause: wrong path splitting (separator) on Windows. Also addressed model cancel issue on both platforms.

<img width="963" alt="Screenshot 2024-02-10 at 12 45 26" src="https://github.com/janhq/jan/assets/133622055/a3c8cbb8-e9d5-47f9-8eeb-609b803464e9">
<img width="964" alt="Screenshot 2024-02-10 at 12 45 38" src="https://github.com/janhq/jan/assets/133622055/12c81628-6269-4eec-9086-06890bd4de37">
<img width="1312" alt="Screenshot 2024-02-10 at 12 44 40" src="https://github.com/janhq/jan/assets/133622055/06a4a6b3-f893-4a1c-9c6b-cd5f51bad72e">


## Fixes Issues

- Closes #1980
## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
