### PR TITLE
fix: wrong monitoring system information type

### DIFF
--- a/core/src/browser/extensions/monitoring.ts
+++ b/core/src/browser/extensions/monitoring.ts
@@ -13,7 +13,7 @@ export abstract class MonitoringExtension extends BaseExtension implements Monit
     return ExtensionTypeEnum.SystemMonitoring
   }
 
-  abstract getGpuSetting(): Promise<GpuSetting>
+  abstract getGpuSetting(): Promise<GpuSetting | undefined>
   abstract getResourcesInfo(): Promise<any>
   abstract getCurrentLoad(): Promise<any>
   abstract getOsInfo(): Promise<OperatingSystemInfo>

--- a/core/src/types/miscellaneous/systemResourceInfo.ts
+++ b/core/src/types/miscellaneous/systemResourceInfo.ts
@@ -32,7 +32,7 @@ export type GpuSettingInfo = {
 }
 
 export type SystemInformation = {
-  gpuSetting: GpuSetting
+  gpuSetting?: GpuSetting
   osInfo?: OperatingSystemInfo
 }
 

--- a/core/src/types/monitoring/monitoringInterface.ts
+++ b/core/src/types/monitoring/monitoringInterface.ts
@@ -20,7 +20,7 @@ export interface MonitoringInterface {
   /**
    * Returns the GPU configuration.
    */
-  getGpuSetting(): Promise<GpuSetting>
+  getGpuSetting(): Promise<GpuSetting | undefined>
 
   /**
    * Returns information about the operating system.

--- a/extensions/inference-nitro-extension/src/index.ts
+++ b/extensions/inference-nitro-extension/src/index.ts
@@ -120,7 +120,7 @@ export default class JanInferenceNitroExtension extends LocalOAIEngine {
     const downloadUrl = CUDA_DOWNLOAD_URL
 
     const url = downloadUrl
-      .replace('<version>', info.gpuSetting.cuda?.version ?? '12.4')
+      .replace('<version>', info.gpuSetting?.cuda?.version ?? '12.4')
       .replace('<platform>', platform)
 
     console.debug('Downloading Cuda Toolkit Dependency: ', url)
@@ -168,11 +168,11 @@ export default class JanInferenceNitroExtension extends LocalOAIEngine {
   override async installationState(): Promise<InstallationState> {
     const info = await systemInformation()
     if (
-      info.gpuSetting.run_mode === 'gpu' &&
-      !info.gpuSetting.vulkan &&
+      info.gpuSetting?.run_mode === 'gpu' &&
+      !info.gpuSetting?.vulkan &&
       info.osInfo &&
       info.osInfo.platform !== 'darwin' &&
-      !info.gpuSetting.cuda?.exist
+      !info.gpuSetting?.cuda?.exist
     ) {
       const janDataFolderPath = await getJanDataFolderPath()
 

--- a/extensions/monitoring-extension/src/index.ts
+++ b/extensions/monitoring-extension/src/index.ts
@@ -16,10 +16,7 @@ enum Settings {
  * JanMonitoringExtension is a extension that provides system monitoring functionality.
  * It implements the MonitoringExtension interface from the @janhq/core package.
  */
-export default class JanMonitoringExtension
-  extends MonitoringExtension
-  implements MonitoringInterface
-{
+export default class JanMonitoringExtension extends MonitoringExtension {
   /**
    * Called when the extension is loaded.
    */

--- a/extensions/tensorrt-llm-extension/src/index.ts
+++ b/extensions/tensorrt-llm-extension/src/index.ts
@@ -70,7 +70,7 @@ export default class TensorRTLLMExtension extends LocalOAIEngine {
       'engines',
       this.provider,
       engineVersion,
-      info.gpuSetting.gpus[0].arch,
+      info.gpuSetting?.gpus[0].arch,
     ])
 
     if (!(await fs.existsSync(executableFolderPath))) {
@@ -148,7 +148,7 @@ export default class TensorRTLLMExtension extends LocalOAIEngine {
     const info = await systemInformation()
 
     if (!this.isCompatible(info)) return 'NotCompatible'
-    const firstGpu = info.gpuSetting.gpus[0]
+    const firstGpu = info.gpuSetting?.gpus[0]
     const janDataFolderPath = await getJanDataFolderPath()
     const engineVersion = TENSORRT_VERSION
 
@@ -184,12 +184,13 @@ export default class TensorRTLLMExtension extends LocalOAIEngine {
   isCompatible(info: SystemInformation): info is Required<SystemInformation> & {
     gpuSetting: { gpus: { arch: string }[] }
   } {
-    const firstGpu = info.gpuSetting.gpus[0]
+    const firstGpu = info.gpuSetting?.gpus[0]
     return (
       !!info.osInfo &&
-      info.gpuSetting?.gpus?.length > 0 &&
-      this.supportedPlatform.includes(info.osInfo.platform) &&
+      !!info.gpuSetting &&
       !!firstGpu &&
+      info.gpuSetting.gpus.length > 0 &&
+      this.supportedPlatform.includes(info.osInfo.platform) &&
       !!firstGpu.arch &&
       firstGpu.name.toLowerCase().includes('nvidia') &&
       this.supportedGpuArch.includes(firstGpu.arch)

--- a/extensions/tensorrt-llm-extension/src/node/index.ts
+++ b/extensions/tensorrt-llm-extension/src/node/index.ts
@@ -148,7 +148,7 @@ async function runEngine(systemInfo: SystemInformation): Promise<void> {
     )
   }
 
-  if (systemInfo.gpuSetting.gpus.length === 0) {
+  if (systemInfo.gpuSetting?.gpus.length === 0) {
     return Promise.reject('No GPU found. Please check your GPU setting.')
   }
 
@@ -164,7 +164,7 @@ async function runEngine(systemInfo: SystemInformation): Promise<void> {
     )
   }
 
-  const gpu = systemInfo.gpuSetting.gpus[0]
+  const gpu = systemInfo.gpuSetting?.gpus[0]
   if (gpu.name.toLowerCase().includes('nvidia') === false) {
     return Promise.reject('No Nvidia GPU found. Please check your GPU setting.')
   }

--- a/web/screens/Settings/CoreExtensions/ExtensionItem.tsx
+++ b/web/screens/Settings/CoreExtensions/ExtensionItem.tsx
@@ -94,17 +94,15 @@ const ExtensionItem: React.FC<Props> = ({ item }) => {
         }
       </div>
 
-      {(!compatibility || compatibility['platform']?.includes(PLATFORM)) && (
-        <div className="flex min-w-[150px] flex-row justify-end">
-          <InstallStateIndicator
-            installProgress={progress}
-            installState={installState}
-            compatibility={compatibility}
-            onInstallClick={onInstallClick}
-            onCancelClick={onCancelInstallingClick}
-          />
-        </div>
-      )}
+      <div className="flex min-w-[150px] flex-row justify-end">
+        <InstallStateIndicator
+          installProgress={progress}
+          installState={installState}
+          compatibility={compatibility}
+          onInstallClick={onInstallClick}
+          onCancelClick={onCancelInstallingClick}
+        />
+      </div>
     </div>
   )
 }

--- a/web/screens/Settings/CoreExtensions/index.tsx
+++ b/web/screens/Settings/CoreExtensions/index.tsx
@@ -8,8 +8,6 @@ import Loader from '@/containers/Loader'
 
 import { formatExtensionsName } from '@/utils/converter'
 
-import ExtensionItem from './ExtensionItem'
-
 import { extensionManager } from '@/extension'
 import Extension from '@/extension/Extension'
 


### PR DESCRIPTION
## Describe Your Changes

- Fixed the issue where the monitoring extension's interface defines GPU Settings as mandatory, but the actual implementation returns a null value due to an incorrect type definition. Now, the interface accurately reflects the optional nature of GPU Settings, and the type definition aligns with the implemented functionality.

- Also fixed the issue where user could not see the `Incompatible` button from Extension Setting's Install Additional Dependencies

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
