### PR TITLE
test: add tests to model settings's Slider Input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ electron/test-data
 electron/test-results
 core/test_results.html
 coverage
+.yarn
+.yarnrc

--- a/electron/.eslintrc.js
+++ b/electron/.eslintrc.js
@@ -34,5 +34,5 @@ module.exports = {
       { name: 'Link', linkAttribute: 'to' },
     ],
   },
-  ignorePatterns: ['build', 'renderer', 'node_modules', '@global'],
+  ignorePatterns: ['build', 'renderer', 'node_modules', '@global', 'playwright-report'],
 }

--- a/web/.eslintrc.js
+++ b/web/.eslintrc.js
@@ -14,6 +14,7 @@ module.exports = {
     '**/*.test.tsx',
     '**/*.test.ts',
     'testRunner.js',
+    'jest.config.js',
   ],
   extends: [
     'next/core-web-vitals',

--- a/web/containers/SliderRightPanel/index.test.tsx
+++ b/web/containers/SliderRightPanel/index.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { fireEvent } from '@testing-library/dom'
+import userEvent from '@testing-library/user-event'
+import SliderRightPanel from './index'
+import '@testing-library/jest-dom'
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+global.ResizeObserver = ResizeObserverMock
+
+describe('SliderRightPanel', () => {
+  const defaultProps = {
+    title: 'Test Slider',
+    disabled: false,
+    min: 0,
+    max: 100,
+    step: 1,
+    description: 'This is a test slider',
+    value: 50,
+    onValueChanged: jest.fn(),
+  }
+
+  it('renders correctly with given props', () => {
+    const { getByText, getByRole } = render(
+      <SliderRightPanel {...defaultProps} />
+    )
+    expect(getByText('Test Slider')).toBeInTheDocument()
+    expect(getByRole('slider')).toBeInTheDocument()
+  })
+
+  it('calls onValueChanged with correct value when input is changed', () => {
+    defaultProps.onValueChanged = jest.fn()
+    const { getByRole } = render(<SliderRightPanel {...defaultProps} />)
+
+    const input = getByRole('textbox')
+    fireEvent.change(input, { target: { value: '75' } })
+    userEvent.tab()
+    fireEvent.blur(input)
+    fireEvent.focusOut(input)
+    fireEvent.mouseUp(input)
+    expect(defaultProps.onValueChanged).toHaveBeenCalledWith(75)
+  })
+
+  it('displays tooltip with max value message when input exceeds max', () => {
+    defaultProps.onValueChanged = jest.fn()
+    const { getByRole } = render(<SliderRightPanel {...defaultProps} />)
+    const input = getByRole('textbox')
+    fireEvent.change(input, { target: { value: '150' } })
+    userEvent.tab()
+    fireEvent.blur(input)
+    fireEvent.focusOut(input)
+    fireEvent.mouseUp(input)
+    expect(defaultProps.onValueChanged).toHaveBeenCalledWith(100)
+  })
+
+  it('displays tooltip with min value message when input is below min', () => {
+    defaultProps.onValueChanged = jest.fn()
+    const { getByRole } = render(<SliderRightPanel {...defaultProps} />)
+    const input = getByRole('textbox')
+    fireEvent.change(input, { target: { value: '0' } })
+    userEvent.tab()
+    fireEvent.blur(input)
+    fireEvent.focusOut(input)
+    fireEvent.mouseUp(input)
+    expect(defaultProps.onValueChanged).toHaveBeenCalledWith(0)
+  })
+
+  it('does not call onValueChanged when input is invalid', () => {
+    defaultProps.onValueChanged = jest.fn()
+    const { getByRole } = render(<SliderRightPanel {...defaultProps} />)
+    const input = getByRole('textbox')
+    fireEvent.change(input, { target: { value: 'invalid' } })
+    expect(defaultProps.onValueChanged).not.toHaveBeenCalledWith(0)
+  })
+
+  // TODO: Add slider tests
+})

--- a/web/containers/SliderRightPanel/index.test.tsx
+++ b/web/containers/SliderRightPanel/index.test.tsx
@@ -69,7 +69,7 @@ describe('SliderRightPanel', () => {
     expect(defaultProps.onValueChanged).toHaveBeenCalledWith(75)
   })
 
-  it('displays tooltip with max value message when input exceeds max', () => {
+  it('calls onValueChanged with max value when input exceeds max', () => {
     defaultProps.onValueChanged = jest.fn()
     const { getByRole } = render(<SliderRightPanel {...defaultProps} />)
     const input = getByRole('textbox')
@@ -78,7 +78,7 @@ describe('SliderRightPanel', () => {
     expect(defaultProps.onValueChanged).toHaveBeenCalledWith(100)
   })
 
-  it('displays tooltip with min value message when input is below min', () => {
+  it('calls onValueChanged with min value when input is below min', () => {
     defaultProps.onValueChanged = jest.fn()
     const { getByRole } = render(<SliderRightPanel {...defaultProps} />)
     const input = getByRole('textbox')

--- a/web/containers/SliderRightPanel/index.test.tsx
+++ b/web/containers/SliderRightPanel/index.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render } from '@testing-library/react'
-import { fireEvent, screen } from '@testing-library/dom'
+import { fireEvent } from '@testing-library/dom'
 import SliderRightPanel from './index'
 import '@testing-library/jest-dom'
 
@@ -12,8 +12,9 @@ class ResizeObserverMock {
 
 global.ResizeObserver = ResizeObserverMock
 
-jest.mock('@radix-ui/react-slider', () => ({
-  Root: ({ children, onValueChange, ...props }: any) => (
+jest.mock('@janhq/joi', () => ({
+  ...jest.requireActual('@janhq/joi'),
+  Slider: ({ children, onValueChange, ...props }: any) => (
     <div data-testid="slider-root" {...props}>
       <input
         data-testid="slider-input"
@@ -26,11 +27,6 @@ jest.mock('@radix-ui/react-slider', () => ({
       {children}
     </div>
   ),
-  Track: ({ children }: any) => (
-    <div data-testid="slider-track">{children}</div>
-  ),
-  Range: () => <div data-testid="slider-range" />,
-  Thumb: () => <div data-testid="slider-thumb" />,
 }))
 
 describe('SliderRightPanel', () => {
@@ -46,9 +42,7 @@ describe('SliderRightPanel', () => {
   }
 
   it('renders correctly with given props', () => {
-    const { getByText } = render(
-      <SliderRightPanel {...defaultProps} />
-    )
+    const { getByText } = render(<SliderRightPanel {...defaultProps} />)
     expect(getByText('Test Slider')).toBeInTheDocument()
   })
 
@@ -63,8 +57,9 @@ describe('SliderRightPanel', () => {
 
   it('calls onValueChanged with correct value when slider is changed', () => {
     defaultProps.onValueChanged = jest.fn()
+    const { getByTestId } = render(<SliderRightPanel {...defaultProps} />)
 
-    const input = screen.getByTestId('slider-input')
+    const input = getByTestId('slider-input')
     fireEvent.change(input, { target: { value: '75' } })
     expect(defaultProps.onValueChanged).toHaveBeenCalledWith(75)
   })

--- a/web/containers/SliderRightPanel/index.tsx
+++ b/web/containers/SliderRightPanel/index.tsx
@@ -90,16 +90,12 @@ const SliderRightPanel = ({
                 // Should not accept invalid value or NaN
                 // E.g. anything changes that trigger onValueChanged
                 // Which is incorrect
-                if (
-                  Number(e.target.value) > Number(max) ||
-                  Number(e.target.value) < Number(min) ||
-                  Number.isNaN(Number(e.target.value))
-                ) {
-                  if (/^\d*\.?\d*$/.test(e.target.value)) {
-                    setVal(e.target.value)
-                  }
-                  return
-                }
+                if (Number(e.target.value) > Number(max)) {
+                  setVal(max.toString())
+                } else if (Number(e.target.value) < Number(min)) {
+                  setVal(min.toString())
+                } else if (Number.isNaN(Number(e.target.value))) return
+
                 onValueChanged?.(Number(e.target.value))
                 // TODO: How to support negative number input?
                 if (/^\d*\.?\d*$/.test(e.target.value)) {

--- a/web/containers/SliderRightPanel/index.tsx
+++ b/web/containers/SliderRightPanel/index.tsx
@@ -6,7 +6,7 @@ import { useClickOutside } from '@janhq/joi'
 import { InfoIcon } from 'lucide-react'
 
 type Props = {
-  name: string
+  name?: string
   title: string
   disabled: boolean
   description: string
@@ -87,7 +87,21 @@ const SliderRightPanel = ({
                 }
               }}
               onChange={(e) => {
+                // Should not accept invalid value or NaN
+                // E.g. anything changes that trigger onValueChanged
+                // Which is incorrect
+                if (
+                  Number(e.target.value) > Number(max) ||
+                  Number(e.target.value) < Number(min) ||
+                  Number.isNaN(Number(e.target.value))
+                ) {
+                  if (/^\d*\.?\d*$/.test(e.target.value)) {
+                    setVal(e.target.value)
+                  }
+                  return
+                }
                 onValueChanged?.(Number(e.target.value))
+                // TODO: How to support negative number input?
                 if (/^\d*\.?\d*$/.test(e.target.value)) {
                   setVal(e.target.value)
                 }

--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -135,9 +135,8 @@ export const useCreateNewThread = () => {
       tools: experimentalEnabled ? [assistantTools] : assistant.tools,
       model: {
         id: defaultModel?.id ?? '*',
-        settings: { ...defaultModel?.settings, ...overriddenSettings } ?? {},
-        parameters:
-          { ...defaultModel?.parameters, ...overriddenParameters } ?? {},
+        settings: { ...defaultModel?.settings, ...overriddenSettings },
+        parameters: { ...defaultModel?.parameters, ...overriddenParameters },
         engine: defaultModel?.engine,
       },
       instructions,

--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -1,5 +1,15 @@
-module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  runner: './testRunner.js',
+const nextJest = require('next/jest')
+
+/** @type {import('jest').Config} */
+const createJestConfig = nextJest({})
+
+// Add any custom config to be passed to Jest
+const config = {
+  coverageProvider: 'v8',
+  testEnvironment: 'jsdom',
+  // Add more setup options before each test is run
+  // setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
 }
+
+// createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
+module.exports = createJestConfig(config)

--- a/web/package.json
+++ b/web/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^14.0.1",
+    "@testing-library/react": "^16.0.1",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.200",
     "@types/node": "20.8.10",
@@ -74,6 +75,7 @@
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-react": "^7.34.0",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "jest-environment-jsdom": "^29.7.0",
     "jest-runner": "^29.7.0",
     "prettier": "^3.0.3",
     "prettier-plugin-tailwindcss": "^0.5.6",

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -5,7 +5,8 @@
     "typeRoots": [
       "./node_modules/@types",
       "./src/types",
-      "../node_modules/@types/jest"
+      "../node_modules/@types/jest",
+      "@testing-library/jest-dom"
     ],
     "allowJs": true,
     "skipLibCheck": true,
@@ -29,5 +30,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules", "**/*.test.ts"]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Describe Your Changes
This PR is a follow-up fix for #3609, where users could get stuck when inputting a value to the model settings input component.

In this PR, it covers the case where users could get stuck in a broken state after inputting an invalid settings value and then force quitting the app immediately. This behavior is hard to reproduce but possible.

Rework web test configurations to resolve the collision between Jest Babel and Next Babel.

Tests have been added to cover such cases.

## Context
We've received a broken app report while testing a feature build; after investigating, we found the root cause and fixed it. However, tests have not been added in this PR due to the incomplete setup.

This PR is to add tests but it turned out that there are missing cases to handle.

## Related PRs

- #3609

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
