### PR TITLE
fix: handle words without space

### DIFF
--- a/web/screens/Thread/ThreadCenterPanel/SimpleTextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/SimpleTextMessage/index.tsx
@@ -201,7 +201,12 @@ const SimpleTextMessage: React.FC<ThreadMessage> = (props) => {
           )}
       </div>
 
-      <div className={twMerge('w-full', !isUser && 'break-all')}>
+      <div
+        className={twMerge(
+          'w-full',
+          !isUser && !text.includes(' ') && 'break-all'
+        )}
+      >
         <>
           {props.content[0]?.type === ContentType.Image && (
             <div className="group/image relative mb-2 inline-flex cursor-pointer overflow-hidden rounded-xl">


### PR DESCRIPTION
## Describe Your Changes

![Screenshot 2024-06-24 at 19 46 29](https://github.com/janhq/jan/assets/10354610/a8ce4b45-cf00-43ad-bc9a-b54bfe046fc7)

add class `break-all` only for text without space

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
