### PR TITLE
fix error handling of core for mistral integration

### DIFF
--- a/core/src/browser/extensions/engines/helpers/sse.ts
+++ b/core/src/browser/extensions/engines/helpers/sse.ts
@@ -38,7 +38,7 @@ export function requestInference(
           const data = await response.json()
           let errorCode = ErrorCode.Unknown;
           if (data.error) {
-            errorCode = data.error.code ?? data.error.type;
+            errorCode = data.error.code ?? data.error.type ?? ErrorCode.Unknown
           } else if (response.status === 401) {
             errorCode = ErrorCode.InvalidApiKey;
           }

--- a/core/src/browser/extensions/engines/helpers/sse.ts
+++ b/core/src/browser/extensions/engines/helpers/sse.ts
@@ -38,7 +38,7 @@ export function requestInference(
           const data = await response.json()
           const error = {
             message: data.error?.message ?? 'Error occurred.',
-            code: data.error?.code ?? data.error?.type ?? ErrorCode.Unknown,
+            code: data.error?.code ?? data.error?.type ?? (data.message ==='Unauthorized'|| data.message === 'No API key found in request')? ErrorCode.InvalidApiKey: ErrorCode.Unknown,
           }
           subscriber.error(error)
           subscriber.complete()

--- a/core/src/browser/extensions/engines/helpers/sse.ts
+++ b/core/src/browser/extensions/engines/helpers/sse.ts
@@ -36,9 +36,15 @@ export function requestInference(
       .then(async (response) => {
         if (!response.ok) {
           const data = await response.json()
+          let errorCode = ErrorCode.Unknown;
+          if (data.error) {
+            errorCode = data.error.code ?? data.error.type;
+          } else if (response.status === 401) {
+            errorCode = ErrorCode.InvalidApiKey;
+          }
           const error = {
             message: data.error?.message ?? 'Error occurred.',
-            code: data.error?.code ?? data.error?.type ?? (data.message ==='Unauthorized'|| data.message === 'No API key found in request')? ErrorCode.InvalidApiKey: ErrorCode.Unknown,
+            code: errorCode,
           }
           subscriber.error(error)
           subscriber.complete()


### PR DESCRIPTION
## Describe Your Changes

-When mistral return 401 response with message:  'Unauthorized'||  'No API key found in request'. Return API key error

## Fixes Issues

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
