### PR TITLE
use `tabular-nums` for percentages in ModelCancelDownload (#2553)

### DIFF
--- a/web/containers/ModalCancelDownload/index.tsx
+++ b/web/containers/ModalCancelDownload/index.tsx
@@ -65,7 +65,9 @@ const ModalCancelDownload: React.FC<Props> = ({ model, isFromList }) => {
                   }) as number
                 }
               />
-              <span>{formatDownloadPercentage(downloadState.percent)}</span>
+              <span className="tabular-nums">
+                {formatDownloadPercentage(downloadState.percent)}
+              </span>
             </div>
           </Button>
         )}


### PR DESCRIPTION
with this patch numbers in percentages have the same width so all the component widths stay the same

https://tailwindcss.com/docs/font-variant-numeric#tabular-figures

## Describe Your Changes

-

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
