### PR TITLE
fix: retrieval stuck at generating response

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -25,25 +25,11 @@ import { migrateExtensions } from './utils/migration'
 import { cleanUpAndQuit } from './utils/clean'
 import { setupExtensions } from './utils/extension'
 import { setupCore } from './utils/setup'
+import { setupReactDevTool } from './utils/dev'
 
 app
   .whenReady()
-  .then(async () => {
-    if (!app.isPackaged) {
-      // Which means you're running from source code
-      const { default: installExtension, REACT_DEVELOPER_TOOLS } = await import(
-        'electron-devtools-installer'
-      ) // Don't use import on top level, since the installer package is dev-only
-      try {
-        const name = installExtension(REACT_DEVELOPER_TOOLS)
-        console.log(`Added Extension: ${name}`)
-      } catch (err) {
-        console.log('An error occurred while installing devtools:')
-        console.error(err)
-        // Only log the error and don't throw it because it's not critical
-      }
-    }
-  })
+  .then(setupReactDevTool)
   .then(setupCore)
   .then(createUserSpace)
   .then(migrateExtensions)

--- a/electron/utils/dev.ts
+++ b/electron/utils/dev.ts
@@ -1,0 +1,18 @@
+import { app } from 'electron'
+
+export const setupReactDevTool = async () => {
+  if (!app.isPackaged) {
+    // Which means you're running from source code
+    const { default: installExtension, REACT_DEVELOPER_TOOLS } = await import(
+      'electron-devtools-installer'
+    ) // Don't use import on top level, since the installer package is dev-only
+    try {
+      const name = installExtension(REACT_DEVELOPER_TOOLS)
+      console.log(`Added Extension: ${name}`)
+    } catch (err) {
+      console.log('An error occurred while installing devtools:')
+      console.error(err)
+      // Only log the error and don't throw it because it's not critical
+    }
+  }
+}

--- a/extensions/assistant-extension/package.json
+++ b/extensions/assistant-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@janhq/assistant-extension",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "This extension enables assistants, including Jan, a default assistant that can call all downloaded models",
   "main": "dist/index.js",
   "node": "dist/node/index.js",

--- a/extensions/assistant-extension/src/node/index.ts
+++ b/extensions/assistant-extension/src/node/index.ts
@@ -1,39 +1,39 @@
 import { getJanDataFolderPath, normalizeFilePath } from "@janhq/core/node";
-import { Retrieval } from "./tools/retrieval";
+import { retrieval } from "./tools/retrieval";
 import path from "path";
 
-const retrieval = new Retrieval();
-
-export async function toolRetrievalUpdateTextSplitter(
+export function toolRetrievalUpdateTextSplitter(
   chunkSize: number,
-  chunkOverlap: number,
+  chunkOverlap: number
 ) {
   retrieval.updateTextSplitter(chunkSize, chunkOverlap);
-  return Promise.resolve();
 }
 export async function toolRetrievalIngestNewDocument(
   file: string,
-  engine: string,
+  engine: string
 ) {
   const filePath = path.join(getJanDataFolderPath(), normalizeFilePath(file));
   const threadPath = path.dirname(filePath.replace("files", ""));
   retrieval.updateEmbeddingEngine(engine);
-  await retrieval.ingestAgentKnowledge(filePath, `${threadPath}/memory`);
-  return Promise.resolve();
+  return retrieval
+    .ingestAgentKnowledge(filePath, `${threadPath}/memory`)
+    .catch((err) => {
+      console.error(err);
+    });
 }
 
 export async function toolRetrievalLoadThreadMemory(threadId: string) {
-  try {
-    await retrieval.loadRetrievalAgent(
-      path.join(getJanDataFolderPath(), "threads", threadId, "memory"),
-    );
-    return Promise.resolve();
-  } catch (err) {
-    console.debug(err);
-  }
+  return retrieval
+    .loadRetrievalAgent(
+      path.join(getJanDataFolderPath(), "threads", threadId, "memory")
+    )
+    .catch((err) => {
+      console.error(err);
+    });
 }
 
 export async function toolRetrievalQueryResult(query: string) {
-  const res = await retrieval.generateResult(query);
-  return Promise.resolve(res);
+  return retrieval.generateResult(query).catch((err) => {
+    console.error(err);
+  });
 }

--- a/extensions/assistant-extension/src/node/tools/retrieval/index.ts
+++ b/extensions/assistant-extension/src/node/tools/retrieval/index.ts
@@ -35,6 +35,7 @@ export class Retrieval {
     if (engine === "nitro") {
       this.embeddingModel = new OpenAIEmbeddings(
         { openAIApiKey: "nitro-embedding" },
+        // TODO: Raw settings
         { basePath: "http://127.0.0.1:3928/v1" },
       );
     } else {
@@ -75,3 +76,5 @@ export class Retrieval {
     return Promise.resolve(serializedDoc);
   };
 }
+
+export const retrieval = new Retrieval();


### PR DESCRIPTION
## Describe Your Changes
Since retrieval is now enabled by default, if users toggle on Experimental Feature. This would lead to an issue where users chat with default remote module without a valid key.

1. Thread stuck at generating response. This is to give a valid error message response.
2. Send wrong message context, without sending a doc but assistant keeps modifying the message context (tool's message template)
3. Redundant requests to VectorDB & Embedding Model

## Fixes Issues

- #1986

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
