### PR TITLE
fix: settings page state loop and dark theme

### DIFF
--- a/core/src/node/helper/config.ts
+++ b/core/src/node/helper/config.ts
@@ -1,8 +1,7 @@
-import { AppConfiguration, SystemResourceInfo } from '../../types'
+import { AppConfiguration } from '../../types'
 import { join } from 'path'
 import fs from 'fs'
 import os from 'os'
-import { log, logServer } from './log'
 import childProcess from 'child_process'
 
 // TODO: move this to core

--- a/web/screens/Settings/Advanced/index.tsx
+++ b/web/screens/Settings/Advanced/index.tsx
@@ -85,14 +85,14 @@ const Advanced = () => {
   useEffect(() => {
     const setUseGpuIfPossible = async () => {
       const settings = await readSettings()
-      setGpuEnabled(settings.run_mode === 'gpu' && gpuList.length > 0)
+      setGpuEnabled(settings.run_mode === 'gpu' && settings.gpus?.length > 0)
       setGpusInUse(settings.gpus_in_use || [])
       if (settings.gpus) {
         setGpuList(settings.gpus)
       }
     }
     setUseGpuIfPossible()
-  }, [readSettings, gpuList])
+  }, [readSettings])
 
   const clearLogs = async () => {
     if (await fs.existsSync(`file://logs`)) {
@@ -258,7 +258,7 @@ const Advanced = () => {
               disabled={gpuList.length === 0 || !gpuEnabled}
               value={selectedGpu.join()}
             >
-              <SelectTrigger className="w-[340px] bg-white">
+              <SelectTrigger className="w-[340px] dark:bg-gray-500 bg-white">
                 <SelectValue placeholder={gpuSelectionPlaceHolder}>
                   <span className="line-clamp-1 w-full pr-8">
                     {selectedGpu.join()}

--- a/web/screens/Settings/Advanced/index.tsx
+++ b/web/screens/Settings/Advanced/index.tsx
@@ -273,7 +273,7 @@ const Advanced = () => {
                       <div className="rounded-lg bg-secondary p-3">
                         {gpuList
                           .filter((gpu) =>
-                            gpu.name.toLowerCase().includes('nvidia')
+                            gpu.name?.toLowerCase().includes('nvidia')
                           )
                           .map((gpu) => (
                             <div


### PR DESCRIPTION
## Describe Your Changes
- The state loop causes performance issues
- The selected GPU device label has low contrast 
- Crash on open settings page

Before
![image](https://github.com/janhq/jan/assets/133622055/880ee843-2dfa-4cd7-b4b7-9a6604e7602b)

Fixed
![Screenshot 2024-02-18 120639](https://github.com/janhq/jan/assets/133622055/ffd48597-89f3-4eea-8ad0-10f3269bf621)

## Fixes Issues

- https://github.com/janhq/jan/issues/1851#issuecomment-1948251901

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
