### PR TITLE
fix: expand assistant and model settings by default

### DIFF
--- a/web/containers/CardSidebar/index.tsx
+++ b/web/containers/CardSidebar/index.tsx
@@ -22,6 +22,7 @@ interface Props {
   rightAction?: ReactNode
   title: string
   asChild?: boolean
+  isShow?: boolean
   hideMoreVerticalAction?: boolean
 }
 export default function CardSidebar({
@@ -30,8 +31,9 @@ export default function CardSidebar({
   asChild,
   rightAction,
   hideMoreVerticalAction,
+  isShow,
 }: Props) {
-  const [show, setShow] = useState(false)
+  const [show, setShow] = useState(isShow ?? false)
   const [more, setMore] = useState(false)
   const [menu, setMenu] = useState<HTMLDivElement | null>(null)
   const [toggle, setToggle] = useState<HTMLDivElement | null>(null)
@@ -67,8 +69,8 @@ export default function CardSidebar({
                 show && 'rotate-180'
               )}
             />
+            <span className="font-bold">{title}</span>
           </button>
-          <span className="font-bold">{title}</span>
         </div>
         <div className="flex">
           {rightAction && rightAction}

--- a/web/containers/OpenAiKeyInput/index.tsx
+++ b/web/containers/OpenAiKeyInput/index.tsx
@@ -30,7 +30,7 @@ const OpenAiKeyInput: React.FC = () => {
   }
 
   return (
-    <div className="mt-4">
+    <div className="my-4">
       <label
         id="thread-title"
         className="mb-2 inline-block font-bold text-gray-600 dark:text-gray-300"

--- a/web/screens/Chat/Sidebar/index.tsx
+++ b/web/screens/Chat/Sidebar/index.tsx
@@ -116,7 +116,7 @@ const Sidebar: React.FC = () => {
           </div>
         </div>
 
-        <CardSidebar title="Assistant">
+        <CardSidebar title="Assistant" isShow={true}>
           <div className="flex flex-col space-y-4 p-2">
             <div className="flex items-center space-x-2">
               <LogoMark width={24} height={24} />
@@ -149,6 +149,47 @@ const Sidebar: React.FC = () => {
                 }}
               />
             </div>
+          </div>
+        </CardSidebar>
+
+        <CardSidebar title="Model" isShow={true}>
+          <div className="px-2 pt-4">
+            <DropdownListSidebar />
+
+            {componentDataRuntimeSetting.length > 0 && (
+              <div className="mt-6">
+                <CardSidebar title="Inference Parameters" asChild>
+                  <div className="px-2 py-4">
+                    <ModelSetting componentData={componentDataRuntimeSetting} />
+                  </div>
+                </CardSidebar>
+              </div>
+            )}
+
+            {componentDataEngineSetting.filter(
+              (x) => x.name === 'prompt_template'
+            ).length !== 0 && (
+              <div className="mt-4">
+                <CardSidebar title="Model Parameters" asChild>
+                  <div className="px-2 py-4">
+                    <SettingComponentBuilder
+                      componentData={componentDataEngineSetting}
+                      selector={(x: any) => x.name === 'prompt_template'}
+                    />
+                  </div>
+                </CardSidebar>
+              </div>
+            )}
+
+            {componentDataEngineSetting.length > 0 && (
+              <div className="my-4">
+                <CardSidebar title="Engine Parameters" asChild>
+                  <div className="px-2 py-4">
+                    <EngineSetting componentData={componentDataEngineSetting} />
+                  </div>
+                </CardSidebar>
+              </div>
+            )}
           </div>
         </CardSidebar>
 
@@ -312,47 +353,6 @@ const Sidebar: React.FC = () => {
               )}
           </div>
         )}
-
-        <CardSidebar title="Model">
-          <div className="px-2 pt-4">
-            <DropdownListSidebar />
-
-            {componentDataRuntimeSetting.length > 0 && (
-              <div className="mt-6">
-                <CardSidebar title="Inference Parameters" asChild>
-                  <div className="px-2 py-4">
-                    <ModelSetting componentData={componentDataRuntimeSetting} />
-                  </div>
-                </CardSidebar>
-              </div>
-            )}
-
-            {componentDataEngineSetting.filter(
-              (x) => x.name === 'prompt_template'
-            ).length !== 0 && (
-              <div className="mt-4">
-                <CardSidebar title="Model Parameters" asChild>
-                  <div className="px-2 py-4">
-                    <SettingComponentBuilder
-                      componentData={componentDataEngineSetting}
-                      selector={(x: any) => x.name === 'prompt_template'}
-                    />
-                  </div>
-                </CardSidebar>
-              </div>
-            )}
-
-            {componentDataEngineSetting.length > 0 && (
-              <div className="my-4">
-                <CardSidebar title="Engine Parameters" asChild>
-                  <div className="px-2 py-4">
-                    <EngineSetting componentData={componentDataEngineSetting} />
-                  </div>
-                </CardSidebar>
-              </div>
-            )}
-          </div>
-        </CardSidebar>
       </div>
     </div>
   )


### PR DESCRIPTION
## Describe Your Changes
I find it quite hard to start a new thread. The assistant and model settings should be at the top and expanded by default. Also fixed API Setting padding

![image](https://github.com/janhq/jan/assets/133622055/32740c4e-1deb-42b8-9dc7-4d3a0fb9bf30)


## Fixes Issues
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
