### PR TITLE
feat: preserve model settings

### DIFF
--- a/core/src/types/model/modelEntity.ts
+++ b/core/src/types/model/modelEntity.ts
@@ -107,6 +107,9 @@ export type ModelMetadata = {
   tags: string[]
   size: number
   cover?: string
+  // These settings to preserve model settings across threads
+  default_ctx_len?: number
+  default_max_tokens?: number
 }
 
 /**

--- a/extensions/model-extension/src/index.ts
+++ b/extensions/model-extension/src/index.ts
@@ -353,7 +353,7 @@ export default class JanModelExtension extends ModelExtension {
   }
 
   /**
-   * Saves a machine learning model.
+   * Saves a model file.
    * @param model - The model to save.
    * @returns A Promise that resolves when the model is saved.
    */

--- a/web/containers/ModelDropdown/index.tsx
+++ b/web/containers/ModelDropdown/index.tsx
@@ -45,6 +45,7 @@ import {
 
 import { extensionManager } from '@/extension'
 
+import { preserveModelSettingsAtom } from '@/helpers/atoms/AppConfig.atom'
 import { inActiveEngineProviderAtom } from '@/helpers/atoms/Extension.atom'
 import {
   configuredModelsAtom,
@@ -89,6 +90,7 @@ const ModelDropdown = ({
   const featuredModel = configuredModels.filter((x) =>
     x.metadata.tags.includes('Featured')
   )
+  const preserveModelSettings = useAtomValue(preserveModelSettingsAtom)
 
   useClickOutside(() => !filterOptionsOpen && setOpen(false), null, [
     dropdownOptions,
@@ -161,13 +163,19 @@ const ModelDropdown = ({
       if (activeThread) {
         // Default setting ctx_len for the model for a better onboarding experience
         // TODO: When Cortex support hardware instructions, we should remove this
+        const defaultContextLength = preserveModelSettings
+          ? model?.metadata?.default_ctx_len
+          : 2048
+        const defaultMaxTokens = preserveModelSettings
+          ? model?.metadata?.default_max_tokens
+          : 2048
         const overriddenSettings =
           model?.settings.ctx_len && model.settings.ctx_len > 2048
-            ? { ctx_len: model.metadata?.default_ctx_len ?? 2048 }
+            ? { ctx_len: defaultContextLength }
             : {}
         const overriddenParameters =
           model?.parameters.max_tokens && model.parameters.max_tokens
-            ? { max_tokens: model.metadata?.default_max_tokens ?? 2048 }
+            ? { max_tokens: defaultMaxTokens }
             : {}
 
         const modelParams = {

--- a/web/containers/ModelDropdown/index.tsx
+++ b/web/containers/ModelDropdown/index.tsx
@@ -163,12 +163,17 @@ const ModelDropdown = ({
         // TODO: When Cortex support hardware instructions, we should remove this
         const overriddenSettings =
           model?.settings.ctx_len && model.settings.ctx_len > 2048
-            ? { ctx_len: 2048 }
+            ? { ctx_len: model.metadata?.default_ctx_len ?? 2048 }
+            : {}
+        const overriddenParameters =
+          model?.parameters.max_tokens && model.parameters.max_tokens
+            ? { max_tokens: model.metadata?.default_max_tokens ?? 2048 }
             : {}
 
         const modelParams = {
           ...model?.parameters,
           ...model?.settings,
+          ...overriddenParameters,
           ...overriddenSettings,
         }
 

--- a/web/helpers/atoms/AppConfig.atom.ts
+++ b/web/helpers/atoms/AppConfig.atom.ts
@@ -7,6 +7,7 @@ const VULKAN_ENABLED = 'vulkanEnabled'
 const IGNORE_SSL = 'ignoreSSLFeature'
 const HTTPS_PROXY_FEATURE = 'httpsProxyFeature'
 const QUICK_ASK_ENABLED = 'quickAskEnabled'
+const PRESERVE_MODEL_SETTINGS = 'preserveModelSettings'
 
 export const janDataFolderPathAtom = atom('')
 
@@ -23,3 +24,9 @@ export const vulkanEnabledAtom = atomWithStorage(VULKAN_ENABLED, false)
 export const quickAskEnabledAtom = atomWithStorage(QUICK_ASK_ENABLED, false)
 
 export const hostAtom = atom('http://localhost:1337/')
+
+// This feature is to allow user to cache model settings on thread creation
+export const preserveModelSettingsAtom = atomWithStorage(
+  PRESERVE_MODEL_SETTINGS,
+  false
+)

--- a/web/helpers/atoms/Model.atom.ts
+++ b/web/helpers/atoms/Model.atom.ts
@@ -34,6 +34,17 @@ export const removeDownloadingModelAtom = atom(
 
 export const downloadedModelsAtom = atom<Model[]>([])
 
+export const updateDownloadedModelAtom = atom(
+  null,
+  (get, set, updatedModel: Model) => {
+    const models: Model[] = get(downloadedModelsAtom).map((c) =>
+      c.id === updatedModel.id ? updatedModel : c
+    )
+
+    set(downloadedModelsAtom, models)
+  }
+)
+
 export const removeDownloadedModelAtom = atom(
   null,
   (get, set, modelId: string) => {

--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -10,7 +10,7 @@ import {
   Model,
   AssistantTool,
 } from '@janhq/core'
-import { atom, useAtomValue, useSetAtom } from 'jotai'
+import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai'
 
 import { copyOverInstructionEnabledAtom } from '@/containers/CopyInstruction'
 import { fileUploadAtom } from '@/containers/Providers/Jotai'
@@ -24,7 +24,10 @@ import useSetActiveThread from './useSetActiveThread'
 
 import { extensionManager } from '@/extension'
 
-import { experimentalFeatureEnabledAtom } from '@/helpers/atoms/AppConfig.atom'
+import {
+  experimentalFeatureEnabledAtom,
+  preserveModelSettingsAtom,
+} from '@/helpers/atoms/AppConfig.atom'
 import { selectedModelAtom } from '@/helpers/atoms/Model.atom'
 import {
   threadsAtom,
@@ -62,6 +65,7 @@ export const useCreateNewThread = () => {
   const copyOverInstructionEnabled = useAtomValue(
     copyOverInstructionEnabledAtom
   )
+  const preserveModelSettings = useAtomValue(preserveModelSettingsAtom)
   const activeThread = useAtomValue(activeThreadAtom)
 
   const experimentalEnabled = useAtomValue(experimentalFeatureEnabledAtom)
@@ -99,15 +103,20 @@ export const useCreateNewThread = () => {
       enabled: true,
       settings: assistant.tools && assistant.tools[0].settings,
     }
-
+    const defaultContextLength = preserveModelSettings
+      ? model?.metadata?.default_ctx_len
+      : 2048
+    const defaultMaxTokens = preserveModelSettings
+      ? model?.metadata?.default_max_tokens
+      : 2048
     const overriddenSettings =
       defaultModel?.settings.ctx_len && defaultModel.settings.ctx_len > 2048
-        ? { ctx_len: defaultModel.metadata?.default_ctx_len ?? 2048 }
+        ? { ctx_len: defaultContextLength }
         : {}
 
     const overriddenParameters =
       defaultModel?.parameters.max_tokens && defaultModel.parameters.max_tokens
-        ? { max_tokens: defaultModel.metadata?.default_max_tokens ?? 2048 }
+        ? { max_tokens: defaultMaxTokens }
         : {}
 
     const createdAt = Date.now()

--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -102,12 +102,12 @@ export const useCreateNewThread = () => {
 
     const overriddenSettings =
       defaultModel?.settings.ctx_len && defaultModel.settings.ctx_len > 2048
-        ? { ctx_len: 2048 }
+        ? { ctx_len: defaultModel.metadata?.default_ctx_len ?? 2048 }
         : {}
 
     const overriddenParameters =
       defaultModel?.parameters.max_tokens && defaultModel.parameters.max_tokens
-        ? { max_tokens: 2048 }
+        ? { max_tokens: defaultModel.metadata?.default_max_tokens ?? 2048 }
         : {}
 
     const createdAt = Date.now()

--- a/web/hooks/useUpdateModelParameters.ts
+++ b/web/hooks/useUpdateModelParameters.ts
@@ -15,6 +15,7 @@ import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { toRuntimeParams, toSettingParams } from '@/utils/modelParam'
 
 import { extensionManager } from '@/extension'
+import { preserveModelSettingsAtom } from '@/helpers/atoms/AppConfig.atom'
 import {
   selectedModelAtom,
   updateDownloadedModelAtom,
@@ -24,7 +25,6 @@ import {
   getActiveThreadModelParamsAtom,
   setThreadModelParamsAtom,
 } from '@/helpers/atoms/Thread.atom'
-import { preserveModelSettingsAtom } from '@/helpers/atoms/AppConfig.atom'
 
 export type UpdateModelParameter = {
   params?: ModelParams

--- a/web/screens/Settings/Advanced/index.tsx
+++ b/web/screens/Settings/Advanced/index.tsx
@@ -65,7 +65,9 @@ const Advanced = () => {
   const [proxyEnabled, setProxyEnabled] = useAtom(proxyEnabledAtom)
   const quickAskEnabled = useAtomValue(quickAskEnabledAtom)
 
-  const [preserveModelSettings, setPreserveModelSettings] = useAtom(preserveModelSettingsAtom)
+  const [preserveModelSettings, setPreserveModelSettings] = useAtom(
+    preserveModelSettingsAtom
+  )
   const [proxy, setProxy] = useAtom(proxyAtom)
   const [ignoreSSL, setIgnoreSSL] = useAtom(ignoreSslAtom)
 
@@ -391,10 +393,13 @@ const Advanced = () => {
           <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">
             <div className="flex-shrink-0 space-y-1">
               <div className="flex gap-x-2">
-                <h6 className="font-semibold capitalize">Preserve Model Settings</h6>
+                <h6 className="font-semibold capitalize">
+                  Preserve Model Settings
+                </h6>
               </div>
               <p className="font-medium leading-relaxed text-[hsla(var(--text-secondary))]">
-                Save model settings changes directly to the model file so that new threads will reuse the previous settings.
+                Save model settings changes directly to the model file so that
+                new threads will reuse the previous settings.
               </p>
             </div>
 

--- a/web/screens/Settings/Advanced/index.tsx
+++ b/web/screens/Settings/Advanced/index.tsx
@@ -35,6 +35,7 @@ import {
   proxyEnabledAtom,
   vulkanEnabledAtom,
   quickAskEnabledAtom,
+  preserveModelSettingsAtom,
 } from '@/helpers/atoms/AppConfig.atom'
 
 type GPU = {
@@ -64,6 +65,7 @@ const Advanced = () => {
   const [proxyEnabled, setProxyEnabled] = useAtom(proxyEnabledAtom)
   const quickAskEnabled = useAtomValue(quickAskEnabledAtom)
 
+  const [preserveModelSettings, setPreserveModelSettings] = useAtom(preserveModelSettingsAtom)
   const [proxy, setProxy] = useAtom(proxyAtom)
   const [ignoreSSL, setIgnoreSSL] = useAtom(ignoreSslAtom)
 
@@ -381,6 +383,24 @@ const Advanced = () => {
             <Switch
               checked={vulkanEnabled}
               onChange={(e) => updateVulkanEnabled(e.target.checked)}
+            />
+          </div>
+        )}
+
+        {experimentalEnabled && (
+          <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">
+            <div className="flex-shrink-0 space-y-1">
+              <div className="flex gap-x-2">
+                <h6 className="font-semibold capitalize">Preserve Model Settings</h6>
+              </div>
+              <p className="font-medium leading-relaxed text-[hsla(var(--text-secondary))]">
+                Save model settings changes directly to the model file so that new threads will reuse the previous settings.
+              </p>
+            </div>
+
+            <Switch
+              checked={preserveModelSettings}
+              onChange={(e) => setPreserveModelSettings(e.target.checked)}
             />
           </div>
         )}


### PR DESCRIPTION
## Describe Your Changes

This PR aims to enhance the UX of thread creation by using the previous model settings for new threads, which will be introduced to users as an experimental feature.

NOTES: This will add 2 new fields into model.json > metadata
```json
"metadata": {
    "default_ctx_len": 4096,
    "default_max_tokens": 4096
}
```

| Preserve Model Settings Feature Toggle|
|:-:|
|<img width="1273" alt="Screenshot 2024-08-21 at 16 27 32" src="https://github.com/user-attachments/assets/eb5ca848-d729-4fcf-9e81-f4678e3f4fb5">|
|New thread with previous model settings|
|<img width="1273" alt="Screenshot 2024-08-21 at 16 30 47" src="https://github.com/user-attachments/assets/43677698-5523-4e79-89d7-fdf04a6b3268">|


## Fixes Issues

- #3377 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
