### PR TITLE
chore: move remote models to bottom of the models hub

### DIFF
--- a/web/screens/Hub/ModelList/index.tsx
+++ b/web/screens/Hub/ModelList/index.tsx
@@ -31,14 +31,14 @@ const ModelList = ({ models }: Props) => {
       }
     })
     featuredModels.sort((m1, m2) => m1.metadata.size - m2.metadata.size)
-    remoteModels.sort((m1, m2) => m1.name.localeCompare(m2.name))
     localModels.sort((m1, m2) => m1.metadata.size - m2.metadata.size)
     remainingModels.sort((m1, m2) => m1.metadata.size - m2.metadata.size)
+    remoteModels.sort((m1, m2) => m1.name.localeCompare(m2.name))
     return [
       ...featuredModels,
-      ...remoteModels,
       ...localModels,
       ...remainingModels,
+      ...remoteModels,
     ]
   }, [models, downloadedModels])
 


### PR DESCRIPTION
## Describe Your Changes
| Remote models should not be prioritized over other local models in the Model Hub screen |
|:-:|
|<img width="1289" alt="Screenshot 2024-08-27 at 13 05 28" src="https://github.com/user-attachments/assets/85a4ff55-b26d-4d08-9bab-60afdd1706ad">|



## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
