### PR TITLE
feat: add model gpt-4 turbo

### DIFF
--- a/extensions/inference-openai-extension/resources/models.json
+++ b/extensions/inference-openai-extension/resources/models.json
@@ -33,6 +33,29 @@
         "url": "https://openai.com"
       }
     ],
+    "id": "gpt-4-turbo",
+    "object": "model",
+    "name": "OpenAI GPT 4 Turbo",
+    "version": "1.0",
+    "description": "OpenAI GPT 4 Turbo model is extremely good",
+    "format": "api",
+    "settings": {},
+    "parameters": {
+      "max_tokens": 4096,
+      "temperature": 0.7
+    },
+    "metadata": {
+      "author": "OpenAI",
+      "tags": ["General", "Big Context Length"]
+    },
+    "engine": "openai"
+  },
+  {
+    "sources": [
+      {
+        "url": "https://openai.com"
+      }
+    ],
     "id": "gpt-4-vision-preview",
     "object": "model",
     "name": "OpenAI GPT 4 with Vision (Preview)",

--- a/extensions/inference-openai-extension/resources/models.json
+++ b/extensions/inference-openai-extension/resources/models.json
@@ -7,9 +7,9 @@
     ],
     "id": "gpt-4-turbo",
     "object": "model",
-    "name": "OpenAI GPT 4",
-    "version": "1.1",
-    "description": "OpenAI GPT 4 model is extremely good",
+    "name": "OpenAI GPT 4 Turbo",
+    "version": "1.2",
+    "description": "OpenAI GPT 4 Turbo model is extremely good",
     "format": "api",
     "settings": {},
     "parameters": {
@@ -24,29 +24,6 @@
     "metadata": {
       "author": "OpenAI",
       "tags": ["General"]
-    },
-    "engine": "openai"
-  },
-  {
-    "sources": [
-      {
-        "url": "https://openai.com"
-      }
-    ],
-    "id": "gpt-4-turbo",
-    "object": "model",
-    "name": "OpenAI GPT 4 Turbo",
-    "version": "1.0",
-    "description": "OpenAI GPT 4 Turbo model is extremely good",
-    "format": "api",
-    "settings": {},
-    "parameters": {
-      "max_tokens": 4096,
-      "temperature": 0.7
-    },
-    "metadata": {
-      "author": "OpenAI",
-      "tags": ["General", "Big Context Length"]
     },
     "engine": "openai"
   },


### PR DESCRIPTION
## Describe Your Changes

- This pull requests add the gpt-4 turbo to the model list. As a user, I prefer use GPT-4 Turbo rather than GPT-4 normal because it's recently cut off knowledge from April 2023, and cheaper price and better than the normal GPT 4 model.
- Thus, I think it should be added to the default list. For the non-technical user, seems a little bit inconvenient as requires additional steps. This PR adds the GPT-4-Turbo model, so when users download it, they can use it without additional steps.


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
