### PR TITLE
fix: app shows wrong toast on stopping inference

### DIFF
--- a/extensions/tensorrt-llm-extension/src/index.ts
+++ b/extensions/tensorrt-llm-extension/src/index.ts
@@ -242,6 +242,7 @@ export default class TensorRTLLMExtension extends LocalOAIEngine {
   }
 
   override stopInference() {
+    if (!this.loadedModel) return
     showToast(
       'Unable to Stop Inference',
       'The model does not support stopping inference.'


### PR DESCRIPTION
## Describe Your Changes

- Fixed an issue where app raises wrong message toast while stopping infernece

## Fixes Issues

- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
