### PR TITLE
fix: add toaster warning when blocked create new thread

### DIFF
--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -10,10 +10,12 @@ import {
   Model,
   AssistantTool,
 } from '@janhq/core'
-import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { atom, useAtomValue, useSetAtom } from 'jotai'
 
 import { copyOverInstructionEnabledAtom } from '@/containers/CopyInstruction'
 import { fileUploadAtom } from '@/containers/Providers/Jotai'
+
+import { toaster } from '@/containers/Toast'
 
 import { generateThreadId } from '@/utils/thread'
 
@@ -93,7 +95,11 @@ export const useCreateNewThread = () => {
       const lastMessage = threads[0]?.metadata?.lastMessage
 
       if (!lastMessage && threads.length) {
-        return null
+        return toaster({
+          title: 'No new thread created.',
+          description: `To avoid piling up empty threads, please reuse previous one before creating new.`,
+          type: 'warning',
+        })
       }
     }
 


### PR DESCRIPTION
## Describe Your Changes

@Van-QA have good feedback here, instead return `null` we just return `toast` instead when user blocked create new thread bc there empty last message

![Screenshot 2024-08-22 at 10 37 30](https://github.com/user-attachments/assets/fb71a1f9-4836-480e-b54c-3c637775389b)

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
