### PR TITLE
fix: message should only be interrupted when i start another thread

### DIFF
--- a/web/containers/Providers/EventHandler.tsx
+++ b/web/containers/Providers/EventHandler.tsx
@@ -177,7 +177,6 @@ export default function EventHandler({ children }: { children: ReactNode }) {
       )
       if (message.status === MessageStatus.Pending) {
         if (message.content.length) {
-          updateThreadWaiting(message.thread_id, false)
           setIsGeneratingResponse(false)
         }
         return

--- a/web/helpers/atoms/ChatMessage.atom.ts
+++ b/web/helpers/atoms/ChatMessage.atom.ts
@@ -16,6 +16,8 @@ import {
  */
 export const chatMessages = atom<Record<string, ThreadMessage[]>>({})
 
+export const readyThreadsMessagesAtom = atom<Record<string, boolean>>({})
+
 /**
  * Return the chat messages for the current active conversation
  */
@@ -34,6 +36,10 @@ export const setConvoMessagesAtom = atom(
     }
     newData[threadId] = messages
     set(chatMessages, newData)
+    set(readyThreadsMessagesAtom, {
+      ...get(readyThreadsMessagesAtom),
+      [threadId]: true,
+    })
   }
 )
 

--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -9,6 +9,8 @@ import {
   ThreadState,
   Model,
   AssistantTool,
+  events,
+  InferenceEvent,
 } from '@janhq/core'
 import { atom, useAtomValue, useSetAtom } from 'jotai'
 
