### PR TITLE
Revert "chore: remove nutjs" and replace nutjs version

### DIFF
--- a/.github/workflows/jan-electron-linter-and-test.yml
+++ b/.github/workflows/jan-electron-linter-and-test.yml
@@ -57,19 +57,19 @@ jobs:
           rm -rf ~/jan
           make clean
 
-      # - name: Get Commit Message for PR
-      #   if : github.event_name == 'pull_request'
-      #   run: |
-      #     echo "REPORT_PORTAL_DESCRIPTION=${{github.event.after}})" >> $GITHUB_ENV
+      - name: Get Commit Message for PR
+        if : github.event_name == 'pull_request'
+        run: |
+          echo "REPORT_PORTAL_DESCRIPTION=${{github.event.after}})" >> $GITHUB_ENV
 
-      # - name: Get Commit Message for push event
-      #   if : github.event_name == 'push'
-      #   run: |
-      #     echo "REPORT_PORTAL_DESCRIPTION=${{github.sha}})" >> $GITHUB_ENV
+      - name: Get Commit Message for push event
+        if : github.event_name == 'push'
+        run: |
+          echo "REPORT_PORTAL_DESCRIPTION=${{github.sha}})" >> $GITHUB_ENV
 
-      # - name: "Config report portal"
-      #   run: |
-      #     make update-playwright-config REPORT_PORTAL_URL=${{ secrets.REPORT_PORTAL_URL }} REPORT_PORTAL_API_KEY=${{ secrets.REPORT_PORTAL_API_KEY }} REPORT_PORTAL_PROJECT_NAME=${{ secrets.REPORT_PORTAL_PROJECT_NAME }} REPORT_PORTAL_LAUNCH_NAME="Jan App macos" REPORT_PORTAL_DESCRIPTION="${{env.REPORT_PORTAL_DESCRIPTION}}"
+      - name: "Config report portal"
+        run: |
+          make update-playwright-config REPORT_PORTAL_URL=${{ secrets.REPORT_PORTAL_URL }} REPORT_PORTAL_API_KEY=${{ secrets.REPORT_PORTAL_API_KEY }} REPORT_PORTAL_PROJECT_NAME=${{ secrets.REPORT_PORTAL_PROJECT_NAME }} REPORT_PORTAL_LAUNCH_NAME="Jan App macos" REPORT_PORTAL_DESCRIPTION="${{env.REPORT_PORTAL_DESCRIPTION}}"
 
       - name: Linter and test
         run: |
@@ -78,9 +78,9 @@ jobs:
           make test
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: "false"
-          # TURBO_API: "${{ secrets.TURBO_API }}"
-          # TURBO_TEAM: "macos"
-          # TURBO_TOKEN: "${{ secrets.TURBO_TOKEN }}"
+          TURBO_API: "${{ secrets.TURBO_API }}"
+          TURBO_TEAM: "macos"
+          TURBO_TOKEN: "${{ secrets.TURBO_TOKEN }}"
 
   test-on-macos-pr-target:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
@@ -141,16 +141,16 @@ jobs:
           }
           make clean
   
-      # - name: Get Commit Message for push event
-      #   if : github.event_name == 'push'
-      #   shell: bash
-      #   run: |
-      #     echo "REPORT_PORTAL_DESCRIPTION=${{github.sha}}" >> $GITHUB_ENV
+      - name: Get Commit Message for push event
+        if : github.event_name == 'push'
+        shell: bash
+        run: |
+          echo "REPORT_PORTAL_DESCRIPTION=${{github.sha}}" >> $GITHUB_ENV
 
