### PR TITLE
fix: fail-fast would cancel matrix jobs as soon as one job fails

### DIFF
--- a/.github/workflows/jan-electron-linter-and-test.yml
+++ b/.github/workflows/jan-electron-linter-and-test.yml
@@ -67,6 +67,7 @@ jobs:
 
   test-on-windows:
     strategy:
+      fail-fast: false
       matrix:
         antivirus-tools: ['mcafee', 'default-windows-security','bit-defender']
     runs-on: windows-desktop-${{ matrix.antivirus-tools }}


### PR DESCRIPTION
## Describe Your Changes
- Fail-fast would cancel matrix jobs as soon as one job fails.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
