### PR TITLE
fix: new thread with overridden settings

### DIFF
--- a/web/containers/DropdownListSidebar/index.tsx
+++ b/web/containers/DropdownListSidebar/index.tsx
@@ -134,10 +134,19 @@ const DropdownListSidebar = ({
       }
 
       if (activeThread) {
+        // Default setting ctx_len for the model for a better onboarding experience
+        // TODO: When Cortex support hardware instructions, we should remove this
+        const overriddenSettings =
+          model?.settings.ctx_len && model.settings.ctx_len > 2048
+            ? { ctx_len: 2048 }
+            : {}
+
         const modelParams = {
           ...model?.parameters,
           ...model?.settings,
+          ...overriddenSettings,
         }
+
         // Update model parameter to the thread state
         setThreadModelParams(activeThread.id, modelParams)
 

--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -94,6 +94,11 @@ export const useCreateNewThread = () => {
       settings: assistant.tools && assistant.tools[0].settings,
     }
 
+    const overriddenSettings =
+      defaultModel?.settings.ctx_len && defaultModel.settings.ctx_len > 2048
+        ? { ctx_len: 2048 }
+        : {}
+
     const createdAt = Date.now()
     const assistantInfo: ThreadAssistantInfo = {
       assistant_id: assistant.id,
@@ -101,7 +106,7 @@ export const useCreateNewThread = () => {
       tools: experimentalEnabled ? [assistantTools] : assistant.tools,
       model: {
         id: defaultModel?.id ?? '*',
-        settings: defaultModel?.settings ?? {},
+        settings: { ...defaultModel?.settings, ...overriddenSettings } ?? {},
         parameters: defaultModel?.parameters ?? {},
         engine: defaultModel?.engine,
       },
@@ -126,6 +131,7 @@ export const useCreateNewThread = () => {
     setThreadModelParams(thread.id, {
       ...defaultModel?.settings,
       ...defaultModel?.parameters,
+      ...overriddenSettings,
     })
 
     // Delete the file upload state


### PR DESCRIPTION
## Describe Your Changes

- Fixed an issue where newly created threads still apply the maximum `ctx_len` setting, which could break model inference since it would use a lot of RAM, not ideal for onboarding new users with new models (e.g., llama3).

<img width="1312" alt="Screenshot 2024-04-24 at 13 41 11" src="https://github.com/janhq/jan/assets/133622055/7c4ad855-06ca-4a12-a1ee-f5c74c40c4db">


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