-      # - name: "Config report portal"
-      #   shell: bash
-      #   run: |
-      #     make update-playwright-config REPORT_PORTAL_URL=${{ secrets.REPORT_PORTAL_URL }} REPORT_PORTAL_API_KEY=${{ secrets.REPORT_PORTAL_API_KEY }} REPORT_PORTAL_PROJECT_NAME=${{ secrets.REPORT_PORTAL_PROJECT_NAME }} REPORT_PORTAL_LAUNCH_NAME="Jan App Windows ${{ matrix.antivirus-tools }}" REPORT_PORTAL_DESCRIPTION="${{env.REPORT_PORTAL_DESCRIPTION}}"
+      - name: "Config report portal"
+        shell: bash
+        run: |
+          make update-playwright-config REPORT_PORTAL_URL=${{ secrets.REPORT_PORTAL_URL }} REPORT_PORTAL_API_KEY=${{ secrets.REPORT_PORTAL_API_KEY }} REPORT_PORTAL_PROJECT_NAME=${{ secrets.REPORT_PORTAL_PROJECT_NAME }} REPORT_PORTAL_LAUNCH_NAME="Jan App Windows ${{ matrix.antivirus-tools }}" REPORT_PORTAL_DESCRIPTION="${{env.REPORT_PORTAL_DESCRIPTION}}"
 
       - name: Linter and test
         shell: powershell
@@ -158,10 +158,10 @@ jobs:
           npm config set registry ${{ secrets.NPM_PROXY }} --global
           yarn config set registry ${{ secrets.NPM_PROXY }} --global
           make test
-        # env:
-        #   TURBO_API: "${{ secrets.TURBO_API }}"
-        #   TURBO_TEAM: "windows"
-        #   TURBO_TOKEN: "${{ secrets.TURBO_TOKEN }}"
+        env:
+          TURBO_API: "${{ secrets.TURBO_API }}"
+          TURBO_TEAM: "windows"
+          TURBO_TOKEN: "${{ secrets.TURBO_TOKEN }}"
   test-on-windows-pr:
     if: (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: windows-desktop-default-windows-security
@@ -189,16 +189,16 @@ jobs:
           }
           make clean
 
-      # - name: Get Commit Message for PR
-      #   if : github.event_name == 'pull_request'
-      #   shell: bash
-      #   run: |
-      #     echo "REPORT_PORTAL_DESCRIPTION=${{github.event.after}}" >> $GITHUB_ENV
+      - name: Get Commit Message for PR
+        if : github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          echo "REPORT_PORTAL_DESCRIPTION=${{github.event.after}}" >> $GITHUB_ENV
 
-      # - name: "Config report portal"
-      #   shell: bash
-      #   run: |
-      #     make update-playwright-config REPORT_PORTAL_URL=${{ secrets.REPORT_PORTAL_URL }} REPORT_PORTAL_API_KEY=${{ secrets.REPORT_PORTAL_API_KEY }} REPORT_PORTAL_PROJECT_NAME=${{ secrets.REPORT_PORTAL_PROJECT_NAME }} REPORT_PORTAL_LAUNCH_NAME="Jan App Windows" REPORT_PORTAL_DESCRIPTION="${{env.REPORT_PORTAL_DESCRIPTION}}"
+      - name: "Config report portal"
+        shell: bash
+        run: |
+          make update-playwright-config REPORT_PORTAL_URL=${{ secrets.REPORT_PORTAL_URL }} REPORT_PORTAL_API_KEY=${{ secrets.REPORT_PORTAL_API_KEY }} REPORT_PORTAL_PROJECT_NAME=${{ secrets.REPORT_PORTAL_PROJECT_NAME }} REPORT_PORTAL_LAUNCH_NAME="Jan App Windows" REPORT_PORTAL_DESCRIPTION="${{env.REPORT_PORTAL_DESCRIPTION}}"
 
       - name: Linter and test
         shell: powershell
@@ -206,10 +206,10 @@ jobs:
           npm config set registry ${{ secrets.NPM_PROXY }} --global
           yarn config set registry ${{ secrets.NPM_PROXY }} --global
           make test
-        # env:
-        #   TURBO_API: "${{ secrets.TURBO_API }}"
-        #   TURBO_TEAM: "windows"
-        #   TURBO_TOKEN: "${{ secrets.TURBO_TOKEN }}"
+        env:
+          TURBO_API: "${{ secrets.TURBO_API }}"
+          TURBO_TEAM: "windows"
+          TURBO_TOKEN: "${{ secrets.TURBO_TOKEN }}"
 
   test-on-windows-pr-target:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
@@ -266,20 +266,20 @@ jobs:
           rm -rf ~/jan
           make clean
 
