### PR TITLE
chore: The monorepo jest configs should not cover extensions - they would be moved to mini repositories soon

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,10 +1,3 @@
 module.exports = {
-  projects: [
-    '<rootDir>/core',
-    '<rootDir>/web',
-    '<rootDir>/joi',
-    '<rootDir>/extensions/inference-nitro-extension',
-    '<rootDir>/extensions/conversational-extension',
-    '<rootDir>/extensions/model-extension',
-  ],
+  projects: ['<rootDir>/core', '<rootDir>/web', '<rootDir>/joi'],
 }


### PR DESCRIPTION
## Describe Your Changes

- Extensions should be ignored while running jest, since it should be covered during packaging.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
