### PR TITLE
feat: textarea auto resize

### DIFF
--- a/joi/src/core/TextArea/TextArea.test.tsx
+++ b/joi/src/core/TextArea/TextArea.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
+import { act } from 'react-dom/test-utils'
 import { TextArea } from './index'
 
 // Mock the styles import
@@ -30,5 +31,59 @@ describe('@joi/core/TextArea', () => {
     render(<TextArea data-testid="custom-textarea" rows={5} />)
     const textareaElement = screen.getByTestId('custom-textarea')
     expect(textareaElement).toHaveAttribute('rows', '5')
+  })
+
+  it('resizes correctly based scrollHeight', () => {
+    const { container } = render(<TextArea autoResize />)
+    const textareaElement = container.querySelector('textarea')
+
+    // Mocking the scrollHeight
+    act(() => {
+      if (textareaElement) {
+        Object.defineProperty(textareaElement, 'scrollHeight', {
+          value: 80,
+          writable: false,
+        })
+        textareaElement.dispatchEvent(new Event('input', { bubbles: true }))
+      }
+    })
+
+    expect(textareaElement.scrollHeight).toBe(80)
+  })
+
+  it('resizes correctly based on min height', () => {
+    const { container } = render(<TextArea autoResize minResize={100} />)
+    const textareaElement = container.querySelector('textarea')
+
+    // Mocking the scrollHeight
+    act(() => {
+      if (textareaElement) {
+        Object.defineProperty(textareaElement, 'scrollHeight', {
+          value: 100,
+          writable: false,
+        })
+        textareaElement.dispatchEvent(new Event('input', { bubbles: true }))
+      }
+    })
+
+    expect(textareaElement.scrollHeight).toBe(100)
+  })
+
+  it('resizes correctly based on max height', () => {
+    const { container } = render(<TextArea autoResize maxResize={400} />)
+    const textareaElement = container.querySelector('textarea')
+
+    // Mocking the scrollHeight
+    act(() => {
+      if (textareaElement) {
+        Object.defineProperty(textareaElement, 'scrollHeight', {
+          value: 400,
+          writable: false,
+        })
+        textareaElement.dispatchEvent(new Event('input', { bubbles: true }))
+      }
+    })
+
+    expect(textareaElement.scrollHeight).toBe(400)
   })
 })

