### PR TITLE
fix: remote engine should not allow reinit

### DIFF
--- a/core/src/types/model/modelEntity.ts
+++ b/core/src/types/model/modelEntity.ts
@@ -19,6 +19,17 @@ export type LlmEngine = (typeof LlmEngines)[number]
 export type LocalEngine = (typeof LocalEngines)[number]
 export type RemoteEngine = (typeof RemoteEngines)[number]
 
+/**
+ * The available engine statuses.
+ */
+export enum EngineStatus  {
+  Ready = 'ready',
+  MissingConfiguration = 'missing_configuration',
+  NotInitialized = 'not_initialized',
+  NotSupported = 'not_supported',
+  Error = 'error',
+} 
+
 export type ModelArtifact = {
   filename: string
   url: string

--- a/web/helpers/atoms/HuggingFace.atom.ts
+++ b/web/helpers/atoms/HuggingFace.atom.ts
@@ -1,4 +1,4 @@
-import { HuggingFaceRepoData } from '@janhq/core/.'
+import { HuggingFaceRepoData } from '@janhq/core'
 import { atom } from 'jotai'
 
 // modals

--- a/web/hooks/useEngineInit.ts
+++ b/web/hooks/useEngineInit.ts
@@ -1,4 +1,5 @@
 import { Engine } from '@cortexso/cortex.js/resources'
+import { EngineStatus } from '@janhq/core'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 
 import useCortex from './useCortex'
@@ -22,7 +23,7 @@ const useEngineInit = () => {
       const engineStatuses = queryCacheData as Engine[]
       engineStatuses.forEach((engine) => {
         if (engine.name === engineName) {
-          engine.status = 'ready'
+          engine.status = EngineStatus.Ready
         }
       })
       console.debug(`Updated engine status: ${engineStatuses}`)

--- a/web/hooks/useHfModelFetchAndDownload.ts
+++ b/web/hooks/useHfModelFetchAndDownload.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 
-import { HuggingFaceRepoData } from '@janhq/core/.'
+import { HuggingFaceRepoData } from '@janhq/core'
 import { useQueryClient } from '@tanstack/react-query'
 
 import { useSetAtom } from 'jotai'

--- a/web/hooks/useSendMessage.ts
+++ b/web/hooks/useSendMessage.ts
@@ -3,6 +3,7 @@ import { useCallback, useRef } from 'react'
 import {
   ChatCompletionCreateParamsNonStreaming,
   ChatCompletionMessageParam,
+  EngineStatus,
   LocalEngines,
   Message,
   MessageContent,
@@ -193,7 +194,7 @@ const useSendMessage = () => {
       return false
     }
 
-    if (engineStatus.status !== 'ready') {
+    if (engineStatus.status !== EngineStatus.Ready) {
       toaster({
         title: errorTitle,
         description: `Engine ${engineStatus.name} is not ready`,

--- a/web/screens/HubScreen2/components/GroupInfo.tsx
+++ b/web/screens/HubScreen2/components/GroupInfo.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo } from 'react'
 
 import Image from 'next/image'
 
-import { RemoteEngine, RemoteEngines } from '@janhq/core'
+import { EngineStatus, RemoteEngine, RemoteEngines } from '@janhq/core'
 
 import { Button } from '@janhq/joi'
 import { useSetAtom } from 'jotai'
@@ -70,7 +70,8 @@ const SetUpComponent: React.FC<SetUpProps> = ({
     () =>
       engineData == null
         ? false
-        : engineData.find((e) => e.name === engine)?.status === 'ready',
+        : engineData.find((e) => e.name === engine)?.status ===
+          EngineStatus.Ready,
     [engineData, engine]
   )
 

--- a/web/screens/HubScreen2/components/HubModelCard.tsx
+++ b/web/screens/HubScreen2/components/HubModelCard.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo } from 'react'
 
-import { LocalEngines, RemoteEngine } from '@janhq/core'
+import { EngineStatus, LocalEngines, RemoteEngine } from '@janhq/core'
 
 import { Button } from '@janhq/joi'
 import { useAtomValue, useSetAtom } from 'jotai'
@@ -54,7 +54,8 @@ const HubModelCard: React.FC<HfModelEntry> = ({ name, downloads, model }) => {
     const isEngineConfigured: boolean =
       engineData == null || model?.engine == null
         ? false
-        : engineData.find((e) => e.name === model.engine)?.status === 'ready'
+        : engineData.find((e) => e.name === model.engine)?.status ===
+          EngineStatus.Ready
 
     const isModelDownloaded = downloadedModels.find(
       (m) => m.model === model!.model
@@ -78,7 +79,8 @@ const HubModelCard: React.FC<HfModelEntry> = ({ name, downloads, model }) => {
       const isApiKeyAdded: boolean =
         engineData == null || model?.engine == null
           ? false
-          : engineData.find((e) => e.name === model.engine)?.status === 'ready'
+          : engineData.find((e) => e.name === model.engine)?.status ===
+            EngineStatus.Ready
 
       const isModelDownloaded = downloadedModels.find(
         (m) => m.model === model.model

--- a/web/screens/HubScreen2/components/RemoteModelCard.tsx
+++ b/web/screens/HubScreen2/components/RemoteModelCard.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 
-import { RemoteEngine } from '@janhq/core'
+import { EngineStatus, RemoteEngine } from '@janhq/core'
 import { useAtomValue, useSetAtom } from 'jotai'
 
 import { toaster } from '@/containers/Toast'
@@ -38,7 +38,8 @@ const RemoteModelCard: React.FC<HfModelEntry> = ({ name, model }) => {
     const isApiKeyAdded: boolean =
       engineData == null || model?.engine == null
         ? false
-        : engineData.find((e) => e.name === model.engine)?.status === 'ready'
+        : engineData.find((e) => e.name === model.engine)?.status ===
+          EngineStatus.Ready
 
     const isModelDownloaded = downloadedModels.find(
       (m) => m.model === model.model

--- a/web/screens/HubScreen2/components/RemoteModelGroup.tsx
+++ b/web/screens/HubScreen2/components/RemoteModelGroup.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 
 import Image from 'next/image'
 
-import { RemoteEngine } from '@janhq/core'
+import { EngineStatus, RemoteEngine } from '@janhq/core'
 import { Button } from '@janhq/joi'
 
 import { useSetAtom } from 'jotai'
@@ -47,7 +47,8 @@ const RemoteModelGroup: React.FC<Props> = ({ data, engine, onSeeAllClick }) => {
     () =>
       engineData == null || engine == null
         ? false
-        : engineData.find((e) => e.name === engine)?.status === 'ready',
+        : engineData.find((e) => e.name === engine)?.status ===
+          EngineStatus.Ready,
     [engineData, engine]
   )
 

--- a/web/screens/HubScreen2/components/SetUpApiKeyModal.tsx
+++ b/web/screens/HubScreen2/components/SetUpApiKeyModal.tsx
@@ -2,6 +2,7 @@ import { Fragment, useCallback, useEffect, useState } from 'react'
 
 import Image from 'next/image'
 
+import { EngineStatus } from '@janhq/core'
 import { Button, Input, Modal } from '@janhq/joi'
 import { useAtom, useSetAtom } from 'jotai'
 import { ArrowUpRight } from 'lucide-react'
@@ -28,7 +29,8 @@ const SetUpApiKeyModal: React.FC = () => {
   useEffect(() => {
     if (!remoteEngine || !engineData) return
     const isEngineReady =
-      engineData.find((e) => e.name === remoteEngine)?.status === 'ready'
+      engineData.find((e) => e.name === remoteEngine)?.status ===
+      EngineStatus.Ready
     const fakeApiKey = '******************************************'
     setApiKey(isEngineReady ? fakeApiKey : '')
   }, [remoteEngine, engineData])

--- a/web/screens/Settings/EngineSetting/index.tsx
+++ b/web/screens/Settings/EngineSetting/index.tsx
@@ -1,4 +1,4 @@
-import { LlmEngine, LlmEngines, LocalEngines } from '@janhq/core/.'
+import { EngineStatus, LlmEngine, LocalEngines } from '@janhq/core'
 import {
   Button,
   ScrollArea,
@@ -69,8 +69,9 @@ const EngineSetting: React.FC = () => {
                   </TableCell>
                   <TableCell>{getStatusTitle(engineStatus.status)}</TableCell>
                   <TableCell>
-                    {LocalEngines.some(e => e === engineStatus.name) && ['ready', 'not_initialized'].includes(
-                      engineStatus.status
+                    {LocalEngines.some((e) => e === engineStatus.name) &&
+                    [EngineStatus.Ready, EngineStatus.NotInitialized].includes(
+                      engineStatus.status as EngineStatus
                     ) ? (
                       <Button
                         theme="primary"
@@ -80,7 +81,7 @@ const EngineSetting: React.FC = () => {
                           )
                         }
                       >
-                        {engineStatus.status === 'ready'
+                        {engineStatus.status === EngineStatus.Ready
                           ? 'Reinstall'
                           : 'Install'}
                       </Button>

--- a/web/screens/Settings/EngineSetting/index.tsx
+++ b/web/screens/Settings/EngineSetting/index.tsx
@@ -1,4 +1,4 @@
-import { LlmEngine } from '@janhq/core/.'
+import { LlmEngine, LlmEngines, LocalEngines } from '@janhq/core/.'
 import {
   Button,
   ScrollArea,
@@ -69,7 +69,7 @@ const EngineSetting: React.FC = () => {
                   </TableCell>
                   <TableCell>{getStatusTitle(engineStatus.status)}</TableCell>
                   <TableCell>
-                    {['ready', 'not_initialized'].includes(
+                    {LocalEngines.some(e => e === engineStatus.name) && ['ready', 'not_initialized'].includes(
                       engineStatus.status
                     ) ? (
                       <Button


### PR DESCRIPTION
## Describe Your Changes

- FIxed an issue where users can reinit remote engines
- Added EngineStatus enum

<img width="870" alt="Screenshot 2024-08-07 121111" src="https://github.com/user-attachments/assets/160941ab-1724-42a4-a5d8-8e478ada7248">


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
