### PR TITLE
chore: deprecate preserve thread settings

### DIFF
--- a/electron/.eslintrc.js
+++ b/electron/.eslintrc.js
@@ -11,8 +11,9 @@ module.exports = {
     'plugin:react/recommended',
   ],
   rules: {
-    '@typescript-eslint/no-non-null-assertion': 'off',
     'react/prop-types': 'off', // In favor of strong typing - no need to dedupe
+    'react/no-is-mounted': 'off',
+    '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-var-requires': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/no-unused-vars': 'off',

--- a/web/.eslintrc.js
+++ b/web/.eslintrc.js
@@ -71,6 +71,7 @@ module.exports = {
     '@next/next/no-img-element': 'off',
     '@next/next/no-html-link-for-pages': 'off',
     'react/display-name': 'off',
+    'react/no-is-mounted': 'off',
     'react-hooks/rules-of-hooks': 'error',
     '@typescript-eslint/no-unused-vars': ['warn'],
     'import/order': [

--- a/web/screens/Settings/Advanced/index.tsx
+++ b/web/screens/Settings/Advanced/index.tsx
@@ -35,7 +35,6 @@ import {
   proxyEnabledAtom,
   vulkanEnabledAtom,
   quickAskEnabledAtom,
-  preserveModelSettingsAtom,
 } from '@/helpers/atoms/AppConfig.atom'
 
 type GPU = {
@@ -65,9 +64,6 @@ const Advanced = () => {
   const [proxyEnabled, setProxyEnabled] = useAtom(proxyEnabledAtom)
   const quickAskEnabled = useAtomValue(quickAskEnabledAtom)
 
-  const [preserveModelSettings, setPreserveModelSettings] = useAtom(
-    preserveModelSettingsAtom
-  )
   const [proxy, setProxy] = useAtom(proxyAtom)
   const [ignoreSSL, setIgnoreSSL] = useAtom(ignoreSslAtom)
 
@@ -385,27 +381,6 @@ const Advanced = () => {
             <Switch
               checked={vulkanEnabled}
               onChange={(e) => updateVulkanEnabled(e.target.checked)}
-            />
-          </div>
-        )}
-
-        {experimentalEnabled && (
-          <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">
-            <div className="flex-shrink-0 space-y-1">
-              <div className="flex gap-x-2">
-                <h6 className="font-semibold capitalize">
-                  Preserve Model Settings
-                </h6>
-              </div>
-              <p className="font-medium leading-relaxed text-[hsla(var(--text-secondary))]">
-                Save model settings changes directly to the model file so that
-                new threads will reuse the previous settings.
-              </p>
-            </div>
-
-            <Switch
-              checked={preserveModelSettings}
-              onChange={(e) => setPreserveModelSettings(e.target.checked)}
             />
           </div>
         )}


### PR DESCRIPTION
## Description

This is a separate PR from #3476, to deprecate the Preserve Thread settings, which are poorly aligned and can be replaced by the future Preset feature.

https://discord.com/channels/1107178041848909847/1283644162838892564/1283749880937971774

## Changes made (Auto Generated)

1. **Removed a feature**: A feature that allowed the user to preserve model settings was removed from the code.
2. **Import removed**: The `preserveModelSettingsAtom` was removed from the code.
3. **Variable and function calls removed**: The `preserveModelSettingsAtom` variable and the `setPreserveModelSettings` function call were removed.
4. **Switch component removed**: The `Switch` component related to the removed feature was removed.
5. **Conditional rendering removed**: The conditionally rendered code block related to the removed feature was removed.

## Screenshots
<img width="1157" alt="Screenshot 2024-09-13 at 14 40 59" src="https://github.com/user-attachments/assets/0e73753a-a154-4e6d-b54a-6252187be59d">


## Fixes Issues
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
