### PR TITLE
fix: model dropdown search result always show downloaded models first

### DIFF
--- a/web/containers/ModelDropdown/index.tsx
+++ b/web/containers/ModelDropdown/index.tsx
@@ -104,8 +104,23 @@ const ModelDropdown = ({
             )
           }
         })
-        .sort((a, b) => a.name.localeCompare(b.name)),
-    [configuredModels, searchText, searchFilter]
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .sort((a, b) => {
+          const aInDownloadedModels = downloadedModels.some(
+            (item) => item.id === a.id
+          )
+          const bInDownloadedModels = downloadedModels.some(
+            (item) => item.id === b.id
+          )
+          if (aInDownloadedModels && !bInDownloadedModels) {
+            return -1
+          } else if (!aInDownloadedModels && bInDownloadedModels) {
+            return 1
+          } else {
+            return 0
+          }
+        }),
+    [configuredModels, searchText, searchFilter, downloadedModels]
   )
 
   useEffect(() => {


### PR DESCRIPTION
## Describe Your Changes

- Search result always showing model downloaded first 

<img width="1360" alt="Screenshot 2024-07-08 at 19 46 35" src="https://github.com/janhq/jan/assets/10354610/f385f54a-3623-4a47-9526-4f19f9466375">

## Fixes Issues

- #3043 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
