### PR TITLE
fix: move jan data folder - error handling for no write permission granted

### DIFF
--- a/web/screens/Settings/Advanced/DataFolder/index.tsx
+++ b/web/screens/Settings/Advanced/DataFolder/index.tsx
@@ -83,7 +83,11 @@ const DataFolder = () => {
         await window.core?.api?.getAppConfigurations()
       const currentJanDataFolder = appConfiguration.data_folder
       appConfiguration.data_folder = destinationPath
-      await fs.syncFile(currentJanDataFolder, destinationPath)
+      const { _, err } = await fs.syncFile(
+        currentJanDataFolder,
+        destinationPath
+      )
+      if (err) throw err
       await window.core?.api?.updateAppConfiguration(appConfiguration)
       console.debug(
         `File sync finished from ${currentJanDataFolder} to ${destinationPath}`
@@ -94,7 +98,7 @@ const DataFolder = () => {
       }, 1200)
       await window.core?.api?.relaunch()
     } catch (e) {
-      console.error(`Error: ${e}`)
+      console.error(e)
       setShowLoader(false)
       setShowChangeFolderError(true)
     }


### PR DESCRIPTION
## Describe Your Changes
Fixed an issue where user could not move Jan Data Folder but got stuck with a broken build.

![Screenshot 2024-02-18 222228](https://github.com/janhq/jan/assets/133622055/22989589-1070-4836-87c6-cd1eb0696f4f)



## Fixes Issues
- #2073 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
