### PR TITLE
fix: quick ask could not register global shortcuts

### DIFF
--- a/electron/utils/shortcut.ts
+++ b/electron/utils/shortcut.ts
@@ -1,0 +1,24 @@
+import { getAppConfigurations } from '@janhq/core/node'
+import { registerShortcut } from './selectedText'
+import { windowManager } from '../managers/window'
+// TODO: Retrieve from config later
+const quickAskHotKey = 'CommandOrControl+J'
+
+export function registerGlobalShortcuts() {
+  if (!getAppConfigurations().quick_ask) return
+  const ret = registerShortcut(quickAskHotKey, (selectedText: string) => {
+    // Feature Toggle for Quick Ask
+    if (!windowManager.isQuickAskWindowVisible()) {
+      windowManager.showQuickAskWindow()
+      windowManager.sendQuickAskSelectedText(selectedText)
+    } else {
+      windowManager.hideQuickAskWindow()
+    }
+  })
+
+  if (!ret) {
+    console.error('Global shortcut registration failed')
+  } else {
+    console.log('Global shortcut registered successfully')
+  }
+}


### PR DESCRIPTION
## Describe Your Changes

- Fixed an issue: The RegisterShortcut function could not retrieve app configurations.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
