### PR TITLE
chore: remove rmdirsync from core api since it is deprecated

### DIFF
--- a/core/src/api/index.ts
+++ b/core/src/api/index.ts
@@ -83,8 +83,9 @@ export enum FileSystemRoute {
   existsSync = 'existsSync',
   readdirSync = 'readdirSync',
   mkdirSync = 'mkdirSync',
+  rm = 'rm',
+  mkdir = 'mkdir',
   readFileSync = 'readFileSync',
-  rmdirSync = 'rmdirSync',
   writeFileSync = 'writeFileSync',
 }
 export enum FileManagerRoute {
@@ -95,8 +96,6 @@ export enum FileManagerRoute {
   getUserHomePath = 'getUserHomePath',
   fileStat = 'fileStat',
   writeBlob = 'writeBlob',
-  mkdir = 'mkdir',
-  rm = 'rm',
 }
 
 export type ApiFunction = (...args: any[]) => any

--- a/core/src/api/index.ts
+++ b/core/src/api/index.ts
@@ -82,7 +82,6 @@ export enum FileSystemRoute {
   unlinkSync = 'unlinkSync',
   existsSync = 'existsSync',
   readdirSync = 'readdirSync',
-  mkdirSync = 'mkdirSync',
   rm = 'rm',
   mkdir = 'mkdir',
   readFileSync = 'readFileSync',

--- a/core/src/extensions/ai-engines/AIEngine.ts
+++ b/core/src/extensions/ai-engines/AIEngine.ts
@@ -36,7 +36,7 @@ export abstract class AIEngine extends BaseExtension {
             // Attempt to create the model folder
             joinPath([janDataFolder, this.modelFolder, model.id]).then((path) =>
               fs
-                .mkdirSync(path)
+                .mkdir(path)
                 .catch()
                 .then(() => path)
             )

--- a/core/src/fs.ts
+++ b/core/src/fs.ts
@@ -35,8 +35,6 @@ const readdirSync = (...args: any[]) => globalThis.core.api?.readdirSync(...args
  * Creates a directory at the specified path.
  * @returns {Promise<any>} A Promise that resolves when the directory is created successfully.
  */
-const mkdirSync = (...args: any[]) => globalThis.core.api?.mkdirSync(...args)
-
 const mkdir = (...args: any[]) => globalThis.core.api?.mkdir(...args)
 
 /**
@@ -93,7 +91,6 @@ export const fs = {
   readFileSync,
   existsSync,
   readdirSync,
-  mkdirSync,
   mkdir,
   rm,
   unlinkSync,

--- a/core/src/fs.ts
+++ b/core/src/fs.ts
@@ -43,10 +43,7 @@ const mkdir = (...args: any[]) => globalThis.core.api?.mkdir(...args)
  * Removes a directory at the specified path.
  * @returns {Promise<any>} A Promise that resolves when the directory is removed successfully.
  */
-const rmdirSync = (...args: any[]) =>
-  globalThis.core.api?.rmdirSync(...args, { recursive: true, force: true })
-
-const rm = (path: string) => globalThis.core.api?.rm(path)
+const rm = (...args: any[]) => globalThis.core.api?.rm(...args, { recursive: true, force: true })
 
 /**
  * Deletes a file from the local file system.
@@ -98,7 +95,6 @@ export const fs = {
   readdirSync,
   mkdirSync,
   mkdir,
-  rmdirSync,
   rm,
   unlinkSync,
   appendFileSync,

--- a/core/src/node/api/processors/fs.ts
+++ b/core/src/node/api/processors/fs.ts
@@ -2,6 +2,7 @@ import { join } from 'path'
 import { normalizeFilePath } from '../../helper/path'
 import { getJanDataFolderPath } from '../../helper'
 import { Processor } from './Processor'
+import fs from 'fs'
 
 export class FileSystem implements Processor {
   observer?: Function
@@ -11,15 +12,65 @@ export class FileSystem implements Processor {
     this.observer = observer
   }
 
-  process(route: string, ...args: any[]): any {
-    return import(FileSystem.moduleName).then((mdl) =>
-      mdl[route](
-        ...args.map((arg: any) =>
-          typeof arg === 'string' && (arg.startsWith(`file:/`) || arg.startsWith(`file:\\`))
-            ? join(getJanDataFolderPath(), normalizeFilePath(arg))
-            : arg
+  process(route: string, ...args: any): any {
+    const instance = this as any
+    const func = instance[route]
+
+    if (func) {
+      return func(...args)
+    } else {
+      return import(FileSystem.moduleName).then((mdl) =>
+        mdl[route](
+          ...args.map((arg: any) => {
+            return typeof arg === 'string' &&
+              (arg.startsWith(`file:/`) || arg.startsWith(`file:\\`))
+              ? join(getJanDataFolderPath(), normalizeFilePath(arg))
+              : arg
+          })
         )
       )
-    )
+    }
+  }
+
+  rm(...args: any): Promise<void> {
+    if (typeof args[0] !== 'string') {
+      throw new Error(`rm error: Invalid argument ${JSON.stringify(args)}`)
+    }
+
+    let path = args[0]
+    if (path.startsWith(`file:/`) || path.startsWith(`file:\\`)) {
+      path = join(getJanDataFolderPath(), normalizeFilePath(path))
+    }
+
+    return new Promise((resolve, reject) => {
+      fs.rm(path, { recursive: true, force: true }, (err) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve()
+        }
+      })
+    })
+  }
+
+  mkdir(...args: any): Promise<void> {
+    if (typeof args[0] !== 'string') {
+      throw new Error(`mkdir error: Invalid argument ${JSON.stringify(args)}`)
+    }
+
+    let path = args[0]
+    if (path.startsWith(`file:/`) || path.startsWith(`file:\\`)) {
+      path = join(getJanDataFolderPath(), normalizeFilePath(path))
+    }
+
+    return new Promise((resolve, reject) => {
+      fs.mkdir(path, { recursive: true }, (err) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve()
+        }
+      })
+    })
   }
 }

--- a/core/src/node/api/processors/fsExt.ts
+++ b/core/src/node/api/processors/fsExt.ts
@@ -88,28 +88,4 @@ export class FSExt implements Processor {
       })
     })
   }
-
-  mkdir(path: string): Promise<void> {
-    return new Promise((resolve, reject) => {
-      fs.mkdir(path, { recursive: true }, (err) => {
-        if (err) {
-          reject(err)
-        } else {
-          resolve()
-        }
-      })
-    })
-  }
-
-  rm(path: string): Promise<void> {
-    return new Promise((resolve, reject) => {
-      fs.rm(path, { recursive: true }, (err) => {
-        if (err) {
-          reject(err)
-        } else {
-          resolve()
-        }
-      })
-    })
-  }
 }

--- a/core/src/node/extension/extension.ts
+++ b/core/src/node/extension/extension.ts
@@ -182,7 +182,7 @@ export default class Extension {
   async uninstall(): Promise<void> {
     const path = ExtensionManager.instance.getExtensionsPath()
     const extPath = resolve(path ?? '', this.name ?? '')
-    await rmdirSync(extPath, { recursive: true })
+    rmdirSync(extPath, { recursive: true })
 
     this.emitUpdate()
   }

--- a/extensions/assistant-extension/src/index.ts
+++ b/extensions/assistant-extension/src/index.ts
@@ -29,7 +29,7 @@ export default class JanAssistantExtension extends AssistantExtension {
       localStorage.getItem(`${EXTENSION_NAME}-version`) !== VERSION ||
       !assistantDirExist
     ) {
-      if (!assistantDirExist) await fs.mkdirSync(JanAssistantExtension._homeDir)
+      if (!assistantDirExist) await fs.mkdir(JanAssistantExtension._homeDir)
 
       // Write assistant metadata
       await this.createJanAssistant()
@@ -184,7 +184,7 @@ export default class JanAssistantExtension extends AssistantExtension {
       JanAssistantExtension._homeDir,
       assistant.id,
     ])
-    if (!(await fs.existsSync(assistantDir))) await fs.mkdirSync(assistantDir)
+    if (!(await fs.existsSync(assistantDir))) await fs.mkdir(assistantDir)
 
     // store the assistant metadata json
     const assistantMetadataPath = await joinPath([

--- a/extensions/assistant-extension/src/index.ts
+++ b/extensions/assistant-extension/src/index.ts
@@ -247,8 +247,7 @@ export default class JanAssistantExtension extends AssistantExtension {
       JanAssistantExtension._homeDir,
       assistant.id,
     ])
-    await fs.rmdirSync(assistantDir)
-    return Promise.resolve()
+    return fs.rm(assistantDir)
   }
 
   private async createJanAssistant(): Promise<void> {

--- a/extensions/conversational-extension/src/index.ts
+++ b/extensions/conversational-extension/src/index.ts
@@ -4,7 +4,6 @@ import {
   ConversationalExtension,
   Thread,
   ThreadMessage,
-  events,
 } from '@janhq/core'
 
 /**
@@ -96,11 +95,7 @@ export default class JSONConversationalExtension extends ConversationalExtension
       `${threadId}`,
     ])
     try {
-      if (await fs.existsSync(path)) {
-        await fs.rmdirSync(path, { recursive: true })
-      } else {
-        console.debug(`${path} does not exist`)
-      }
+      await fs.rm(path)
     } catch (err) {
       console.error(err)
     }

--- a/extensions/conversational-extension/src/index.ts
+++ b/extensions/conversational-extension/src/index.ts
@@ -20,7 +20,7 @@ export default class JSONConversationalExtension extends ConversationalExtension
    */
   async onLoad() {
     if (!(await fs.existsSync(JSONConversationalExtension._threadFolder))) {
-      await fs.mkdirSync(JSONConversationalExtension._threadFolder)
+      await fs.mkdir(JSONConversationalExtension._threadFolder)
     }
   }
 
@@ -75,7 +75,7 @@ export default class JSONConversationalExtension extends ConversationalExtension
         JSONConversationalExtension._threadInfoFileName,
       ])
       if (!(await fs.existsSync(threadDirPath))) {
-        await fs.mkdirSync(threadDirPath)
+        await fs.mkdir(threadDirPath)
       }
 
       await fs.writeFileSync(threadJsonPath, JSON.stringify(thread, null, 2))
@@ -112,11 +112,11 @@ export default class JSONConversationalExtension extends ConversationalExtension
         JSONConversationalExtension._threadMessagesFileName,
       ])
       if (!(await fs.existsSync(threadDirPath)))