-      # - name: Get Commit Message for PR
-      #   if : github.event_name == 'pull_request'
-      #   run: |
-      #     echo "REPORT_PORTAL_DESCRIPTION=${{github.event.after}}" >> $GITHUB_ENV
+      - name: Get Commit Message for PR
+        if : github.event_name == 'pull_request'
+        run: |
+          echo "REPORT_PORTAL_DESCRIPTION=${{github.event.after}}" >> $GITHUB_ENV
 
-      # - name: Get Commit Message for push event
-      #   if : github.event_name == 'push'
-      #   run: |
-      #     echo "REPORT_PORTAL_DESCRIPTION=${{github.sha}}" >> $GITHUB_ENV
+      - name: Get Commit Message for push event
+        if : github.event_name == 'push'
+        run: |
+          echo "REPORT_PORTAL_DESCRIPTION=${{github.sha}}" >> $GITHUB_ENV
 
-      # - name: "Config report portal"
-      #   shell: bash
-      #   run: |
-      #     make update-playwright-config REPORT_PORTAL_URL=${{ secrets.REPORT_PORTAL_URL }} REPORT_PORTAL_API_KEY=${{ secrets.REPORT_PORTAL_API_KEY }} REPORT_PORTAL_PROJECT_NAME=${{ secrets.REPORT_PORTAL_PROJECT_NAME }} REPORT_PORTAL_LAUNCH_NAME="Jan App Linux" REPORT_PORTAL_DESCRIPTION="${{env.REPORT_PORTAL_DESCRIPTION}}"
+      - name: "Config report portal"
+        shell: bash
+        run: |
+          make update-playwright-config REPORT_PORTAL_URL=${{ secrets.REPORT_PORTAL_URL }} REPORT_PORTAL_API_KEY=${{ secrets.REPORT_PORTAL_API_KEY }} REPORT_PORTAL_PROJECT_NAME=${{ secrets.REPORT_PORTAL_PROJECT_NAME }} REPORT_PORTAL_LAUNCH_NAME="Jan App Linux" REPORT_PORTAL_DESCRIPTION="${{env.REPORT_PORTAL_DESCRIPTION}}"
 
       - name: Linter and test
         run: |
@@ -288,10 +288,10 @@ jobs:
           npm config set registry ${{ secrets.NPM_PROXY }} --global
           yarn config set registry ${{ secrets.NPM_PROXY }} --global
           make test
-        # env:
-        #   TURBO_API: "${{ secrets.TURBO_API }}"
-        #   TURBO_TEAM: "linux"
-        #   TURBO_TOKEN: "${{ secrets.TURBO_TOKEN }}"
+        env:
+          TURBO_API: "${{ secrets.TURBO_API }}"
+          TURBO_TEAM: "linux"
+          TURBO_TOKEN: "${{ secrets.TURBO_TOKEN }}"
 
   test-on-ubuntu-pr-target:
     runs-on: [self-hosted, Linux, ubuntu-desktop]

--- a/electron/package.json
+++ b/electron/package.json
@@ -104,7 +104,7 @@
     "request": "^2.88.2",
     "request-progress": "^3.0.0",
     "ulidx": "^2.3.0",
