### PR TITLE
fix: allow user to reinit engine from settings page

### DIFF
--- a/web/screens/Settings/EngineSetting/index.tsx
+++ b/web/screens/Settings/EngineSetting/index.tsx
@@ -1,4 +1,6 @@
+import { LlmEngine } from '@janhq/core/.'
 import {
+  Button,
   ScrollArea,
   Table,
   TableBody,
@@ -9,6 +11,7 @@ import {
   TableRow,
 } from '@janhq/joi'
 
+import useEngineInit from '@/hooks/useEngineInit'
 import useEngineQuery from '@/hooks/useEngineQuery'
 
 import LoadingIndicator from '@/screens/HubScreen2/components/LoadingIndicator'
@@ -20,6 +23,8 @@ const getStatusTitle = (status: string) => {
 
 const EngineSetting: React.FC = () => {
   const { isLoading, data } = useEngineQuery()
+
+  const initializeEngine = useEngineInit()
 
   if (isLoading) {
     return (
@@ -48,6 +53,7 @@ const EngineSetting: React.FC = () => {
               <TableHead>Description</TableHead>
               <TableHead>Version</TableHead>
               <TableHead>Status</TableHead>
+              <TableHead>Install</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
@@ -62,6 +68,28 @@ const EngineSetting: React.FC = () => {
                     {engineStatus.version}
                   </TableCell>
                   <TableCell>{getStatusTitle(engineStatus.status)}</TableCell>
+                  <TableCell>
+                    {['ready', 'not_initialized'].includes(
+                      engineStatus.status
+                    ) ? (
+                      <Button
+                        theme="primary"
+                        onClick={() =>
+                          initializeEngine.mutate(
+                            engineStatus.name as LlmEngine
+                          )
+                        }
+                      >
+                        {engineStatus.status === 'ready'
+                          ? 'Reinstall'
+                          : 'Install'}
+                      </Button>
+                    ) : (
+                      <Button theme="ghost" disabled>
+                        N/A
+                      </Button>
+                    )}
+                  </TableCell>
                 </TableRow>
               )
             })}


### PR DESCRIPTION
## Describe Your Changes

As a user, I want to be able to reinitialize the engine to get the latest version or repair a broken installation.

<img width="1167" alt="Screenshot 2024-08-06 at 14 32 30" src="https://github.com/user-attachments/assets/afc510a4-2e87-465e-ae75-4c833145a3c4">
<img width="1167" alt="Screenshot 2024-08-06 at 14 33 03" src="https://github.com/user-attachments/assets/d5cb1d08-c2ee-40b8-a611-aa573f5baec6">

## Fixes Issues

- #3250

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
