### PR TITLE
feat: add remote model command-r

### DIFF
--- a/extensions/inference-cohere-extension/resources/models.json
+++ b/extensions/inference-cohere-extension/resources/models.json
@@ -1,4 +1,4 @@
-  [
+[
   {
     "sources": [
       {
@@ -19,7 +19,37 @@
     },
     "metadata": {
       "author": "Cohere",
-      "tags": ["General", "Big Context Length"]
+      "tags": [
+        "General",
+        "Big Context Length"
+      ]
+    },
+    "engine": "cohere"
+  },
+  {
+    "sources": [
+      {
+        "url": "https://cohere.com"
+      }
+    ],
+    "id": "command-r",
+    "object": "model",
+    "name": "Command R",
+    "version": "1.0",
+    "description": "Command R is an instruction-following conversational model that performs language tasks at a higher quality, more reliably, and with a longer context than previous models. It can be used for complex workflows like code generation, retrieval augmented generation (RAG), tool use, and agents.",
+    "format": "api",
+    "settings": {},
+    "parameters": {
+      "max_tokens": 128000,
+      "temperature": 0.7,
+      "stream": false
+    },
+    "metadata": {
+      "author": "Cohere",
+      "tags": [
+        "General",
+        "Big Context Length"
+      ]
     },
     "engine": "cohere"
   }


### PR DESCRIPTION
## Describe Your Changes
- Current remote model only has command-r+. Thus, this PR adds the command-r to the remote model list, so user can use another price option.

- Price: https://cohere.com/pricing
![image](https://github.com/janhq/jan/assets/150573299/5af084bc-53d6-41e3-aa71-5d7e8e96f376)


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
