### PR TITLE
refactor: introduce message request builder

### DIFF
--- a/web/utils/messageRequestBuilder.ts
+++ b/web/utils/messageRequestBuilder.ts
@@ -1,0 +1,130 @@
+import {
+  ChatCompletionMessage,
+  ChatCompletionMessageContent,
+  ChatCompletionMessageContentText,
+  ChatCompletionMessageContentType,
+  ChatCompletionRole,
+  MessageRequest,
+  MessageRequestType,
+  MessageStatus,
+  ModelInfo,
+  Thread,
+  ThreadMessage,
+} from '@janhq/core'
+import { ulid } from 'ulidx'
+
+import { FileType } from '@/containers/Providers/Jotai'
+
+export class MessageRequestBuilder {
+  msgId: string
+  type: MessageRequestType
+  messages: ChatCompletionMessage[]
+  model: ModelInfo
+  thread: Thread
+
+  constructor(
+    type: MessageRequestType,
+    model: ModelInfo,
+    thread: Thread,
+    messages: ThreadMessage[]
+  ) {
+    this.msgId = ulid()
+    this.type = type
+    this.model = model
+    this.thread = thread
+    this.messages = messages
+      .filter((e) => e.status !== MessageStatus.Error)
+      .map<ChatCompletionMessage>((msg) => ({
+        role: msg.role,
+        content: msg.content[0]?.text.value ?? '',
+      }))
+  }
+
+  // Chainable
+  pushMessage(
+    message: string,
+    base64Blob: string | undefined,
+    fileContentType: FileType
+  ) {
+    if (base64Blob && fileContentType === 'pdf')
+      return this.addDocMessage(message)
+    else if (base64Blob && fileContentType === 'image') {
+      return this.addImageMessage(message, base64Blob)
+    }
+    this.messages = [
+      ...this.messages,
+      {
+        role: ChatCompletionRole.User,
+        content: message,
+      },
+    ]
+    return this
+  }
+
+  // Chainable
+  addSystemMessage(message: string | undefined) {
+    if (!message || message.trim() === '') return this
+    this.messages = [
+      {
+        role: ChatCompletionRole.System,
+        content: message,
+      },
+      ...this.messages,
+    ]
+    return this
+  }
+
+  // Chainable
+  addDocMessage(prompt: string) {
+    const message: ChatCompletionMessage = {
+      role: ChatCompletionRole.User,
+      content: [
+        {
+          type: ChatCompletionMessageContentType.Text,
+          text: prompt,
+        } as ChatCompletionMessageContentText,
+        {
+          type: ChatCompletionMessageContentType.Doc,
+          doc_url: {
+            url: `threads/${this.thread.id}/files/${this.msgId}.pdf`,
+          },
+        },
+      ] as ChatCompletionMessageContent,
+    }
+    this.messages = [message, ...this.messages]
+    return this
+  }
+
+  // Chainable
+  addImageMessage(prompt: string, base64: string) {
+    const message: ChatCompletionMessage = {
+      role: ChatCompletionRole.User,
+      content: [
+        {
+          type: ChatCompletionMessageContentType.Text,
+          text: prompt,
+        } as ChatCompletionMessageContentText,
+        {
+          type: ChatCompletionMessageContentType.Image,
+          image_url: {
+            url: base64,
+          },
+        },
+      ] as ChatCompletionMessageContent,
+    }
+
+    this.messages = [message, ...this.messages]
+    return this
+  }
+
+  build(): MessageRequest {
+    return {
+      id: this.msgId,
+      type: this.type,
+      threadId: this.thread.id,
+      messages: this.messages,
+      model: this.model,
+      thread: this.thread,
+    }
+  }
+}

--- a/web/utils/threadMessageBuilder.ts
+++ b/web/utils/threadMessageBuilder.ts
@@ -1,0 +1,74 @@
+import {
+  ChatCompletionRole,
+  ContentType,
+  MessageStatus,
+  ThreadContent,
+  ThreadMessage,
+} from '@janhq/core'
+
+import { FileInfo } from '@/containers/Providers/Jotai'
+
+import { MessageRequestBuilder } from './messageRequestBuilder'
+
+export class ThreadMessageBuilder {
+  messageRequest: MessageRequestBuilder
+
+  content: ThreadContent[] = []
+
+  constructor(messageRequest: MessageRequestBuilder) {
+    this.messageRequest = messageRequest
+  }
+
+  build(): ThreadMessage {
+    const timestamp = Date.now()
+    return {
+      id: this.messageRequest.msgId,
+      thread_id: this.messageRequest.thread.id,
+      role: ChatCompletionRole.User,
+      status: MessageStatus.Ready,
+      created: timestamp,
+      updated: timestamp,
+      object: 'thread.message',
+      content: this.content,
+    }
+  }
+
+  pushMessage(
+    prompt: string,
+    base64: string | undefined,
+    fileUpload: FileInfo[]
+  ) {
+    if (base64 && fileUpload[0]?.type === 'image') {
+      this.content.push({
+        type: ContentType.Image,
+        text: {
+          value: prompt,
+          annotations: [base64],
+        },
+      })
+    }
+
+    if (base64 && fileUpload[0]?.type === 'pdf') {
+      this.content.push({
+        type: ContentType.Pdf,
+        text: {
+          value: prompt,
+          annotations: [base64],
+          name: fileUpload[0].file.name,
+          size: fileUpload[0].file.size,
+        },
+      })
+    }
+
+    if (prompt && !base64) {
+      this.content.push({
+        type: ContentType.Text,
+        text: {
+          value: prompt,
+          annotations: [],
+        },
+      })
+    }
+    return this
+  }
+}


### PR DESCRIPTION
## Describe Your Changes

- There is a lot of logic added to the `sendChatMessage` and `resendMessage` hooks, making it difficult to maintain and add new message types (currently limited to text, PDF, and image). It would be better to refactor them using Builders.

## Fixes Issues

- #2470

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
