### PR TITLE
fix: #3667 - The recommended label should be hidden

### DIFF
--- a/web/containers/ModelLabel/ModelLabel.test.tsx
+++ b/web/containers/ModelLabel/ModelLabel.test.tsx
@@ -1,0 +1,100 @@
+import React from 'react'
+import { render, waitFor, screen } from '@testing-library/react'
+import { useAtomValue } from 'jotai'
+import { useActiveModel } from '@/hooks/useActiveModel'
+import { useSettings } from '@/hooks/useSettings'
+import ModelLabel from '@/containers/ModelLabel'
+
+jest.mock('jotai', () => ({
+  useAtomValue: jest.fn(),
+  atom: jest.fn(),
+}))
+
+jest.mock('@/hooks/useActiveModel', () => ({
+  useActiveModel: jest.fn(),
+}))
+
+jest.mock('@/hooks/useSettings', () => ({
+  useSettings: jest.fn(),
+}))
+
+describe('ModelLabel', () => {
+  const mockUseAtomValue = useAtomValue as jest.Mock
+  const mockUseActiveModel = useActiveModel as jest.Mock
+  const mockUseSettings = useSettings as jest.Mock
+
+  const defaultProps: any = {
+    metadata: {
+      author: 'John Doe', // Add the 'author' property with a value
+      tags: ['8B'],
+      size: 100,
+    },
+    compact: false,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders NotEnoughMemoryLabel when minimumRamModel is greater than totalRam', async () => {
+    mockUseAtomValue
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0)
+    mockUseActiveModel.mockReturnValue({
+      activeModel: { metadata: { size: 0 } },
+    })
+    mockUseSettings.mockReturnValue({ settings: { run_mode: 'cpu' } })
+
+    render(<ModelLabel {...defaultProps} />)
+    await waitFor(() => {
+      expect(screen.getByText('Not enough RAM')).toBeDefined()
+    })
+  })
+
+  it('renders SlowOnYourDeviceLabel when minimumRamModel is less than totalRam but greater than availableRam', async () => {
+    mockUseAtomValue
+      .mockReturnValueOnce(100)
+      .mockReturnValueOnce(50)
+      .mockReturnValueOnce(10)
+    mockUseActiveModel.mockReturnValue({
+      activeModel: { metadata: { size: 0 } },
+    })
+    mockUseSettings.mockReturnValue({ settings: { run_mode: 'cpu' } })
+
+    const props = {
+      ...defaultProps,
+      metadata: {
+        ...defaultProps.metadata,
+        size: 50,
+      },
+    }
+
+    render(<ModelLabel {...props} />)
+    await waitFor(() => {
+      expect(screen.getByText('Slow on your device')).toBeDefined()
+    })
+  })
+
+  it('renders nothing when minimumRamModel is less than availableRam', () => {
+    mockUseAtomValue
+      .mockReturnValueOnce(100)
+      .mockReturnValueOnce(50)
+      .mockReturnValueOnce(0)
+    mockUseActiveModel.mockReturnValue({
+      activeModel: { metadata: { size: 0 } },
+    })
+    mockUseSettings.mockReturnValue({ settings: { run_mode: 'cpu' } })
+
+    const props = {
+      ...defaultProps,
+      metadata: {
+        ...defaultProps.metadata,
+        size: 10,
+      },
+    }
+
+    const { container } = render(<ModelLabel {...props} />)
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/web/containers/ModelLabel/index.tsx
+++ b/web/containers/ModelLabel/index.tsx
@@ -10,8 +10,6 @@ import { useSettings } from '@/hooks/useSettings'
 
 import NotEnoughMemoryLabel from './NotEnoughMemoryLabel'
 
-import RecommendedLabel from './RecommendedLabel'
-
 import SlowOnYourDeviceLabel from './SlowOnYourDeviceLabel'
 
 import {
@@ -53,9 +51,7 @@ const ModelLabel = ({ metadata, compact }: Props) => {
         />
       )
     }
-    if (minimumRamModel < availableRam && !compact) {
-      return <RecommendedLabel />
-    }
+
     if (minimumRamModel < totalRam && minimumRamModel > availableRam) {
       return <SlowOnYourDeviceLabel compact={compact} />
     }


### PR DESCRIPTION
## Description
It can be confusing when a recommended tag is applied to all models using the `model size < available RAM/VRAM` formula, because in reality, these models can still perform slowly on users' machines due to lack of GPU acceleration and the need to handle large contexts.

## Decision
Hide the "Recommended" tag in the Hub and only display compatibility tags for models that are marked as "Slow on your device" or "Not enough RAM".

## Fixes Issues
- #3667

## Screenshots 

<img width="1339" alt="Screenshot 2024-09-17 at 15 01 59" src="https://github.com/user-attachments/assets/3f4529a0-10b7-4470-abd4-bbd533203f41">


## Changes made

**Changes in `ModelLabel.test.tsx`:**

Three test cases are defined to cover different scenarios:
    *   The first test case checks if the `ModelLabel` component renders the `NotEnoughMemoryLabel` when the minimum RAM model is greater than the total RAM.
    *   The second test case checks if the `ModelLabel` component renders the `SlowOnYourDeviceLabel` when the minimum RAM model is less than the total RAM but greater than the available RAM.
    *   The third test case checks if the `ModelLabel` component renders nothing when the minimum RAM model is less than the available RAM.

**Changes in `index.tsx`:**

1.  The `index.tsx` file has been updated to remove the `RecommendedLabel` import and component invocation.
2.  The `ModelLabel` component's logic has been updated to only render the `SlowOnYourDeviceLabel` when the minimum RAM model is less than the total RAM and the available RAM. The `RecommendedLabel` component is no longer conditionally rendered.
