### PR TITLE
fix: add max context length option for model

### DIFF
--- a/core/src/types/model/modelEntity.ts
+++ b/core/src/types/model/modelEntity.ts
@@ -105,6 +105,7 @@ export type ModelMetadata = {
  */
 export type ModelSettingParams = {
   ctx_len?: number
+  max_ctx_len?: number
   ngl?: number
   embedding?: boolean
   n_parallel?: number

--- a/web/utils/componentSettings.ts
+++ b/web/utils/componentSettings.ts
@@ -29,9 +29,8 @@ export const getConfigurationsData = (
               break
             case 'ctx_len':
               componentSetting.controllerProps.max =
-                selectedModel?.settings.ctx_len ||
-                componentSetting.controllerProps.max ||
-                2048
+                selectedModel?.settings.max_ctx_len ??
+                componentSetting.controllerProps.max
               break
           }
         }


### PR DESCRIPTION
## Describe Your Changes

- Adding max context length option for model. It can override the default max context length (4096)

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
