### PR TITLE
chore: disable internal REST endpoints due to a vulnerability issue

### DIFF
--- a/core/src/node/api/restful/v1.ts
+++ b/core/src/node/api/restful/v1.ts
@@ -1,16 +1,16 @@
 import { HttpServer } from '../HttpServer'
 import { commonRouter } from './common'
-import { downloadRouter } from './app/download'
-import { handleRequests } from './app/handlers'
 
 export const v1Router = async (app: HttpServer) => {
   // MARK: Public API Routes
   app.register(commonRouter)
 
   // MARK: Internal Application Routes
-  handleRequests(app)
+  // DEPRECATED: Vulnerability possible issues
+  // handleRequests(app)
 
   // Expanded route for tracking download progress
   // TODO: Replace by Observer Wrapper (ZeroMQ / Vanilla Websocket)
-  app.register(downloadRouter)
+  // DEPRECATED: Jan FE Docker deploy is deprecated
+  // app.register(downloadRouter)
 }


### PR DESCRIPTION
## Describe Your Changes

API Server should only expose OpenAI compatible endpoints. All of the internal endpoints that support Jan Web Docker should be disabled.

The latest release actually gated access to the APIs from outside of Jan Resources, but this is to ensure that no such cases are left.

## Fixes Issues

- ##3379 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
