### PR TITLE
fix: fix crash when model name not ready

### DIFF
--- a/web/screens/Settings/HuggingFaceRepoDetailModal/ModelSegmentInfo/index.tsx
+++ b/web/screens/Settings/HuggingFaceRepoDetailModal/ModelSegmentInfo/index.tsx
@@ -13,11 +13,12 @@ const ModelSegmentInfo: React.FC = () => {
   )
 
   const { author, modelName, downloads, modelUrl } = useMemo(() => {
-    const author =
-      (importingHuggingFaceRepoData?.cardData['model_creator'] as string) ??
-      'N/A'
-    const modelName =
-      (importingHuggingFaceRepoData?.cardData['model_name'] as string) ?? 'N/A'
+    const cardData = importingHuggingFaceRepoData?.cardData
+    const author = (cardData?.['model_creator'] ?? 'N/A') as string
+    const modelName = (cardData?.['model_name'] ??
+      importingHuggingFaceRepoData?.id ??
+      'N/A') as string
+
     const modelUrl = importingHuggingFaceRepoData?.modelUrl ?? 'N/A'
     const downloads = importingHuggingFaceRepoData?.downloads ?? 0
 


### PR DESCRIPTION
## Describe Your Changes

- Fix crash when Hugging Face does not return model name. Tested with: `crusoeai/Llama-3-8B-Instruct-262k-GGUF`

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
