### PR TITLE
fix: correct time-weighted retrieval toggle

### DIFF
--- a/web/app/search/layout.tsx
+++ b/web/app/search/layout.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react'
 
-import { AppConfiguration, getUserHomePath, joinPath } from '@janhq/core'
+import { AppConfiguration, getUserHomePath } from '@janhq/core'
 
 import { useSetAtom } from 'jotai'
 

--- a/web/containers/Providers/DataLoader.tsx
+++ b/web/containers/Providers/DataLoader.tsx
@@ -2,7 +2,7 @@
 
 import { Fragment, ReactNode, useEffect } from 'react'
 
-import { AppConfiguration, getUserHomePath, joinPath } from '@janhq/core'
+import { AppConfiguration, getUserHomePath } from '@janhq/core'
 import { useSetAtom } from 'jotai'
 
 import useAssistants from '@/hooks/useAssistants'

--- a/web/screens/Thread/ThreadRightPanel/Tools/index.tsx
+++ b/web/screens/Thread/ThreadRightPanel/Tools/index.tsx
@@ -213,7 +213,6 @@ const Tools = () => {
                     <div className="ml-auto flex items-center justify-between">
                       <Switch
                         name="use-time-weighted-retriever"
-                        className="mr-2"
                         checked={
                           activeThread?.assistants[0].tools[0]
                             .useTimeWeightedRetriever || false

--- a/web/screens/Thread/ThreadRightPanel/Tools/index.tsx
+++ b/web/screens/Thread/ThreadRightPanel/Tools/index.tsx
@@ -27,7 +27,7 @@ const Tools = () => {
   const componentDataAssistantSetting = getConfigurationsData(
     (activeThread?.assistants[0]?.tools &&
       activeThread?.assistants[0]?.tools[0]?.settings) ??
-    {}
+      {}
   )
 
   useEffect(() => {
@@ -223,7 +223,6 @@ const Tools = () => {
                         }
                       />
                     </div>
-
                   </div>
                 </div>
                 <AssistantSetting

--- a/web/screens/Thread/ThreadRightPanel/Tools/index.tsx
+++ b/web/screens/Thread/ThreadRightPanel/Tools/index.tsx
@@ -27,7 +27,7 @@ const Tools = () => {
   const componentDataAssistantSetting = getConfigurationsData(
     (activeThread?.assistants[0]?.tools &&
       activeThread?.assistants[0]?.tools[0]?.settings) ??
-      {}
+    {}
   )
 
   useEffect(() => {
@@ -183,19 +183,6 @@ const Tools = () => {
                           your specific use case."
                       />
                     </label>
-                    <div className="ml-auto flex items-center justify-between">
-                      <Switch
-                        name="use-time-weighted-retriever"
-                        className="mr-2"
-                        checked={
-                          activeThread?.assistants[0].tools[0]
-                            .useTimeWeightedRetriever || false
-                        }
-                        onChange={(e) =>
-                          onTimeWeightedRetrieverSwitchUpdate(e.target.checked)
-                        }
-                      />
-                    </div>
                   </div>
 
                   <div className="w-full">
@@ -223,6 +210,20 @@ const Tools = () => {
                                 also considers when they were added to give
                                 newer ones more importance."
                     />
+                    <div className="ml-auto flex items-center justify-between">
+                      <Switch
+                        name="use-time-weighted-retriever"
+                        className="mr-2"
+                        checked={
+                          activeThread?.assistants[0].tools[0]
+                            .useTimeWeightedRetriever || false
+                        }
+                        onChange={(e) =>
+                          onTimeWeightedRetrieverSwitchUpdate(e.target.checked)
+                        }
+                      />
+                    </div>
+
                   </div>
                 </div>
                 <AssistantSetting


### PR DESCRIPTION
## Describe Your Changes

- It is placed in the wrong position before (Vector Database section)

| Correct Time-Weighted Retrieval Toggle Position |
|:-:|
|<img width="1292" alt="Screenshot 2024-08-26 at 14 51 32" src="https://github.com/user-attachments/assets/c0999b9e-d0ab-4cb0-9e71-645711d86318">|


## Fixes Issues

- #3460 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
