### PR TITLE
fix: mismatching between nightly build and version - jan about

### DIFF
--- a/electron/utils/menu.ts
+++ b/electron/utils/menu.ts
@@ -8,7 +8,14 @@ const template: (Electron.MenuItemConstructorOptions | Electron.MenuItem)[] = [
   {
     label: app.name,
     submenu: [
-      { role: 'about' },
+      {
+        label: `About ${app.name}`,
+        click: () =>
+          dialog.showMessageBox({
+            title: `Jan`,
+            message: `Jan Version v${app.getVersion()}${app.getVersion().includes('-') ? ' (Nightly)' : ''}\n\nCopyright © 2024 Jan`,
+          }),
+      },
       {
         label: 'Check for Updates...',
         click: () =>
@@ -31,36 +38,7 @@ const template: (Electron.MenuItemConstructorOptions | Electron.MenuItem)[] = [
             }),
       },
       { type: 'separator' },
-      { role: 'services' },
-      { type: 'separator' },
-      { role: 'hide' },
-      { role: 'hideOthers' },
-      { role: 'unhide' },
-      { type: 'separator' },
       { role: 'quit' },
-    ],
-  },
-  {
-    label: 'Edit',
-    submenu: [
-      { role: 'undo' },
-      { role: 'redo' },
-      { type: 'separator' },
-      { role: 'cut' },
-      { role: 'copy' },
-      { role: 'paste' },
-      ...(isMac
-        ? [
-            { role: 'pasteAndMatchStyle' },
-            { role: 'delete' },
-            { role: 'selectAll' },
-            { type: 'separator' },
-            {
-              label: 'Speech',
-              submenu: [{ role: 'startSpeaking' }, { role: 'stopSpeaking' }],
-            },
-          ]
-        : [{ role: 'delete' }, { type: 'separator' }, { role: 'selectAll' }]),
     ],
   },
   {

--- a/web/containers/Layout/BottomBar/index.tsx
+++ b/web/containers/Layout/BottomBar/index.tsx
@@ -186,7 +186,7 @@ const BottomBar = () => {
         )}
         {/* VERSION is defined by webpack, please see next.config.js */}
         <span className="text-xs text-muted-foreground">
-          Jan v{VERSION ?? ''}
+          Jan v{VERSION ?? ''} {VERSION.includes('-') ? ' (Nightly)' : ''}
         </span>
         <div className="mt-1 flex items-center gap-x-2">
           {menuLinks


### PR DESCRIPTION
## Describe Your Changes
Addressed an issue where the content of the Jan About dialog differs across platforms
![Screenshot 2024-02-21 124221](https://github.com/janhq/jan/assets/133622055/7049e2a4-a5d2-42d8-8e39-9d68df246314)
![Screenshot 2024-02-21 124214](https://github.com/janhq/jan/assets/133622055/13d517fc-d405-4e96-bfd3-f1d214a18f5f)

## Fixes Issues

- #2112

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
