### PR TITLE
feat: jan accessibility and selected text retrieval

### DIFF
--- a/core/src/api/index.ts
+++ b/core/src/api/index.ts
@@ -31,6 +31,7 @@ export enum AppEvent {
   onAppUpdateDownloadUpdate = 'onAppUpdateDownloadUpdate',
   onAppUpdateDownloadError = 'onAppUpdateDownloadError',
   onAppUpdateDownloadSuccess = 'onAppUpdateDownloadSuccess',
+  onSelectedText = 'onSelectedText',
 }
 
 export enum DownloadRoute {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, shell } from 'electron'
+import { app, BrowserWindow, ipcRenderer, shell } from 'electron'
 import { join } from 'path'
 /**
  * Managers
@@ -25,6 +25,20 @@ import { setupCore } from './utils/setup'
 import { setupReactDevTool } from './utils/dev'
 import { cleanLogs } from './utils/log'
 
+import { getSelectedText, registerShortcut } from 'electron-selected-text'
+import { AppEvent } from '@janhq/core'
+
+const printSelectedText = (selectedText: any) => {
+  WindowManager.instance.currentWindow?.focus()
+  log(`Selected Text: ${selectedText}`)
+  WindowManager.instance.currentWindow?.webContents.send(
+    AppEvent.onSelectedText,
+    selectedText
+  )
+}
+
+getSelectedText().then(printSelectedText)
+
 app
   .whenReady()
   .then(setupReactDevTool)
@@ -42,6 +56,12 @@ app
         createMainWindow()
       }
     })
+
+    const ret = registerShortcut('CommandOrControl+J', printSelectedText)
+
+    if (!ret) {
+      console.warn('registration failed')
+    }
   })
   .then(() => cleanLogs())
 

--- a/electron/package.json
+++ b/electron/package.json
@@ -80,6 +80,7 @@
     "@janhq/server": "link:./server",
     "@npmcli/arborist": "^7.1.0",
     "@uiball/loaders": "^1.3.0",
+    "electron-selected-text": "^1.1.2",
     "electron-store": "^8.1.0",
     "electron-updater": "^6.1.7",
     "fs-extra": "^11.2.0",

--- a/web/containers/Providers/ClipboardListener.tsx
+++ b/web/containers/Providers/ClipboardListener.tsx
@@ -1,0 +1,32 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { Fragment, PropsWithChildren, useCallback, useEffect } from 'react'
+
+import { useSetAtom } from 'jotai'
+
+import { currentPromptAtom } from './Jotai'
+
+const ClipboardListener = ({ children }: PropsWithChildren) => {
+  const setCurrentPrompt = useSetAtom(currentPromptAtom)
+
+  const onSelectedText = useCallback(
+    (text: any) => {
+      console.log('received selected text')
+      console.log(text)
+      setCurrentPrompt(text)
+    },
+    [setCurrentPrompt]
+  )
+
+  useEffect(() => {
+    if (window && window.electronAPI) {
+      window.electronAPI.onSelectedText((_event: string, text: string) =>
+        onSelectedText(text)
+      )
+    }
+    return () => {}
+  }, [onSelectedText])
+
+  return <Fragment>{children}</Fragment>
+}
+
+export default ClipboardListener

--- a/web/containers/Providers/EventHandler.tsx
+++ b/web/containers/Providers/EventHandler.tsx
@@ -15,6 +15,7 @@ import {
   MessageRequestType,
   ModelEvent,
   Thread,
+  AppEvent,
 } from '@janhq/core'
 import { useAtomValue, useSetAtom } from 'jotai'
 import { ulid } from 'ulid'

--- a/web/containers/Providers/EventListener.tsx
+++ b/web/containers/Providers/EventListener.tsx
@@ -8,6 +8,7 @@ import { useSetAtom } from 'jotai'
 import { setDownloadStateAtom } from '@/hooks/useDownloadState'
 
 import AppUpdateListener from './AppUpdateListener'
+import ClipboardListener from './ClipboardListener'
 import EventHandler from './EventHandler'
 
 import ModelImportListener from './ModelImportListener'
@@ -55,9 +56,11 @@ const EventListenerWrapper = ({ children }: PropsWithChildren) => {
 
   return (
     <AppUpdateListener>
-      <ModelImportListener>
-        <EventHandler>{children}</EventHandler>
-      </ModelImportListener>
+      <ClipboardListener>
+        <ModelImportListener>
+          <EventHandler>{children}</EventHandler>
+        </ModelImportListener>
+      </ClipboardListener>
     </AppUpdateListener>
   )
 }


### PR DESCRIPTION
## Describe Your Changes
PoC draft for Jan accessibility, shortcut and retrieve selected text from any apps

NOTES: Please do not merge, this PR is for demo & example purpose only.

NOTES: Linux can do this directly using Electron API - clipboard.get("selected")

Request accessibility permission:

<img width="529" alt="Screenshot 2024-02-26 at 23 30 33" src="https://github.com/janhq/jan/assets/133622055/6fb2999b-002e-4a49-859e-041880a92139">

Permission granted
<img width="496" alt="Screenshot 2024-02-26 at 23 30 41" src="https://github.com/janhq/jan/assets/133622055/898bc2a6-656e-4834-8be9-ff55edadba25">

Use the Command + J shortcut to summon Jan with selected text from other apps prefilled (TODO: spawn overlay)

https://github.com/janhq/jan/assets/133622055/a6d75f83-9ee6-4e64-9304-0fc48965111f

TODO:
- [] robotjs alternative? https://github.com/nut-tree/nut.js
- [] Create new window as overlay?

cc @urmauur @janhq/bd 

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
