### PR TITLE
fix: Jan should have access to it resource folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ extensions/*-extension/bin/vulkaninfo
 
 # Turborepo
 .turbo
+electron/test-data
+electron/test-results

--- a/core/src/node/api/processors/app.ts
+++ b/core/src/node/api/processors/app.ts
@@ -77,8 +77,8 @@ export class App implements Processor {
       port: args?.port,
       isCorsEnabled: args?.isCorsEnabled,
       isVerboseEnabled: args?.isVerboseEnabled,
-      schemaPath: join(await appResourcePath(), 'docs', 'openapi', 'jan.yaml'),
-      baseDir: join(await appResourcePath(), 'docs', 'openapi'),
+      schemaPath: join(appResourcePath(), 'docs', 'openapi', 'jan.yaml'),
+      baseDir: join(appResourcePath(), 'docs', 'openapi'),
       prefix: args?.prefix,
     })
   }

--- a/core/src/node/api/processors/extension.ts
+++ b/core/src/node/api/processors/extension.ts
@@ -42,7 +42,7 @@ export class Extension implements Processor {
    * @returns An array of paths to the base extensions.
    */
   async baseExtensions() {
-    const baseExtensionPath = join(await appResourcePath(), 'pre-install')
+    const baseExtensionPath = join(appResourcePath(), 'pre-install')
     return readdirSync(baseExtensionPath)
       .filter((file) => extname(file) === '.tgz')
       .map((file) => join(baseExtensionPath, file))

--- a/core/src/node/helper/config.ts
+++ b/core/src/node/helper/config.ts
@@ -1,5 +1,5 @@
 import { AppConfiguration, SettingComponentProps } from '../../types'
-import { join } from 'path'
+import { join, resolve } from 'path'
 import fs from 'fs'
 import os from 'os'
 import childProcess from 'child_process'
@@ -10,7 +10,10 @@ const configurationFileName = 'settings.json'
 // TODO: do not default the os.homedir
 const defaultJanDataFolder = join(os?.homedir() || '', 'jan')
 const defaultAppConfig: AppConfiguration = {
-  data_folder: defaultJanDataFolder,
+  data_folder:
+    process.env.CI === 'e2e'
+      ? process.env.APP_CONFIG_PATH ?? resolve('./test-data')
+      : defaultJanDataFolder,
   quick_ask: false,
 }
 
@@ -20,6 +23,7 @@ const defaultAppConfig: AppConfiguration = {
  * @returns {AppConfiguration} The app configurations.
  */
 export const getAppConfigurations = (): AppConfiguration => {
+  if (process.env.CI === 'e2e') return defaultAppConfig
   // Retrieve Application Support folder path
   // Fallback to user home directory if not found
   const configurationFile = getConfigurationFilePath()

--- a/core/src/node/helper/path.ts
+++ b/core/src/node/helper/path.ts
@@ -11,6 +11,10 @@ export function normalizeFilePath(path: string): string {
   return path.replace(/^(file:[\\/]+)([^:\s]+)$/, '$2')
 }
 
+/**
+ * App resources path
+ * Returns string - The current application directory.
+ */
 export function appResourcePath() {
   try {
     const electron = require('electron')

--- a/electron/utils/migration.ts
+++ b/electron/utils/migration.ts
@@ -11,11 +11,7 @@ import {
   lstatSync,
 } from 'fs'
 import Store from 'electron-store'
-import {
-  getJanExtensionsPath,
-  getJanDataFolderPath,
-  appResourcePath,
-} from '@janhq/core/node'
+import { getJanDataFolderPath, appResourcePath } from '@janhq/core/node'
 
 /**
  * Migrates the extensions & themes.
@@ -43,9 +39,9 @@ async function migrateThemes() {
   if (!existsSync(join(getJanDataFolderPath(), 'themes')))
     mkdirSync(join(getJanDataFolderPath(), 'themes'), { recursive: true })
 
-  const themes = readdirSync(join(await appResourcePath(), 'themes'))
+  const themes = readdirSync(join(appResourcePath(), 'themes'))
   for (const theme of themes) {
-    const themePath = join(await appResourcePath(), 'themes', theme)
+    const themePath = join(appResourcePath(), 'themes', theme)
     if (existsSync(themePath) && !lstatSync(themePath).isDirectory()) {
       continue
     }

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -2,7 +2,6 @@ import { PropsWithChildren } from 'react'
 
 import { Metadata } from 'next'
 
-import 'katex/dist/katex.min.css'
 import '@/styles/main.scss'
 
 export const metadata: Metadata = {

--- a/web/styles/main.scss
+++ b/web/styles/main.scss
@@ -5,6 +5,7 @@
 @import 'tailwindcss/utilities';
 
 @import '@janhq/joi/dist/main.css';
+@import 'katex/dist/katex.min.css';
 
 @import './base/global.scss';
 


### PR DESCRIPTION
## Describe Your Changes

The latest patch raises errors in some cases where the app could not access its resources, e.g. Application Support and App Resources, which is critical.

There are a couple of small code refactoring where:
- css import should be in main.scss files
- application resources should not do async (consistent with others)
- isolated test config. E.g., while running a test with the same package, it should generate data under rootDir/test-data; running the same package without a test environment generates data under a 'jan data' folder.

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
