### PR TITLE
Add gray box around user message

### DIFF
--- a/web/screens/Thread/ThreadCenterPanel/SimpleTextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/SimpleTextMessage/index.tsx
@@ -160,7 +160,13 @@ const SimpleTextMessage: React.FC<Props> = ({ isLatestMessage, msg }) => {
   }, [msg.content])
 
   return (
-    <div className="group relative mx-auto p-4">
+    // <div className="group relative mx-auto p-4  ">
+    <div
+      className={twMerge(
+        'group relative mx-auto p-4',
+        isUser && 'bg-gray-100 border border-gray-100 rounded-lg shadow-lg'
+      )}
+    >
       <div
         className={twMerge(
           'mb-2 flex items-center justify-start gap-x-2',


### PR DESCRIPTION
## Describe Your Changes

Improve reachability of user messages. Currently, when scrolling, it is very difficult to distinguish where the bot message ends and the user message starts. 90% of the time in my daily workflow, I look for past user prompts to edit them and resubmit. With the box, it's very easy to find them.

This style is inspired from ChatGPT and Claude interfaces.

Keep in mind: I'm aware this gray box is not very good looking; we can work on that. What do you think?

https://github.com/user-attachments/assets/4e038036-fa48-4a74-ab85-6d22cb88ba67

**Open to Discussion**: Please let me know if you want to discuss it in Discord @ marcodifrancesco, or replying to this thread 🙋.

## Self Checklist

- [x] Added relevant comments, esp in complex areas - *None*
- [x] Updated docs (for bug fixes / features) - *None*
- [ ] Created issues for follow-up changes or refactoring needed
