### PR TITLE
docs: Fix navbar issues. Keep stay when clicked other menu items from the sidebar

### DIFF
--- a/docs/src/theme/Layout/index.js
+++ b/docs/src/theme/Layout/index.js
@@ -32,7 +32,8 @@ export default function Layout(props) {
 
   const location = useLocation();
 
-  const isAllowedPath = allowedPaths.includes(location.pathname);
+  const isAllowedPath = allowedPaths.some(path => location.pathname.startsWith(path));
+
   return (
     <LayoutProvider>
       <PageMetadata title={title} description={description} />


### PR DESCRIPTION
## Describe Your Changes

- Change this `allowedPaths.includes(location.pathname);` into `allowedPaths.some(path => location.pathname.startsWith(path));` by using the startsWith() it will cover child paths such as /guides/integrations, /guides/extensions, /developers/architecture, etc., as long as the parent path is included in `allowedPaths`.

## Fixes Issues

- Closes #2252

## Self Checklist

- [ ] Added relevant comments, especially in complex areas
- [x] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