-        await fs.mkdirSync(threadDirPath)
+        await fs.mkdir(threadDirPath)
 
       if (message.content[0]?.type === 'image') {
         const filesPath = await joinPath([threadDirPath, 'files'])
-        if (!(await fs.existsSync(filesPath))) await fs.mkdirSync(filesPath)
+        if (!(await fs.existsSync(filesPath))) await fs.mkdir(filesPath)
 
         const imagePath = await joinPath([filesPath, `${message.id}.png`])
         const base64 = message.content[0].text.annotations[0]
@@ -129,7 +129,7 @@ export default class JSONConversationalExtension extends ConversationalExtension
 
       if (message.content[0]?.type === 'pdf') {
         const filesPath = await joinPath([threadDirPath, 'files'])
-        if (!(await fs.existsSync(filesPath))) await fs.mkdirSync(filesPath)
+        if (!(await fs.existsSync(filesPath))) await fs.mkdir(filesPath)
 
         const filePath = await joinPath([filesPath, `${message.id}.pdf`])
         const blob = message.content[0].text.annotations[0]
@@ -179,8 +179,7 @@ export default class JSONConversationalExtension extends ConversationalExtension
         threadDirPath,
         JSONConversationalExtension._threadMessagesFileName,
       ])
-      if (!(await fs.existsSync(threadDirPath)))
-        await fs.mkdirSync(threadDirPath)
+      if (!(await fs.existsSync(threadDirPath))) await fs.mkdir(threadDirPath)
       await fs.writeFileSync(
         threadMessagePath,
         messages.map((msg) => JSON.stringify(msg)).join('\n') +

--- a/extensions/huggingface-extension/src/index.ts
+++ b/extensions/huggingface-extension/src/index.ts
@@ -137,7 +137,7 @@ export default class JanHuggingFaceExtension extends HuggingFaceExtension {
   ): Promise<void> {
     if (this.interrupted) return
     const modelDirPath = await this.getModelDirPath(repoID)
-    if (!(await fs.existsSync(modelDirPath))) await fs.mkdirSync(modelDirPath)
+    if (!(await fs.existsSync(modelDirPath))) await fs.mkdir(modelDirPath)
     const files = this.getFileList(repoData)
     const filePaths: string[] = []
 

--- a/extensions/huggingface-extension/src/index.ts
+++ b/extensions/huggingface-extension/src/index.ts
@@ -15,7 +15,6 @@ import {
   log,
   DownloadRequest,
 } from '@janhq/core'
-import { ggufMetadata } from 'hyllama'
 
 declare global {
   interface Window {
@@ -394,7 +393,6 @@ export default class JanHuggingFaceExtension extends HuggingFaceExtension {
       const localPath = await joinPath([modelDirPath, filePath])
       await abortDownload(localPath)
     }
-    // ;(await fs.existsSync(modelDirPath)) && (await fs.rmdirSync(modelDirPath))
 
     executeOnMain(NODE_MODULE_PATH, 'killProcesses')
   }

--- a/extensions/inference-groq-extension/src/index.ts
+++ b/extensions/inference-groq-extension/src/index.ts
@@ -41,7 +41,7 @@ export default class JanInferenceGroqExtension extends RemoteOAIEngine {
     super.onLoad()
 
     if (!(await fs.existsSync(this._engineDir))) {
-      await fs.mkdirSync(this._engineDir).catch((err) => console.debug(err))
+      await fs.mkdir(this._engineDir)
     }
 
     this.writeDefaultEngineSettings()

--- a/extensions/inference-openai-extension/src/index.ts
+++ b/extensions/inference-openai-extension/src/index.ts
@@ -45,9 +45,7 @@ export default class JanInferenceOpenAIExtension extends RemoteOAIEngine {
     super.onLoad()
 
     if (!(await fs.existsSync(JanInferenceOpenAIExtension._engineDir))) {
-      await fs
-        .mkdirSync(JanInferenceOpenAIExtension._engineDir)
-        .catch((err) => console.debug(err))
+      await fs.mkdir(JanInferenceOpenAIExtension._engineDir)
     }
 
     this.writeDefaultEngineSettings()

--- a/extensions/inference-triton-trtllm-extension/src/index.ts
+++ b/extensions/inference-triton-trtllm-extension/src/index.ts
@@ -40,7 +40,7 @@ export default class JanInferenceTritonTrtLLMExtension extends RemoteOAIEngine {
   async onLoad() {
     super.onLoad()
     if (!(await fs.existsSync(this._engineDir))) {
-      await fs.mkdirSync(this._engineDir).catch((err) => console.debug(err))
+      await fs.mkdir(this._engineDir)
     }
 
     this.writeDefaultEngineSettings()

--- a/extensions/model-extension/src/index.ts
+++ b/extensions/model-extension/src/index.ts
@@ -100,7 +100,7 @@ export default class JanModelExtension extends ModelExtension {
   ): Promise<void> {
     // create corresponding directory
     const modelDirPath = await joinPath([JanModelExtension._homeDir, model.id])
-    if (!(await fs.existsSync(modelDirPath))) await fs.mkdirSync(modelDirPath)
+    if (!(await fs.existsSync(modelDirPath))) await fs.mkdir(modelDirPath)
 
     if (model.engine === InferenceEngine.nitro_tensorrt_llm) {
       if (!gpuSettings || gpuSettings.gpus.length === 0) {
@@ -630,7 +630,7 @@ export default class JanModelExtension extends ModelExtension {
     }
 
     const modelFolderPath = await this.getModelFolderName(modelFolderName)
-    await fs.mkdirSync(modelFolderPath)
+    await fs.mkdir(modelFolderPath)
 
     const uniqueFolderName = await baseName(modelFolderPath)
     const modelBinaryFile = binaryName.endsWith(

--- a/extensions/model-extension/src/index.ts
+++ b/extensions/model-extension/src/index.ts
@@ -249,7 +249,7 @@ export default class JanModelExtension extends ModelExtension {
         modelInfo.metadata?.author?.toLowerCase() === 'user'
       if (isUserImportModel) {
         // just delete the folder
-        return fs.rmdirSync(dirPath)
+        return fs.rm(dirPath)
       }
 
       // remove all files under dirPath except model.json

--- a/extensions/tensorrt-llm-extension/src/index.ts
+++ b/extensions/tensorrt-llm-extension/src/index.ts
@@ -151,10 +151,11 @@ export default class TensorRTLLMExtension extends LocalOAIEngine {
 
     for (const model of models) {
       const modelPath = await joinPath([modelFolderPath, model.id])
-      console.debug(`modelPath: ${modelPath}`)
-      if (await fs.existsSync(modelPath)) {
-        console.debug(`Removing model ${modelPath}`)
-        await fs.rmdirSync(modelPath)
+
+      try {
+        await fs.rm(modelPath)
+      } catch (err) {
+        console.error(`Error removing model ${modelPath}`, err)
       }
     }
     events.emit(ModelEvent.OnModelsUpdate, {})

--- a/web/screens/Settings/Advanced/index.tsx
+++ b/web/screens/Settings/Advanced/index.tsx
@@ -138,9 +138,12 @@ const Advanced = () => {
   }, [readSettings, setGpuList, setGpuEnabled, setGpusInUse, setVulkanEnabled])
 
   const clearLogs = async () => {
-    if (await fs.existsSync(`file://logs`)) {
-      await fs.rmdirSync(`file://logs`, { recursive: true })
+    try {
+      await fs.rm(`file://logs`)
+    } catch (err) {
+      console.error('Error clearing logs: ', err)
     }
+
     toaster({
       title: 'Logs cleared',
       description: 'All logs have been cleared.',


### PR DESCRIPTION
## Describe Your Changes

- Remove rmdirsync from core API since it's deprecated: 
```
DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
```

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
