### PR TITLE
feat: add turborepo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ extensions/inference-nitro-extension/bin/saved-*
 extensions/inference-nitro-extension/bin/*.tar.gz
 extensions/inference-nitro-extension/bin/vulkaninfoSDK.exe
 extensions/inference-nitro-extension/bin/vulkaninfo
+
+
+# Turborepo
+.turbo

--- a/electron/package.json
+++ b/electron/package.json
@@ -61,6 +61,8 @@
     "test:e2e": "playwright test --workers=1",
     "copy:assets": "rimraf --glob \"./pre-install/*.tgz\" && cpx \"../pre-install/*.tgz\" \"./pre-install\"",
     "dev": "yarn copy:assets && tsc -p . && electron .",
+    "compile": "tsc -p .",
+    "start": "electron .",
     "build": "yarn copy:assets && run-script-os",
     "build:test": "yarn copy:assets && run-script-os",
     "build:test:darwin": "tsc -p . && electron-builder -p never -m --dir",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "build:extensions": "run-script-os",
     "build:test": "yarn copy:assets && yarn build:web && yarn workspace jan build:test",
     "build": "yarn build:web && yarn build:electron",
-    "build:publish": "yarn copy:assets && yarn build:web && yarn workspace jan build:publish"
+    "build:publish": "yarn copy:assets && yarn build:web && yarn workspace jan build:publish",
+    "turbo:electron": "turbo run dev --parallel --filter=!@janhq/server"
   },
   "devDependencies": {
     "concurrently": "^8.2.1",

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "build": {
+      "outputs": [".next/**", "!.next/cache/**"]
+    },
+    "dev": {
+      "cache": false
+    },
+    "web#build": {
+      "dependsOn": ["@janhq/core#build"]
+    },
+    "web:dev": {
+      "cache": false,
+      "persistent": true,
+      "dependsOn": ["@janhq/core#build", "@janhq/uikit#build"]
+    },
+    "electron:dev": {
+      "cache": false,
+      "persistent": true,
+      "dependsOn": ["@janhq/core#build", "@janhq/server#build", "jan#compile"]
+    },
+    "electron#build": {
+      "dependsOn": ["web#build", "server#build", "core#build"],
+      "cache": false
+    },
+    "type-check": {}
+  }
+}


### PR DESCRIPTION
## Describe Your Changes
Currently, developers are struggling with the build step where they have to remember the build steps and combine them for a faster build time.

There are so many steps to remember, such as:

build:core
build:uikit
build:web
build:server
build:electron ...
and the order...

Makefile does help, but the build time has increased dramatically.

Now with Turborepo, we have incremental build support and can easily manage build dependencies.

<img width="1011" alt="Screenshot 2024-03-04 at 12 13 05" src="https://github.com/janhq/jan/assets/133622055/58f6bd33-b11f-44a6-b61e-fc196ff716e1">

```shelll
npm install -g turbo

// Run dev
yarn turbo:electron
```
cc @hiento09 please help define build commands

Fixes #2224