@@ -30,6 +32,7 @@ import {
   threadStatesAtom,
   updateThreadAtom,
   setThreadModelParamsAtom,
+  isGeneratingResponseAtom,
 } from '@/helpers/atoms/Thread.atom'
 
 const createNewThreadAtom = atom(null, (get, set, newThread: Thread) => {
@@ -57,6 +60,7 @@ export const useCreateNewThread = () => {
   const setSelectedModel = useSetAtom(selectedModelAtom)
   const setThreadModelParams = useSetAtom(setThreadModelParamsAtom)
   const { experimentalFeature } = useContext(FeatureToggleContext)
+  const setIsGeneratingResponse = useSetAtom(isGeneratingResponseAtom)
 
   const { recommendedModel, downloadedModels } = useRecommendedModel()
 
@@ -66,6 +70,10 @@ export const useCreateNewThread = () => {
     assistant: Assistant,
     model?: Model | undefined
   ) => {
+    // Stop generating if any
+    setIsGeneratingResponse(false)
+    events.emit(InferenceEvent.OnInferenceStopped, {})
+
     const defaultModel = model ?? recommendedModel ?? downloadedModels[0]
 
     // check last thread message, if there empty last message use can not create thread

--- a/web/hooks/useSetActiveThread.ts
+++ b/web/hooks/useSetActiveThread.ts
@@ -1,5 +1,3 @@
-import { useCallback } from 'react'
-
 import { ExtensionTypeEnum, Thread, ConversationalExtension } from '@janhq/core'
 
 import { useAtomValue, useSetAtom } from 'jotai'
@@ -21,28 +19,20 @@ export default function useSetActiveThread() {
   const setThreadModelParams = useSetAtom(setThreadModelParamsAtom)
   const readyMessageThreads = useAtomValue(readyThreadsMessagesAtom)
 
-  const setActiveThread = useCallback(
-    async (thread: Thread) => {
-      // Load local messages only if there are no messages in the state
-      if (!readyMessageThreads[thread.id]) {
-        const messages = await getLocalThreadMessage(thread.id)
-        setThreadMessage(thread.id, messages)
-      }
+  const setActiveThread = async (thread: Thread) => {
+    // Load local messages only if there are no messages in the state
+    if (!readyMessageThreads[thread.id]) {
+      const messages = await getLocalThreadMessage(thread.id)
+      setThreadMessage(thread.id, messages)
+    }
 
-      setActiveThreadId(thread.id)
-      const modelParams: ModelParams = {
-        ...thread.assistants[0]?.model?.parameters,
-        ...thread.assistants[0]?.model?.settings,
-      }
-      setThreadModelParams(thread.id, modelParams)
-    },
-    [
-      setActiveThreadId,
-      setThreadMessage,
-      setThreadModelParams,
-      readyMessageThreads,
-    ]
-  )
+    setActiveThreadId(thread.id)
+    const modelParams: ModelParams = {
+      ...thread.assistants[0]?.model?.parameters,
+      ...thread.assistants[0]?.model?.settings,
+    }
+    setThreadModelParams(thread.id, modelParams)
+  }
 
   return { setActiveThread }
 }

--- a/web/hooks/useSetActiveThread.ts
+++ b/web/hooks/useSetActiveThread.ts
@@ -14,7 +14,6 @@ import { extensionManager } from '@/extension'
 import { setConvoMessagesAtom } from '@/helpers/atoms/ChatMessage.atom'
 import {
   ModelParams,
-  isGeneratingResponseAtom,
   setActiveThreadIdAtom,
   setThreadModelParamsAtom,
 } from '@/helpers/atoms/Thread.atom'
@@ -23,13 +22,9 @@ export default function useSetActiveThread() {
   const setActiveThreadId = useSetAtom(setActiveThreadIdAtom)
   const setThreadMessage = useSetAtom(setConvoMessagesAtom)
   const setThreadModelParams = useSetAtom(setThreadModelParamsAtom)
-  const setIsGeneratingResponse = useSetAtom(isGeneratingResponseAtom)
 
   const setActiveThread = useCallback(
     async (thread: Thread) => {
-      setIsGeneratingResponse(false)
-      events.emit(InferenceEvent.OnInferenceStopped, thread.id)
-
       // load the corresponding messages
       const messages = await getLocalThreadMessage(thread.id)
       setThreadMessage(thread.id, messages)
@@ -41,12 +36,7 @@ export default function useSetActiveThread() {
       }
       setThreadModelParams(thread.id, modelParams)
     },
-    [
-      setActiveThreadId,
-      setThreadMessage,
-      setThreadModelParams,
-      setIsGeneratingResponse,
-    ]
+    [setActiveThreadId, setThreadMessage, setThreadModelParams]
   )
 
   return { setActiveThread }

--- a/web/hooks/useThreads.ts
+++ b/web/hooks/useThreads.ts
@@ -9,8 +9,6 @@ import {
 
 import { useSetAtom } from 'jotai'
 
-import useSetActiveThread from './useSetActiveThread'
-
 import { extensionManager } from '@/extension/ExtensionManager'
 import {
   ModelParams,
@@ -24,7 +22,6 @@ const useThreads = () => {
   const setThreadStates = useSetAtom(threadStatesAtom)
   const setThreads = useSetAtom(threadsAtom)
   const setThreadModelRuntimeParams = useSetAtom(threadModelParamsAtom)
-  const { setActiveThread } = useSetActiveThread()
   const setThreadDataReady = useSetAtom(threadDataReadyAtom)
 
   useEffect(() => {
@@ -56,16 +53,11 @@ const useThreads = () => {
       setThreadStates(localThreadStates)
       setThreads(localThreads)
       setThreadModelRuntimeParams(threadModelParams)
-
-      if (localThreads.length > 0) {
-        setActiveThread(localThreads[0])
-      }
       setThreadDataReady(true)
     }
 
     getThreads()
   }, [
-    setActiveThread,
     setThreadModelRuntimeParams,
     setThreadStates,
     setThreads,

--- a/web/screens/Chat/ChatInput/index.tsx
+++ b/web/screens/Chat/ChatInput/index.tsx
@@ -38,6 +38,8 @@ import { getCurrentChatMessagesAtom } from '@/helpers/atoms/ChatMessage.atom'
 import {
   activeThreadAtom,
   getActiveThreadIdAtom,
+  isGeneratingResponseAtom,
+  threadStatesAtom,
   waitingToSendMessage,
 } from '@/helpers/atoms/Thread.atom'
 
@@ -57,6 +59,12 @@ const ChatInput: React.FC = () => {
   const imageInputRef = useRef<HTMLInputElement>(null)
   const [showAttacmentMenus, setShowAttacmentMenus] = useState(false)
   const { experimentalFeature } = useContext(FeatureToggleContext)
+  const isGeneratingResponse = useAtomValue(isGeneratingResponseAtom)
+  const threadStates = useAtomValue(threadStatesAtom)
+
+  const isStreamingResponse = Object.values(threadStates).some(
+    (threadState) => threadState.waitingForResponse
+  )
 
   const onPromptChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setCurrentPrompt(e.target.value)
@@ -235,7 +243,9 @@ const ChatInput: React.FC = () => {
         accept="application/pdf"
       />
 
-      {messages[messages.length - 1]?.status !== MessageStatus.Pending ? (
+      {messages[messages.length - 1]?.status !== MessageStatus.Pending &&
+      !isGeneratingResponse &&
+      !isStreamingResponse ? (
         <Button
           size="lg"
           disabled={

--- a/web/screens/Chat/ThreadList/index.tsx
+++ b/web/screens/Chat/ThreadList/index.tsx
@@ -49,8 +49,17 @@ export default function ThreadList() {
   useEffect(() => {
     if (threadDataReady && assistants.length > 0 && threads.length === 0) {
       requestCreateNewThread(assistants[0])
+    } else if (threadDataReady && !activeThreadId) {
+      setActiveThread(threads[0])
     }
-  }, [assistants, threads, threadDataReady, requestCreateNewThread])
+  }, [
+    assistants,
+    threads,
+    threadDataReady,
+    requestCreateNewThread,
+    activeThreadId,
+    setActiveThread,
+  ])
 
   return (
     <div className="px-3 py-4">


### PR DESCRIPTION
## Describe Your Changes

- Users should be able to switch between threads to inspect messages and also see the current sending request from another thread, which they can cancel mid-request.
<img width="1312" alt="Screenshot 2024-02-16 at 15 46 33" src="https://github.com/janhq/jan/assets/133622055/62b682c2-36ba-407c-877c-2876b9d2ca95">

- Users would see that the request is cancelled after creating a new thread and go back
<img width="1312" alt="Screenshot 2024-02-16 at 15 46 39" src="https://github.com/janhq/jan/assets/133622055/f05134de-3d3e-4a6d-96ed-edef301dd431">

- Better UX with seamless threads navigation, fixed the issue where user could not see streaming message after going back from another thread (due to in-memory states & local data overwritten)

- Fixed state loop of useThreads, set active thread from component level

## Fixes Issues

- #1191

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
