### PR TITLE
fix: #3476 - Mismatch id between model json and path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ core/test_results.html
 coverage
 .yarn
 .yarnrc
+*.tsbuildinfo

--- a/core/src/browser/core.test.ts
+++ b/core/src/browser/core.test.ts
@@ -1,98 +1,109 @@
-import { openExternalUrl } from './core';
-import { joinPath } from './core';
-import { openFileExplorer } from './core';
-import { getJanDataFolderPath } from './core';
-import { abortDownload } from './core';
-import { getFileSize } from './core';
-import { executeOnMain } from './core';
+import { openExternalUrl } from './core'
+import { joinPath } from './core'
+import { openFileExplorer } from './core'
+import { getJanDataFolderPath } from './core'
+import { abortDownload } from './core'
+import { getFileSize } from './core'
+import { executeOnMain } from './core'
 
-it('should open external url', async () => {
-  const url = 'http://example.com';
-  globalThis.core = {
-    api: {
-      openExternalUrl: jest.fn().mockResolvedValue('opened')
+describe('test core apis', () => {
+  it('should open external url', async () => {
+    const url = 'http://example.com'
+    globalThis.core = {
+      api: {
+        openExternalUrl: jest.fn().mockResolvedValue('opened'),
+      },
     }
-  };
-  const result = await openExternalUrl(url);
-  expect(globalThis.core.api.openExternalUrl).toHaveBeenCalledWith(url);
-  expect(result).toBe('opened');
-});
+    const result = await openExternalUrl(url)
+    expect(globalThis.core.api.openExternalUrl).toHaveBeenCalledWith(url)
+    expect(result).toBe('opened')
+  })
 
-
-it('should join paths', async () => {
-  const paths = ['/path/one', '/path/two'];
-  globalThis.core = {
-    api: {
-      joinPath: jest.fn().mockResolvedValue('/path/one/path/two')
+  it('should join paths', async () => {
+    const paths = ['/path/one', '/path/two']
+    globalThis.core = {
+      api: {
+        joinPath: jest.fn().mockResolvedValue('/path/one/path/two'),
+      },
     }
-  };
-  const result = await joinPath(paths);
-  expect(globalThis.core.api.joinPath).toHaveBeenCalledWith(paths);
-  expect(result).toBe('/path/one/path/two');
-});
+    const result = await joinPath(paths)
+    expect(globalThis.core.api.joinPath).toHaveBeenCalledWith(paths)
+    expect(result).toBe('/path/one/path/two')
+  })
 
-
-it('should open file explorer', async () => {
-  const path = '/path/to/open';
-  globalThis.core = {
-    api: {
-      openFileExplorer: jest.fn().mockResolvedValue('opened')
+  it('should open file explorer', async () => {
+    const path = '/path/to/open'
+    globalThis.core = {
+      api: {
+        openFileExplorer: jest.fn().mockResolvedValue('opened'),
+      },
     }
-  };
-  const result = await openFileExplorer(path);
-  expect(globalThis.core.api.openFileExplorer).toHaveBeenCalledWith(path);
-  expect(result).toBe('opened');
-});
+    const result = await openFileExplorer(path)
+    expect(globalThis.core.api.openFileExplorer).toHaveBeenCalledWith(path)
+    expect(result).toBe('opened')
+  })
 
-
-it('should get jan data folder path', async () => {
-  globalThis.core = {
-    api: {
-      getJanDataFolderPath: jest.fn().mockResolvedValue('/path/to/jan/data')
+  it('should get jan data folder path', async () => {
+    globalThis.core = {
+      api: {
+        getJanDataFolderPath: jest.fn().mockResolvedValue('/path/to/jan/data'),
+      },
     }
-  };
-  const result = await getJanDataFolderPath();
-  expect(globalThis.core.api.getJanDataFolderPath).toHaveBeenCalled();
-  expect(result).toBe('/path/to/jan/data');
-});
+    const result = await getJanDataFolderPath()
+    expect(globalThis.core.api.getJanDataFolderPath).toHaveBeenCalled()
+    expect(result).toBe('/path/to/jan/data')
+  })
 
-
-it('should abort download', async () => {
-  const fileName = 'testFile';
-  globalThis.core = {
-    api: {
-      abortDownload: jest.fn().mockResolvedValue('aborted')
+  it('should abort download', async () => {
+    const fileName = 'testFile'
+    globalThis.core = {
+      api: {
+        abortDownload: jest.fn().mockResolvedValue('aborted'),
+      },
     }
-  };
-  const result = await abortDownload(fileName);
-  expect(globalThis.core.api.abortDownload).toHaveBeenCalledWith(fileName);
-  expect(result).toBe('aborted');
-});
+    const result = await abortDownload(fileName)
+    expect(globalThis.core.api.abortDownload).toHaveBeenCalledWith(fileName)
+    expect(result).toBe('aborted')
+  })
 
-
-it('should get file size', async () => {
-  const url = 'http://example.com/file';
-  globalThis.core = {
-    api: {
-      getFileSize: jest.fn().mockResolvedValue(1024)
+  it('should get file size', async () => {
+    const url = 'http://example.com/file'
+    globalThis.core = {
+      api: {
+        getFileSize: jest.fn().mockResolvedValue(1024),
+      },
     }
-  };
-  const result = await getFileSize(url);
-  expect(globalThis.core.api.getFileSize).toHaveBeenCalledWith(url);
-  expect(result).toBe(1024);
-});
+    const result = await getFileSize(url)
+    expect(globalThis.core.api.getFileSize).toHaveBeenCalledWith(url)
+    expect(result).toBe(1024)
+  })
 
-
-it('should execute function on main process', async () => {
-  const extension = 'testExtension';
-  const method = 'testMethod';
-  const args = ['arg1', 'arg2'];
-  globalThis.core = {
-    api: {
-      invokeExtensionFunc: jest.fn().mockResolvedValue('result')
+  it('should execute function on main process', async () => {
+    const extension = 'testExtension'
+    const method = 'testMethod'
+    const args = ['arg1', 'arg2']
+    globalThis.core = {
+      api: {
+        invokeExtensionFunc: jest.fn().mockResolvedValue('result'),
+      },
     }
-  };
-  const result = await executeOnMain(extension, method, ...args);
-  expect(globalThis.core.api.invokeExtensionFunc).toHaveBeenCalledWith(extension, method, ...args);
-  expect(result).toBe('result');
-});
+    const result = await executeOnMain(extension, method, ...args)
+    expect(globalThis.core.api.invokeExtensionFunc).toHaveBeenCalledWith(extension, method, ...args)
+    expect(result).toBe('result')
+  })
+})
+
+describe('dirName - just a pass thru api', () => {
+  it('should retrieve the directory name from a file path', async () => {
+    const mockDirName = jest.fn()
+    globalThis.core = {
+      api: {
+        dirName: mockDirName.mockResolvedValue('/path/to'),
+      },
+    }
+    // Normal file path with extension
+    const path = '/path/to/file.txt'
+    await globalThis.core.api.dirName(path)
+    expect(mockDirName).toHaveBeenCalledWith(path)
+  })
+})

--- a/core/src/browser/core.ts
+++ b/core/src/browser/core.ts
@@ -69,6 +69,13 @@ const joinPath: (paths: string[]) => Promise<string> = (paths) =>
   globalThis.core.api?.joinPath(paths)
 
 /**
+ * Get dirname of a file path.
+ * @param path - The file path to retrieve dirname.
+ * @returns {Promise<string>} A promise that resolves the dirname.
+ */
+const dirName: (path: string) => Promise<string> = (path) => globalThis.core.api?.dirName(path)
+
+/**
  * Retrieve the basename from an url.
  * @param path - The path to retrieve.
  * @returns {Promise<string>} A promise that resolves with the basename.
@@ -161,5 +168,6 @@ export {
   systemInformation,
   showToast,
   getFileSize,
+  dirName,
   FileStat,
 }

--- a/core/src/browser/extensions/engines/AIEngine.ts
+++ b/core/src/browser/extensions/engines/AIEngine.ts
@@ -2,7 +2,7 @@ import { getJanDataFolderPath, joinPath } from '../../core'
 import { events } from '../../events'
 import { BaseExtension } from '../../extension'
 import { fs } from '../../fs'
-import { MessageRequest, Model, ModelEvent } from '../../../types'
+import { MessageRequest, Model, ModelEvent, ModelFile } from '../../../types'
 import { EngineManager } from './EngineManager'
 
 /**
@@ -21,7 +21,7 @@ export abstract class AIEngine extends BaseExtension {
   override onLoad() {
     this.registerEngine()
 
-    events.on(ModelEvent.OnModelInit, (model: Model) => this.loadModel(model))
+    events.on(ModelEvent.OnModelInit, (model: ModelFile) => this.loadModel(model))
     events.on(ModelEvent.OnModelStop, (model: Model) => this.unloadModel(model))
   }
 
@@ -78,7 +78,7 @@ export abstract class AIEngine extends BaseExtension {
   /**
    * Loads the model.
    */
-  async loadModel(model: Model): Promise<any> {
+  async loadModel(model: ModelFile): Promise<any> {
     if (model.engine.toString() !== this.provider) return Promise.resolve()
     events.emit(ModelEvent.OnModelReady, model)
     return Promise.resolve()

--- a/core/src/browser/extensions/engines/LocalOAIEngine.ts
+++ b/core/src/browser/extensions/engines/LocalOAIEngine.ts
@@ -1,6 +1,6 @@
-import { executeOnMain, getJanDataFolderPath, joinPath, systemInformation } from '../../core'
+import { executeOnMain, systemInformation, dirName } from '../../core'
 import { events } from '../../events'
-import { Model, ModelEvent } from '../../../types'
+import { Model, ModelEvent, ModelFile } from '../../../types'
 import { OAIEngine } from './OAIEngine'
 
 /**
@@ -14,22 +14,24 @@ export abstract class LocalOAIEngine extends OAIEngine {
   unloadModelFunctionName: string = 'unloadModel'
 
   /**
-   * On extension load, subscribe to events.
+   * This class represents a base for local inference providers in the OpenAI architecture.
+   * It extends the OAIEngine class and provides the implementation of loading and unloading models locally.
+   * The loadModel function subscribes to the ModelEvent.OnModelInit event, loading models when initiated.
+   * The unloadModel function subscribes to the ModelEvent.OnModelStop event, unloading models when stopped.
    */
   override onLoad() {
     super.onLoad()
     // These events are applicable to local inference providers
-    events.on(ModelEvent.OnModelInit, (model: Model) => this.loadModel(model))
+    events.on(ModelEvent.OnModelInit, (model: ModelFile) => this.loadModel(model))
     events.on(ModelEvent.OnModelStop, (model: Model) => this.unloadModel(model))
   }
 
   /**
    * Load the model.
    */
-  override async loadModel(model: Model): Promise<void> {
+  override async loadModel(model: ModelFile): Promise<void> {
     if (model.engine.toString() !== this.provider) return
-    const modelFolderName = 'models'
-    const modelFolder = await joinPath([await getJanDataFolderPath(), modelFolderName, model.id])
+    const modelFolder = await dirName(model.file_path)
     const systemInfo = await systemInformation()
     const res = await executeOnMain(
       this.nodeModule,

--- a/core/src/browser/extensions/model.ts
+++ b/core/src/browser/extensions/model.ts
@@ -4,6 +4,7 @@ import {
   HuggingFaceRepoData,
   ImportingModel,
   Model,
+  ModelFile,
   ModelInterface,
   OptionType,
 } from '../../types'
@@ -26,11 +27,10 @@ export abstract class ModelExtension extends BaseExtension implements ModelInter
   ): Promise<void>
   abstract cancelModelDownload(modelId: string): Promise<void>
   abstract deleteModel(modelId: string): Promise<void>
-  abstract saveModel(model: Model): Promise<void>
-  abstract getDownloadedModels(): Promise<Model[]>
-  abstract getConfiguredModels(): Promise<Model[]>
+  abstract getDownloadedModels(): Promise<ModelFile[]>
+  abstract getConfiguredModels(): Promise<ModelFile[]>
   abstract importModels(models: ImportingModel[], optionType: OptionType): Promise<void>
-  abstract updateModelInfo(modelInfo: Partial<Model>): Promise<Model>
+  abstract updateModelInfo(modelInfo: Partial<ModelFile>): Promise<ModelFile>
   abstract fetchHuggingFaceRepoData(repoId: string): Promise<HuggingFaceRepoData>
   abstract getDefaultModel(): Promise<Model>
 }

--- a/core/src/browser/extensions/model.ts
+++ b/core/src/browser/extensions/model.ts
@@ -26,7 +26,7 @@ export abstract class ModelExtension extends BaseExtension implements ModelInter
     network?: { proxy: string; ignoreSSL?: boolean }
   ): Promise<void>
   abstract cancelModelDownload(modelId: string): Promise<void>
-  abstract deleteModel(modelId: string): Promise<void>
+  abstract deleteModel(model: ModelFile): Promise<void>
   abstract getDownloadedModels(): Promise<ModelFile[]>
   abstract getConfiguredModels(): Promise<ModelFile[]>
   abstract importModels(models: ImportingModel[], optionType: OptionType): Promise<void>

--- a/core/src/node/api/processors/app.test.ts
+++ b/core/src/node/api/processors/app.test.ts
@@ -1,3 +1,8 @@
+jest.mock('../../helper', () => ({
+  ...jest.requireActual('../../helper'),
+  getJanDataFolderPath: () => './app',
+}))
+import { dirname } from 'path'
 import { App } from './app'
 
 it('should call stopServer', () => {
@@ -6,7 +11,7 @@ it('should call stopServer', () => {
   jest.mock('@janhq/server', () => ({
     stopServer: stopServerMock,
   }))
-  const result = app.stopServer()
+  app.stopServer()
   expect(stopServerMock).toHaveBeenCalled()
 })
 
@@ -41,8 +46,12 @@ it('should call correct function with provided arguments using process method', 
 
 it('should retrieve the directory name from a file path (Unix/Windows)', async () => {
   const app = new App()
-  const path13 = 'C:/Users/John Doe/Desktop/file.txt'
-  expect(await app.dirName(path13)).toBe(
-    process.platform === 'win32' ? 'C:\\Users\\John Doe\\Desktop' : 'C:/Users/John Doe/Desktop'
-  )
+  const path = 'C:/Users/John Doe/Desktop/file.txt'
+  expect(await app.dirName(path)).toBe('C:/Users/John Doe/Desktop')
+})
+
+it('should retrieve the directory name when using file protocol', async () => {
+  const app = new App()
+  const path = 'file:/models/file.txt'
+  expect(await app.dirName(path)).toBe(process.platform === 'win32' ? 'app\\models' : 'app/models')
 })

--- a/core/src/node/api/processors/app.test.ts
+++ b/core/src/node/api/processors/app.test.ts
@@ -1,40 +1,48 @@
-import { App } from './app';
+import { App } from './app'
 
 it('should call stopServer', () => {
-  const app = new App();
-  const stopServerMock = jest.fn().mockResolvedValue('Server stopped');
+  const app = new App()
+  const stopServerMock = jest.fn().mockResolvedValue('Server stopped')
   jest.mock('@janhq/server', () => ({
-    stopServer: stopServerMock
-  }));
-  const result = app.stopServer();
-  expect(stopServerMock).toHaveBeenCalled();
-});
+    stopServer: stopServerMock,
+  }))
+  const result = app.stopServer()
+  expect(stopServerMock).toHaveBeenCalled()
+})
 
 it('should correctly retrieve basename', () => {
-  const app = new App();
-  const result = app.baseName('/path/to/file.txt');
-  expect(result).toBe('file.txt');
-});
+  const app = new App()
+  const result = app.baseName('/path/to/file.txt')
+  expect(result).toBe('file.txt')
+})
 
 it('should correctly identify subdirectories', () => {
-  const app = new App();
-  const basePath = process.platform === 'win32' ? 'C:\\path\\to' : '/path/to';
-  const subPath = process.platform === 'win32' ? 'C:\\path\\to\\subdir' : '/path/to/subdir';
-  const result = app.isSubdirectory(basePath, subPath);
-  expect(result).toBe(true);
-});
+  const app = new App()
+  const basePath = process.platform === 'win32' ? 'C:\\path\\to' : '/path/to'
+  const subPath = process.platform === 'win32' ? 'C:\\path\\to\\subdir' : '/path/to/subdir'
+  const result = app.isSubdirectory(basePath, subPath)
+  expect(result).toBe(true)
+})
 
 it('should correctly join multiple paths', () => {
-  const app = new App();
-  const result = app.joinPath(['path', 'to', 'file']);
-  const expectedPath = process.platform === 'win32' ? 'path\\to\\file' : 'path/to/file';
-  expect(result).toBe(expectedPath);
-});
+  const app = new App()
+  const result = app.joinPath(['path', 'to', 'file'])
+  const expectedPath = process.platform === 'win32' ? 'path\\to\\file' : 'path/to/file'
+  expect(result).toBe(expectedPath)
+})
 
 it('should call correct function with provided arguments using process method', () => {
-  const app = new App();
-  const mockFunc = jest.fn();
-  app.joinPath = mockFunc;
-  app.process('joinPath', ['path1', 'path2']);
-  expect(mockFunc).toHaveBeenCalledWith(['path1', 'path2']);
-});
+  const app = new App()
+  const mockFunc = jest.fn()
+  app.joinPath = mockFunc
+  app.process('joinPath', ['path1', 'path2'])
+  expect(mockFunc).toHaveBeenCalledWith(['path1', 'path2'])
+})
+
+it('should retrieve the directory name from a file path (Unix/Windows)', async () => {
+  const app = new App()
+  const path13 = 'C:/Users/John Doe/Desktop/file.txt'
+  expect(await app.dirName(path13)).toBe(
+    process.platform === 'win32' ? 'C:\\Users\\John Doe\\Desktop' : 'C:/Users/John Doe/Desktop'
+  )
+})

