### PR TITLE
fix: deleting threads manually breaks model settings and document upload

### DIFF
--- a/web/hooks/useSendChatMessage.ts
+++ b/web/hooks/useSendChatMessage.ts
@@ -249,6 +249,15 @@ export default function useSendChatMessage() {
 
     let modelRequest =
       selectedModelRef?.current ?? activeThreadRef.current.assistants[0].model
+
+    // Fallback support for previous broken threads
+    if (activeThreadRef.current?.assistants[0]?.model?.id === '*') {
+      activeThreadRef.current.assistants[0].model = {
+        id: modelRequest.id,
+        settings: modelRequest.settings,
+        parameters: modelRequest.parameters,
+      }
+    }
     if (runtimeParams.stream == null) {
       runtimeParams.stream = true
     }

--- a/web/screens/Chat/ThreadList/index.tsx
+++ b/web/screens/Chat/ThreadList/index.tsx
@@ -9,6 +9,7 @@ import { GalleryHorizontalEndIcon, MoreVerticalIcon } from 'lucide-react'
 import { twMerge } from 'tailwind-merge'
 
 import { useCreateNewThread } from '@/hooks/useCreateNewThread'
+import useRecommendedModel from '@/hooks/useRecommendedModel'
 import useSetActiveThread from '@/hooks/useSetActiveThread'
 
 import { displayDate } from '@/utils/datetime'
@@ -35,6 +36,7 @@ export default function ThreadList() {
   const threadDataReady = useAtomValue(threadDataReadyAtom)
   const { requestCreateNewThread } = useCreateNewThread()
   const setEditMessage = useSetAtom(editMessageAtom)
+  const { recommendedModel, downloadedModels } = useRecommendedModel()
 
   const onThreadClick = useCallback(
     (thread: Thread) => {
@@ -50,8 +52,14 @@ export default function ThreadList() {
    * and there are no threads available
    */
   useEffect(() => {
-    if (threadDataReady && assistants.length > 0 && threads.length === 0) {
-      requestCreateNewThread(assistants[0])
+    if (
+      threadDataReady &&
+      assistants.length > 0 &&
+      threads.length === 0 &&
+      (recommendedModel || downloadedModels[0])
+    ) {
+      const model = recommendedModel || downloadedModels[0]
+      requestCreateNewThread(assistants[0], model)
     } else if (threadDataReady && !activeThreadId) {
       setActiveThread(threads[0])
     }
@@ -62,6 +70,8 @@ export default function ThreadList() {
     requestCreateNewThread,
     activeThreadId,
     setActiveThread,
+    recommendedModel,
+    downloadedModels,
   ])
 
   return (


### PR DESCRIPTION
## Describe Your Changes

Fixed an issue where a newly created thread could not get model linked correctly. This lead to a couple of critical issues where: 
- Blank model settings
- Upload documents but not ingested

Newly created thread with blank model settings:
![Screenshot_2024-03-22_at_12 43 31](https://github.com/janhq/jan/assets/133622055/e63e4cb5-4836-4410-b39e-93d90dbe6fb8)

Old, broken threads will have files ingested successfully afterward.
<img width="1312" alt="Screenshot 2024-03-22 at 13 04 50" src="https://github.com/janhq/jan/assets/133622055/a1d8ca80-f574-4e26-87d6-c2322f3028d2">



## Fixes Issues

- #2175

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
