### PR TITLE
fix: wrong response header for non streamed responses

### DIFF
--- a/core/src/node/api/restful/helper/builder.ts
+++ b/core/src/node/api/restful/helper/builder.ts
@@ -353,7 +353,7 @@ export const chatCompletions = async (request: any, reply: any) => {
     reply.code(400).send(response)
   } else {
     reply.raw.writeHead(200, {
-      'Content-Type': 'text/event-stream',
+      'Content-Type': request.body.stream === true ? 'text/event-stream' : 'application/json',
       'Cache-Control': 'no-cache',
       'Connection': 'keep-alive',
       'Access-Control-Allow-Origin': '*',


### PR DESCRIPTION
## Describe Your Changes

```curl
{
  "messages": [
    {
      "content": "Hello!",
      "role": "user"
    }
  ],
  "model": "tinyllama-1.1b",
  "stream": false,
  "max_tokens": 2048
}
```

<img width="1035" alt="Screenshot 2024-04-03 at 20 51 40" src="https://github.com/janhq/jan/assets/133622055/d24e19eb-bada-4ca2-955e-56ea048694f9">


## Fixes Issues

- #2560 
- #2429 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
