### PR TITLE
fix: enable window control button on linux

### DIFF
--- a/web/containers/Layout/TopPanel/index.tsx
+++ b/web/containers/Layout/TopPanel/index.tsx
@@ -97,7 +97,7 @@ const TopPanel = () => {
             <PaletteIcon size={16} className="cursor-pointer" />
           </Button>
 
-          {isWindows && (
+          {!isMac && (
             <div className="flex items-center gap-x-2">
               <Button
                 theme="icon"


### PR DESCRIPTION
## Describe Your Changes
![image](https://github.com/janhq/jan/assets/10354610/cee76a27-c44b-4713-8354-7008212edaf2)

since we make the transparent window and frameless, the native topbar will gone, so we need to enable the window control button on Linux and windows

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, especially in complex areas
- [ ] Updated docs (for bug fixes/features)
- [ ] Created issues for follow-up changes or refactoring needed
