### PR TITLE
fix: download model error does not reset state in model hub

### DIFF
--- a/core/src/node/api/processors/download.ts
+++ b/core/src/node/api/processors/download.ts
@@ -42,6 +42,24 @@ export class Downloader implements Processor {
     // Downloading file to a temp file first
     const downloadingTempFile = `${destination}.download`
 
+    // adding initial download state
+    const initialDownloadState: DownloadState = {
+      modelId,
+      fileName,
+      time: {
+        elapsed: 0,
+        remaining: 0,
+      },
+      speed: 0,
+      percent: 0,
+      size: {
+        total: 0,
+        transferred: 0,
+      },
+      downloadState: 'downloading',
+    }
+    DownloadManager.instance.downloadProgressMap[modelId] = initialDownloadState
+
     progress(rq, {})
       .on('progress', (state: any) => {
         const downloadState: DownloadState = {


### PR DESCRIPTION
## Describe Your Changes

- Download error does not have the model id, so main app can't find the corresponding model to remove it from downloading model state.

## Fixes Issues

- #2080 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