--- a/core/src/node/api/processors/app.ts
+++ b/core/src/node/api/processors/app.ts
@@ -1,4 +1,4 @@
-import { basename, isAbsolute, join, relative } from 'path'
+import { basename, dirname, isAbsolute, join, relative } from 'path'
 
 import { Processor } from './Processor'
 import {
@@ -6,6 +6,8 @@ import {
   appResourcePath,
   getAppConfigurations as appConfiguration,
   updateAppConfiguration,
+  normalizeFilePath,
+  getJanDataFolderPath,
 } from '../../helper'
 
 export class App implements Processor {
@@ -26,6 +28,18 @@ export class App implements Processor {
    */
   joinPath(args: any[]) {
     return join(...args)
+  }
+
+  /**
+   * Get dirname of a file path.
+   * @param path - The file path to retrieve dirname.
+   */
+  dirName(path: string) {
+    const arg =
+      path.startsWith(`file:/`) || path.startsWith(`file:\\`)
+        ? join(getJanDataFolderPath(), normalizeFilePath(path))
+        : path
+    return dirname(arg)
   }
 
   /**

--- a/core/src/types/api/index.ts
+++ b/core/src/types/api/index.ts
@@ -37,6 +37,7 @@ export enum AppRoute {
   getAppConfigurations = 'getAppConfigurations',
   updateAppConfiguration = 'updateAppConfiguration',
   joinPath = 'joinPath',
+  dirName = 'dirName',
   isSubdirectory = 'isSubdirectory',
   baseName = 'baseName',
   startServer = 'startServer',

--- a/core/src/types/file/index.ts
+++ b/core/src/types/file/index.ts
@@ -52,3 +52,18 @@ type DownloadSize = {
   total: number
   transferred: number
 }
+
+/**
+ * The file metadata
+ */
+export type FileMetadata = {
+  /**
+   * The origin file path.
+   */
+  file_path: string
+
+  /**
+   * The file name.
+   */
+  file_name: string
+}

--- a/core/src/types/model/modelEntity.ts
+++ b/core/src/types/model/modelEntity.ts
@@ -1,3 +1,5 @@
+import { FileMetadata } from '../file'
+
 /**
  * Represents the information about a model.
  * @stored
@@ -151,3 +153,8 @@ export type ModelRuntimeParams = {
 export type ModelInitFailed = Model & {
   error: Error
 }
+
+/**
+ * ModelFile is the model.json entity and it's file metadata
+ */
+export type ModelFile = Model & FileMetadata

--- a/core/src/types/model/modelInterface.ts
+++ b/core/src/types/model/modelInterface.ts
@@ -1,5 +1,5 @@
 import { GpuSetting } from '../miscellaneous'
-import { Model } from './modelEntity'
+import { Model, ModelFile } from './modelEntity'
 
 /**
  * Model extension for managing models.
@@ -29,7 +29,7 @@ export interface ModelInterface {
    * @param modelId - The ID of the model to delete.
    * @returns A Promise that resolves when the model has been deleted.
    */
-  deleteModel(modelId: string): Promise<void>
+  deleteModel(model: ModelFile): Promise<void>
 
   /**
    * Gets a list of downloaded models.

--- a/core/src/types/model/modelInterface.ts
+++ b/core/src/types/model/modelInterface.ts
@@ -32,13 +32,6 @@ export interface ModelInterface {
   deleteModel(modelId: string): Promise<void>
 
   /**
-   * Saves a model.
-   * @param model - The model to save.
-   * @returns A Promise that resolves when the model has been saved.
-   */
-  saveModel(model: Model): Promise<void>
-
-  /**
    * Gets a list of downloaded models.
    * @returns A Promise that resolves with an array of downloaded models.
    */

--- a/electron/.eslintrc.js
+++ b/electron/.eslintrc.js
@@ -11,8 +11,9 @@ module.exports = {
     'plugin:react/recommended',
   ],
   rules: {
-    '@typescript-eslint/no-non-null-assertion': 'off',
     'react/prop-types': 'off', // In favor of strong typing - no need to dedupe
+    'react/no-is-mounted': 'off',
+    '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-var-requires': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/no-unused-vars': 'off',

--- a/extensions/inference-nitro-extension/src/index.ts
+++ b/extensions/inference-nitro-extension/src/index.ts
@@ -22,6 +22,7 @@ import {
   downloadFile,
   DownloadState,
   DownloadEvent,
+  ModelFile,
 } from '@janhq/core'
 
 declare const CUDA_DOWNLOAD_URL: string
@@ -94,7 +95,7 @@ export default class JanInferenceNitroExtension extends LocalOAIEngine {
     this.nitroProcessInfo = health
   }
 
-  override loadModel(model: Model): Promise<void> {
+  override loadModel(model: ModelFile): Promise<void> {
     if (model.engine !== this.provider) return Promise.resolve()
     this.getNitroProcessHealthIntervalId = setInterval(
       () => this.periodicallyGetNitroHealth(),

--- a/extensions/inference-nitro-extension/src/node/index.ts
+++ b/extensions/inference-nitro-extension/src/node/index.ts
@@ -6,12 +6,12 @@ import fetchRT from 'fetch-retry'
 import {
   log,
   getSystemResourceInfo,
-  Model,
   InferenceEngine,
   ModelSettingParams,
   PromptTemplate,
   SystemInformation,
   getJanDataFolderPath,
+  ModelFile,
 } from '@janhq/core/node'
 import { executableNitroFile } from './execute'
 import terminate from 'terminate'
@@ -25,7 +25,7 @@ const fetchRetry = fetchRT(fetch)
  */
 interface ModelInitOptions {
   modelFolder: string
-  model: Model
+  model: ModelFile
 }
 // The PORT to use for the Nitro subprocess
 const PORT = 3928

--- a/extensions/model-extension/jest.config.js
+++ b/extensions/model-extension/jest.config.js
@@ -1,0 +1,9 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    'node_modules/@janhq/core/.+\\.(j|t)s?$': 'ts-jest',
+  },
+  transformIgnorePatterns: ['node_modules/(?!@janhq/core/.*)'],
+}

--- a/extensions/model-extension/package.json
+++ b/extensions/model-extension/package.json
@@ -8,6 +8,7 @@
   "author": "Jan <service@jan.ai>",
   "license": "AGPL-3.0",
   "scripts": {
+    "test": "jest",
     "build": "tsc --module commonjs && rollup -c rollup.config.ts --configPlugin @rollup/plugin-typescript --bundleConfigAsCjs",
     "build:publish": "rimraf *.tgz --glob && yarn build && npm pack && cpx *.tgz ../../pre-install"
   },

--- a/extensions/model-extension/rollup.config.ts
+++ b/extensions/model-extension/rollup.config.ts
@@ -27,7 +27,7 @@ export default [
       // Allow json resolution
       json(),
       //     Compile TypeScript files
-      typescript({ useTsconfigDeclarationDir: true }),
+      typescript({ useTsconfigDeclarationDir: true, exclude: ['**/__tests__', '**/*.test.ts'], }),
       // Compile TypeScript files
       // Allow bundling cjs modules (unlike webpack, rollup doesn't understand cjs)
       // commonjs(),
@@ -62,7 +62,7 @@ export default [
       // Allow json resolution
       json(),
       // Compile TypeScript files
-      typescript({ useTsconfigDeclarationDir: true }),
+      typescript({ useTsconfigDeclarationDir: true, exclude: ['**/__tests__', '**/*.test.ts'], }),
       // Allow bundling cjs modules (unlike webpack, rollup doesn't understand cjs)
       commonjs(),
       // Allow node_modules resolution, so you can use 'external' to control

--- a/extensions/model-extension/src/index.test.ts
+++ b/extensions/model-extension/src/index.test.ts
@@ -1,0 +1,564 @@
+const readDirSyncMock = jest.fn()
+const existMock = jest.fn()
+const readFileSyncMock = jest.fn()
+
+jest.mock('@janhq/core', () => ({
+  ...jest.requireActual('@janhq/core/node'),
+  fs: {
+    existsSync: existMock,
+    readdirSync: readDirSyncMock,
+    readFileSync: readFileSyncMock,
+    fileStat: () => ({
+      isDirectory: false,
+    }),
+  },
+  dirName: jest.fn(),
+  joinPath: (paths) => paths.join('/'),
+  ModelExtension: jest.fn(),
+}))
+
+import JanModelExtension from '.'
+import { fs, dirName } from '@janhq/core'
+
+describe('JanModelExtension', () => {
+  let sut: JanModelExtension
+
+  beforeAll(() => {
+    // @ts-ignore
+    sut = new JanModelExtension()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('getConfiguredModels', () => {
+    describe("when there's no models are pre-populated", () => {
+      it('should return empty array', async () => {
+        // Mock configured models data
+        const configuredModels = []
+        existMock.mockReturnValue(true)
+        readDirSyncMock.mockReturnValue([])
+
+        const result = await sut.getConfiguredModels()
+        expect(result).toEqual([])
+      })
+    })
+
+    describe("when there's are pre-populated models - all flattened", () => {
+      it('returns configured models data - flatten folder - with correct file_path and model id', async () => {
+        // Mock configured models data
+        const configuredModels = [
+          {
+            id: '1',
+            name: 'Model 1',
+            version: '1.0.0',
+            description: 'Model 1 description',
+            object: {
+              type: 'model',
+              uri: 'http://localhost:5000/models/model1',
+            },
+            format: 'onnx',
+            sources: [],
+            created: new Date(),
+            updated: new Date(),
+            parameters: {},
+            settings: {},
+            metadata: {},
+            engine: 'test',
+          } as any,
+          {
+            id: '2',
+            name: 'Model 2',
+            version: '2.0.0',
+            description: 'Model 2 description',
+            object: {
+              type: 'model',
+              uri: 'http://localhost:5000/models/model2',
+            },
+            format: 'onnx',
+            sources: [],
+            parameters: {},
+            settings: {},
+            metadata: {},
+            engine: 'test',
+          } as any,
+        ]
+        existMock.mockReturnValue(true)
+
+        readDirSyncMock.mockImplementation((path) => {
+          if (path === 'file://models') return ['model1', 'model2']
+          else return ['model.json']
+        })
+
+        readFileSyncMock.mockImplementation((path) => {
+          if (path.includes('model1'))
+            return JSON.stringify(configuredModels[0])
+          else return JSON.stringify(configuredModels[1])
+        })
+
+        const result = await sut.getConfiguredModels()
+        expect(result).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              file_path: 'file://models/model1/model.json',
+              id: '1',
+            }),
+            expect.objectContaining({
+              file_path: 'file://models/model2/model.json',
+              id: '2',
+            }),
+          ])
+        )
+      })
+    })
+
+    describe("when there's are pre-populated models - there are nested folders", () => {
+      it('returns configured models data - flatten folder - with correct file_path and model id', async () => {
+        // Mock configured models data
+        const configuredModels = [
+          {
+            id: '1',
+            name: 'Model 1',
+            version: '1.0.0',
+            description: 'Model 1 description',
+            object: {
+              type: 'model',
+              uri: 'http://localhost:5000/models/model1',
+            },
+            format: 'onnx',
+            sources: [],
+            created: new Date(),
+            updated: new Date(),
+            parameters: {},
+            settings: {},
+            metadata: {},
+            engine: 'test',
+          } as any,
+          {
+            id: '2',
+            name: 'Model 2',
+            version: '2.0.0',
+            description: 'Model 2 description',
+            object: {
+              type: 'model',
+              uri: 'http://localhost:5000/models/model2',
+            },
+            format: 'onnx',
+            sources: [],
+            parameters: {},
+            settings: {},
+            metadata: {},
+            engine: 'test',
+          } as any,
+        ]
+        existMock.mockReturnValue(true)
+
+        readDirSyncMock.mockImplementation((path) => {
+          if (path === 'file://models') return ['model1', 'model2/model2-1']
+          else return ['model.json']
+        })
+
+        readFileSyncMock.mockImplementation((path) => {
+          if (path.includes('model1'))
+            return JSON.stringify(configuredModels[0])
+          else if (path.includes('model2/model2-1'))
+            return JSON.stringify(configuredModels[1])
+        })
+
+        const result = await sut.getConfiguredModels()
+        expect(result).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              file_path: 'file://models/model1/model.json',
+              id: '1',
+            }),
+            expect.objectContaining({
+              file_path: 'file://models/model2/model2-1/model.json',
+              id: '2',
+            }),
+          ])
+        )
+      })
+    })
+  })
+
+  describe('getDownloadedModels', () => {
+    describe('no models downloaded', () => {
+      it('should return empty array', async () => {
+        // Mock downloaded models data
+        const downloadedModels = []
+        existMock.mockReturnValue(true)
+        readDirSyncMock.mockReturnValue([])
+
+        const result = await sut.getDownloadedModels()
+        expect(result).toEqual([])
+      })
+    })
+    describe('only one model is downloaded', () => {
+      describe('flatten folder', () => {
+        it('returns downloaded models - with correct file_path and model id', async () => {
+          // Mock configured models data
+          const configuredModels = [
+            {
+              id: '1',
+              name: 'Model 1',
+              version: '1.0.0',
+              description: 'Model 1 description',
+              object: {
+                type: 'model',
+                uri: 'http://localhost:5000/models/model1',
+              },
+              format: 'onnx',
+              sources: [],
+              created: new Date(),
+              updated: new Date(),
+              parameters: {},
+              settings: {},
+              metadata: {},
+              engine: 'test',
+            } as any,
+            {
+              id: '2',
+              name: 'Model 2',
+              version: '2.0.0',
+              description: 'Model 2 description',
+              object: {
+                type: 'model',
+                uri: 'http://localhost:5000/models/model2',
+              },
+              format: 'onnx',
+              sources: [],
+              parameters: {},
+              settings: {},
+              metadata: {},
+              engine: 'test',
+            } as any,
+          ]
+          existMock.mockReturnValue(true)
+
+          readDirSyncMock.mockImplementation((path) => {
+            if (path === 'file://models') return ['model1', 'model2']
+            else if (path === 'file://models/model1')
+              return ['model.json', 'test.gguf']
+            else return ['model.json']
+          })
+
+          readFileSyncMock.mockImplementation((path) => {
+            if (path.includes('model1'))
+              return JSON.stringify(configuredModels[0])
+            else return JSON.stringify(configuredModels[1])
+          })
+
+          const result = await sut.getDownloadedModels()
+          expect(result).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                file_path: 'file://models/model1/model.json',
+                id: '1',
+              }),
+            ])
+          )
+        })
+      })
+    })
+
+    describe('all models are downloaded', () => {
+      describe('nested folders', () => {
+        it('returns downloaded models - with correct file_path and model id', async () => {
+          // Mock configured models data
+          const configuredModels = [
+            {
+              id: '1',
+              name: 'Model 1',
+              version: '1.0.0',
+              description: 'Model 1 description',
+              object: {
+                type: 'model',
+                uri: 'http://localhost:5000/models/model1',
+              },
+              format: 'onnx',
+              sources: [],
+              created: new Date(),
+              updated: new Date(),
+              parameters: {},
+              settings: {},
+              metadata: {},
+              engine: 'test',
+            } as any,
+            {
+              id: '2',
+              name: 'Model 2',
+              version: '2.0.0',
+              description: 'Model 2 description',
+              object: {
+                type: 'model',
+                uri: 'http://localhost:5000/models/model2',
+              },
+              format: 'onnx',
+              sources: [],
+              parameters: {},
+              settings: {},
+              metadata: {},
+              engine: 'test',
+            } as any,
+          ]
+          existMock.mockReturnValue(true)
+
+          readDirSyncMock.mockImplementation((path) => {
+            if (path === 'file://models') return ['model1', 'model2/model2-1']
+            else return ['model.json', 'test.gguf']
+          })
+
+          readFileSyncMock.mockImplementation((path) => {
+            if (path.includes('model1'))
+              return JSON.stringify(configuredModels[0])
+            else return JSON.stringify(configuredModels[1])
+          })
+
+          const result = await sut.getDownloadedModels()
+          expect(result).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({
+                file_path: 'file://models/model1/model.json',
+                id: '1',
+              }),
+              expect.objectContaining({
+                file_path: 'file://models/model2/model2-1/model.json',
+                id: '2',
+              }),
+            ])
+          )
+        })
+      })
+    })
+
+    describe('all models are downloaded with uppercased GGUF files', () => {
+      it('returns downloaded models - with correct file_path and model id', async () => {
+        // Mock configured models data
+        const configuredModels = [
+          {
+            id: '1',
+            name: 'Model 1',
+            version: '1.0.0',
+            description: 'Model 1 description',
+            object: {
+              type: 'model',
+              uri: 'http://localhost:5000/models/model1',
+            },
+            format: 'onnx',
+            sources: [],
+            created: new Date(),
+            updated: new Date(),
+            parameters: {},
+            settings: {},
+            metadata: {},
+            engine: 'test',
+          } as any,
+          {
+            id: '2',
+            name: 'Model 2',
+            version: '2.0.0',
+            description: 'Model 2 description',
+            object: {
+              type: 'model',
+              uri: 'http://localhost:5000/models/model2',
+            },
+            format: 'onnx',
+            sources: [],
+            parameters: {},
+            settings: {},
+            metadata: {},
+            engine: 'test',
+          } as any,
+        ]
+        existMock.mockReturnValue(true)
+
+        readDirSyncMock.mockImplementation((path) => {
+          if (path === 'file://models') return ['model1', 'model2/model2-1']
+          else if (path === 'file://models/model1')
+            return ['model.json', 'test.GGUF']
+          else return ['model.json', 'test.gguf']
+        })
+
+        readFileSyncMock.mockImplementation((path) => {
+          if (path.includes('model1'))
+            return JSON.stringify(configuredModels[0])
+          else return JSON.stringify(configuredModels[1])
+        })
+
+        const result = await sut.getDownloadedModels()
+        expect(result).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              file_path: 'file://models/model1/model.json',
+              id: '1',
+            }),
+            expect.objectContaining({
+              file_path: 'file://models/model2/model2-1/model.json',
+              id: '2',
+            }),
+          ])
+        )
+      })
+    })
+
+    describe('all models are downloaded - GGUF & Tensort RT', () => {
+      it('returns downloaded models - with correct file_path and model id', async () => {
+        // Mock configured models data
+        const configuredModels = [
+          {
+            id: '1',
+            name: 'Model 1',
+            version: '1.0.0',
+            description: 'Model 1 description',
+            object: {
+              type: 'model',
+              uri: 'http://localhost:5000/models/model1',
+            },
+            format: 'onnx',
+            sources: [],
+            created: new Date(),
+            updated: new Date(),
+            parameters: {},
+            settings: {},
+            metadata: {},
+            engine: 'test',
+          } as any,
+          {
+            id: '2',
+            name: 'Model 2',
+            version: '2.0.0',
+            description: 'Model 2 description',
+            object: {
+              type: 'model',
+              uri: 'http://localhost:5000/models/model2',
+            },
+            format: 'onnx',
+            sources: [],
+            parameters: {},
+            settings: {},
+            metadata: {},
+            engine: 'test',
+          } as any,
+        ]
+        existMock.mockReturnValue(true)
+
+        readDirSyncMock.mockImplementation((path) => {
+          if (path === 'file://models') return ['model1', 'model2/model2-1']
+          else if (path === 'file://models/model1')
+            return ['model.json', 'test.gguf']
+          else return ['model.json', 'test.engine']
+        })
+
+        readFileSyncMock.mockImplementation((path) => {
+          if (path.includes('model1'))
+            return JSON.stringify(configuredModels[0])
+          else return JSON.stringify(configuredModels[1])
+        })
+
+        const result = await sut.getDownloadedModels()
+        expect(result).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              file_path: 'file://models/model1/model.json',
+              id: '1',
+            }),
+            expect.objectContaining({
+              file_path: 'file://models/model2/model2-1/model.json',
+              id: '2',
+            }),
+          ])
+        )
+      })
+    })
+  })
+
+  describe('deleteModel', () => {
+    describe('model is a GGUF model', () => {
+      it('should delete the GGUF file', async () => {
+        fs.unlinkSync = jest.fn()
+        const dirMock = dirName as jest.Mock
+        dirMock.mockReturnValue('file://models/model1')
+
+        fs.readFileSync = jest.fn().mockReturnValue(JSON.stringify({}))
+
+        readDirSyncMock.mockImplementation((path) => {
+          return ['model.json', 'test.gguf']
+        })
+
+        existMock.mockReturnValue(true)
+
+        await sut.deleteModel({
+          file_path: 'file://models/model1/model.json',
+        } as any)
+
+        expect(fs.unlinkSync).toHaveBeenCalledWith(
+          'file://models/model1/test.gguf'
+        )
+      })
+
+      it('no gguf file presented', async () => {
+        fs.unlinkSync = jest.fn()
+        const dirMock = dirName as jest.Mock
+        dirMock.mockReturnValue('file://models/model1')
+
+        fs.readFileSync = jest.fn().mockReturnValue(JSON.stringify({}))
+
+        readDirSyncMock.mockReturnValue(['model.json'])
+
+        existMock.mockReturnValue(true)
+
+        await sut.deleteModel({
+          file_path: 'file://models/model1/model.json',
+        } as any)
+
+        expect(fs.unlinkSync).toHaveBeenCalledTimes(0)
+      })
+
+      it('delete an imported model', async () => {
+        fs.rm = jest.fn()
+        const dirMock = dirName as jest.Mock
+        dirMock.mockReturnValue('file://models/model1')
+
+        readDirSyncMock.mockReturnValue(['model.json', 'test.gguf'])
+
+        // MARK: This is a tricky logic implement?
+        // I will just add test for now but will align on the legacy implementation
+        fs.readFileSync = jest.fn().mockReturnValue(
+          JSON.stringify({
+            metadata: {
+              author: 'user',
+            },
+          })
+        )
+
+        existMock.mockReturnValue(true)
+
+        await sut.deleteModel({
+          file_path: 'file://models/model1/model.json',
+        } as any)
+
+        expect(fs.rm).toHaveBeenCalledWith('file://models/model1')
+      })
+
+      it('delete tensorrt-models', async () => {
+        fs.rm = jest.fn()
+        const dirMock = dirName as jest.Mock
+        dirMock.mockReturnValue('file://models/model1')
+
+        readDirSyncMock.mockReturnValue(['model.json', 'test.engine'])
+
+        fs.readFileSync = jest.fn().mockReturnValue(JSON.stringify({}))
+
+        existMock.mockReturnValue(true)
+
+        await sut.deleteModel({
+          file_path: 'file://models/model1/model.json',
+        } as any)
+
+        expect(fs.unlinkSync).toHaveBeenCalledWith('file://models/model1/test.engine')
+      })
+    })
+  })
+})

