### PR TITLE
chore: set default context length to 2048

### DIFF
--- a/extensions/model-extension/src/index.ts
+++ b/extensions/model-extension/src/index.ts
@@ -853,7 +853,7 @@ export default class JanModelExtension extends ModelExtension {
     if (config.max_sequence_length) return config.max_sequence_length
     if (config.max_position_embeddings) return config.max_position_embeddings
     if (config.n_ctx) return config.n_ctx
-    return 4096
+    return 2048
   }
 
   /**
@@ -883,7 +883,7 @@ export default class JanModelExtension extends ModelExtension {
     } catch (err) {
       log(`[Conversion]::Debug: Error using hf-to-gguf.py, trying convert.py`)
 
-      let ctx = 4096
+      let ctx = 2048
       try {
         const config = await fs.readFileSync(
           await joinPath([modelDirPath, 'config.json']),

--- a/web/screens/Chat/ModelSetting/predefinedComponent.ts
+++ b/web/screens/Chat/ModelSetting/predefinedComponent.ts
@@ -36,7 +36,7 @@ export const presetConfiguration: Record<string, SettingComponentProps> = {
       min: 0,
       max: 4096,
       step: 128,
-      value: 4096,
+      value: 2048,
     },
     requireModelReload: true,
     configType: 'setting',

--- a/web/utils/componentSettings.ts
+++ b/web/utils/componentSettings.ts
@@ -31,7 +31,7 @@ export const getConfigurationsData = (
               componentSetting.controllerProps.max =
                 selectedModel?.settings.ctx_len ||
                 componentSetting.controllerProps.max ||
-                4096
+                2048
               break
           }
         }


### PR DESCRIPTION
## Describe Your Changes

- Set default context length to 2048

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
