### PR TITLE
fix: #3698 - o1 preview models do not work with max_tokens

### DIFF
--- a/extensions/inference-openai-extension/jest.config.js
+++ b/extensions/inference-openai-extension/jest.config.js
@@ -1,0 +1,9 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  transform: {
+    'node_modules/@janhq/core/.+\\.(j|t)s?$': 'ts-jest',
+  },
+  transformIgnorePatterns: ['node_modules/(?!@janhq/core/.*)'],
+}

--- a/extensions/inference-openai-extension/src/OpenAIExtension.test.ts
+++ b/extensions/inference-openai-extension/src/OpenAIExtension.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+jest.mock('@janhq/core', () => ({
+  ...jest.requireActual('@janhq/core/node'),
+  RemoteOAIEngine: jest.fn().mockImplementation(() => ({
+    onLoad: jest.fn(),
+    registerSettings: jest.fn(),
+    registerModels: jest.fn(),
+    getSetting: jest.fn(),
+    onSettingUpdate: jest.fn(),
+  })),
+}))
+import JanInferenceOpenAIExtension, { Settings } from '.'
+
+describe('JanInferenceOpenAIExtension', () => {
+  let extension: JanInferenceOpenAIExtension
+
+  beforeEach(() => {
+    // @ts-ignore
+    extension = new JanInferenceOpenAIExtension()
+  })
+
+  it('should initialize with settings and models', async () => {
+    await extension.onLoad()
+    // Assuming there are some default SETTINGS and MODELS being registered
+    expect(extension.apiKey).toBe(undefined)
+    expect(extension.inferenceUrl).toBe('')
+  })
+
+  it('should transform the payload for preview models', () => {
+    const payload: any = {
+      max_tokens: 100,
+      model: 'o1-mini',
+      // Add other required properties...
+    }
+
+    const transformedPayload = extension.transformPayload(payload)
+    expect(transformedPayload.max_completion_tokens).toBe(payload.max_tokens)
+    expect(transformedPayload).not.toHaveProperty('max_tokens')
+    expect(transformedPayload).toHaveProperty('max_completion_tokens')
+  })
+
+  it('should not transform the payload for non-preview models', () => {
+    const payload: any = {
+      max_tokens: 100,
+      model: 'non-preview-model',
+      // Add other required properties...
+    }
+
+    const transformedPayload = extension.transformPayload(payload)
+    expect(transformedPayload).toEqual(payload)
+  })
+})

--- a/extensions/inference-openai-extension/tsconfig.json
+++ b/extensions/inference-openai-extension/tsconfig.json
@@ -10,5 +10,6 @@
     "skipLibCheck": true,
     "rootDir": "./src"
   },
-  "include": ["./src"]
+  "include": ["./src"],
+  "exclude": ["**/*.test.ts"]
 }


### PR DESCRIPTION
## Describe Your Changes
This PR addresses the issue where OpenAI preview models don't work with the `max_tokens` parameter. We'll likely deprecate `model.json` for remote models at least, so we're not introducing new model parameter support. Instead, we're using the standard payload transform that's been applied to other providers.

The changes are mostly about adding tests.

> When making a request using o1-preview or o1-mini, getting:

> Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.
Jan’s in beta. Access troubleshooting assistance now.

> Cannot change these model parameters settings.

| o1-preview |
|:-:|
|![64707](https://github.com/user-attachments/assets/09d7e0ce-0200-43b5-9428-2998620ee8a3)|

| gpt-3.5-turbo|
|:-:|
|![45537](https://github.com/user-attachments/assets/31271a74-be3d-4c45-b7eb-cdde69e200e7)|

## Fixes Issues

- Fixes #3698 

### Additions and Changes:

1. **Addition of Jest Configuration:**
    - A new Jest configuration file `jest.config.js` has been added under `extensions/inference-openai-extension`. This setting includes configurations such as `preset`, `testEnvironment`, and custom transformations for testing `@janhq/core` modules.

2. **Addition of Jest Test File:**
    - A new Jest test file `OpenAIExtension.test.ts` has been added under `src`. This test suite mocks the `@janhq/core` module and includes tests for the `JanInferenceOpenAIExtension` class, including initialization, payload transformation, and other functionalities specific to different model types.

3. **Modifications to `index.ts`:**
    - The `index.ts` file has been modified to incorporate new exports and enums, and introduce a `transformPayload` method within the `JanInferenceOpenAIExtension` class. The payload transformation accounts for differences between preview models (`o1-mini`, `o1-preview`) and non-preview models.
    - The payload transformation specifically handles fields like `max_completion_tokens` for preview models, while other models retain their original payload structure.

4. **Changes to `tsconfig.json`:**
    - The TypeScript configuration file in `tsconfig.json` adds an `"exclude"` field to exclude test files (those ending in `.test.ts`) from compilation. This likely ensures that unit test files are not included in the final production build.