### PR TITLE
fix: #3558 wrong model metadata import or download from HuggingFace

### DIFF
--- a/extensions/model-extension/src/index.ts
+++ b/extensions/model-extension/src/index.ts
@@ -572,7 +572,6 @@ export default class JanModelExtension extends ModelExtension {
       ])
     )
 
-    const eos_id = metadata?.['tokenizer.ggml.eos_token_id']
     const updatedModel = await this.retrieveGGUFMetadata(metadata)
 
     if (!defaultModel) {
@@ -594,9 +593,6 @@ export default class JanModelExtension extends ModelExtension {
       parameters: {
         ...defaultModel.parameters,
         ...updatedModel.parameters,
-        stop: eos_id
-          ? [metadata['tokenizer.ggml.tokens'][eos_id] ?? '']
-          : defaultModel.parameters.stop,
       },
       settings: {
         ...defaultModel.settings,

--- a/extensions/model-extension/src/index.ts
+++ b/extensions/model-extension/src/index.ts
@@ -24,6 +24,7 @@ import {
   ModelEvent,
   ModelFile,
   dirName,
+  ModelSettingParams,
 } from '@janhq/core'
 
 import { extractFileName } from './helpers/path'
@@ -80,11 +81,27 @@ export default class JanModelExtension extends ModelExtension {
     gpuSettings?: GpuSetting,
     network?: { ignoreSSL?: boolean; proxy?: string }
   ): Promise<void> {
-    // create corresponding directory
+    // Create corresponding directory
     const modelDirPath = await joinPath([JanModelExtension._homeDir, model.id])
     if (!(await fs.existsSync(modelDirPath))) await fs.mkdir(modelDirPath)
     const modelJsonPath = await joinPath([modelDirPath, 'model.json'])
+
+    // Download HF model - model.json not exist
     if (!(await fs.existsSync(modelJsonPath))) {
+      // It supports only one source for HF download
+      const metadata = await this.fetchModelMetadata(model.sources[0].url)
+      const updatedModel = await this.retrieveGGUFMetadata(metadata)
+      if (updatedModel) {
+        // Update model settings
+        model.settings = {
+          ...model.settings,
+          ...updatedModel.settings,
+        }
+        model.parameters = {
+          ...model.parameters,
+          ...updatedModel.parameters,
+        }
+      }
       await fs.writeFileSync(modelJsonPath, JSON.stringify(model, null, 2))
       events.emit(ModelEvent.OnModelsUpdate, {})
     }
@@ -327,7 +344,7 @@ export default class JanModelExtension extends ModelExtension {
       // Should depend on sources?
       const isUserImportModel =
         modelInfo.metadata?.author?.toLowerCase() === 'user'
-        if (isUserImportModel) {
+      if (isUserImportModel) {
         // just delete the folder
         return fs.rm(dirPath)
       }
@@ -556,6 +573,7 @@ export default class JanModelExtension extends ModelExtension {
     )
 
     const eos_id = metadata?.['tokenizer.ggml.eos_token_id']
+    const updatedModel = await this.retrieveGGUFMetadata(metadata)
 
     if (!defaultModel) {
       console.error('Unable to find default model')
@@ -575,18 +593,14 @@ export default class JanModelExtension extends ModelExtension {
       ],
       parameters: {
         ...defaultModel.parameters,
+        ...updatedModel.parameters,
         stop: eos_id
           ? [metadata['tokenizer.ggml.tokens'][eos_id] ?? '']
           : defaultModel.parameters.stop,
       },
       settings: {
         ...defaultModel.settings,
-        prompt_template:
-          metadata?.parsed_chat_template ??
-          defaultModel.settings.prompt_template,
-        ctx_len:
-          metadata?.['llama.context_length'] ?? defaultModel.settings.ctx_len,
-        ngl: (metadata?.['llama.block_count'] ?? 32) + 1,
+        ...updatedModel.settings,
         llama_model_path: binaryFileName,
       },
       created: Date.now(),
@@ -666,9 +680,9 @@ export default class JanModelExtension extends ModelExtension {
       'retrieveGGUFMetadata',
       modelBinaryPath
     )
-    const eos_id = metadata?.['tokenizer.ggml.eos_token_id']
 
     const binaryFileName = await baseName(modelBinaryPath)
+    const updatedModel = await this.retrieveGGUFMetadata(metadata)
 
     const model: Model = {
       ...defaultModel,
@@ -682,19 +696,12 @@ export default class JanModelExtension extends ModelExtension {
       ],
       parameters: {
         ...defaultModel.parameters,
-        stop: eos_id
-          ? [metadata?.['tokenizer.ggml.tokens'][eos_id] ?? '']
-          : defaultModel.parameters.stop,
+        ...updatedModel.parameters,
       },
 
       settings: {
         ...defaultModel.settings,
-        prompt_template:
-          metadata?.parsed_chat_template ??
-          defaultModel.settings.prompt_template,
-        ctx_len:
-          metadata?.['llama.context_length'] ?? defaultModel.settings.ctx_len,
-        ngl: (metadata?.['llama.block_count'] ?? 32) + 1,
+        ...updatedModel.settings,
         llama_model_path: binaryFileName,
       },
       created: Date.now(),
@@ -859,5 +866,36 @@ export default class JanModelExtension extends ModelExtension {
       LocalImportModelEvent.onLocalImportModelFinished,
       importedModels
     )
+  }
+
+  /**
+   * Retrieve Model Settings from GGUF Metadata
+   * @param metadata
+   * @returns
+   */
+  async retrieveGGUFMetadata(metadata: any): Promise<Partial<Model>> {
+    const template = await executeOnMain(NODE, 'renderJinjaTemplate', metadata)
+    const defaultModel = DEFAULT_MODEL as Model
+    const eos_id = metadata['tokenizer.ggml.eos_token_id']
+    const architecture = metadata['general.architecture']
+
+    return {
+      settings: {
+        prompt_template: template ?? defaultModel.settings.prompt_template,
+        ctx_len:
+          metadata[`${architecture}.context_length`] ??
+          metadata['llama.context_length'] ??
+          4096,
+        ngl:
+          (metadata[`${architecture}.block_count`] ??
+            metadata['llama.block_count'] ??
+            32) + 1,
+      },
+      parameters: {
+        stop: eos_id
+          ? [metadata?.['tokenizer.ggml.tokens'][eos_id] ?? '']
+          : defaultModel.parameters.stop,
+      },
+    }
   }
 }

--- a/extensions/model-extension/src/node/node.test.ts
+++ b/extensions/model-extension/src/node/node.test.ts
@@ -1,0 +1,53 @@
+import { renderJinjaTemplate } from './index'
+import { Template } from '@huggingface/jinja'
+
+jest.mock('@huggingface/jinja', () => ({
+  Template: jest.fn((template: string) => ({
+    render: jest.fn(() => `${template}_rendered`),
+  })),
+}))
+
+describe('renderJinjaTemplate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks() // Clear mocks between tests
+  })
+
+  it('should render the template with correct parameters', () => {
+    const metadata = {
+      'tokenizer.chat_template': 'Hello, {{ messages }}!',
+      'tokenizer.ggml.eos_token_id': 0,
+      'tokenizer.ggml.bos_token_id': 1,
+      'tokenizer.ggml.tokens': ['EOS', 'BOS'],
+    }
+
+    const renderedTemplate = renderJinjaTemplate(metadata)
+
+    expect(Template).toHaveBeenCalledWith('Hello, {{ messages }}!')
+
+    expect(renderedTemplate).toBe('Hello, {{ messages }}!_rendered')
+  })
+
+  it('should handle missing token IDs gracefully', () => {
+    const metadata = {
+      'tokenizer.chat_template': 'Hello, {{ messages }}!',
+      'tokenizer.ggml.eos_token_id': 0,
+      'tokenizer.ggml.tokens': ['EOS'],
+    }
+
+    const renderedTemplate = renderJinjaTemplate(metadata)
+
+    expect(Template).toHaveBeenCalledWith('Hello, {{ messages }}!')
+
+    expect(renderedTemplate).toBe('')
+  })
+
+  it('should handle empty template gracefully', () => {
+    const metadata = {}
+
+    const renderedTemplate = renderJinjaTemplate(metadata)
+
+    expect(Template).toHaveBeenCalledWith(undefined)
+
+    expect(renderedTemplate).toBe("")
+  })
+})


### PR DESCRIPTION
## Describe Your Changes

When downloading the HF GGUF model via URL import from the model hub, the model is using default settings instead of the correct settings. The fixed context length is set to 2048, the prompt template is incorrect, and there is an issue with the stop word. However, importing GGUF directly seems to resolve these issues.

### Steps to reproduce

Download the HF GGUF model from the model hub using URL import.
Check the settings for context length, prompt template, and stop word.
Compare the settings with the correct settings for the GGUF model.

### Expected behavior
The HF GGUF model downloaded via URL import should have the correct settings for context length, prompt template, and stop word, matching the settings when GGUF is imported directly.

### Additional context
The issue seems to be specific to downloading the HF GGUF model via URL import from the model hub. Importing GGUF directly does not exhibit the same issue with default settings.

## Fixes Issues

- Fixes #3558
- Fixes #3714 
- Fixes #3708

## Screenshots 
| Qwen 2.5 download from HF |
|:-:|
|<img width="1339" alt="Screenshot 2024-09-23 at 20 41 21" src="https://github.com/user-attachments/assets/ce16dc2e-410f-450f-a623-50ecd67a3dca">|


## Code Changes

1. `extensions/model-extension/src/index.test.ts`
2. `extensions/model-extension/src/index.ts`
3. `extensions/model-extension/src/node/index.ts`
4. `extensions/model-extension/src/node/node.test.ts`

Here's a summary of the major changes across these files:

### `index.test.ts`
- Added mock functions for new dependencies (`downloadMock`, `mkdirMock`, `writeFileSyncMock`, `copyFileMock`).
- Added setup for a global `fetch` mock.
- Imported additional functions for testing (`renderJinjaTemplate`, `Template`).
- Added a new test case for `downloadModel` with invalid gguf metadata.

### `index.ts`
- Added support for downloading HF model metadata by fetching and retrieving GGUF metadata.
- Improved the creation and update of model settings and parameters using fetched metadata.
- Added a new method `retrieveGGUFMetadata` that returns a partially updated model based on metadata.
- Handled conflicts and updated `parameters` and `settings` using GGUF metadata.
- Refactored the eos token handling and merging model configurations.

### `node/index.ts`
- Removed the original implementation of `renderedTemplate` from the GGUF metadata parsing process.
- Added a new function `renderJinjaTemplate` for parsing Jinja templates based on the metadata.

### `node/node.test.ts`
- Added tests for the `renderJinjaTemplate` function.
- Includes tests handling cases where token IDs are missing or the template is empty.

### Detailed Examples
- **GGUF Metadata Handling**: Added code to check for and update model settings based on metadata attributes like `eos_token_id`, `context_length`, `block_count`, etc.
  ```typescript
  await fs.writeFileSync(modelJsonPath, JSON.stringify(model, null, 2))
  const updatedModel = await this.retrieveGGUFMetadata(metadata)
  model.settings = { ...model.settings, ...updatedModel.settings };
  ```

- **Infrastructural Mocks in Tests**: Created mocks and their respective test setups to emulate filesystem and network behaviors for more deterministic tests.
  ```typescript
  global.fetch = jest.fn(() => Promise.resolve(...));
  expect(sut.downloadModel(...)).rejects.toBeTruthy();
  ```

These changes all seem aimed to improve the robustness and flexibility of model handling within the codebase, especially concerning dynamically adjusting to metadata from fetched models.