### PR TITLE
feat: openrouter model settings

### DIFF
--- a/extensions/inference-openrouter-extension/resources/settings.json
+++ b/extensions/inference-openrouter-extension/resources/settings.json
@@ -19,5 +19,15 @@
       "value": "",
       "type": "password"
     }
+  },
+  {
+    "key": "openrouter-model",
+    "title": "Model",
+    "description": "If the model parameter is omitted, the user or payer's default is used. Otherwise, remember to select a value for model from the [supported models](https://openrouter.ai/docs/models) or API, and include the organization prefix.",
+    "controllerType": "input",
+    "controllerProps": {
+      "placeholder": "Leave empty for default model",
+      "value": ""
+    } 
   }
 ]


### PR DESCRIPTION
## Describe Your Changes

- Per #3110 - OpenRouter extension should route requests to the default model (by omitting it from the request) instead of "auto" (which is costly).
- This PR also registers new settings from the OpenRouter extension, allowing users to input the model they want to use. Adding a full list of OpenRouter supported models would bring hundreds of remote models that would clutter the UI and are not the primary feature.

| Openrouter uses default model |
|:-:|
|<img width="1362" alt="Screenshot 2024-08-20 at 21 21 43" src="https://github.com/user-attachments/assets/dc65e156-21ae-47e4-b4a5-9e45cee5cf83">|
| Openrouter extension registers model input setting |
|<img width="1273" alt="Screenshot 2024-08-20 at 21 31 14" src="https://github.com/user-attachments/assets/5097ba04-7b88-44cf-a97d-e4c58bab24ca">|
|<img width="1315" alt="Screenshot 2024-08-20 at 21 25 43" src="https://github.com/user-attachments/assets/5e747604-d7ea-4e55-a987-decb082cb6b8">|

## Fixes Issues

- #3110 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