-    "@nut-tree/nut-js": "github:nut-tree/nut.js#4.2.0"
+    "@nut-tree-fork/nut-js": "^4.2.1"
   },
   "devDependencies": {
     "@electron/notarize": "^2.1.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -104,7 +104,7 @@
     "request": "^2.88.2",
     "request-progress": "^3.0.0",
     "ulidx": "^2.3.0",
-    "@nut-tree/nut-js": "^4.0.0"
+    "@nut-tree/nut-js": "github:nut-tree/nut.js#4.2.0"
   },
   "devDependencies": {
     "@electron/notarize": "^2.1.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -104,7 +104,7 @@
     "request": "^2.88.2",
     "request-progress": "^3.0.0",
     "ulidx": "^2.3.0",
-    "@nut-tree-fork/nut-js": "^4.2.1"
+    "@kirillvakalov/nut-tree__nut-js": "4.2.1-2"
   },
   "devDependencies": {
     "@electron/notarize": "^2.1.0",

--- a/electron/package.json
+++ b/electron/package.json
@@ -103,7 +103,8 @@
     "pacote": "^17.0.4",
     "request": "^2.88.2",
     "request-progress": "^3.0.0",
-    "ulidx": "^2.3.0"
+    "ulidx": "^2.3.0",
+    "@nut-tree/nut-js": "^4.0.0"
   },
   "devDependencies": {
     "@electron/notarize": "^2.1.0",

--- a/electron/utils/selectedText.ts
+++ b/electron/utils/selectedText.ts
@@ -1,24 +1,23 @@
 import { clipboard, globalShortcut } from 'electron'
+import { keyboard, Key } from '@nut-tree/nut-js'
 
 /**
  * Gets selected text by synthesizing the keyboard shortcut
  * "CommandOrControl+c" then reading text from the clipboard
  */
 export const getSelectedText = async () => {
-  // TODO: Implement this function
-  // const currentClipboardContent = clipboard.readText() // preserve clipboard content
-  // clipboard.clear()
-  // const hotkeys: Key[] = [
-  //   process.platform === 'darwin' ? Key.LeftCmd : Key.LeftControl,
-  //   Key.C,
-  // ]
-  // await keyboard.pressKey(...hotkeys)
-  // await keyboard.releaseKey(...hotkeys)
-  // await new Promise((resolve) => setTimeout(resolve, 200)) // add a delay before checking clipboard
-  // const selectedText = clipboard.readText()
-  // clipboard.writeText(currentClipboardContent)
-  // return selectedText
-  return ''
+  const currentClipboardContent = clipboard.readText() // preserve clipboard content
+  clipboard.clear()
+  const hotkeys: Key[] = [
+    process.platform === 'darwin' ? Key.LeftCmd : Key.LeftControl,
+    Key.C,
+  ]
+  await keyboard.pressKey(...hotkeys)
+  await keyboard.releaseKey(...hotkeys)
+  await new Promise((resolve) => setTimeout(resolve, 200)) // add a delay before checking clipboard
+  const selectedText = clipboard.readText()
+  clipboard.writeText(currentClipboardContent)
+  return selectedText
 }
 
 /**

--- a/electron/utils/selectedText.ts
+++ b/electron/utils/selectedText.ts
@@ -1,5 +1,5 @@
 import { clipboard, globalShortcut } from 'electron'
-import { keyboard, Key } from '@nut-tree/nut-js'
+import { keyboard, Key } from "@nut-tree-fork/nut-js"
 
 /**
  * Gets selected text by synthesizing the keyboard shortcut

--- a/electron/utils/selectedText.ts
+++ b/electron/utils/selectedText.ts
@@ -1,5 +1,5 @@
 import { clipboard, globalShortcut } from 'electron'
-import { keyboard, Key } from "@nut-tree-fork/nut-js"
+import { keyboard, Key } from "@kirillvakalov/nut-tree__nut-js"
 
 /**
  * Gets selected text by synthesizing the keyboard shortcut

--- a/web/screens/Settings/Advanced/index.tsx
+++ b/web/screens/Settings/Advanced/index.tsx
@@ -439,7 +439,7 @@ const Advanced = () => {
           />
         </div>
 
-        {experimentalEnabled && (
+        {!isLinux && experimentalEnabled && (
           <div className="flex w-full items-start justify-between border-b border-border py-4 first:pt-0 last:border-none">
             <div className="flex-shrink-0 space-y-1.5">
               <div className="flex gap-x-2">

--- a/web/screens/Settings/Advanced/index.tsx
+++ b/web/screens/Settings/Advanced/index.tsx
@@ -439,7 +439,7 @@ const Advanced = () => {
           />
         </div>
 
-        {!isLinux && experimentalEnabled && (
+        {experimentalEnabled && (
           <div className="flex w-full items-start justify-between border-b border-border py-4 first:pt-0 last:border-none">
             <div className="flex-shrink-0 space-y-1.5">
               <div className="flex gap-x-2">


### PR DESCRIPTION
- Reverts janhq/jan#2860

- In the nutjs section of the package.json file, replace the version with this URL: `github:nut-tree/nut.js#4.2.0`. This will install it from Git directly

- Fix https://github.com/janhq/jan/issues/2850