### PR TITLE
Add support for 'o1-preview' and 'o1-mini' models

### DIFF
--- a/extensions/inference-openai-extension/resources/models.json
+++ b/extensions/inference-openai-extension/resources/models.json
@@ -119,5 +119,65 @@
       ]
     },
     "engine": "openai"
+  },
+  {
+    "sources": [
+      {
+        "url": "https://openai.com"
+      }
+    ],
+    "id": "o1-preview",
+    "object": "model",
+    "name": "OpenAI o1-preview",
+    "version": "1.0",
+    "description": "OpenAI o1-preview is a new model with complex reasoning",
+    "format": "api",
+    "settings": {},
+    "parameters": {
+      "max_tokens": 4096,
+      "temperature": 0.7,
+      "top_p": 0.95,
+      "stream": true,
+      "stop": [],
+      "frequency_penalty": 0,
+      "presence_penalty": 0
+    },
+    "metadata": {
+      "author": "OpenAI",
+      "tags": [
+        "General"
+      ]
+    },
+    "engine": "openai"
+  },
+  {
+    "sources": [
+      {
+        "url": "https://openai.com"
+      }
+    ],
+    "id": "o1-mini",
+    "object": "model",
+    "name": "OpenAI o1-mini",
+    "version": "1.0",
+    "description": "OpenAI o1-mini is a lightweight reasoning model",
+    "format": "api",
+    "settings": {},
+    "parameters": {
+      "max_tokens": 4096,
+      "temperature": 0.7,
+      "top_p": 0.95,
+      "stream": true,
+      "stop": [],
+      "frequency_penalty": 0,
+      "presence_penalty": 0
+    },
+    "metadata": {
+      "author": "OpenAI",
+      "tags": [
+        "General"
+      ]
+    },
+    "engine": "openai"
   }
 ]


### PR DESCRIPTION
Add support for 'o1-preview' and 'o1-mini' model names in the OpenAI API.

* **Update `models.json`**:
  - Add 'o1-preview' model details with appropriate parameters and metadata.
  - Add 'o1-mini' model details with appropriate parameters and metadata.

Closes #3652 

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/janhq/jan?shareId=ebcc39a6-99ad-46f5-a233-e0f75289c885).