### PR TITLE
chore: correct copy for Jan data folder to highlight original Jan data folder intact upon relocation

### DIFF
--- a/web/screens/Settings/Advanced/DataFolder/ModalChangeDirectory.tsx
+++ b/web/screens/Settings/Advanced/DataFolder/ModalChangeDirectory.tsx
@@ -36,7 +36,15 @@ const ModalChangeDirectory: React.FC<Props> = ({
         <p className="text-muted-foreground">
           Are you sure you want to relocate Jan data folder to{' '}
           <span className="font-medium text-foreground">{destinationPath}</span>
-          ? A restart will be required afterward.
+          ? <br /> A restart is required afterward, and the original folder
+          remains intact.
+          <br />
+          {isWindows && (
+            <span>
+              Note that Jan will not erase the new Jan data folder upon future
+              uninstallation.
+            </span>
+          )}
         </p>
         <ModalFooter>
           <div className="flex gap-x-2">


### PR DESCRIPTION
## Describe Your Changes

- correct copy for Jan data folder to highlight original Jan data folder intact upon relocation
- MacOS
<img width="297" alt="image" src="https://github.com/janhq/jan/assets/64197333/c28a8992-cb25-4519-a0f0-b44897946b3c">

- Windows
<img width="364" alt="image" src="https://github.com/janhq/jan/assets/64197333/2213bc00-56ad-497b-9189-bb4a2a2285a3">


## Fixes Issues

- https://github.com/janhq/jan/issues/2377#issuecomment-2060747141

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
