### PR TITLE
chore: change jan default data folder path to app's userData

### DIFF
--- a/core/src/node/api/processors/fsExt.ts
+++ b/core/src/node/api/processors/fsExt.ts
@@ -1,7 +1,7 @@
 import { join } from 'path'
 import fs from 'fs'
 import { appResourcePath, normalizeFilePath, validatePath } from '../../helper/path'
-import { getJanDataFolderPath, getJanDataFolderPath as getPath } from '../../helper'
+import { defaultAppConfig, getJanDataFolderPath, getJanDataFolderPath as getPath } from '../../helper'
 import { Processor } from './Processor'
 import { FileStat } from '../../../types'
 
@@ -28,9 +28,10 @@ export class FSExt implements Processor {
     return appResourcePath()
   }
 
-  // Handles the 'getUserHomePath' IPC event. This event is triggered to get the user home path.
+  // Handles the 'getUserHomePath' IPC event. This event is triggered to get the user app data path.
+  // CAUTION: This would not return OS home path but the app data path.
   getUserHomePath() {
-    return process.env[process.platform == 'win32' ? 'USERPROFILE' : 'HOME']
+    return defaultAppConfig().data_folder
   }
 
   // handle fs is directory here

--- a/core/src/node/helper/config.ts
+++ b/core/src/node/helper/config.ts
@@ -158,7 +158,7 @@ export const getEngineConfiguration = async (engineId: string) => {
  */
 export const defaultAppConfig = (): AppConfiguration => {
   const { app } = require('electron')
-  const defaultJanDataFolder = join(app?.getPath('userData') ?? os?.homedir() ?? '', 'jan')
+  const defaultJanDataFolder = join(app?.getPath('userData') ?? os?.homedir() ?? '', 'data')
   return {
     data_folder:
       process.env.CI === 'e2e'

--- a/core/src/node/helper/config.ts
+++ b/core/src/node/helper/config.ts
@@ -156,7 +156,7 @@ export const getEngineConfiguration = async (engineId: string) => {
  * $XDG_CONFIG_HOME or ~/.config on Linux
  * ~/Library/Application Support on macOS
  */
-const defaultAppConfig = (): AppConfiguration => {
+export const defaultAppConfig = (): AppConfiguration => {
   const { app } = require('electron')
   const defaultJanDataFolder = join(app?.getPath('userData') ?? os?.homedir() ?? '', 'jan')
   return {

--- a/web/app/search/layout.tsx
+++ b/web/app/search/layout.tsx
@@ -38,8 +38,7 @@ export default function RootLayout() {
 
   useEffect(() => {
     async function getDefaultJanDataFolder() {
-      const homePath = await getUserHomePath()
-      const defaultJanDataFolder = await joinPath([homePath, 'jan'])
+      const defaultJanDataFolder = await getUserHomePath()
 
       setJanDefaultDataFolder(defaultJanDataFolder)
     }

--- a/web/containers/Providers/DataLoader.tsx
+++ b/web/containers/Providers/DataLoader.tsx
@@ -47,8 +47,7 @@ const DataLoader: React.FC<Props> = ({ children }) => {
 
   useEffect(() => {
     async function getDefaultJanDataFolder() {
-      const homePath = await getUserHomePath()
-      const defaultJanDataFolder = await joinPath([homePath, 'jan'])
+      const defaultJanDataFolder = await getUserHomePath()
 
       setJanDefaultDataFolder(defaultJanDataFolder)
     }

--- a/web/hooks/useFactoryReset.ts
+++ b/web/hooks/useFactoryReset.ts
@@ -34,7 +34,16 @@ export default function useFactoryReset() {
       }
 
       const janDataFolderPath = appConfiguration!.data_folder
+      // 1: Stop running model
+      setFactoryResetState(FactoryResetState.StoppingModel)
+      await stopModel()
+      await new Promise((resolve) => setTimeout(resolve, 4000))
 
+      // 2: Delete the old jan data folder
+      setFactoryResetState(FactoryResetState.DeletingData)
+      await fs.rm(janDataFolderPath)
+
+      // 3: Set the default jan data folder
       if (!keepCurrentFolder) {
         // set the default jan data folder to user's home directory
         const configuration: AppConfiguration = {
@@ -44,17 +53,12 @@ export default function useFactoryReset() {
         await window.core?.api?.updateAppConfiguration(configuration)
       }
 
-      setFactoryResetState(FactoryResetState.StoppingModel)
-      await stopModel()
-      await new Promise((resolve) => setTimeout(resolve, 4000))
-
-      setFactoryResetState(FactoryResetState.DeletingData)
-      await fs.rm(janDataFolderPath)
-
+      // 4: Clear app local storage
       setFactoryResetState(FactoryResetState.ClearLocalStorage)
       // reset the localStorage
       localStorage.clear()
 
+      // 5: Relaunch the app
       await window.core?.api?.relaunch()
     },
     [defaultJanDataFolder, stopModel, setFactoryResetState]


### PR DESCRIPTION
## Describe Your Changes

Currently, we are setting the Jan default data folder path to the user's home directory. It would be better to change it back to the app's `appData` folder, which is defined by the OS and used by the Electron app.

```
appData Per-user application data directory, which by default points to:
%APPDATA% on Windows
$XDG_CONFIG_HOME or ~/.config on Linux
~/Library/Application Support on macOS
userData The directory for storing your app's configuration files, which by default is the appData directory appended with your app's name. By convention files storing user data should be written to this directory, and it is not recommended to write large files here because some environments may backup this directory to cloud storage.
```

> https://www.electronjs.org/docs/latest/api/app

So when a user does a fresh install of Jan, they will see Jan under ~/[Jan app data]/jan. They can delete either only the Jan user data folder or the entire Jan app data folder.

Also fixed an issue where users could not reset the path on the latest stable release.

| Jan Data Folder Settings |
|:-:|
|<img width="1273" alt="Screenshot 2024-08-22 at 17 34 34" src="https://github.com/user-attachments/assets/d3c64214-255b-4322-bc00-f4734a72a682">|
|<img width="1273" alt="Screenshot 2024-08-23 at 14 08 05" src="https://github.com/user-attachments/assets/ba2df74b-2239-43f0-9fa5-6825aa40e03f">|



## Fixes Issues

- #3329

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
