### PR TITLE
fix: app emits ugly errors when retrieving settings

### DIFF
--- a/core/src/browser/extension.ts
+++ b/core/src/browser/extension.ts
@@ -168,6 +168,7 @@ export abstract class BaseExtension implements ExtensionType {
     ])
 
     try {
+      if (!(await fs.existsSync(settingPath))) return []
       const content = await fs.readFileSync(settingPath, 'utf-8')
       const settings: SettingComponentProps[] = JSON.parse(content)
       return settings

--- a/web/containers/ListContainer/index.tsx
+++ b/web/containers/ListContainer/index.tsx
@@ -15,7 +15,6 @@ const ListContainer = ({ children }: Props) => {
     const currentScrollTop = event.currentTarget.scrollTop
 
     if (prevScrollTop.current > currentScrollTop) {
-      console.debug('User is manually scrolling up')
       isUserManuallyScrollingUp.current = true
     } else {
       const currentScrollTop = event.currentTarget.scrollTop
@@ -23,7 +22,6 @@ const ListContainer = ({ children }: Props) => {
       const clientHeight = event.currentTarget.clientHeight
 
       if (currentScrollTop + clientHeight >= scrollHeight) {
-        console.debug('Scrolled to the bottom')
         isUserManuallyScrollingUp.current = false
       }
     }

--- a/web/hooks/useRecommendedModel.ts
+++ b/web/hooks/useRecommendedModel.ts
@@ -72,9 +72,6 @@ export default function useRecommendedModel() {
     // if we don't have [lastUsedModelId], then we can just use the first model
     // in the downloaded list
     if (!lastUsedModelId) {
-      console.debug(
-        `No last used model, using first model in list ${models[0].id}}`
-      )
       setRecommendedModel(models[0])
       return
     }
@@ -90,7 +87,6 @@ export default function useRecommendedModel() {
       return
     }
 
-    console.debug(`Using last used model ${lastUsedModel.id}`)
     setRecommendedModel(lastUsedModel)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [getAndSortDownloadedModels, activeThread])


### PR DESCRIPTION
## Describe Your Changes

There are issues where the app tries to read files or folders without checking their availability, emitting a bunch of errors that confuse users.

| Ugly Errors |
|:--:|
| <img width="928" alt="Screenshot 2024-08-16 at 22 56 26" src="https://github.com/user-attachments/assets/bc6eb90b-865b-4ad6-b256-4390a6f07da9"> |
| *Fixed by checking file exist* |

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
