### PR TITLE
fix: quick app windows, tray and dock behaviors

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -43,6 +43,12 @@ const gotTheLock = app.requestSingleInstanceLock()
 
 app
   .whenReady()
+  .then(() => {
+    if (!gotTheLock) {
+      app.quit()
+      throw new Error('Another instance of the app is already running')
+    }
+  })
   .then(setupReactDevTool)
   .then(setupCore)
   .then(createUserSpace)
@@ -63,21 +69,19 @@ app
     log(`Version: ${app.getVersion()}`)
   })
   .then(() => {
-    if (!gotTheLock) {
-      app.quit()
-    } else {
-      app.on('second-instance', (_event, _commandLine, _workingDirectory) => {
-        // Someone tried to run a second instance, we should focus our window.
-        windowManager.showMainWindow()
-      })
-    }
     app.on('activate', () => {
       if (!BrowserWindow.getAllWindows().length) {
         createMainWindow()
+      } else {
+        windowManager.showMainWindow()
       }
     })
   })
   .then(() => cleanLogs())
+
+app.on('second-instance', (_event, _commandLine, _workingDirectory) => {
+  windowManager.showMainWindow()
+})
 
 app.on('ready', () => {
   registerGlobalShortcuts()

--- a/electron/managers/mainWindowConfig.ts
+++ b/electron/managers/mainWindowConfig.ts
@@ -5,7 +5,7 @@ export const mainWindowConfig: Electron.BrowserWindowConstructorOptions = {
   width: DEFAULT_WIDTH,
   minWidth: DEFAULT_WIDTH,
   height: DEFAULT_HEIGHT,
-  skipTaskbar: true,
+  skipTaskbar: false,
   show: true,
   trafficLightPosition: {
     x: 10,

--- a/electron/managers/tray.ts
+++ b/electron/managers/tray.ts
@@ -13,20 +13,28 @@ class TrayManager {
     const tray = new Tray(iconPath)
     tray.setToolTip(app.getName())
 
-    const contextMenu = Menu.buildFromTemplate([
-      {
-        label: 'Open Jan',
-        type: 'normal',
-        click: () => windowManager.showMainWindow(),
-      },
-      {
-        label: 'Open Quick Ask',
-        type: 'normal',
-        click: () => windowManager.showQuickAskWindow(),
-      },
-      { label: 'Quit', type: 'normal', click: () => app.quit() },
-    ])
-    tray.setContextMenu(contextMenu)
+    tray.on('click', () => {
+      windowManager.showQuickAskWindow()
+    })
+
+    // Add context menu for windows only
+    if (process.platform === 'win32') {
+      const contextMenu = Menu.buildFromTemplate([
+        {
+          label: 'Open Jan',
+          type: 'normal',
+          click: () => windowManager.showMainWindow(),
+        },
+        {
+          label: 'Open Quick Ask',
+          type: 'normal',
+          click: () => windowManager.showQuickAskWindow(),
+        },
+        { label: 'Quit', type: 'normal', click: () => app.quit() },
+      ])
+
+      tray.setContextMenu(contextMenu)
+    }
     this.currentTray = tray
   }
 

--- a/electron/managers/window.ts
+++ b/electron/managers/window.ts
@@ -73,15 +73,11 @@ class WindowManager {
   hideMainWindow(): void {
     this.mainWindow?.hide()
     this._mainWindowVisible = false
-    // Only macos
-    if (process.platform === 'darwin') app.dock.hide()
   }
 
   showMainWindow(): void {
     this.mainWindow?.show()
     this._mainWindowVisible = true
-    // Only macos
-    if (process.platform === 'darwin') app.dock.show()
   }
 
   hideQuickAskWindow(): void {

--- a/web/containers/Providers/KeyListener.tsx
+++ b/web/containers/Providers/KeyListener.tsx
@@ -24,10 +24,6 @@ export default function KeyListener({ children }: Props) {
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        window.core?.api?.hideMainWindow()
-      }
-
       const prefixKey = isMac ? e.metaKey : e.ctrlKey
 
       if (e.key === 'b' && prefixKey) {


### PR DESCRIPTION
## Describe Your Changes
- Keep Jan app to stay on the dock when running, even if the main window is closed. (Hidden before)
- Show Jan's app's main window when users click it in the dock or open it from a quick action.
- Click on app tray icon, quick ask window should be shown
- Should not hide main window when pressing `esc`

## Fixes Issues

- #2305

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
