### PR TITLE
fix: clean working dir with long space support on Windows

### DIFF
--- a/.github/workflows/jan-electron-linter-and-test.yml
+++ b/.github/workflows/jan-electron-linter-and-test.yml
@@ -73,10 +73,10 @@ jobs:
     steps:
       - name: Clean workspace
         run: |
-          Remove-Item -Path .\* -Force -Recurse
+          Remove-Item -Path "\\?\$(Get-Location)\*" -Force -Recurse
           $path = "$Env:APPDATA\jan"
           if (Test-Path $path) {
-              Remove-Item $path -Recurse -Force
+              Remove-Item "\\?\$path" -Recurse -Force
           } else {
               Write-Output "Folder does not exist."
           }


### PR DESCRIPTION
## Describe Your Changes

- CI might fail due to long file path on Windows.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
