### PR TITLE
fix: using type text instead number for avoid region issue

### DIFF
--- a/web/containers/SliderRightPanel/index.tsx
+++ b/web/containers/SliderRightPanel/index.tsx
@@ -28,8 +28,10 @@ const SliderRightPanel = ({
   onValueChanged,
 }: Props) => {
   const [showTooltip, setShowTooltip] = useState({ max: false, min: false })
+  const [val, setVal] = useState(value.toString())
 
   useClickOutside(() => setShowTooltip({ max: false, min: false }), null, [])
+
   return (
     <div className="flex flex-col">
       <div className="mb-3 flex items-center gap-x-2">
@@ -48,7 +50,10 @@ const SliderRightPanel = ({
         <div className="relative w-full">
           <Slider
             value={[value]}
-            onValueChange={(e) => onValueChanged?.(e[0])}
+            onValueChange={(e) => {
+              onValueChanged?.(e[0])
+              setVal(e[0].toString())
+            }}
             min={min}
             max={max}
             step={step}
@@ -63,24 +68,29 @@ const SliderRightPanel = ({
           open={showTooltip.max || showTooltip.min}
           trigger={
             <Input
-              type="number"
+              type="text"
               className="-mt-4 h-8 w-[60px]"
               min={min}
               max={max}
-              value={String(value)}
+              value={val}
               disabled={disabled}
               textAlign="right"
               onBlur={(e) => {
                 if (Number(e.target.value) > Number(max)) {
                   onValueChanged?.(Number(max))
+                  setVal(max.toString())
                   setShowTooltip({ max: true, min: false })
                 } else if (Number(e.target.value) < Number(min)) {
                   onValueChanged?.(Number(min))
+                  setVal(min.toString())
                   setShowTooltip({ max: false, min: true })
                 }
               }}
               onChange={(e) => {
-                onValueChanged?.(Number(e.target.value))
+                onValueChanged?.(e.target.value)
+                if (/^\d*\.?\d*$/.test(e.target.value)) {
+                  setVal(e.target.value)
+                }
               }}
             />
           }


### PR DESCRIPTION
## Describe Your Changes

- [X] replace type number with text for input to avoid region issue number format
- [X] prevent user input alphabets or symbol, the input should only accepted `0-9` and `.`

Now the value input allow `0.5` instead `0,5`

![Screenshot 2024-09-03 at 13 01 30](https://github.com/user-attachments/assets/8253b644-9110-4013-a0fd-edfd81d64139)

## Fixes Issues

- Closes #3481 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
