### PR TITLE
fix: regenerate message should not include the assistant's previous response

### DIFF
--- a/core/src/browser/extensions/engines/OAIEngine.ts
+++ b/core/src/browser/extensions/engines/OAIEngine.ts
@@ -102,7 +102,7 @@ export abstract class OAIEngine extends AIEngine {
         events.emit(MessageEvent.OnMessageUpdate, message)
       },
       error: async (err: any) => {
-        console.error(`Inference error: ${JSON.stringify(err, null, 2)}`)
+        console.error(`Inference error:`, err)
         if (this.isCancelled || message.content.length) {
           message.status = MessageStatus.Stopped
           events.emit(MessageEvent.OnMessageUpdate, message)

--- a/web/hooks/useSendChatMessage.ts
+++ b/web/hooks/useSendChatMessage.ts
@@ -102,7 +102,9 @@ export default function useSendChatMessage() {
       activeThreadRef.current.assistants[0].model ?? selectedModelRef.current,
       activeThreadRef.current,
       currentMessages
-    ).addSystemMessage(activeThreadRef.current.assistants[0]?.instructions)
+    )
+      .addSystemMessage(activeThreadRef.current.assistants[0]?.instructions)
+      .removeLastAssistantMessage()
 
     const modelId =
       selectedModelRef.current?.id ??

--- a/web/utils/messageRequestBuilder.ts
+++ b/web/utils/messageRequestBuilder.ts
@@ -117,6 +117,19 @@ export class MessageRequestBuilder {
     return this
   }
 
+  removeLastAssistantMessage() {
+    const lastMessageIndex = this.messages.length - 1
+    if (
+      this.messages.length &&
+      this.messages[lastMessageIndex] &&
+      this.messages[lastMessageIndex].role === ChatCompletionRole.Assistant
+    ) {
+      this.messages.pop()
+    }
+
+    return this
+  }
+
   build(): MessageRequest {
     return {
       id: this.msgId,


### PR DESCRIPTION
## Describe Your Changes

Regenerate message should include latest user message, not assistant's last response.

## Fixes Issues

- #2582

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
