### PR TITLE
fix: #3513 - Anthropic extension does not forward the system prompt

### DIFF
--- a/extensions/inference-anthropic-extension/jest.config.js
+++ b/extensions/inference-anthropic-extension/jest.config.js
@@ -1,0 +1,9 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    'node_modules/@janhq/core/.+\\.(j|t)s?$': 'ts-jest',
+  },
+  transformIgnorePatterns: ['node_modules/(?!@janhq/core/.*)'],
+}

--- a/extensions/inference-anthropic-extension/package.json
+++ b/extensions/inference-anthropic-extension/package.json
@@ -9,6 +9,7 @@
   "author": "Jan <service@jan.ai>",
   "license": "AGPL-3.0",
   "scripts": {
+    "test": "jest test",
     "build": "tsc -b . && webpack --config webpack.config.js",
     "build:publish": "rimraf *.tgz --glob && yarn build && npm pack && cpx *.tgz ../../pre-install",
     "sync:core": "cd ../.. && yarn build:core && cd extensions && rm yarn.lock &&  cd inference-anthropic-extension && yarn && yarn build:publish"

--- a/extensions/inference-anthropic-extension/src/anthropic.test.ts
+++ b/extensions/inference-anthropic-extension/src/anthropic.test.ts
@@ -1,0 +1,77 @@
+// Import necessary modules
+import JanInferenceAnthropicExtension, { Settings } from '.'
+import { PayloadType, ChatCompletionRole } from '@janhq/core'
+
+// Mocks
+jest.mock('@janhq/core', () => ({
+  RemoteOAIEngine: jest.fn().mockImplementation(() => ({
+    registerSettings: jest.fn(),
+    registerModels: jest.fn(),
+    getSetting: jest.fn(),
+    onChange: jest.fn(),
+    onSettingUpdate: jest.fn(),
+    onLoad: jest.fn(),
+    headers: jest.fn(),
+  })),
+  PayloadType: jest.fn(),
+  ChatCompletionRole: {
+    User: 'user' as const,
+    Assistant: 'assistant' as const,
+    System: 'system' as const,
+  },
+}))
+
+// Helper functions
+const createMockPayload = (): PayloadType => ({
+  messages: [
+    { role: ChatCompletionRole.System, content: 'Meow' },
+    { role: ChatCompletionRole.User, content: 'Hello' },
+    { role: ChatCompletionRole.Assistant, content: 'Hi there' },
+  ],
+  model: 'claude-v1',
+  stream: false,
+})
+
+describe('JanInferenceAnthropicExtension', () => {
+  let extension: JanInferenceAnthropicExtension
+
+  beforeEach(() => {
+    extension = new JanInferenceAnthropicExtension('', '')
+    extension.apiKey = 'mock-api-key'
+    extension.inferenceUrl = 'mock-endpoint'
+    jest.clearAllMocks()
+  })
+
+  it('should initialize with correct settings', async () => {
+    await extension.onLoad()
+    expect(extension.apiKey).toBe('mock-api-key')
+    expect(extension.inferenceUrl).toBe('mock-endpoint')
+  })
+
+  it('should transform payload correctly', () => {
+    const payload = createMockPayload()
+    const transformedPayload = extension.transformPayload(payload)
+
+    expect(transformedPayload).toEqual({
+      max_tokens: 4096,
+      model: 'claude-v1',
+      stream: false,
+      system: 'Meow',
+      messages: [
+        { role: 'user', content: 'Hello' },
+        { role: 'assistant', content: 'Hi there' },
+      ],
+    })
+  })
+
+  it('should transform response correctly', () => {
+    const nonStreamResponse = { content: [{ text: 'Test response' }] }
+    const streamResponse =
+      'data: {"type":"content_block_delta","delta":{"text":"Hello"}}'
+
+    expect(extension.transformResponse(nonStreamResponse)).toBe('Test response')
+    expect(extension.transformResponse(streamResponse)).toBe('Hello')
+    expect(extension.transformResponse('')).toBe('')
+    expect(extension.transformResponse('event: something')).toBe('')
+  })
+})

--- a/extensions/inference-anthropic-extension/src/index.ts
+++ b/extensions/inference-anthropic-extension/src/index.ts
@@ -13,7 +13,7 @@ import { ChatCompletionRole } from '@janhq/core'
 declare const SETTINGS: Array<any>
 declare const MODELS: Array<any>
 
-enum Settings {
+export enum Settings {
   apiKey = 'anthropic-api-key',
   chatCompletionsEndPoint = 'chat-completions-endpoint',
 }
@@ -23,6 +23,7 @@ type AnthropicPayloadType = {
   model?: string
   max_tokens?: number
   messages?: Array<{ role: string; content: string }>
+  system?: string
 }
 
 /**
@@ -113,6 +114,10 @@ export default class JanInferenceAnthropicExtension extends RemoteOAIEngine {
           role: 'assistant',
           content: item.content as string,
         })
+      } else if (item.role === ChatCompletionRole.System) {
+        // When using Claude, you can dramatically improve its performance by using the system parameter to give it a role. 
+        // This technique, known as role prompting, is the most powerful way to use system prompts with Claude.
+        convertedData.system = item.content as string
       }
     })
 

--- a/extensions/inference-anthropic-extension/tsconfig.json
+++ b/extensions/inference-anthropic-extension/tsconfig.json
@@ -10,5 +10,6 @@
     "skipLibCheck": true,
     "rootDir": "./src"
   },
-  "include": ["./src"]
+  "include": ["./src"],
+  "exclude": ["**/*.test.ts"]
 }


### PR DESCRIPTION
## Describe Your Changes

#### Current behavior
Instructions are not sent when using the Claude 3.5 model. They work with other models (tested Open AI).

### Minimum reproduction step
1. Select Claude 3.5 model.
2. Enter instructions e.g. "You will play the role of Hal, a highly knowledgeable AI assistant with a humorous and often sarcastic personality. Engage in conversation with the user, providing informative and helpful responses while injecting wit, irony, and playful jabs. Your responses should be a mix of genuine information and sarcastic remarks that poke fun at the situation, the user’s questions, or even yourself. Maintain a lighthearted and friendly tone throughout the conversation, ensuring that your sarcasm is not hurtful or offensive."
3. Send a chat "What's your name"
4. Model will respond: "My name is Claude."
5. Switch to GPT4o model and ask the same question.
6. Model will correctly identify it's name.

### Expected behavior
Model should respond based on the instructions provided.

### Screenshots

| Instructions |
|:-:|
|<img width="1339" alt="Screenshot 2024-09-23 at 16 23 11" src="https://github.com/user-attachments/assets/6c0bed49-9371-4630-a705-493a6c652201">|
|![Screenshot 2024-09-23 at 16 31 29](https://github.com/user-attachments/assets/be897c74-a1d8-48c1-afbd-d4659726f552)|


## Changes made

1. **Addition of Test Configuration**:
   - A new Jest configuration file (`jest.config.js`) is added to the project.
   - This config is set up to utilize the `ts-jest` preset and specifies the testing environment to be `node`. The configuration also includes transforms and transformIgnorePatterns, allowing for specific module transformations and exclusions.

2. **Update to `package.json`**:
   - A new `test` script is added to run the Jest tests.
  
3. **Creation of Test File**:
   - A new test file (`anthropic.test.ts`) is created within the `src` directory.
   - This test file imports the `JanInferenceAnthropicExtension` and mocks necessary dependencies from `@janhq/core`.
   - Tests are defined for initialization, payload transformation, and response transformation functionalities of the `JanInferenceAnthropicExtension` class.
  
4. **Update to `index.ts`**:
   - The `Settings` enum is exported.
   - The `AnthropicPayloadType` interface is updated to include a `system` property.
   - The `transformPayload` method is enhanced to recognize and handle the `System` role as part of the `messages` array, assigning its content to the `system` property.

5. **Update `tsconfig.json`**:
   - The targets included in the TypeScript configuration now exclude `**/*.test.ts` files.
