### PR TITLE
fix space between progress bar and title list of gpu

### DIFF
--- a/web/containers/Layout/BottomBar/SystemMonitor/index.tsx
+++ b/web/containers/Layout/BottomBar/SystemMonitor/index.tsx
@@ -140,7 +140,7 @@ const SystemMonitor = () => {
               {gpus.length > 0 && (
                 <div className="mb-4 border-b border-border pb-4 last:border-none">
                   {gpus.map((gpu, index) => (
-                    <div key={index} className="mt-4 flex flex-col gap-2">
+                    <div key={index} className="mt-4 flex flex-col gap-x-2">
                       <div className="flex w-full items-start justify-between">
                         <span className="line-clamp-1 w-1/2 font-bold">
                           {gpu.name}


### PR DESCRIPTION
## Describe Your Changes
- fix consistent space system monitor 

Before
<img width="354" alt="image-8" src="https://github.com/janhq/jan/assets/10354610/224d0e20-535d-442f-b9f0-cabc4a82178f">

After
![Screenshot 2024-02-27 at 20 18 23](https://github.com/janhq/jan/assets/10354610/60672030-5b21-4646-bb3e-354807f62e0b)

cc @Van-QA 

## Fixes Issues

#2039

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
