### PR TITLE
use `tabular-nums` for percentages in ModelCancelDownload

### DIFF
--- a/web/containers/ModalCancelDownload/index.tsx
+++ b/web/containers/ModalCancelDownload/index.tsx
@@ -65,7 +65,9 @@ const ModalCancelDownload: React.FC<Props> = ({ model, isFromList }) => {
                   }) as number
                 }
               />
-              <span>{formatDownloadPercentage(downloadState.percent)}</span>
+              <span className="tabular-nums">
+                {formatDownloadPercentage(downloadState.percent)}
+              </span>
             </div>
           </Button>
         )}


### PR DESCRIPTION
## Describe Your Changes

- add the `tabular-nums` class name to where download percentages render to have the same width so all the components' widths stay the same  
  https://tailwindcss.com/docs/font-variant-numeric#tabular-figures

Before:
<img width="726" alt="Screenshot 2024-04-01 at 12 31 03" src="https://github.com/janhq/jan/assets/413984/a26c4018-f383-43b8-919e-86198df373f2">

After:
<img width="729" alt="Screenshot 2024-04-01 at 12 31 16" src="https://github.com/janhq/jan/assets/413984/414ace9c-b0b2-4d94-a7be-646ecfbd5c8a">

## Fixes Issues

- Closes N/A

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
