### PR TITLE
fix: better kill process tensorrt-llm

### DIFF
--- a/extensions/tensorrt-llm-extension/package.json
+++ b/extensions/tensorrt-llm-extension/package.json
@@ -37,10 +37,10 @@
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@rollup/plugin-replace": "^5.0.5",
+    "@types/decompress": "4.2.7",
     "@types/node": "^20.11.4",
     "@types/os-utils": "^0.0.4",
     "@types/tcp-port-used": "^1.0.4",
-    "@types/decompress": "4.2.7",
     "cpx": "^1.5.0",
     "download-cli": "^1.1.1",
     "rimraf": "^3.0.2",
@@ -58,6 +58,7 @@
     "path-browserify": "^1.0.1",
     "rxjs": "^7.8.1",
     "tcp-port-used": "^1.0.2",
+    "terminate": "^2.6.1",
     "ulidx": "^2.3.0"
   },
   "engines": {
@@ -72,6 +73,7 @@
     "tcp-port-used",
     "fetch-retry",
     "decompress",
-    "@janhq/core"
+    "@janhq/core",
+    "terminate"
   ]
 }


### PR DESCRIPTION
## Describe Your Changes

- Sending a kill signal to the nitro instance will be queued and not processed until all inference requests are completed, which is inefficient. Attempting to kill the subprocesses directly could be a more efficient approach.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
