### PR TITLE
fix: toolbar overlap chat input

### DIFF
--- a/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
@@ -392,7 +392,7 @@ const ChatInput = () => {
         {activeSettingInputBox && (
           <div
             className={twMerge(
-              'absolute bottom-[6px] left-[1px] flex w-[calc(100%-2px)] items-center justify-between rounded-lg bg-[hsla(var(--textarea-bg))] p-3',
+              'absolute bottom-[6px] left-[1px] flex w-[calc(100%-10px)] items-center justify-between rounded-b-lg bg-[hsla(var(--center-panel-bg))] p-3 pr-0',
               !activeThread && 'bg-transparent',
               stateModel.loading && 'bg-transparent'
             )}


### PR DESCRIPTION
## Describe Your Changes

- Fix toolbar chat input overlap
<img width="1104" alt="Screenshot 2024-09-23 at 13 53 25" src="https://github.com/user-attachments/assets/aeee2d4a-dd35-4fdb-85e7-f80de8b22080">
<img width="1103" alt="Screenshot 2024-09-23 at 13 53 11" src="https://github.com/user-attachments/assets/db7a1cff-d3ec-4187-916e-c8a5084b11d1">
<img width="1043" alt="Screenshot 2024-09-23 at 13 54 06" src="https://github.com/user-attachments/assets/984481f9-d41e-4828-ac28-27dd655cbc17">
<img width="1053" alt="Screenshot 2024-09-23 at 13 53 54" src="https://github.com/user-attachments/assets/44e0c0dd-82d6-40bd-ae99-669dcbf6e667">

### Known Issue
We are using `bg-textarea` for our toolbar because the `textarea` is on the right panel and needs a blur effect. 
That’s why we don’t set a background for the textarea, instead, the toolbar background should match the center panel. 

The code changes only update the background class for the toolbar element and reposition the toolbar to fit with the chat input, as the toolbar is positioned absolutely

## Fixes Issues

- Closes #3647 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
