### PR TITLE
fix: add a minimum height for the main window otherwise it shrinks

### DIFF
--- a/electron/managers/mainWindowConfig.ts
+++ b/electron/managers/mainWindowConfig.ts
@@ -1,8 +1,10 @@
 const DEFAULT_MIN_WIDTH = 400
+const DEFAULT_MIN_HEIGHT = 300
 
 export const mainWindowConfig: Electron.BrowserWindowConstructorOptions = {
   skipTaskbar: false,
   minWidth: DEFAULT_MIN_WIDTH,
+  minHeight: DEFAULT_MIN_HEIGHT,
   show: true,
   transparent: true,
   frame: false,


### PR DESCRIPTION
## Describe Your Changes

Fixed an issue where double-clicking the app toolbar to maximize or minimize would shrink it to a super-minimized size that was un-interactable.

| Minimized issue |
|:-:|
|<img width="512" alt="Screenshot 2024-08-26 at 13 49 18" src="https://github.com/user-attachments/assets/f880544b-11e1-482c-9cce-eff1e6c9c70a">|
| Fixed | 
|<img width="512" alt="Screenshot 2024-08-26 at 13 54 07" src="https://github.com/user-attachments/assets/e3e3d0a3-0940-4157-ad6f-eb65593711e0">|

## Fixes Issues

- #3459 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
