### PR TITLE
fix: app does not gracefully stop a model

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -149,7 +149,7 @@ export const stopServer = async () => {
     // Log server stop
     if (isVerbose) logServer(`Debug: Server stopped`)
     // Stop the server
-    await server.close()
+    await server?.close()
   } catch (e) {
     // Log any errors
     if (isVerbose) logServer(`Error: ${e}`)

--- a/web/hooks/useActiveModel.ts
+++ b/web/hooks/useActiveModel.ts
@@ -115,7 +115,8 @@ export function useActiveModel() {
   }
 
   const stopModel = useCallback(async () => {
-    if (!activeModel) return
+    if (!activeModel || (stateModel.state === 'stop' && stateModel.loading))
+      return
 
     setStateModel({ state: 'stop', loading: true, model: activeModel.id })
     const engine = EngineManager.instance().get(activeModel.engine)
@@ -126,7 +127,7 @@ export function useActiveModel() {
         setActiveModel(undefined)
         setStateModel({ state: 'start', loading: false, model: '' })
       })
-  }, [activeModel, setActiveModel, setStateModel])
+  }, [activeModel, stateModel, setActiveModel, setStateModel])
 
   return { activeModel, startModel, stopModel, stateModel }
 }


### PR DESCRIPTION
## Describe Your Changes
This is to reduce the duplication of nitro-killing requests. One at a time
> Noticed the same while using the context length slider.
Each numerical change during a single slide triggers a nitro kill.
This spam can lead to a limbo state where nitro is not stopped and time-out messages flood the logs.

## Fixes Issues

- #2486 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
