### PR TITLE
fix: correct prompt template for Phi3 Medium model

### DIFF
--- a/extensions/inference-nitro-extension/package.json
+++ b/extensions/inference-nitro-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janhq/inference-cortex-extension",
   "productName": "Cortex Inference Engine",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "This extension embeds cortex.cpp, a lightweight inference engine written in C++. See https://jan.ai.\nAdditional dependencies could be installed to run without Cuda Toolkit installation.",
   "main": "dist/index.js",
   "node": "dist/node/index.cjs.js",

--- a/extensions/inference-nitro-extension/resources/models/phi3-medium/model.json
+++ b/extensions/inference-nitro-extension/resources/models/phi3-medium/model.json
@@ -8,12 +8,12 @@
     "id": "phi3-medium",
     "object": "model",
     "name": "Phi-3 Medium Instruct Q4",
-    "version": "1.3",
+    "version": "1.4",
     "description": "Phi-3 Medium is Microsoft's latest SOTA model.",
     "format": "gguf",
     "settings": {
       "ctx_len": 128000,
-      "prompt_template": "<|user|> {prompt}<|end|><|assistant|><|end|>",
+      "prompt_template": "<|user|> {prompt}<|end|><|assistant|>",
       "llama_model_path": "Phi-3-medium-128k-instruct-Q4_K_M.gguf",
       "ngl": 33
     },


### PR DESCRIPTION
## Description

- There was an issue with the Phi-3 Medium prompt template (0.5.3), which lead to a wrong output like this:

| <Assistant> |
|:-:|
|![Sept 16 Screenshot from Discord](https://github.com/user-attachments/assets/d787f733-28b3-41ba-b7c4-ac1ed426f18c)|

- This is the second attempt at correcting the model prompt template, and the result should be like this:

| <Assistant> |
|:-:|
|![Sept 16 Screenshot from Discord (1)](https://github.com/user-attachments/assets/50188778-998d-4496-a2d3-3ce2f1dafdc5)|

## Changes made
1. The model version has been updated from "1.3" to "1.4".

2. The prompt template has been modified:
   - Old: "<|user|> {prompt}<|end|><|assistant|><|end|>"
   - New: "<|user|> {prompt}<|end|><|assistant|>"

   The main difference is the removal of "<|end|>" after "<|assistant|>".

## Fixes Issues

- #3608

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
