### PR TITLE
fix: #3515 - The default assistant instructions are ignored

### DIFF
--- a/web/hooks/useCreateNewThread.test.ts
+++ b/web/hooks/useCreateNewThread.test.ts
@@ -1,0 +1,224 @@
+// useCreateNewThread.test.ts
+import { renderHook, act } from '@testing-library/react'
+import { useCreateNewThread } from './useCreateNewThread'
+import { useAtomValue, useSetAtom } from 'jotai'
+import { useActiveModel } from './useActiveModel'
+import useRecommendedModel from './useRecommendedModel'
+import useSetActiveThread from './useSetActiveThread'
+import { extensionManager } from '@/extension'
+import { toaster } from '@/containers/Toast'
+
+// Mock the dependencies
+jest.mock('jotai', () => {
+  const originalModule = jest.requireActual('jotai')
+  return {
+    ...originalModule,
+    useAtomValue: jest.fn(),
+    useSetAtom: jest.fn(),
+  }
+})
+jest.mock('./useActiveModel')
+jest.mock('./useRecommendedModel')
+jest.mock('./useSetActiveThread')
+jest.mock('@/extension')
+jest.mock('@/containers/Toast')
+
+describe('useCreateNewThread', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should create a new thread', async () => {
+    const mockSetAtom = jest.fn()
+    ;(useSetAtom as jest.Mock).mockReturnValue(mockSetAtom)
+    ;(useAtomValue as jest.Mock).mockReturnValue({
+      metadata: {},
+      assistants: [
+        {
+          id: 'assistant1',
+          name: 'Assistant 1',
+          instructions: undefined,
+        },
+      ],
+    })
+    ;(useActiveModel as jest.Mock).mockReturnValue({ stopInference: jest.fn() })
+    ;(useRecommendedModel as jest.Mock).mockReturnValue({
+      recommendedModel: { id: 'model1', parameters: [], settings: [] },
+      downloadedModels: [],
+    })
+    ;(useSetActiveThread as jest.Mock).mockReturnValue({
+      setActiveThread: jest.fn(),
+    })
+    ;(extensionManager.get as jest.Mock).mockReturnValue({
+      saveThread: jest.fn(),
+    })
+
+    const { result } = renderHook(() => useCreateNewThread())
+
+    await act(async () => {
+      await result.current.requestCreateNewThread({
+        id: 'assistant1',
+        name: 'Assistant 1',
+        model: {
+          id: 'model1',
+          parameters: [],
+          settings: [],
+        },
+      } as any)
+    })
+
+    expect(mockSetAtom).toHaveBeenCalledTimes(6) // Check if all the necessary atoms were set
+    expect(extensionManager.get).toHaveBeenCalled()
+  })
+
+  it('should create a new thread with instructions', async () => {
+    const mockSetAtom = jest.fn()
+    ;(useSetAtom as jest.Mock).mockReturnValue(mockSetAtom)
+    ;(useAtomValue as jest.Mock).mockReturnValueOnce(false)
+    ;(useAtomValue as jest.Mock).mockReturnValue({
+      metadata: {},
+      assistants: [
+        {
+          id: 'assistant1',
+          name: 'Assistant 1',
+          instructions: 'Hello Jan',
+        },
+      ],
+    })
+    ;(useAtomValue as jest.Mock).mockReturnValueOnce(false)
+    ;(useActiveModel as jest.Mock).mockReturnValue({ stopInference: jest.fn() })
+    ;(useRecommendedModel as jest.Mock).mockReturnValue({
+      recommendedModel: { id: 'model1', parameters: [], settings: [] },
+      downloadedModels: [],
+    })
+    ;(useSetActiveThread as jest.Mock).mockReturnValue({
+      setActiveThread: jest.fn(),
+    })
+    ;(extensionManager.get as jest.Mock).mockReturnValue({
+      saveThread: jest.fn(),
+    })
+
+    const { result } = renderHook(() => useCreateNewThread())
+
+    await act(async () => {
+      await result.current.requestCreateNewThread({
+        id: 'assistant1',
+        name: 'Assistant 1',
+        instructions: "Hello Jan Assistant",
+        model: {
+          id: 'model1',
+          parameters: [],
+          settings: [],
+        },
+      } as any)
+    })
+
+    expect(mockSetAtom).toHaveBeenCalledTimes(6) // Check if all the necessary atoms were set
+    expect(extensionManager.get).toHaveBeenCalled()
+    expect(mockSetAtom).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        assistants: expect.arrayContaining([
+          expect.objectContaining({ instructions: 'Hello Jan Assistant' }),
+        ]),
+      })
+    )
+  })
+
+  it('should create a new thread with previous instructions', async () => {
+    const mockSetAtom = jest.fn()
+    ;(useSetAtom as jest.Mock).mockReturnValue(mockSetAtom)
+    ;(useAtomValue as jest.Mock).mockReturnValueOnce(true)
+    ;(useAtomValue as jest.Mock).mockReturnValueOnce({
+      metadata: {},
+      assistants: [
+        {
+          id: 'assistant1',
+          name: 'Assistant 1',
+          instructions: 'Hello Jan',
+        },
+      ],
+    })
+    ;(useAtomValue as jest.Mock).mockReturnValueOnce(true)
+    ;(useActiveModel as jest.Mock).mockReturnValue({ stopInference: jest.fn() })
+    ;(useRecommendedModel as jest.Mock).mockReturnValue({
+      recommendedModel: { id: 'model1', parameters: [], settings: [] },
+      downloadedModels: [],
+    })
+    ;(useSetActiveThread as jest.Mock).mockReturnValue({
+      setActiveThread: jest.fn(),
+    })
+    ;(extensionManager.get as jest.Mock).mockReturnValue({
+      saveThread: jest.fn(),
+    })
+
+    const { result } = renderHook(() => useCreateNewThread())
+
+    await act(async () => {
+      await result.current.requestCreateNewThread({
+        id: 'assistant1',
+        name: 'Assistant 1',
+        model: {
+          id: 'model1',
+          parameters: [],
+          settings: [],
+        },
+      } as any)
+    })
+
+    expect(mockSetAtom).toHaveBeenCalledTimes(6) // Check if all the necessary atoms were set
+    expect(extensionManager.get).toHaveBeenCalled()
+    expect(mockSetAtom).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        assistants: expect.arrayContaining([
+          expect.objectContaining({ instructions: 'Hello Jan' }),
+        ]),
+      })
+    )
+  })
+
+  it('should show a warning toast if trying to create an empty thread', async () => {
+    ;(useAtomValue as jest.Mock).mockReturnValue([{ metadata: {} }]) // Mock an empty thread
+    ;(useRecommendedModel as jest.Mock).mockReturnValue({
+      recommendedModel: null,
+      downloadedModels: [],
+    })
+
+    const { result } = renderHook(() => useCreateNewThread())
+
+    await act(async () => {
+      await result.current.requestCreateNewThread({
+        id: 'assistant1',
+        name: 'Assistant 1',
+        tools: [],
+      } as any)
+    })
+
+    expect(toaster).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'No new thread created.',
+        type: 'warning',
+      })
+    )
+  })
+
+  it('should update thread metadata', async () => {
+    const mockUpdateThread = jest.fn()
+    ;(useSetAtom as jest.Mock).mockReturnValue(mockUpdateThread)
+    ;(extensionManager.get as jest.Mock).mockReturnValue({
+      saveThread: jest.fn(),
+    })
+
+    const { result } = renderHook(() => useCreateNewThread())
+
+    const mockThread = { id: 'thread1', title: 'Test Thread' }
+
+    await act(async () => {
+      await result.current.updateThreadMetadata(mockThread as any)
+    })
+
+    expect(mockUpdateThread).toHaveBeenCalledWith(mockThread)
+    expect(extensionManager.get).toHaveBeenCalled()
+  })
+})