--- a/joi/src/core/TextArea/TextArea.test.tsx
+++ b/joi/src/core/TextArea/TextArea.test.tsx
@@ -70,7 +70,7 @@ describe('@joi/core/TextArea', () => {
   })
 
   it('resizes correctly based on max height', () => {
-    const { container } = render(<TextArea autoResize maxResize={400} />)
+    const { container } = render(<TextArea autoResize maxResize={200} />)
     const textareaElement = container.querySelector('textarea')
 
     // Mocking the scrollHeight

--- a/joi/src/core/TextArea/TextArea.test.tsx
+++ b/joi/src/core/TextArea/TextArea.test.tsx
@@ -1,10 +1,8 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, act } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import { act } from 'react-dom/test-utils'
 import { TextArea } from './index'
 
-// Mock the styles import
 jest.mock('./styles.scss', () => ({}))
 
 describe('@joi/core/TextArea', () => {
@@ -33,57 +31,39 @@ describe('@joi/core/TextArea', () => {
     expect(textareaElement).toHaveAttribute('rows', '5')
   })
 
-  it('resizes correctly based scrollHeight', () => {
-    const { container } = render(<TextArea autoResize />)
-    const textareaElement = container.querySelector('textarea')
+  it('should auto resize the textarea based on minResize', () => {
+    render(<TextArea autoResize minResize={10} />)
 
-    // Mocking the scrollHeight
-    act(() => {
-      if (textareaElement) {
-        Object.defineProperty(textareaElement, 'scrollHeight', {
-          value: 80,
-          writable: false,
-        })
-        textareaElement.dispatchEvent(new Event('input', { bubbles: true }))
-      }
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+
+    Object.defineProperty(textarea, 'scrollHeight', {
+      value: 20,
+      writable: true,
     })
 
-    expect(textareaElement.scrollHeight).toBe(80)
+    act(() => {
+      textarea.value = 'Short text'
+      textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+
+    expect(textarea.style.height).toBe('10px')
   })
 
-  it('resizes correctly based on min height', () => {
-    const { container } = render(<TextArea autoResize minResize={100} />)
-    const textareaElement = container.querySelector('textarea')
+  it('should auto resize the textarea based on maxResize', () => {
+    render(<TextArea autoResize maxResize={40} />)
 
-    // Mocking the scrollHeight
-    act(() => {
-      if (textareaElement) {
-        Object.defineProperty(textareaElement, 'scrollHeight', {
-          value: 100,
-          writable: false,
-        })
-        textareaElement.dispatchEvent(new Event('input', { bubbles: true }))
-      }
+    const textarea = screen.getByRole('textbox') as HTMLTextAreaElement
+
+    Object.defineProperty(textarea, 'scrollHeight', {
+      value: 100,
+      writable: true,
     })
 
-    expect(textareaElement.scrollHeight).toBe(100)
-  })
-
-  it('resizes correctly based on max height', () => {
-    const { container } = render(<TextArea autoResize maxResize={200} />)
-    const textareaElement = container.querySelector('textarea')
-
-    // Mocking the scrollHeight
     act(() => {
-      if (textareaElement) {
-        Object.defineProperty(textareaElement, 'scrollHeight', {
-          value: 400,
-          writable: false,
-        })
-        textareaElement.dispatchEvent(new Event('input', { bubbles: true }))
-      }
+      textarea.value = 'A very long text that should exceed max height'
+      textarea.dispatchEvent(new Event('input', { bubbles: true }))
     })
 
-    expect(textareaElement.scrollHeight).toBe(400)
+    expect(textarea.style.height).toBe('40px')
   })
 })

--- a/joi/src/core/TextArea/index.tsx
+++ b/joi/src/core/TextArea/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, forwardRef, useRef, useEffect } from 'react'
+import React, { forwardRef, useRef, useEffect } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 import './styles.scss'
@@ -15,30 +15,21 @@ export interface TextAreaProps
 
 const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
   (
-    { autoResize, minResize = 84, maxResize = 250, className, ...props },
+    { autoResize, minResize = 80, maxResize = 250, className, ...props },
     ref
   ) => {
     const textareaRef = useRef<HTMLTextAreaElement>(null)
 
     useEffect(() => {
-      if (autoResize && textareaRef.current?.clientHeight) {
+      if (autoResize && textareaRef.current) {
         const textarea = textareaRef.current
-        textarea.style.height = minResize + 'px'
-        textarea.style.overflow = 'hidden'
-
-        const scrollHeight = textareaRef.current.scrollHeight
-
-        textareaRef.current.style.height = scrollHeight + 'px'
-
-        textareaRef.current.style.height =
-          textareaRef.current.scrollHeight + 'px'
-
-        textareaRef.current.style.maxHeight = maxResize + 'px'
-
-        textareaRef.current.style.overflow =
-          textareaRef.current.scrollHeight >= maxResize ? 'auto' : 'hidden'
+        textarea.style.height = 'auto'
+        const scrollHeight = textarea.scrollHeight
+        const newHeight = Math.min(maxResize, Math.max(minResize, scrollHeight))
+        textarea.style.height = `${newHeight}px`
+        textarea.style.overflow = newHeight >= maxResize ? 'auto' : 'hidden'
       }
-    }, [props.value])
+    }, [props.value, autoResize, minResize, maxResize])
 
     return (
       <div className="textarea__wrapper">

--- a/joi/src/core/TextArea/index.tsx
+++ b/joi/src/core/TextArea/index.tsx
@@ -1,19 +1,50 @@
-import React, { ReactNode, forwardRef } from 'react'
+import React, { ReactNode, forwardRef, useRef, useEffect } from 'react'
 import { twMerge } from 'tailwind-merge'
 
 import './styles.scss'
-import { ScrollArea } from '../ScrollArea'
+
+type ResizeProps = {
+  autoResize?: boolean
+  minResize?: number
+  maxResize?: number
+}
 
 export interface TextAreaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+  extends ResizeProps,
+    React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
 
 const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
-  ({ className, ...props }, ref) => {
+  (
+    { autoResize, minResize = 84, maxResize = 250, className, ...props },
+    ref
+  ) => {
+    const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+    useEffect(() => {
+      if (autoResize && textareaRef.current?.clientHeight) {
+        const textarea = textareaRef.current
+        textarea.style.height = minResize + 'px'
+        textarea.style.overflow = 'hidden'
+
+        const scrollHeight = textareaRef.current.scrollHeight
+
+        textareaRef.current.style.height = scrollHeight + 'px'
+
+        textareaRef.current.style.height =
+          textareaRef.current.scrollHeight + 'px'
+
+        textareaRef.current.style.maxHeight = maxResize + 'px'
+
+        textareaRef.current.style.overflow =
+          textareaRef.current.scrollHeight >= maxResize ? 'auto' : 'hidden'
+      }
+    }, [props.value])
+
     return (
       <div className="textarea__wrapper">
         <textarea
           className={twMerge('textarea', className)}
-          ref={ref}
+          ref={autoResize ? textareaRef : ref}
           {...props}
         />
       </div>

--- a/web/containers/ModelConfigInput/index.tsx
+++ b/web/containers/ModelConfigInput/index.tsx
@@ -36,7 +36,7 @@ const ModelConfigInput = ({
     <TextArea
       placeholder={placeholder}
       onChange={(e) => onValueChanged?.(e.target.value)}
-      cols={50}
+      autoResize
       value={value}
       disabled={disabled}
     />

--- a/web/containers/ModelSetting/SettingComponent.tsx
+++ b/web/containers/ModelSetting/SettingComponent.tsx
@@ -20,6 +20,8 @@ const SettingComponent: React.FC<Props> = ({
   disabled = false,
   onValueUpdated,
 }) => {
+  console.log(componentProps)
+
   const components = componentProps.map((data) => {
     switch (data.controllerType) {
       case 'slider': {

--- a/web/containers/ModelSetting/SettingComponent.tsx
+++ b/web/containers/ModelSetting/SettingComponent.tsx
@@ -20,8 +20,6 @@ const SettingComponent: React.FC<Props> = ({
   disabled = false,
   onValueUpdated,
 }) => {
-  console.log(componentProps)
-
   const components = componentProps.map((data) => {
     switch (data.controllerType) {
       case 'slider': {

--- a/web/screens/Thread/ThreadRightPanel/index.tsx
+++ b/web/screens/Thread/ThreadRightPanel/index.tsx
@@ -247,7 +247,7 @@ const ThreadRightPanel = () => {
                 id="assistant-instructions"
                 placeholder="Eg. You are a helpful assistant."
                 value={activeThread?.assistants[0].instructions ?? ''}
-                rows={8}
+                autoResize
                 onChange={onAssistantInstructionChanged}
               />
             </div>


### PR DESCRIPTION
## Describe Your Changes

`TextArea` component enhances user experience by automatically adjusting its height based on content, while also allowing customization through props. This makes it suitable for dynamic input scenarios where the amount of text can vary significantly.

```tsx
autoResize?: boolean
minResize?: number
maxResize?: number
```

`Auto-Resizing Logic`

The `useEffect` hook adjusts the height of the textarea based on its scroll height whenever the value changes.
It sets the height to the minimum value initially, then adjusts it based on the content, ensuring it does not exceed the maximum height.

https://github.com/user-attachments/assets/1c8cedb1-3b14-4d95-9e81-f34531f423e1

## Fixes Issues

- Closes #3649 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
