### PR TITLE
chore: update conditional starter screen after cortex load

### DIFF
--- a/web/screens/Thread/index.tsx
+++ b/web/screens/Thread/index.tsx
@@ -12,6 +12,7 @@ import ThreadCenterPanel from './ThreadCenterPanel'
 import EmptyModel from './ThreadCenterPanel/ChatBody/EmptyModel'
 import ThreadRightPanel from './ThreadRightPanel'
 
+import { waitingForCortexAtom } from '@/helpers/atoms/App.atom'
 import { downloadedModelsAtom } from '@/helpers/atoms/Model.atom'
 import {
   isAnyRemoteModelConfiguredAtom,
@@ -20,6 +21,7 @@ import {
 
 const ThreadScreen = () => {
   const downloadedModels = useAtomValue(downloadedModelsAtom)
+  const waitingForCortex = useAtomValue(waitingForCortexAtom)
   const isAnyRemoteModelConfigured = useAtomValue(
     isAnyRemoteModelConfiguredAtom
   )
@@ -35,6 +37,8 @@ const ThreadScreen = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAnyRemoteModelConfigured])
+
+  if (waitingForCortex) return null
 
   return (
     <div className="relative flex h-full w-full flex-1 overflow-x-hidden">


### PR DESCRIPTION
## Describe Your Changes

The case when cortex still loading we not display screen, bc thread screen now depend with cortex, in thread screen we have conditional to check downloaded models and any remote model setup, so thread screen will depends on cortex already load ot not.

![Screenshot 2024-08-01 at 12 49 46](https://github.com/user-attachments/assets/efbe5597-bacf-4554-838a-aa421ae10d87)

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
