### PR TITLE
fix: do not migrate extensions from quick ask window

### DIFF
--- a/web/containers/Providers/index.tsx
+++ b/web/containers/Providers/index.tsx
@@ -4,6 +4,8 @@ import { PropsWithChildren, useEffect, useState } from 'react'
 
 import { Toaster } from 'react-hot-toast'
 
+import { usePathname } from 'next/navigation'
+
 import { TooltipProvider } from '@janhq/uikit'
 
 import GPUDriverPrompt from '@/containers/GPUDriverPromptModal'
@@ -29,6 +31,7 @@ import { extensionManager } from '@/extension'
 
 const Providers = (props: PropsWithChildren) => {
   const { children } = props
+  const pathname = usePathname()
 
   const [setupCore, setSetupCore] = useState(false)
   const [activated, setActivated] = useState(false)
@@ -40,6 +43,11 @@ const Providers = (props: PropsWithChildren) => {
 
     setTimeout(async () => {
       if (!isCoreExtensionInstalled()) {
+        // TODO: Proper window handle
+        // Do not migrate extension from quick ask window
+        if (pathname === '/search') {
+          return
+        }
         setSettingUp(true)
         await setupBaseExtensions()
         return


### PR DESCRIPTION
## Describe Your Changes
- Fixed an issue where the Quick Ask window performs extension migration in the background, which breaks the application

## Fixes Issues

- #2305 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
