### PR TITLE
Patch name assistant

### DIFF
--- a/web/screens/Chat/SimpleTextMessage/index.tsx
+++ b/web/screens/Chat/SimpleTextMessage/index.tsx
@@ -44,12 +44,14 @@ import {
   editMessageAtom,
   getCurrentChatMessagesAtom,
 } from '@/helpers/atoms/ChatMessage.atom'
+import { activeThreadAtom } from '@/helpers/atoms/Thread.atom'
 
 const SimpleTextMessage: React.FC<ThreadMessage> = (props) => {
   let text = ''
   const isUser = props.role === ChatCompletionRole.User
   const isSystem = props.role === ChatCompletionRole.System
   const editMessage = useAtomValue(editMessageAtom)
+  const activeThread = useAtomValue(activeThreadAtom)
 
   if (props.content && props.content.length > 0) {
     text = props.content[0]?.text?.value ?? ''
@@ -178,7 +180,9 @@ const SimpleTextMessage: React.FC<ThreadMessage> = (props) => {
             isUser && 'text-gray-500'
           )}
         >
-          {props.role}
+          {isUser
+            ? props.role
+            : activeThread?.assistants[0].assistant_name ?? props.role}
         </div>
         <p className="text-xs font-medium text-gray-400">
           {displayDate(props.created)}


### PR DESCRIPTION
## Describe Your Changes

- The name of the assistant is taken from the settings of the thread

Before:
<img width="1312" alt="image" src="https://github.com/janhq/jan/assets/2690324/8fc67162-8d20-413a-acf6-e145250fdb9e">

Now:
<img width="1312" alt="image" src="https://github.com/janhq/jan/assets/2690324/6970b5b7-d91d-4475-a32c-09cfdf695e4b">


## Fixes Issues

- Partially #2510


## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [x] Updated docs (for bug fixes / features)
- [x] Created issues for follow-up changes or refactoring needed
