### PR TITLE
fix: missing type number for slider input right panel

### DIFF
--- a/web/containers/SliderRightPanel/index.tsx
+++ b/web/containers/SliderRightPanel/index.tsx
@@ -51,7 +51,7 @@ const SliderRightPanel = ({
           <Slider
             value={[value]}
             onValueChange={(e) => {
-              onValueChanged?.(e[0])
+              onValueChanged?.(Number(e[0]))
               setVal(e[0].toString())
             }}
             min={min}
@@ -87,7 +87,7 @@ const SliderRightPanel = ({
                 }
               }}
               onChange={(e) => {
-                onValueChanged?.(e.target.value)
+                onValueChanged?.(Number(e.target.value))
                 if (/^\d*\.?\d*$/.test(e.target.value)) {
                   setVal(e.target.value)
                 }


### PR DESCRIPTION
## Describe Your Changes

Sorry my bad, the value should be Number instead string

Context:
There was an issue with a feature build that was behind the update, where the application loaded a model with some string parameters that should have been numbers.

To reproduce:
Build from any commits prior to this fix and behind the update.
Input a number into any number input box
Chat with model
See the error

![Screenshot 2024-09-09 at 16 30 50](https://github.com/user-attachments/assets/4aaab891-dcd5-45da-97a6-01fe69d18a31)

![Screenshot 2024-09-09 at 16 31 12](https://github.com/user-attachments/assets/d86302d0-b3f7-4a6d-bf24-4e11246d5102)

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [X] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
