### PR TITLE
fix: small leftover issues with new starter screen

### DIFF
--- a/electron/tests/e2e/thread.e2e.spec.ts
+++ b/electron/tests/e2e/thread.e2e.spec.ts
@@ -1,32 +1,29 @@
 import { expect } from '@playwright/test'
 import { page, test, TIMEOUT } from '../config/fixtures'
 
-test('Select GPT model from Hub and Chat with Invalid API Key', async ({ hubPage }) => {
+test('Select GPT model from Hub and Chat with Invalid API Key', async ({
+  hubPage,
+}) => {
   await hubPage.navigateByMenu()
   await hubPage.verifyContainerVisible()
 
   // Select the first GPT model
   await page
     .locator('[data-testid^="use-model-btn"][data-testid*="gpt"]')
-    .first().click()
-
-  // Attempt to create thread and chat in Thread page
-  await page
-    .getByTestId('btn-create-thread')
+    .first()
     .click()
 
-  await page
-    .getByTestId('txt-input-chat')
-    .fill('dummy value')
+  await page.getByTestId('txt-input-chat').fill('dummy value')
 
-  await page
-    .getByTestId('btn-send-chat')
-    .click()
+  await page.getByTestId('btn-send-chat').click()
 
-  await page.waitForFunction(() => {
-    const loaders = document.querySelectorAll('[data-testid$="loader"]');
-    return !loaders.length;
-  }, { timeout: TIMEOUT });
+  await page.waitForFunction(
+    () => {
+      const loaders = document.querySelectorAll('[data-testid$="loader"]')
+      return !loaders.length
+    },
+    { timeout: TIMEOUT }
+  )
 
   const APIKeyError = page.getByTestId('invalid-API-key-error')
   await expect(APIKeyError).toBeVisible({

--- a/web/containers/Layout/RibbonPanel/index.tsx
+++ b/web/containers/Layout/RibbonPanel/index.tsx
@@ -12,17 +12,18 @@ import { twMerge } from 'tailwind-merge'
 
 import { MainViewState } from '@/constants/screens'
 
-import { localEngines } from '@/utils/modelEngine'
-
 import { mainViewStateAtom, showLeftPanelAtom } from '@/helpers/atoms/App.atom'
 import { editMessageAtom } from '@/helpers/atoms/ChatMessage.atom'
 import { serverEnabledAtom } from '@/helpers/atoms/LocalServer.atom'
-import { downloadedModelsAtom } from '@/helpers/atoms/Model.atom'
+
 import {
   reduceTransparentAtom,
   selectedSettingAtom,
 } from '@/helpers/atoms/Setting.atom'
-import { threadsAtom } from '@/helpers/atoms/Thread.atom'
+import {
+  isDownloadALocalModelAtom,
+  threadsAtom,
+} from '@/helpers/atoms/Thread.atom'
 
 export default function RibbonPanel() {
   const [mainViewState, setMainViewState] = useAtom(mainViewStateAtom)
@@ -32,8 +33,9 @@ export default function RibbonPanel() {
   const matches = useMediaQuery('(max-width: 880px)')
   const reduceTransparent = useAtomValue(reduceTransparentAtom)
   const setSelectedSetting = useSetAtom(selectedSettingAtom)
-  const downloadedModels = useAtomValue(downloadedModelsAtom)
+
   const threads = useAtomValue(threadsAtom)
+  const isDownloadALocalModel = useAtomValue(isDownloadALocalModelAtom)
 
   const onMenuClick = (state: MainViewState) => {
     if (mainViewState === state) return
@@ -42,10 +44,6 @@ export default function RibbonPanel() {
     setMainViewState(state)
     setEditMessage('')
   }
-
-  const isDownloadALocalModel = downloadedModels.some((x) =>
-    localEngines.includes(x.engine)
-  )
 
   const RibbonNavMenus = [
     {

--- a/web/containers/Layout/TopPanel/index.tsx
+++ b/web/containers/Layout/TopPanel/index.tsx
@@ -34,6 +34,11 @@ import {
   reduceTransparentAtom,
   selectedSettingAtom,
 } from '@/helpers/atoms/Setting.atom'
+import {
+  isAnyRemoteModelConfiguredAtom,
+  isDownloadALocalModelAtom,
+  threadsAtom,
+} from '@/helpers/atoms/Thread.atom'
 import { activeTabThreadRightPanelAtom } from '@/helpers/atoms/ThreadRightPanel.atom'
 
 const TopPanel = () => {
@@ -46,6 +51,11 @@ const TopPanel = () => {
   const assistants = useAtomValue(assistantsAtom)
   const [activeTabThreadRightPanel, setActiveTabThreadRightPanel] = useAtom(
     activeTabThreadRightPanelAtom
+  )
+  const threads = useAtomValue(threadsAtom)
+  const isDownloadALocalModel = useAtomValue(isDownloadALocalModelAtom)
+  const isAnyRemoteModelConfigured = useAtomValue(
+    isAnyRemoteModelConfiguredAtom
   )
 
   const onCreateNewThreadClick = () => {
@@ -93,18 +103,20 @@ const TopPanel = () => {
               )}
             </Fragment>
           )}
-          {mainViewState === MainViewState.Thread && (
-            <Button
-              data-testid="btn-create-thread"
-              onClick={onCreateNewThreadClick}
-              theme="icon"
-            >
-              <PenSquareIcon
-                size={16}
-                className="cursor-pointer text-[hsla(var(--text-secondary))]"
-              />
-            </Button>
-          )}
+          {mainViewState === MainViewState.Thread &&
+            Boolean(threads.length) &&
+            (isDownloadALocalModel || isAnyRemoteModelConfigured) && (
+              <Button
+                data-testid="btn-create-thread"
+                onClick={onCreateNewThreadClick}
+                theme="icon"
+              >
+                <PenSquareIcon
+                  size={16}
+                  className="cursor-pointer text-[hsla(var(--text-secondary))]"
+                />
+              </Button>
+            )}
         </div>
         <div className="unset-drag flex items-center gap-x-2">
           {mainViewState !== MainViewState.Hub &&

--- a/web/containers/Layout/TopPanel/index.tsx
+++ b/web/containers/Layout/TopPanel/index.tsx
@@ -103,20 +103,24 @@ const TopPanel = () => {
               )}
             </Fragment>
           )}
-          {mainViewState === MainViewState.Thread &&
-            Boolean(threads.length) &&
-            (isDownloadALocalModel || isAnyRemoteModelConfigured) && (
-              <Button
-                data-testid="btn-create-thread"
-                onClick={onCreateNewThreadClick}
-                theme="icon"
-              >
-                <PenSquareIcon
-                  size={16}
-                  className="cursor-pointer text-[hsla(var(--text-secondary))]"
-                />
-              </Button>
-            )}
+          {mainViewState === MainViewState.Thread && (
+            <Button
+              data-testid="btn-create-thread"
+              onClick={onCreateNewThreadClick}
+              theme="icon"
+              className={twMerge(
+                'invisible',
+                Boolean(threads.length) &&
+                  (isDownloadALocalModel || isAnyRemoteModelConfigured) &&
+                  'visible'
+              )}
+            >
+              <PenSquareIcon
+                size={16}
+                className="cursor-pointer text-[hsla(var(--text-secondary))]"
+              />
+            </Button>
+          )}
         </div>
         <div className="unset-drag flex items-center gap-x-2">
           {mainViewState !== MainViewState.Hub &&

--- a/web/containers/Layout/TopPanel/index.tsx
+++ b/web/containers/Layout/TopPanel/index.tsx
@@ -23,6 +23,7 @@ import { toaster } from '@/containers/Toast'
 import { MainViewState } from '@/constants/screens'
 
 import { useCreateNewThread } from '@/hooks/useCreateNewThread'
+import { useStarterScreen } from '@/hooks/useStarterScreen'
 
 import {
   mainViewStateAtom,
@@ -34,11 +35,6 @@ import {
   reduceTransparentAtom,
   selectedSettingAtom,
 } from '@/helpers/atoms/Setting.atom'
-import {
-  isAnyRemoteModelConfiguredAtom,
-  isDownloadALocalModelAtom,
-  threadsAtom,
-} from '@/helpers/atoms/Thread.atom'
 import { activeTabThreadRightPanelAtom } from '@/helpers/atoms/ThreadRightPanel.atom'
 
 const TopPanel = () => {
@@ -52,11 +48,6 @@ const TopPanel = () => {
   const [activeTabThreadRightPanel, setActiveTabThreadRightPanel] = useAtom(
     activeTabThreadRightPanelAtom
   )
-  const threads = useAtomValue(threadsAtom)
-  const isDownloadALocalModel = useAtomValue(isDownloadALocalModelAtom)
-  const isAnyRemoteModelConfigured = useAtomValue(
-    isAnyRemoteModelConfiguredAtom
-  )
 
   const onCreateNewThreadClick = () => {
     if (!assistants.length)
@@ -67,6 +58,8 @@ const TopPanel = () => {
       })
     requestCreateNewThread(assistants[0])
   }
+
+  const { isShowStarterScreen } = useStarterScreen()
 
   return (
     <div
@@ -103,17 +96,11 @@ const TopPanel = () => {
               )}
             </Fragment>
           )}
-          {mainViewState === MainViewState.Thread && (
+          {mainViewState === MainViewState.Thread && !isShowStarterScreen && (
             <Button
               data-testid="btn-create-thread"
               onClick={onCreateNewThreadClick}
               theme="icon"
-              className={twMerge(
-                'invisible',
-                Boolean(threads.length) &&
-                  (isDownloadALocalModel || isAnyRemoteModelConfigured) &&
-                  'visible'
-              )}
             >
               <PenSquareIcon
                 size={16}

--- a/web/helpers/atoms/Thread.atom.ts
+++ b/web/helpers/atoms/Thread.atom.ts
@@ -152,3 +152,6 @@ export const modalActionThreadAtom = atom<{
   showModal: undefined,
   thread: undefined,
 })
+
+export const isDownloadALocalModelAtom = atom<boolean>(false)
+export const isAnyRemoteModelConfiguredAtom = atom<boolean>(false)

--- a/web/hooks/useStarterScreen.ts
+++ b/web/hooks/useStarterScreen.ts
@@ -63,13 +63,8 @@ export function useStarterScreen() {
     (x) => x.apiKey.length > 1
   )
 
-  let isShowStarterScreen
-
-  isShowStarterScreen =
+  const isShowStarterScreen =
     !isAnyRemoteModelConfigured && !isDownloadALocalModel && !threads.length
-
-  // Remove this part when we rework on starter screen
-  isShowStarterScreen = false
 
   return {
     extensionHasSettings,

--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/OnDeviceStarterScreen/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/OnDeviceStarterScreen/index.tsx
@@ -58,9 +58,21 @@ const OnDeviceStarterScreen = ({ extensionHasSettings }: Props) => {
   const configuredModels = useAtomValue(configuredModelsAtom)
   const setMainViewState = useSetAtom(mainViewStateAtom)
 
-  const featuredModel = configuredModels.filter(
-    (x) => x.metadata.tags.includes('Featured') && x.metadata.size < 5000000000
-  )
+  const recommendModel = ['gemma-2-2b-it', 'llama3.1-8b-instruct']
+
+  const featuredModel = configuredModels.filter((x) => {
+    const manualRecommendModel = configuredModels.filter((x) =>
+      recommendModel.includes(x.id)
+    )
+
+    if (manualRecommendModel.length === 2) {
+      return x.id === recommendModel[0] || x.id === recommendModel[1]
+    } else {
+      return (
+        x.metadata.tags.includes('Featured') && x.metadata.size < 5000000000
+      )
+    }
+  })
 
   const remoteModel = configuredModels.filter(
     (x) => !localEngines.includes(x.engine)

--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/OnDeviceStarterScreen/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/OnDeviceStarterScreen/index.tsx
@@ -105,7 +105,7 @@ const OnDeviceStarterScreen = ({ extensionHasSettings }: Props) => {
               width={48}
               height={48}
             />
-            <h1 className="text-base font-semibold">Select a model to start</h1>
+            <h1 className="text-base font-medium">Select a model to start</h1>
             <div className="mt-6 w-[320px] md:w-[400px]">
               <Fragment>
                 <div className="relative" ref={refDropdown}>
@@ -120,7 +120,7 @@ const OnDeviceStarterScreen = ({ extensionHasSettings }: Props) => {
                   />
                   <div
                     className={twMerge(
-                      'absolute left-0 top-10 max-h-[240px] w-full overflow-x-auto rounded-lg border border-[hsla(var(--app-border))] bg-[hsla(var(--app-bg))]',
+                      'absolute left-0 top-10 z-20 max-h-[240px] w-full overflow-x-auto rounded-lg border border-[hsla(var(--app-border))] bg-[hsla(var(--app-bg))]',
                       !isOpen ? 'invisible' : 'visible'
                     )}
                   >
@@ -205,11 +205,11 @@ const OnDeviceStarterScreen = ({ extensionHasSettings }: Props) => {
                   return (
                     <div
                       key={featModel.id}
-                      className="my-2 flex items-center justify-between gap-2 border-b border-[hsla(var(--app-border))] py-4 last:border-none"
+                      className="my-2 flex items-center justify-between gap-2 border-b border-[hsla(var(--app-border))] pb-4 pt-1 last:border-none"
                     >
                       <div className="w-full text-left">
-                        <h6>{featModel.name}</h6>
-                        <p className="mt-4 text-[hsla(var(--text-secondary))]">
+                        <h6 className="font-medium">{featModel.name}</h6>
+                        <p className="mt-2 font-medium text-[hsla(var(--text-secondary))]">
                           {featModel.metadata.author}
                         </p>
                       </div>
@@ -250,7 +250,7 @@ const OnDeviceStarterScreen = ({ extensionHasSettings }: Props) => {
                           >
                             Download
                           </Button>
-                          <span className="font-medium text-[hsla(var(--text-secondary))]">
+                          <span className="text-[hsla(var(--text-secondary))]">
                             {toGibibytes(featModel.metadata.size)}
                           </span>
                         </div>
@@ -259,7 +259,7 @@ const OnDeviceStarterScreen = ({ extensionHasSettings }: Props) => {
                   )
                 })}
 
-                <div className="mb-4 mt-8 flex items-center justify-between">
+                <div className="mb-2 mt-8 flex items-center justify-between">
                   <h2 className="text-[hsla(var(--text-secondary))]">
                     Cloud Models
                   </h2>
@@ -270,7 +270,7 @@ const OnDeviceStarterScreen = ({ extensionHasSettings }: Props) => {
                     return (
                       <div
                         key={rowIndex}
-                        className="my-2 flex items-center justify-center gap-4 md:gap-10"
+                        className="my-2 flex items-center gap-4 md:gap-10"
                       >
                         {row.map((remoteEngine) => {
                           const engineLogo = getLogoEngine(
@@ -300,7 +300,7 @@ const OnDeviceStarterScreen = ({ extensionHasSettings }: Props) => {
                                 />
                               )}
 
-                              <p>
+                              <p className="font-medium">
                                 {getTitleByEngine(
                                   remoteEngine as InferenceEngine
                                 )}

--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/OnDeviceStarterScreen/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/OnDeviceStarterScreen/index.tsx
@@ -216,28 +216,30 @@ const OnDeviceStarterScreen = ({ extensionHasSettings }: Props) => {
 
                       {isDownloading ? (
                         <div className="flex w-full items-center gap-2">
-                          {Object.values(downloadStates).map((item, i) => (
-                            <div
-                              className="flex w-full items-center gap-2"
-                              key={i}
-                            >
-                              <Progress
-                                className="w-full"
-                                value={
-                                  formatDownloadPercentage(item?.percent, {
-                                    hidePercentage: true,
-                                  }) as number
-                                }
-                              />
-                              <div className="flex items-center justify-between gap-x-2">
-                                <div className="flex gap-x-2">
-                                  <span className="font-medium text-[hsla(var(--primary-bg))]">
-                                    {formatDownloadPercentage(item?.percent)}
-                                  </span>
+                          {Object.values(downloadStates)
+                            .filter((x) => x.modelId === featModel.id)
+                            .map((item, i) => (
+                              <div
+                                className="flex w-full items-center gap-2"
+                                key={i}
+                              >
+                                <Progress
+                                  className="w-full"
+                                  value={
+                                    formatDownloadPercentage(item?.percent, {
+                                      hidePercentage: true,
+                                    }) as number
+                                  }
+                                />
+                                <div className="flex items-center justify-between gap-x-2">
+                                  <div className="flex gap-x-2">
+                                    <span className="font-medium text-[hsla(var(--primary-bg))]">
+                                      {formatDownloadPercentage(item?.percent)}
+                                    </span>
+                                  </div>
                                 </div>
                               </div>
-                            </div>
-                          ))}
+                            ))}
                         </div>
                       ) : (
                         <div className="flex flex-col items-end justify-end gap-2">

--- a/web/screens/Thread/index.test.tsx
+++ b/web/screens/Thread/index.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import ThreadScreen from './index'
+import { useStarterScreen } from '../../hooks/useStarterScreen'
+import '@testing-library/jest-dom'
+
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+// Mock the useStarterScreen hook
+jest.mock('@/hooks/useStarterScreen')
+
+describe('ThreadScreen', () => {
+  it('renders OnDeviceStarterScreen when isShowStarterScreen is true', () => {
+    ;(useStarterScreen as jest.Mock).mockReturnValue({
+      isShowStarterScreen: true,
+      extensionHasSettings: false,
+    })
+
+    const { getByText } = render(<ThreadScreen />)
+    expect(getByText('Select a model to start')).toBeInTheDocument()
+  })
+
+  it('renders Thread panels when isShowStarterScreen is false', () => {
+    ;(useStarterScreen as jest.Mock).mockReturnValue({
+      isShowStarterScreen: false,
+      extensionHasSettings: false,
+    })
+
+    const { getByText } = render(<ThreadScreen />)
+    expect(getByText('Welcome!')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Describe Your Changes

1. Disable the "New Threads" icon on the top
![image](https://github.com/user-attachments/assets/ea747944-3bac-43b2-a359-6f42e8d11a5d)

2. Duplicate render progress bar when more than one download from feat/suggestion model.
<img width="1032" alt="Screenshot 2024-09-14 at 23 01 20" src="https://github.com/user-attachments/assets/03bf1a58-0092-4fdb-94db-a91f356539bc">

3. @louis-jan temporary with hard-coded recommend model

4. Overlap progress bar when dropdown search open

![image](https://github.com/user-attachments/assets/6e840a29-f00f-4045-aaad-bec1a4c53e69)

5. Cloud model should be left aligned
![image](https://github.com/user-attachments/assets/e9b754e8-8c0d-4938-a3ee-bc0b265d84e7)

6. Update UI regarding miss font weight and spacing
![image](https://github.com/user-attachments/assets/aabf35f6-03af-4ca4-8d35-bc7fc747c479)



### Changes code:

1. Update conditional render `New threads` icon when user downloads a local model or configured any cloud model and thread length 
<img width="1038" alt="Screenshot 2024-09-15 at 00 34 40" src="https://github.com/user-attachments/assets/257b9030-d0b3-464d-b9b2-7ee005e11a93">

2. The new code filters the `downloadStates` object values using the condition `x.modelId === featModel.id`. This means that only items with a `modelId` matching `featModel.id` will be rendered.
<img width="1042" alt="Screenshot 2024-09-14 at 23 24 14" src="https://github.com/user-attachments/assets/91508ffe-0471-4b84-b20a-e23115155911">

3. temporary with hard-coded recommend model 

4. Update `z-index` to avoid overlap, since the element dropdown options is absolute 
<img width="1055" alt="Screenshot 2024-09-15 at 00 42 34" src="https://github.com/user-attachments/assets/a5f18c43-aca4-46a0-a600-5cbc14aedddf">

5. Removed justify center flex 
 <img width="1119" alt="Screenshot 2024-09-15 at 00 47 24" src="https://github.com/user-attachments/assets/dc81aeeb-ff74-47f8-a410-9037199d5a55">

6. Change some class font weight and spacing
<img width="1094" alt="Screenshot 2024-09-15 at 01 01 35" src="https://github.com/user-attachments/assets/f5b94fda-5db4-440a-a226-5f65a3ce7a85">


## Fixes Issues

- Closes #3660  
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
