### PR TITLE
chore: add back GPU information to system monitoring bar

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: report
+name: Report
 about: Create a report to help us improve Jan
 title: 'bug: '
 labels: 'type: bug'

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,7 +1,7 @@
 ---
-name: Bug report
+name: report
 about: Create a report to help us improve Jan
-title: 'bug: [DESCRIPTION]'
+title: 'bug: '
 labels: 'type: bug'
 assignees: ''
 

--- a/core/src/types/events/resource.event.ts
+++ b/core/src/types/events/resource.event.ts
@@ -7,9 +7,15 @@ export interface ResourceStatus {
   cpu: {
     usage: number
   }
+  gpus: GpuInfo[]
 }
 
 export interface UsedMemInfo {
   total: number
   used: number
+}
+
+export interface GpuInfo {
+  name: string | undefined
+  vram: UsedMemInfo
 }

--- a/electron/package.json
+++ b/electron/package.json
@@ -123,7 +123,7 @@
     "request": "^2.88.2",
     "request-progress": "^3.0.0",
     "@kirillvakalov/nut-tree__nut-js": "4.2.1-2",
-    "cortexso": "v0.5.0-40"
+    "cortexso": "v0.5.0-43"
   },
   "devDependencies": {
     "@types/js-yaml": "4.0.9",

--- a/web/containers/Layout/BottomPanel/SystemMonitor/index.tsx
+++ b/web/containers/Layout/BottomPanel/SystemMonitor/index.tsx
@@ -35,7 +35,7 @@ const SystemMonitor: React.FC = () => {
   const [usedRam, setUsedRam] = useAtom(usedRamAtom)
   const [totalRam, setTotalRam] = useAtom(totalRamAtom)
   const [cpuUsage, setCpuUsage] = useAtom(cpuUsageAtom)
-  const gpus = useAtomValue(gpusAtom)
+  const [gpus, setGpus] = useAtom(gpusAtom)
 
   const [showFullScreen, setShowFullScreen] = useState(false)
   const [showSystemMonitorPanel, setShowSystemMonitorPanel] = useAtom(
@@ -63,13 +63,18 @@ const SystemMonitor: React.FC = () => {
           setUsedRam(resourceEvent.mem.used)
           setTotalRam(resourceEvent.mem.total)
           setCpuUsage(resourceEvent.cpu.usage)
+          setGpus(
+            resourceEvent.gpus?.filter(
+              (gpu) => gpu.name && gpu.vram.used && gpu.vram.total
+            ) ?? []
+          )
         } catch (err) {
           console.error(err)
         }
       },
       signal: abortControllerRef.current.signal,
     })
-  }, [host, setTotalRam, setUsedRam, setCpuUsage])
+  }, [host, setTotalRam, setUsedRam, setCpuUsage, setGpus])
 
   const unregister = useCallback(() => {
     if (!abortControllerRef.current) return
@@ -195,8 +200,7 @@ const SystemMonitor: React.FC = () => {
                         <div className="flex gap-x-2">
                           <div className="">
                             <span>
-                              {gpu.memoryTotal - gpu.memoryFree}/
-                              {gpu.memoryTotal}
+                              {gpu.vram.used}/{gpu.vram.total}
                             </span>
                             <span> MB</span>
                           </div>
@@ -205,12 +209,17 @@ const SystemMonitor: React.FC = () => {
 
                       <div className="flex items-center gap-x-4">
                         <Progress
-                          value={gpu.utilization}
+                          value={Math.round(
+                            (gpu.vram.used / Math.max(gpu.vram.total, 1)) * 100
+                          )}
                           className="w-full"
                           size="small"
                         />
                         <span className="flex-shrink-0 ">
-                          {gpu.utilization}%
+                          {Math.round(
+                            (gpu.vram.used / Math.max(gpu.vram.total, 1)) * 100
+                          )}
+                          %
                         </span>
                       </div>
                     </div>

--- a/web/helpers/atoms/SystemBar.atom.ts
+++ b/web/helpers/atoms/SystemBar.atom.ts
@@ -1,3 +1,4 @@
+import { GpuInfo } from '@janhq/core/.'
 import { atom } from 'jotai'
 
 export const totalRamAtom = atom<number>(0)
@@ -5,7 +6,7 @@ export const usedRamAtom = atom<number>(0)
 
 export const cpuUsageAtom = atom<number>(0)
 
-export const gpusAtom = atom<Record<string, never>[]>([])
+export const gpusAtom = atom<GpuInfo[]>([])
 
 export const nvidiaTotalVramAtom = atom<number>(0)
 export const availableVramAtom = atom<number>(0)


### PR DESCRIPTION
## Describe Your Changes

This PR is to add back GPU information to system monitoring bar where:
- GPU information is added to /system/events/resources body since cortex 0.5.0-43
- It supports different GPU vendors
- I'm not quite sure why FE shows MB instead of GB unit so I leave it as is

Windows:

Before loading models
<img width="888" alt="Screenshot 2024-08-12 194348" src="https://github.com/user-attachments/assets/18d7c430-22e5-442a-8169-dc1cbf9f6451">

After loaded a model
<img width="888" alt="Screenshot 2024-08-12 194840" src="https://github.com/user-attachments/assets/a43dd71e-5f19-4fdf-b68b-58aa78319e16">

MacOS: 
<img width="1300" alt="Screenshot 2024-08-12 at 20 09 22" src="https://github.com/user-attachments/assets/73144dba-3592-40ed-ab0c-4357f8a7a7c9">

## Fixes Issues
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
