### PR TITLE
Feat: Add new Llama 3 and models to Groq Extension

### DIFF
--- a/extensions/inference-groq-extension/resources/models.json
+++ b/extensions/inference-groq-extension/resources/models.json
@@ -5,6 +5,90 @@
         "url": "https://groq.com"
       }
     ],
+    "id": "llama3-70b-8192",
+    "object": "model",
+    "name": "Groq Llama 3 70b",
+    "version": "1.0",
+    "description": "Groq Llama 3 70b with supercharged speed!",
+    "format": "api",
+    "settings": {
+      "text_model": false
+    },
+    "parameters": {
+      "max_tokens": 8192,
+      "temperature": 0.7,
+      "top_p": 1,
+      "stop": null,
+      "stream": true
+    },
+    "metadata": {
+      "author": "Meta",
+      "tags": ["General", "Big Context Length"]
+    },
+    "engine": "groq"
+  },
+  {
+    "sources": [
+      {
+        "url": "https://groq.com"
+      }
+    ],
+    "id": "llama3-8b-8192",
+    "object": "model",
+    "name": "Groq Llama 3 8b",
+    "version": "1.0",
+    "description": "Groq Llama 3 8b with supercharged speed!",
+    "format": "api",
+    "settings": {
+      "text_model": false
+    },
+    "parameters": {
+      "max_tokens": 8192,
+      "temperature": 0.7,
+      "top_p": 1,
+      "stop": null,
+      "stream": true
+    },
+    "metadata": {
+      "author": "Meta",
+      "tags": ["General", "Big Context Length"]
+    },
+    "engine": "groq"
+  },
+  {
+    "sources": [
+      {
+        "url": "https://groq.com"
+      }
+    ],
+    "id": "gemma-7b-it",
+    "object": "model",
+    "name": "Groq Gemma 7b Instruct",
+    "version": "1.0",
+    "description": "Groq Gemma 7b Instruct with supercharged speed!",
+    "format": "api",
+    "settings": {
+      "text_model": false
+    },
+    "parameters": {
+      "max_tokens": 4096,
+      "temperature": 0.7,
+      "top_p": 1,
+      "stop": null,
+      "stream": true
+    },
+    "metadata": {
+      "author": "Google",
+      "tags": ["General"]
+    },
+    "engine": "groq"
+  },
+  {
+    "sources": [
+      {
+        "url": "https://groq.com"
+      }
+    ],
     "id": "llama2-70b-4096",
     "object": "model",
     "name": "Groq Llama 2 70b",


### PR DESCRIPTION
## Describe Your Changes

- Adds new Llama 3 models 8B and 80B for the Groq inference extension
- Adds Gemma 7B It model for Groq inference extension