### PR TITLE
fix: missing api key error handling

### DIFF
--- a/core/src/browser/extensions/engines/helpers/sse.ts
+++ b/core/src/browser/extensions/engines/helpers/sse.ts
@@ -38,7 +38,7 @@ export function requestInference(
           const data = await response.json()
           const error = {
             message: data.error?.message ?? 'Error occurred.',
-            code: data.error?.code ?? ErrorCode.Unknown,
+            code: data.error?.code ?? data.error?.type ?? ErrorCode.Unknown,
           }
           subscriber.error(error)
           subscriber.complete()

--- a/core/src/types/message/messageEntity.ts
+++ b/core/src/types/message/messageEntity.ts
@@ -85,6 +85,8 @@ export enum ErrorCode {
 
   InsufficientQuota = 'insufficient_quota',
 
+  InvalidRequestError = 'invalid_request_error',
+
   Unknown = 'unknown',
 }
 

--- a/web/screens/Chat/ErrorMessage/index.tsx
+++ b/web/screens/Chat/ErrorMessage/index.tsx
@@ -41,6 +41,7 @@ const ErrorMessage = ({ message }: { message: ThreadMessage }) => {
       case ErrorCode.Unknown:
         return 'Apologies, something’s amiss!'
       case ErrorCode.InvalidApiKey:
+      case ErrorCode.InvalidRequestError:
         return (
           <span>
             Invalid API key. Please check your API key from{' '}


### PR DESCRIPTION
## Describe Your Changes
Fix issue where app fails to handle missing API key input

Updated error handling to address the scenario where the application fails to prompt users for an API key input. Instead of displaying a vague "something's amiss" message, the application now accurately notifies users of the missing API key and redirects them to the settings for key configuration.

Changes Made:
- Improved error handling to detect missing API key input
- Updated error message for clarity and user guidance

<img width="1312" alt="Screenshot 2024-04-08 at 12 11 03" src="https://github.com/janhq/jan/assets/133622055/46d81c85-cdaf-43a6-a04c-316e23261e49">

## Fixes Issues

- #2644

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