--- a/extensions/model-extension/tsconfig.json
+++ b/extensions/model-extension/tsconfig.json
@@ -10,5 +10,6 @@
     "skipLibCheck": true,
     "rootDir": "./src"
   },
-  "include": ["./src"]
+  "include": ["./src"],
+  "exclude": ["**/*.test.ts"]
 }

--- a/extensions/tensorrt-llm-extension/src/index.ts
+++ b/extensions/tensorrt-llm-extension/src/index.ts
@@ -23,6 +23,7 @@ import {
   ModelEvent,
   getJanDataFolderPath,
   SystemInformation,
+  ModelFile,
 } from '@janhq/core'
 
 /**
@@ -137,7 +138,7 @@ export default class TensorRTLLMExtension extends LocalOAIEngine {
     events.emit(ModelEvent.OnModelsUpdate, {})
   }
 
-  override async loadModel(model: Model): Promise<void> {
+  override async loadModel(model: ModelFile): Promise<void> {
     if ((await this.installationState()) === 'Installed')
       return super.loadModel(model)
 

--- a/web/.eslintrc.js
+++ b/web/.eslintrc.js
@@ -71,6 +71,7 @@ module.exports = {
     '@next/next/no-img-element': 'off',
     '@next/next/no-html-link-for-pages': 'off',
     'react/display-name': 'off',
+    'react/no-is-mounted': 'off',
     'react-hooks/rules-of-hooks': 'error',
     '@typescript-eslint/no-unused-vars': ['warn'],
     'import/order': [

--- a/web/containers/ModelDropdown/index.tsx
+++ b/web/containers/ModelDropdown/index.tsx
@@ -222,6 +222,7 @@ const ModelDropdown = ({
         if (model)
           updateModelParameter(activeThread, {
             params: modelParams,
+            modelPath: model.file_path,
             modelId: model.id,
             engine: model.engine,
           })

--- a/web/containers/ModelDropdown/index.tsx
+++ b/web/containers/ModelDropdown/index.tsx
@@ -46,7 +46,6 @@ import {
 
 import { extensionManager } from '@/extension'
 
-import { preserveModelSettingsAtom } from '@/helpers/atoms/AppConfig.atom'
 import { inActiveEngineProviderAtom } from '@/helpers/atoms/Extension.atom'
 import {
   configuredModelsAtom,
@@ -91,8 +90,6 @@ const ModelDropdown = ({
   const featuredModel = configuredModels.filter((x) =>
     x.metadata.tags.includes('Featured')
   )
-  const preserveModelSettings = useAtomValue(preserveModelSettingsAtom)
-
   const { updateThreadMetadata } = useCreateNewThread()
 
   useClickOutside(() => !filterOptionsOpen && setOpen(false), null, [
@@ -191,27 +188,14 @@ const ModelDropdown = ({
           ],
         })
 
-        // Default setting ctx_len for the model for a better onboarding experience
-        // TODO: When Cortex support hardware instructions, we should remove this
-        const defaultContextLength = preserveModelSettings
-          ? model?.metadata?.default_ctx_len
-          : 2048
-        const defaultMaxTokens = preserveModelSettings
-          ? model?.metadata?.default_max_tokens
-          : 2048
         const overriddenSettings =
-          model?.settings.ctx_len && model.settings.ctx_len > 2048
-            ? { ctx_len: defaultContextLength ?? 2048 }
-            : {}
-        const overriddenParameters =
-          model?.parameters.max_tokens && model.parameters.max_tokens
-            ? { max_tokens: defaultMaxTokens ?? 2048 }
+          model?.settings.ctx_len && model.settings.ctx_len > 4096
+            ? { ctx_len: 4096 }
             : {}
 
         const modelParams = {
           ...model?.parameters,
           ...model?.settings,
-          ...overriddenParameters,
           ...overriddenSettings,
         }
 
@@ -236,7 +220,6 @@ const ModelDropdown = ({
       setThreadModelParams,
       updateModelParameter,
       updateThreadMetadata,
-      preserveModelSettings,
     ]
   )
 

--- a/web/helpers/atoms/AppConfig.atom.ts
+++ b/web/helpers/atoms/AppConfig.atom.ts
@@ -7,7 +7,6 @@ const VULKAN_ENABLED = 'vulkanEnabled'
 const IGNORE_SSL = 'ignoreSSLFeature'
 const HTTPS_PROXY_FEATURE = 'httpsProxyFeature'
 const QUICK_ASK_ENABLED = 'quickAskEnabled'
-const PRESERVE_MODEL_SETTINGS = 'preserveModelSettings'
 
 export const janDataFolderPathAtom = atom('')
 
@@ -24,9 +23,3 @@ export const vulkanEnabledAtom = atomWithStorage(VULKAN_ENABLED, false)
 export const quickAskEnabledAtom = atomWithStorage(QUICK_ASK_ENABLED, false)
 
 export const hostAtom = atom('http://localhost:1337/')
-
-// This feature is to allow user to cache model settings on thread creation
-export const preserveModelSettingsAtom = atomWithStorage(
-  PRESERVE_MODEL_SETTINGS,
-  false
-)

--- a/web/helpers/atoms/Model.atom.ts
+++ b/web/helpers/atoms/Model.atom.ts
@@ -1,4 +1,4 @@
-import { ImportingModel, Model, InferenceEngine } from '@janhq/core'
+import { ImportingModel, Model, InferenceEngine, ModelFile } from '@janhq/core'
 import { atom } from 'jotai'
 
 import { localEngines } from '@/utils/modelEngine'
@@ -32,13 +32,13 @@ export const removeDownloadingModelAtom = atom(
   }
 )
 
-export const downloadedModelsAtom = atom<Model[]>([])
+export const downloadedModelsAtom = atom<ModelFile[]>([])
 
 export const updateDownloadedModelAtom = atom(
   null,
   (get, set, updatedModel: Model) => {
-    const models: Model[] = get(downloadedModelsAtom).map((c) =>
-      c.id === updatedModel.id ? updatedModel : c
+    const models: ModelFile[] = get(downloadedModelsAtom).map((c) =>
+      c.id === updatedModel.id ? { ...c, updatedModel } : c
     )
 
     set(downloadedModelsAtom, models)
@@ -57,7 +57,7 @@ export const removeDownloadedModelAtom = atom(
   }
 )
 
-export const configuredModelsAtom = atom<Model[]>([])
+export const configuredModelsAtom = atom<ModelFile[]>([])
 
 export const defaultModelAtom = atom<Model | undefined>(undefined)
 
@@ -144,6 +144,6 @@ export const updateImportingModelAtom = atom(
   }
 )
 
-export const selectedModelAtom = atom<Model | undefined>(undefined)
+export const selectedModelAtom = atom<ModelFile | undefined>(undefined)
 
 export const showEngineListModelAtom = atom<InferenceEngine[]>(localEngines)

--- a/web/helpers/atoms/Model.atom.ts
+++ b/web/helpers/atoms/Model.atom.ts
@@ -34,17 +34,6 @@ export const removeDownloadingModelAtom = atom(
 
 export const downloadedModelsAtom = atom<ModelFile[]>([])
 
-export const updateDownloadedModelAtom = atom(
-  null,
-  (get, set, updatedModel: Model) => {
-    const models: ModelFile[] = get(downloadedModelsAtom).map((c) =>
-      c.id === updatedModel.id ? { ...c, updatedModel } : c
-    )
-
-    set(downloadedModelsAtom, models)
-  }
-)
-
 export const removeDownloadedModelAtom = atom(
   null,
   (get, set, modelId: string) => {

--- a/web/hooks/useActiveModel.ts
+++ b/web/hooks/useActiveModel.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef } from 'react'
 
-import { EngineManager, Model } from '@janhq/core'
+import { EngineManager, Model, ModelFile } from '@janhq/core'
 import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai'
 
 import { toaster } from '@/containers/Toast'
@@ -11,7 +11,7 @@ import { vulkanEnabledAtom } from '@/helpers/atoms/AppConfig.atom'
 import { downloadedModelsAtom } from '@/helpers/atoms/Model.atom'
 import { activeThreadAtom } from '@/helpers/atoms/Thread.atom'
 
-export const activeModelAtom = atom<Model | undefined>(undefined)
+export const activeModelAtom = atom<ModelFile | undefined>(undefined)
 export const loadModelErrorAtom = atom<string | undefined>(undefined)
 
 type ModelState = {
@@ -37,7 +37,7 @@ export function useActiveModel() {
   const [pendingModelLoad, setPendingModelLoad] = useAtom(pendingModelLoadAtom)
   const isVulkanEnabled = useAtomValue(vulkanEnabledAtom)
 
-  const downloadedModelsRef = useRef<Model[]>([])
+  const downloadedModelsRef = useRef<ModelFile[]>([])
 
   useEffect(() => {
     downloadedModelsRef.current = downloadedModels

--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -27,10 +27,7 @@ import useSetActiveThread from './useSetActiveThread'
 
 import { extensionManager } from '@/extension'
 
-import {
-  experimentalFeatureEnabledAtom,
-  preserveModelSettingsAtom,
-} from '@/helpers/atoms/AppConfig.atom'
+import { experimentalFeatureEnabledAtom } from '@/helpers/atoms/AppConfig.atom'
 import { selectedModelAtom } from '@/helpers/atoms/Model.atom'
 import {
   threadsAtom,
@@ -68,7 +65,6 @@ export const useCreateNewThread = () => {
   const copyOverInstructionEnabled = useAtomValue(
     copyOverInstructionEnabledAtom
   )
-  const preserveModelSettings = useAtomValue(preserveModelSettingsAtom)
   const activeThread = useAtomValue(activeThreadAtom)
 
   const experimentalEnabled = useAtomValue(experimentalFeatureEnabledAtom)
@@ -110,19 +106,13 @@ export const useCreateNewThread = () => {
       enabled: true,
       settings: assistant.tools && assistant.tools[0].settings,
     }
-    const defaultContextLength = preserveModelSettings
-      ? defaultModel?.metadata?.default_ctx_len
-      : 2048
-    const defaultMaxTokens = preserveModelSettings
-      ? defaultModel?.metadata?.default_max_tokens
-      : 2048
     const overriddenSettings =
       defaultModel?.settings.ctx_len && defaultModel.settings.ctx_len > 2048
-        ? { ctx_len: defaultContextLength ?? 2048 }
+        ? { ctx_len: 4096 }
         : {}
 
     const overriddenParameters = defaultModel?.parameters.max_tokens
-      ? { max_tokens: defaultMaxTokens ?? 2048 }
+      ? { max_tokens: 4096 }
       : {}
 
     const createdAt = Date.now()

--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -7,7 +7,6 @@ import {
   Thread,
   ThreadAssistantInfo,
   ThreadState,
-  Model,
   AssistantTool,
   ModelFile,
 } from '@janhq/core'

--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -9,6 +9,7 @@ import {
   ThreadState,
   Model,
   AssistantTool,
+  ModelFile,
 } from '@janhq/core'
 import { atom, useAtomValue, useSetAtom } from 'jotai'
 
@@ -80,7 +81,7 @@ export const useCreateNewThread = () => {
 
   const requestCreateNewThread = async (
     assistant: Assistant,
-    model?: Model | undefined
+    model?: ModelFile | undefined
   ) => {
     // Stop generating if any
     setIsGeneratingResponse(false)

--- a/web/hooks/useDeleteModel.ts
+++ b/web/hooks/useDeleteModel.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 
-import { ExtensionTypeEnum, ModelExtension, Model } from '@janhq/core'
+import { ExtensionTypeEnum, ModelExtension, ModelFile } from '@janhq/core'
 
 import { useSetAtom } from 'jotai'
 
@@ -13,8 +13,8 @@ export default function useDeleteModel() {
   const removeDownloadedModel = useSetAtom(removeDownloadedModelAtom)
 
   const deleteModel = useCallback(
-    async (model: Model) => {
-      await localDeleteModel(model.id)
+    async (model: ModelFile) => {
+      await localDeleteModel(model)
       removeDownloadedModel(model.id)
       toaster({
         title: 'Model Deletion Successful',
@@ -28,5 +28,7 @@ export default function useDeleteModel() {
   return { deleteModel }
 }
 
-const localDeleteModel = async (id: string) =>
-  extensionManager.get<ModelExtension>(ExtensionTypeEnum.Model)?.deleteModel(id)
+const localDeleteModel = async (model: ModelFile) =>
+  extensionManager
+    .get<ModelExtension>(ExtensionTypeEnum.Model)
+    ?.deleteModel(model)

--- a/web/hooks/useModels.ts
+++ b/web/hooks/useModels.ts
@@ -5,6 +5,7 @@ import {
   Model,
   ModelEvent,
   ModelExtension,
+  ModelFile,
   events,
 } from '@janhq/core'
 
@@ -63,12 +64,12 @@ const getLocalDefaultModel = async (): Promise<Model | undefined> =>
     .get<ModelExtension>(ExtensionTypeEnum.Model)
     ?.getDefaultModel()
 
-const getLocalConfiguredModels = async (): Promise<Model[]> =>
+const getLocalConfiguredModels = async (): Promise<ModelFile[]> =>
   extensionManager
     .get<ModelExtension>(ExtensionTypeEnum.Model)
     ?.getConfiguredModels() ?? []
 
-const getLocalDownloadedModels = async (): Promise<Model[]> =>
+const getLocalDownloadedModels = async (): Promise<ModelFile[]> =>
   extensionManager
     .get<ModelExtension>(ExtensionTypeEnum.Model)
     ?.getDownloadedModels() ?? []

--- a/web/hooks/useRecommendedModel.ts
+++ b/web/hooks/useRecommendedModel.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react'
 
-import { Model, InferenceEngine } from '@janhq/core'
+import { Model, InferenceEngine, ModelFile } from '@janhq/core'
 
 import { atom, useAtomValue } from 'jotai'
 
@@ -24,12 +24,16 @@ export const LAST_USED_MODEL_ID = 'last-used-model-id'
  */
 export default function useRecommendedModel() {
   const activeModel = useAtomValue(activeModelAtom)
-  const [sortedModels, setSortedModels] = useState<Model[]>([])
-  const [recommendedModel, setRecommendedModel] = useState<Model | undefined>()
+  const [sortedModels, setSortedModels] = useState<ModelFile[]>([])
+  const [recommendedModel, setRecommendedModel] = useState<
+    ModelFile | undefined
+  >()
   const activeThread = useAtomValue(activeThreadAtom)
   const downloadedModels = useAtomValue(downloadedModelsAtom)
 
-  const getAndSortDownloadedModels = useCallback(async (): Promise<Model[]> => {
+  const getAndSortDownloadedModels = useCallback(async (): Promise<
+    ModelFile[]
+  > => {
     const models = downloadedModels.sort((a, b) =>
       a.engine !== InferenceEngine.nitro && b.engine === InferenceEngine.nitro
         ? 1

--- a/web/hooks/useUpdateModelParameters.ts
+++ b/web/hooks/useUpdateModelParameters.ts
@@ -6,6 +6,7 @@ import {
   InferenceEngine,
   Model,
   ModelExtension,
+  ModelFile,
   Thread,
   ThreadAssistantInfo,
 } from '@janhq/core'
@@ -31,6 +32,7 @@ import {
 export type UpdateModelParameter = {
   params?: ModelParams
   modelId?: string
+  modelPath?: string
   engine?: InferenceEngine
 }
 
@@ -99,7 +101,8 @@ export default function useUpdateModelParameters() {
             default_ctx_len: defaultContextLength,
             default_max_tokens: defaultMaxTokens,
           },
-        } as Partial<Model>
+          file_path: settings.modelPath ?? selectedModel?.file_path,
+        } as Partial<ModelFile>
 
         const model = await extensionManager
           .get<ModelExtension>(ExtensionTypeEnum.Model)

--- a/web/hooks/useUpdateModelParameters.ts
+++ b/web/hooks/useUpdateModelParameters.ts
@@ -4,9 +4,6 @@ import {
   ConversationalExtension,
   ExtensionTypeEnum,
   InferenceEngine,
-  Model,
-  ModelExtension,
-  ModelFile,
   Thread,
   ThreadAssistantInfo,
 } from '@janhq/core'
@@ -15,14 +12,8 @@ import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 
 import { toRuntimeParams, toSettingParams } from '@/utils/modelParam'
 
-import useRecommendedModel from './useRecommendedModel'
-
 import { extensionManager } from '@/extension'
-import { preserveModelSettingsAtom } from '@/helpers/atoms/AppConfig.atom'
-import {
-  selectedModelAtom,
-  updateDownloadedModelAtom,
-} from '@/helpers/atoms/Model.atom'
+import { selectedModelAtom } from '@/helpers/atoms/Model.atom'
 import {
   ModelParams,
   getActiveThreadModelParamsAtom,
@@ -38,11 +29,8 @@ export type UpdateModelParameter = {
 
 export default function useUpdateModelParameters() {
   const activeModelParams = useAtomValue(getActiveThreadModelParamsAtom)
-  const [selectedModel, setSelectedModel] = useAtom(selectedModelAtom)
+  const [selectedModel] = useAtom(selectedModelAtom)
   const setThreadModelParams = useSetAtom(setThreadModelParamsAtom)
-  const updateDownloadedModel = useSetAtom(updateDownloadedModelAtom)
-  const preserveModelFeatureEnabled = useAtomValue(preserveModelSettingsAtom)
-  const { recommendedModel, setRecommendedModel } = useRecommendedModel()
 
   const updateModelParameter = useCallback(
     async (thread: Thread, settings: UpdateModelParameter) => {
@@ -77,51 +65,8 @@ export default function useUpdateModelParameters() {
       await extensionManager
         .get<ConversationalExtension>(ExtensionTypeEnum.Conversational)
         ?.saveThread(updatedThread)
-
-      // Persists default settings to model file
-      // Do not overwrite ctx_len and max_tokens
-      if (preserveModelFeatureEnabled) {
-        const defaultContextLength = settingParams.ctx_len
-        const defaultMaxTokens = runtimeParams.max_tokens
-
-        // eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-unused-vars
-        const { ctx_len, ...toSaveSettings } = settingParams
-        // eslint-disable-next-line @typescript-eslint/naming-convention, @typescript-eslint/no-unused-vars
-        const { max_tokens, ...toSaveParams } = runtimeParams
-
-        const updatedModel = {
-          id: settings.modelId ?? selectedModel?.id,
-          parameters: {
-            ...toSaveSettings,
-          },
-          settings: {
-            ...toSaveParams,
-          },
-          metadata: {
-            default_ctx_len: defaultContextLength,
-            default_max_tokens: defaultMaxTokens,
-          },
-          file_path: settings.modelPath ?? selectedModel?.file_path,
-        } as Partial<ModelFile>
-
-        const model = await extensionManager
-          .get<ModelExtension>(ExtensionTypeEnum.Model)
-          ?.updateModelInfo(updatedModel)
-        if (model) updateDownloadedModel(model)
-        if (selectedModel?.id === model?.id) setSelectedModel(model)
-        if (recommendedModel?.id === model?.id) setRecommendedModel(model)
-      }
     },
-    [
-      activeModelParams,
-      selectedModel,
-      setThreadModelParams,
-      preserveModelFeatureEnabled,
-      updateDownloadedModel,
-      setSelectedModel,
-      recommendedModel,
-      setRecommendedModel,
-    ]
+    [activeModelParams, selectedModel, setThreadModelParams]
   )
 
   const processStopWords = (params: ModelParams): ModelParams => {

--- a/web/screens/Hub/ModelList/ModelHeader/index.tsx
+++ b/web/screens/Hub/ModelList/ModelHeader/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 
-import { Model } from '@janhq/core'
+import { Model, ModelFile } from '@janhq/core'
 import { Button, Badge, Tooltip } from '@janhq/joi'
 
 import { useAtomValue, useSetAtom } from 'jotai'
@@ -38,7 +38,7 @@ import {
 } from '@/helpers/atoms/SystemBar.atom'
 
 type Props = {
-  model: Model
+  model: ModelFile
   onClick: () => void
   open: string
 }

--- a/web/screens/Hub/ModelList/ModelHeader/index.tsx
+++ b/web/screens/Hub/ModelList/ModelHeader/index.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 
-import { Model, ModelFile } from '@janhq/core'
+import { ModelFile } from '@janhq/core'
 import { Button, Badge, Tooltip } from '@janhq/joi'
 
 import { useAtomValue, useSetAtom } from 'jotai'

--- a/web/screens/Hub/ModelList/ModelItem/index.tsx
+++ b/web/screens/Hub/ModelList/ModelItem/index.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-import { Model } from '@janhq/core'
+import { ModelFile } from '@janhq/core'
 import { Badge } from '@janhq/joi'
 
 import { twMerge } from 'tailwind-merge'
@@ -12,7 +12,7 @@ import ModelItemHeader from '@/screens/Hub/ModelList/ModelHeader'
 import { toGibibytes } from '@/utils/converter'
 
 type Props = {
-  model: Model
+  model: ModelFile
 }
 
 const ModelItem: React.FC<Props> = ({ model }) => {

--- a/web/screens/Hub/ModelList/index.tsx
+++ b/web/screens/Hub/ModelList/index.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 
-import { Model } from '@janhq/core'
+import { ModelFile } from '@janhq/core'
 
 import { useAtomValue } from 'jotai'
 
@@ -9,16 +9,16 @@ import ModelItem from '@/screens/Hub/ModelList/ModelItem'
 import { downloadedModelsAtom } from '@/helpers/atoms/Model.atom'
 
 type Props = {
-  models: Model[]
+  models: ModelFile[]
 }
 
 const ModelList = ({ models }: Props) => {
   const downloadedModels = useAtomValue(downloadedModelsAtom)
-  const sortedModels: Model[] = useMemo(() => {
-    const featuredModels: Model[] = []
-    const remoteModels: Model[] = []
-    const localModels: Model[] = []
-    const remainingModels: Model[] = []
+  const sortedModels: ModelFile[] = useMemo(() => {
+    const featuredModels: ModelFile[] = []
+    const remoteModels: ModelFile[] = []
+    const localModels: ModelFile[] = []
+    const remainingModels: ModelFile[] = []
     models.forEach((m) => {
       if (m.metadata?.tags?.includes('Featured')) {
         featuredModels.push(m)

--- a/web/screens/Settings/Advanced/index.tsx
+++ b/web/screens/Settings/Advanced/index.tsx
@@ -35,7 +35,6 @@ import {
   proxyEnabledAtom,
   vulkanEnabledAtom,
   quickAskEnabledAtom,
-  preserveModelSettingsAtom,
 } from '@/helpers/atoms/AppConfig.atom'
 
 type GPU = {
@@ -65,9 +64,6 @@ const Advanced = () => {
   const [proxyEnabled, setProxyEnabled] = useAtom(proxyEnabledAtom)
   const quickAskEnabled = useAtomValue(quickAskEnabledAtom)
 
-  const [preserveModelSettings, setPreserveModelSettings] = useAtom(
-    preserveModelSettingsAtom
-  )
   const [proxy, setProxy] = useAtom(proxyAtom)
   const [ignoreSSL, setIgnoreSSL] = useAtom(ignoreSslAtom)
 
@@ -385,27 +381,6 @@ const Advanced = () => {
             <Switch
               checked={vulkanEnabled}
               onChange={(e) => updateVulkanEnabled(e.target.checked)}
-            />
-          </div>
-        )}
-
-        {experimentalEnabled && (
-          <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">
-            <div className="flex-shrink-0 space-y-1">
-              <div className="flex gap-x-2">
-                <h6 className="font-semibold capitalize">
-                  Preserve Model Settings
-                </h6>
-              </div>
-              <p className="font-medium leading-relaxed text-[hsla(var(--text-secondary))]">
-                Save model settings changes directly to the model file so that
-                new threads will reuse the previous settings.
-              </p>
-            </div>
-
-            <Switch
-              checked={preserveModelSettings}
-              onChange={(e) => setPreserveModelSettings(e.target.checked)}
             />
           </div>
         )}

--- a/web/screens/Settings/HuggingFaceRepoDetailModal/ModelDownloadRow/index.tsx
+++ b/web/screens/Settings/HuggingFaceRepoDetailModal/ModelDownloadRow/index.tsx
@@ -4,6 +4,7 @@ import {
   DownloadState,
   HuggingFaceRepoData,
   Model,
+  ModelFile,
   Quantization,
 } from '@janhq/core'
 import { Badge, Button, Progress } from '@janhq/joi'
@@ -53,7 +54,7 @@ const ModelDownloadRow: React.FC<Props> = ({
   const { requestCreateNewThread } = useCreateNewThread()
   const setMainViewState = useSetAtom(mainViewStateAtom)
   const assistants = useAtomValue(assistantsAtom)
-  const isDownloaded = downloadedModels.find((md) => md.id === fileName) != null
+  const downloadedModel = downloadedModels.find((md) => md.id === fileName)
 
   const setHfImportingStage = useSetAtom(importHuggingFaceModelStageAtom)
   const defaultModel = useAtomValue(defaultModelAtom)
@@ -100,12 +101,12 @@ const ModelDownloadRow: React.FC<Props> = ({
       alert('No assistant available')
       return
     }
-    await requestCreateNewThread(assistants[0], model)
+    await requestCreateNewThread(assistants[0], downloadedModel)
     setMainViewState(MainViewState.Thread)
     setHfImportingStage('NONE')
   }, [
     assistants,
-    model,
+    downloadedModel,
     requestCreateNewThread,
     setMainViewState,
     setHfImportingStage,
@@ -139,7 +140,7 @@ const ModelDownloadRow: React.FC<Props> = ({
         </Badge>
       </div>
 
-      {isDownloaded ? (
+      {downloadedModel ? (
         <Button
           variant="soft"
           className="min-w-[98px]"

--- a/web/screens/Settings/HuggingFaceRepoDetailModal/ModelDownloadRow/index.tsx
+++ b/web/screens/Settings/HuggingFaceRepoDetailModal/ModelDownloadRow/index.tsx
@@ -4,7 +4,6 @@ import {
   DownloadState,
   HuggingFaceRepoData,
   Model,
-  ModelFile,
   Quantization,
 } from '@janhq/core'
 import { Badge, Button, Progress } from '@janhq/joi'

--- a/web/screens/Settings/MyModels/MyModelList/index.tsx
+++ b/web/screens/Settings/MyModels/MyModelList/index.tsx
@@ -1,6 +1,6 @@
 import { memo, useState } from 'react'
 
-import { InferenceEngine, Model } from '@janhq/core'
+import { InferenceEngine, ModelFile } from '@janhq/core'
 import { Badge, Button, Tooltip, useClickOutside } from '@janhq/joi'
 import { useAtom } from 'jotai'
 import {
@@ -21,7 +21,7 @@ import { localEngines } from '@/utils/modelEngine'
 import { serverEnabledAtom } from '@/helpers/atoms/LocalServer.atom'
 
 type Props = {
-  model: Model
+  model: ModelFile
   groupTitle?: string
 }
 


### PR DESCRIPTION
## Describe Your Changes

This PR addresses issue #3476, where manually added models are broken due to a mismatched ID between the model.json file and the folder path, as the model_id in the JSON file does not match the folder name where the model is stored, causing issues with model recognition and functionality.

The first attempt in the past to address this is to make model_id the same as folder structure BUT that could lead to an issue where: 
- Model ID should not be auto-generated in some cases (remote models).
- The folder structure is not the source of truth (nested / symlink).

After thinking through, one of the better fixes is to work with ModelFile (a type alias of Model & File), where:

1. It contains Model metadata, which is used widely in the app.
2. It contains File metadata, which is used for file path retrieval.
3. Remove the constraint of model ID and the JSON file path.

**Deprecate Model Preserve Settings (will be replaced by Preset)**
It's also removed the Preserve Model Settings, which isn't aligned well and might cause unexpected error (direct model.json overwrite)
https://discord.com/channels/1107178041848909847/1283644162838892564/1283749880937971774

## Changes made (Generated)

**Changes in `Advanced` component**
* Removed `preserveModelSettingsAtom` import and related code.
* Removed the "Preserve Model Settings" section.

**Changes in `ModelDownloadRow` component**
* Renamed `isDownloaded` to `downloadedModel`.
* Updated `requestCreateNewThread` function to use `downloadedModel` instead of `model`.

**Changes in `MyModelList` component**
* Renamed `model` type to `ModelFile`.

**Removed features**
* `restoreModelSettings` functionality has been removed.

**Refactoring**
* Improved variable names and code organization.

**Removed deprecated code**
* Removed `isDownloaded` variable and replaced with `downloadedModel`.

**Other changes**
* Improved type definitions and code consistency.

## Added test cases (Generated)

1. **getDownloadedModels() with GGUF files**:
   - Test case checks if `getDownloadedModels()` returns downloaded models with correct file paths and model IDs.
   - Test case checks if `getDownloadedModels()` returns downloaded models when there are GGUF files in the model folder.
   - Test case checks if `getDownloadedModels()` returns downloaded models when there are multiple GGUF files in the model folder (for nested folders).

2. **getDownloadedModels() with uppercased GGUF files**:
   - Test case checks if `getDownloadedModels()` returns downloaded models with correct file paths and model IDs.
   - Test case checks if `getDownloadedModels()` returns downloaded models when there are uppercased GGUF files in the model folder.

3. **getDownloadedModels() with GGUF & TensorRT files**:
   - Test case checks if `getDownloadedModels()` returns downloaded models with correct file paths and model IDs.
   - Test case checks if `getDownloadedModels()` returns downloaded models when there are both GGUF and TensorRT files in the model folder.

4. **deleteModel() for GGUF models**:
   - Test case checks if `deleteModel()` deletes the GGUF file when the model is a GGUF model.
   - Test case checks if `deleteModel()` does not delete any files when the GGUF file is not present.
   - Test case checks if `deleteModel()` deletes the entire model folder when the model is an imported model.
   - Test case checks if `deleteModel()` deletes the TensorRT file when the model is a TensorRT model.

5. (Implicit) Test case checks if `deleteModel()` calls `fs.unlinkSync()` for GGUF files and `fs.rm()` for TensorRT files and entire model folders for imported models.

## Fixes Issues

- #3476

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
