### PR TITLE
fix: validate path in fs

### DIFF
--- a/core/src/browser/fs.ts
+++ b/core/src/browser/fs.ts
@@ -64,10 +64,6 @@ const appendFileSync = (...args: any[]) => globalThis.core.api?.appendFileSync(.
 const syncFile: (src: string, dest: string) => Promise<any> = (src, dest) =>
   globalThis.core.api?.syncFile(src, dest)
 
-/**
- * Copy file sync.
- */
-const copyFileSync = (...args: any[]) => globalThis.core.api?.copyFileSync(...args)
 
 const copyFile: (src: string, dest: string) => Promise<void> = (src, dest) =>
   globalThis.core.api?.copyFile(src, dest)
@@ -95,7 +91,6 @@ export const fs = {
   rm,
   unlinkSync,
   appendFileSync,
-  copyFileSync,
   copyFile,
   syncFile,
   fileStat,

--- a/core/src/node/api/processors/download.ts
+++ b/core/src/node/api/processors/download.ts
@@ -1,6 +1,6 @@
 import { resolve, sep } from 'path'
 import { DownloadEvent } from '../../../types/api'
-import { normalizeFilePath } from '../../helper/path'
+import { normalizeFilePath, validatePath } from '../../helper/path'
 import { getJanDataFolderPath } from '../../helper'
 import { DownloadManager } from '../../helper/download'
 import { createWriteStream, renameSync } from 'fs'
@@ -37,6 +37,7 @@ export class Downloader implements Processor {
     const modelId = array.pop() ?? ''
 
     const destination = resolve(getJanDataFolderPath(), normalizedPath)
+    validatePath(destination)
     const rq = request({ url, strictSSL, proxy })
 
     // Put request to download manager instance

--- a/core/src/node/api/processors/fs.ts
+++ b/core/src/node/api/processors/fs.ts
@@ -1,5 +1,5 @@
 import { join, resolve } from 'path'
-import { normalizeFilePath } from '../../helper/path'
+import { normalizeFilePath, validatePath } from '../../helper/path'
 import { getJanDataFolderPath } from '../../helper'
 import { Processor } from './Processor'
 import fs from 'fs'
@@ -35,12 +35,8 @@ export class FileSystem implements Processor {
             if(path.startsWith(`http://`) || path.startsWith(`https://`)) {
               return path
             }
-            const janDataFolderPath = getJanDataFolderPath()
             const absolutePath = resolve(path)
-            if(!absolutePath.startsWith(janDataFolderPath)) {
-              throw new Error(`Invalid path: ${absolutePath}`)
-            }
-
+            validatePath(absolutePath)
             return absolutePath
           })
         )
@@ -58,11 +54,8 @@ export class FileSystem implements Processor {
       path = join(getJanDataFolderPath(), normalizeFilePath(path))
     }
 
-    const janDataFolderPath = getJanDataFolderPath()
     const absolutePath = resolve(path)
-    if(!absolutePath.startsWith(janDataFolderPath)) {
-      throw new Error(`Invalid path: ${absolutePath}`)
-    }
+    validatePath(absolutePath)
 
     return new Promise((resolve, reject) => {
       fs.rm(absolutePath, { recursive: true, force: true }, (err) => {
@@ -85,11 +78,8 @@ export class FileSystem implements Processor {
       path = join(getJanDataFolderPath(), normalizeFilePath(path))
     }
 
-    const janDataFolderPath = getJanDataFolderPath()
     const absolutePath = resolve(path)
-    if(!absolutePath.startsWith(janDataFolderPath)) {
-      throw new Error(`Invalid path: ${absolutePath}`)
-    }
+    validatePath(absolutePath)
 
     return new Promise((resolve, reject) => {
       fs.mkdir(absolutePath, { recursive: true }, (err) => {

--- a/core/src/node/api/processors/fsExt.ts
+++ b/core/src/node/api/processors/fsExt.ts
@@ -1,6 +1,6 @@
 import { join } from 'path'
 import fs from 'fs'
-import { appResourcePath, normalizeFilePath } from '../../helper/path'
+import { appResourcePath, normalizeFilePath, validatePath } from '../../helper/path'
 import { getJanDataFolderPath, getJanDataFolderPath as getPath } from '../../helper'
 import { Processor } from './Processor'
 import { FileStat } from '../../../types'
@@ -21,6 +21,7 @@ export class FSExt implements Processor {
   // Handles the 'syncFile' IPC event. This event is triggered to synchronize a file from a source path to a destination path.
   syncFile(src: string, dest: string) {
     const reflect = require('@alumna/reflect')
+    validatePath(dest)
     return reflect({
       src,
       dest,
@@ -70,14 +71,18 @@ export class FSExt implements Processor {
   writeBlob(path: string, data: any) {
     try {
       const normalizedPath = normalizeFilePath(path)
+      
       const dataBuffer = Buffer.from(data, 'base64')
-      fs.writeFileSync(join(getJanDataFolderPath(), normalizedPath), dataBuffer)
+      const writePath = join(getJanDataFolderPath(), normalizedPath)
+      validatePath(writePath)
+      fs.writeFileSync(writePath, dataBuffer)
     } catch (err) {
       console.error(`writeFile ${path} result: ${err}`)
     }
   }
 
   copyFile(src: string, dest: string): Promise<void> {
+    validatePath(dest)
     return new Promise((resolve, reject) => {
       fs.copyFile(src, dest, (err) => {
         if (err) {

--- a/core/src/node/helper/config.ts
+++ b/core/src/node/helper/config.ts
@@ -7,7 +7,8 @@ import childProcess from 'child_process'
 const configurationFileName = 'settings.json'
 
 // TODO: do no specify app name in framework module
-const defaultJanDataFolder = join(os.homedir(), 'jan')
+// TODO: do not default the os.homedir
+const defaultJanDataFolder = join(os?.homedir() || '', 'jan')
 const defaultAppConfig: AppConfiguration = {
   data_folder: defaultJanDataFolder,
   quick_ask: false,

--- a/core/src/node/helper/config.ts
+++ b/core/src/node/helper/config.ts
@@ -7,7 +7,7 @@ import childProcess from 'child_process'
 const configurationFileName = 'settings.json'
 
 // TODO: do no specify app name in framework module
-const defaultJanDataFolder = join(os.homedir(), 'jan')
+const defaultJanDataFolder = join(os?.homedir(), 'jan')
 const defaultAppConfig: AppConfiguration = {
   data_folder: defaultJanDataFolder,
   quick_ask: false,

--- a/core/src/node/helper/config.ts
+++ b/core/src/node/helper/config.ts
@@ -7,7 +7,7 @@ import childProcess from 'child_process'
 const configurationFileName = 'settings.json'
 
 // TODO: do no specify app name in framework module
-const defaultJanDataFolder = join(os?.homedir(), 'jan')
+const defaultJanDataFolder = join(os.homedir(), 'jan')
 const defaultAppConfig: AppConfiguration = {
   data_folder: defaultJanDataFolder,
   quick_ask: false,

--- a/core/src/node/helper/path.ts
+++ b/core/src/node/helper/path.ts
@@ -1,4 +1,5 @@
-import { join } from 'path'
+import { join, resolve } from 'path'
+import { getJanDataFolderPath } from './config'
 
 /**
  * Normalize file path
@@ -32,4 +33,12 @@ export async function appResourcePath(): Promise<string> {
   }
   // server
   return join(global.core.appPath(), '../../..')
+}
+
+export function validatePath(path: string) {
+  const janDataFolderPath = getJanDataFolderPath()
+  const absolutePath = resolve(__dirname, path)
+  if (!absolutePath.startsWith(janDataFolderPath)) {
+    throw new Error(`Invalid path: ${absolutePath}`)
+  }
 }

--- a/core/src/types/api/index.ts
+++ b/core/src/types/api/index.ts
@@ -90,7 +90,6 @@ export enum ExtensionRoute {
 }
 export enum FileSystemRoute {
   appendFileSync = 'appendFileSync',
-  copyFileSync = 'copyFileSync',
   unlinkSync = 'unlinkSync',
   existsSync = 'existsSync',
   readdirSync = 'readdirSync',

--- a/core/tests/node/path.test.ts
+++ b/core/tests/node/path.test.ts
@@ -1,5 +1,9 @@
 import { normalizeFilePath } from "../../src/node/helper/path";
 
+jest.mock('os', () => ({
+  homedir: jest.fn().mockReturnValue('/mock/home/dir')
+}));
+
 describe("Test file normalize", () => {
   test("returns no file protocol prefix on Unix", async () => {
     expect(normalizeFilePath("file://test.txt")).toBe("test.txt");

--- a/core/tests/node/path.test.ts
+++ b/core/tests/node/path.test.ts
@@ -1,9 +1,5 @@
 import { normalizeFilePath } from "../../src/node/helper/path";
 
-jest.mock('os', () => ({
-  homedir: jest.fn().mockReturnValue('/mock/home/dir')
-}));
-
 describe("Test file normalize", () => {
   test("returns no file protocol prefix on Unix", async () => {
     expect(normalizeFilePath("file://test.txt")).toBe("test.txt");


### PR DESCRIPTION
## Describe Your Changes

-  validate path in fs, only allow access to the file in the Jan folder

before the fix
   - invalid path:
![image](https://github.com/janhq/jan/assets/170505949/4ee2f8e3-2c16-4297-a2e5-d35435427f58)

after the fix:
   - valid path:
![image](https://github.com/janhq/jan/assets/170505949/e5cccd70-37f5-4efb-a289-3ee8d8741184)
![image](https://github.com/janhq/jan/assets/170505949/e05f1675-4a49-459d-a33d-3ac34bebba11)
![image](https://github.com/janhq/jan/assets/170505949/93c309b9-e9c8-451a-8848-da1c2b44bf15)

   - invalid path:
![image](https://github.com/janhq/jan/assets/170505949/af9785ec-d2f6-404b-ae28-1549c02c4dde)
![image](https://github.com/janhq/jan/assets/170505949/87d31735-3340-4051-bd82-be70bc95375b)
![image](https://github.com/janhq/jan/assets/170505949/f3670bf2-edad-4e31-9033-ebe6daec8045)






## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
