### PR TITLE
fix: does not register global shortcut when quick ask is disabled

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -83,6 +83,8 @@ app.on('second-instance', (_event, _commandLine, _workingDirectory) => {
 })
 
 app.on('ready', () => {
+  if (!getAppConfigurations().quick_ask) return
+
   registerGlobalShortcuts()
 })
 
@@ -119,8 +121,6 @@ function createMainWindow() {
 function registerGlobalShortcuts() {
   const ret = registerShortcut(quickAskHotKey, (selectedText: string) => {
     // Feature Toggle for Quick Ask
-    if (!getAppConfigurations().quick_ask) return
-
     if (!windowManager.isQuickAskWindowVisible()) {
       windowManager.showQuickAskWindow()
       windowManager.sendQuickAskSelectedText(selectedText)


### PR DESCRIPTION
## Describe Your Changes

- Fixed an issue: The app registers a global shortcut even when it's not enabled.

## Fixes Issues

- #2589 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