--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -115,7 +115,7 @@ export const useCreateNewThread = () => {
       : {}
 
     const createdAt = Date.now()
-    let instructions: string | undefined = undefined
+    let instructions: string | undefined = assistant.instructions
     if (copyOverInstructionEnabled) {
       instructions = activeThread?.assistants[0]?.instructions ?? undefined
     }


### PR DESCRIPTION
## Describe Your Changes

Fixed the issue #3515 

> Default instructions are no longer read from the configuration file when launching a new thread on linux.
I tried to remove the ~/jan file, remove my .AppImage file and install it from deb source (with today latest version) then fill again the "instructions" field in ~/jan/assistant/jan/assistant.json . Nothing work. I have to copy / paste my instructions from one thread to another instead of just spawning a new thread and go with my "all purpose for my needs" dev instructions.

## Fixes Issues

- Closes #3515

## Changes made

### New Tests in `useCreateNewThread.test.ts`

1. **Creating a New Thread:**
   - **Test Case**: `it('should create a new thread')`
   - **Description**: This test mocks the dependencies and verifies that the `requestCreateNewThread` function properly sets up and saves a new thread. Expectations include checking that specific atoms were set and that the `extensionManager.get` method was called.
  
2. **Creating a New Thread with Instructions:**
   - **Test Case**: `it('should create a new thread with instructions')`
   - **Description**: This test mocks the dependencies and adds an instruction to the new assistant. The test expects the new assistant to have the correct instruction and that the necessary atoms were set.

3. **Creating a New Thread with Previous Instructions:**
   - **Test Case**: `it('should create a new thread with previous instructions')`
   - **Description**: Similar to the previous test, this test uses previous instructions from another assistant. The test ensures that the correct instructions are copied and the atoms were set.

4. **Creating an Empty Thread (With Warning Toast):**
   - **Test Case**: `it('should show a warning toast if trying to create an empty thread')`
   - **Description**: This test simulates a situation where creating a thread is not possible due to missing required data. The expectation is that a warning toast is shown.

5. **Updating Thread Metadata:**
   - **Test Case**: `it('should update thread metadata')`
   - **Description**: This test mocks the dependencies and checks if the metadata of an existing thread can be updated successfully.

### Code Change

1. **Modification in `useCreateNewThread.ts`:**
   - The variable `instructions` is now initialized with `assistant.instructions` instead of `undefined`.
   - **Before**:
     ```typescript
     let instructions: string | undefined = undefined
     ```
   - **After**:
     ```typescript
     let instructions: string | undefined = assistant.instructions
     ```

This change reflects the behavior where the instructions of the assistant are directly used if they are available.
