### PR TITLE
Add API prefix settings

### DIFF
--- a/core/src/node/api/processors/app.ts
+++ b/core/src/node/api/processors/app.ts
@@ -83,6 +83,7 @@ export class App implements Processor {
       isVerboseEnabled: args?.isVerboseEnabled,
       schemaPath: join(await appResourcePath(), 'docs', 'openapi', 'jan.yaml'),
       baseDir: join(await appResourcePath(), 'docs', 'openapi'),
+      prefix: args?.prefix,
     })
   }
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -39,6 +39,7 @@ export interface ServerConfig {
   isVerboseEnabled?: boolean
   schemaPath?: string
   baseDir?: string
+  prefix?: string
   storageAdataper?: any
 }
 
@@ -119,7 +120,7 @@ export const startServer = async (configs?: ServerConfig): Promise<boolean> => {
       server.addHook('preHandler', configs.storageAdataper)
 
     // Register API routes
-    await server.register(v1Router, { prefix: '/v1' })
+    await server.register(v1Router, { prefix: configs?.prefix ?? '/v1' })
     // Start listening for requests
     await server
       .listen({

--- a/web/helpers/atoms/ApiServer.atom.ts
+++ b/web/helpers/atoms/ApiServer.atom.ts
@@ -4,6 +4,7 @@ export const hostOptions = ['127.0.0.1', '0.0.0.0']
 
 export const apiServerPortAtom = atomWithStorage('apiServerPort', '1337')
 export const apiServerHostAtom = atomWithStorage('apiServerHost', '127.0.0.1')
+export const apiServerPrefix = atomWithStorage('apiServerPrefix', '/v1')
 
 export const apiServerCorsEnabledAtom = atomWithStorage(
   'apiServerCorsEnabled',


### PR DESCRIPTION
## Describe Your Changes

- I added a new field to the server API settings

<img width="344" alt="image" src="https://github.com/janhq/jan/assets/2690324/61de10ac-faf0-438e-8724-4922c0d1ce79">
<img width="322" alt="image" src="https://github.com/janhq/jan/assets/2690324/f0f975c3-34d8-4b79-a24a-680dceb6a476">

You can change prefix for another clients.

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
