### PR TITLE
fix: #3673 - API responds with Request body is too large

### DIFF
--- a/core/src/node/api/restful/helper/builder.ts
+++ b/core/src/node/api/restful/helper/builder.ts
@@ -353,8 +353,10 @@ export const chatCompletions = async (request: any, reply: any) => {
     body: JSON.stringify(request.body),
   })
   if (response.status !== 200) {
-    console.error(response)
-    reply.code(400).send(response)
+    // Forward the error response to client via reply
+    const responseBody = await response.text()
+    const responseHeaders = Object.fromEntries(response.headers)
+    reply.code(response.status).headers(responseHeaders).send(responseBody)
   } else {
     reply.raw.writeHead(200, {
       'Content-Type': request.body.stream === true ? 'text/event-stream' : 'application/json',

--- a/server/index.ts
+++ b/server/index.ts
@@ -67,6 +67,11 @@ export const startServer = async (configs?: ServerConfig): Promise<boolean> => {
     // Initialize Fastify server with logging
     server = fastify({
       logger: new Logger(),
+      // Set body limit to 100MB - Default is 1MB
+      // According to OpenAI - a batch input file can be up to 100 MB in size
+      // Whisper endpoints accept up to 25MB
+      // Vision endpoints accept up to 4MB
+      bodyLimit: 104_857_600
     })
 
     // Register CORS if enabled


### PR DESCRIPTION
## Describe Your Changes
This addresses the issue where the Jan API server gates requests based on body size, rejecting any larger than 1MB. This PR increases the accepted request body size and also handles errors gracefully.

> I'm trying to integrate OpenAI LLMs like, gpt-4-turbo, gpt-4o...etc to integrate with LaVague-QA framework for Test Automation. While LaVague is sending request to the LLM running in Jan.AI is responding with "Request body is too large" error.

### Steps to Reproduce
1.Download the LLM gpt-4-turbo OR gpt-4o using Jan.AI interface
2.Make an API call to LLM (gpt-4-turbo OR gpt-4o)
3.Observe the response returned "Request body is too large"
Note: Attaching the API request body.

## Screenshots 

| Error handling |
|:-:|
|![28536](https://github.com/user-attachments/assets/453cd282-2267-45d8-8ea4-305da6dc8a2c)|

| Succeed |
|:-:|
|![97740](https://github.com/user-attachments/assets/c433a9cf-47ed-4a8c-b312-4b6ae5e2bf6b)|


## Fixes Issues

- Fixes #3673

## Code changes

1. `core/src/node/api/restful/helper/builder.test.ts`:
   - Added a new test case to check error handling when the status is not OK (400).
   - The test mocks a 400 status response and verifies that the error is properly forwarded.

2. `core/src/node/api/restful/helper/builder.ts`:
   - Modified the error handling in the `chatCompletions` function.
   - Instead of just logging the error and sending a 400 status, it now forwards the complete error response (including status code, headers, and body) to the client.

3. `server/index.ts`:
   - Added a `bodyLimit` configuration to the Fastify server initialization.
   - Set the body limit to 100MB (104,857,600 bytes), up from the default 1MB.
   - Added comments explaining the rationale for this limit, citing OpenAI's file size limits for various endpoints.

These changes improve error handling and reporting in the API, and increase the maximum allowed request body size to accommodate larger file uploads for certain AI model endpoints.
