### PR TITLE
Fix issue github action failed due to a deprecated github action step

### DIFF
--- a/.github/workflows/jan-electron-build-nightly.yml
+++ b/.github/workflows/jan-electron-build-nightly.yml
@@ -88,12 +88,12 @@ jobs:
         with:
           ref: ${{ needs.set-public-provider.outputs.ref }}
       - name: Download mac-x64 artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: latest-mac-x64
           path: ./latest-mac-x64
       - name: Download mac-arm artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: latest-mac-arm64
           path: ./latest-mac-arm64

--- a/.github/workflows/jan-electron-build.yml
+++ b/.github/workflows/jan-electron-build.yml
@@ -79,12 +79,12 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Download mac-x64 artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: latest-mac-x64
           path: ./latest-mac-x64
       - name: Download mac-arm artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: latest-mac-arm64
           path: ./latest-mac-arm64

--- a/.github/workflows/jan-electron-linter-and-test.yml
+++ b/.github/workflows/jan-electron-linter-and-test.yml
@@ -59,7 +59,7 @@ jobs:
         run: yarn test:coverage
 
       - name: Upload code coverage for ref branch
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ref-lcov.info
           path: ./coverage/lcov.info
@@ -341,7 +341,7 @@ jobs:
           make clean
 
       - name: Download code coverage report from base branch
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ref-lcov.info
 

--- a/.github/workflows/template-build-linux-x64.yml
+++ b/.github/workflows/template-build-linux-x64.yml
@@ -102,14 +102,14 @@ jobs:
 
       - name: Upload Artifact .deb file
         if: inputs.public_provider != 'github'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: jan-linux-amd64-${{ inputs.new_version }}-deb
           path: ./electron/dist/*.deb
 
       - name: Upload Artifact .AppImage file
         if: inputs.public_provider != 'github'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: jan-linux-amd64-${{ inputs.new_version }}-AppImage
           path: ./electron/dist/*.AppImage

--- a/.github/workflows/template-build-macos-arm64.yml
+++ b/.github/workflows/template-build-macos-arm64.yml
@@ -148,13 +148,13 @@ jobs:
 
       - name: Upload Artifact
         if: inputs.public_provider != 'github'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: jan-mac-arm64-${{ inputs.new_version }}
           path: ./electron/dist/jan-mac-arm64-${{ inputs.new_version }}.dmg
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: latest-mac-arm64
           path: ./electron/dist/latest-mac.yml

--- a/.github/workflows/template-build-macos-x64.yml
+++ b/.github/workflows/template-build-macos-x64.yml
@@ -148,13 +148,13 @@ jobs:
 
       - name: Upload Artifact
         if: inputs.public_provider != 'github'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: jan-mac-x64-${{ inputs.new_version }}
           path: ./electron/dist/jan-mac-x64-${{ inputs.new_version }}.dmg
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: latest-mac-x64
           path: ./electron/dist/latest-mac.yml

--- a/.github/workflows/template-build-windows-x64.yml
+++ b/.github/workflows/template-build-windows-x64.yml
@@ -136,7 +136,7 @@ jobs:
 
       - name: Upload Artifact
         if: inputs.public_provider != 'github'
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: jan-win-x64-${{ inputs.new_version }}
           path: ./electron/dist/*.exe


### PR DESCRIPTION
## Describe Your Changes

Fix issue github action failed due to a deprecated github action step: 
- Upgrade actions/upload-artifact@v2 to actions/upload-artifact@v4

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
