### PR TITLE
fix: resize left and panel when scroll area show

### DIFF
--- a/web/containers/LeftPanelContainer/index.tsx
+++ b/web/containers/LeftPanelContainer/index.tsx
@@ -106,7 +106,7 @@ const LeftPanelContainer = ({ children }: Props) => {
           <Fragment>
             <div
               className={twMerge(
-                'group/resize absolute right-0 top-0 h-full w-1 flex-shrink-0 flex-grow-0 resize-x blur-sm hover:cursor-col-resize hover:bg-[hsla(var(--resize-bg))]',
+                'group/resize absolute right-0 top-0 z-[9999] h-full w-1 flex-shrink-0 flex-grow-0 resize-x blur-sm hover:cursor-col-resize hover:bg-[hsla(var(--resize-bg))]',
                 isResizing && 'cursor-col-resize bg-[hsla(var(--resize-bg))]',
                 !reduceTransparent && 'shadow-sm'
               )}

--- a/web/containers/RightPanelContainer/index.tsx
+++ b/web/containers/RightPanelContainer/index.tsx
@@ -109,7 +109,7 @@ const RightPanelContainer = ({ children }: Props) => {
           <Fragment>
             <div
               className={twMerge(
-                'group/resize absolute left-0 top-0 h-full w-1 flex-shrink-0 flex-grow-0 resize-x blur-sm hover:cursor-col-resize hover:bg-[hsla(var(--resize-bg))]',
+                'group/resize absolute left-0 top-0 z-[9999] h-full w-1 flex-shrink-0 flex-grow-0 resize-x blur-sm hover:cursor-col-resize hover:bg-[hsla(var(--resize-bg))]',
                 isResizing && 'cursor-col-resize bg-[hsla(var(--resize-bg))]',
                 !reduceTransparent && 'shadow-sm'
               )}


### PR DESCRIPTION
## Describe Your Changes

it's great find from @Van-QA 

- make resize left and right panel on top scroll area

since we make force default show scroll area will overlap the resize element, so i reverse resize element z index on top of scroll area

you can tested on setting left panel 


## Fixes Issues

![Screenshot 2024-08-27 at 13 11 52](https://github.com/user-attachments/assets/edc82759-788b-440c-828d-44dc39760e05)

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
