### PR TITLE
fix: #3727 LLM model download fail can still be used

### DIFF
--- a/core/src/node/api/processors/download.test.ts
+++ b/core/src/node/api/processors/download.test.ts
@@ -8,7 +8,7 @@ jest.mock('../../helper', () => ({
 
 jest.mock('../../helper/path', () => ({
   validatePath: jest.fn().mockReturnValue('path/to/folder'),
-  normalizeFilePath: () => '/Users/path/to/file.gguf',
+  normalizeFilePath: () => process.platform === 'win32' ? 'C:\\Users\path\\to\\file.gguf' : '/Users/path/to/file.gguf',
 }))
 
 jest.mock(

--- a/core/src/node/api/processors/download.test.ts
+++ b/core/src/node/api/processors/download.test.ts
@@ -1,59 +1,131 @@
-import { Downloader } from './download';
-import { DownloadEvent } from '../../../types/api';
-import { DownloadManager } from '../../helper/download';
+import { Downloader } from './download'
+import { DownloadEvent } from '../../../types/api'
+import { DownloadManager } from '../../helper/download'
 
-it('should handle getFileSize errors correctly', async () => {
-  const observer = jest.fn();
-  const url = 'http://example.com/file';
+jest.mock('../../helper', () => ({
+  getJanDataFolderPath: jest.fn().mockReturnValue('path/to/folder'),
+}))
 
-  const downloader = new Downloader(observer);
-  const requestMock = jest.fn((options, callback) => {
-    callback(new Error('Test error'), null);
-  });
-  jest.mock('request', () => requestMock);
+jest.mock('../../helper/path', () => ({
+  validatePath: jest.fn().mockReturnValue('path/to/folder'),
+  normalizeFilePath: () => '/Users/path/to/file.gguf',
+}))
 
-  await expect(downloader.getFileSize(observer, url)).rejects.toThrow('Test error');
-});
+jest.mock(
+  'request',
+  jest.fn().mockReturnValue(() => ({
+    on: jest.fn(),
+  }))
+)
 
+jest.mock('fs', () => ({
+  createWriteStream: jest.fn(),
+}))
 
-it('should pause download correctly', () => {
-  const observer = jest.fn();
-  const fileName = process.platform === 'win32' ? 'C:\\path\\to\\file' : 'path/to/file';
+jest.mock('request-progress', () => {
+  return jest.fn().mockImplementation(() => {
+    return {
+      on: jest.fn().mockImplementation((event, callback) => {
+        if (event === 'error') {
+          callback(new Error('Download failed'))
+        }
+        return {
+          on: jest.fn().mockImplementation((event, callback) => {
+            if (event === 'error') {
+              callback(new Error('Download failed'))
+            }
+            return {
+              on: jest.fn().mockImplementation((event, callback) => {
+                if (event === 'error') {
+                  callback(new Error('Download failed'))
+                }
+                return { pipe: jest.fn() }
+              }),
+            }
+          }),
+        }
+      }),
+    }
+  })
+})
 
-  const downloader = new Downloader(observer);
-  const pauseMock = jest.fn();
-  DownloadManager.instance.networkRequests[fileName] = { pause: pauseMock };
+describe('Downloader', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+  it('should handle getFileSize errors correctly', async () => {
+    const observer = jest.fn()
+    const url = 'http://example.com/file'
 
-  downloader.pauseDownload(observer, fileName);
+    const downloader = new Downloader(observer)
+    const requestMock = jest.fn((options, callback) => {
+      callback(new Error('Test error'), null)
+    })
+    jest.mock('request', () => requestMock)
 
-  expect(pauseMock).toHaveBeenCalled();
-});
+    await expect(downloader.getFileSize(observer, url)).rejects.toThrow('Test error')
+  })
 
-it('should resume download correctly', () => {
-  const observer = jest.fn();
-  const fileName = process.platform === 'win32' ? 'C:\\path\\to\\file' : 'path/to/file';
+  it('should pause download correctly', () => {
+    const observer = jest.fn()
+    const fileName = process.platform === 'win32' ? 'C:\\path\\to\\file' : 'path/to/file'
 
-  const downloader = new Downloader(observer);
-  const resumeMock = jest.fn();
-  DownloadManager.instance.networkRequests[fileName] = { resume: resumeMock };
+    const downloader = new Downloader(observer)
+    const pauseMock = jest.fn()
+    DownloadManager.instance.networkRequests[fileName] = { pause: pauseMock }
 
-  downloader.resumeDownload(observer, fileName);
+    downloader.pauseDownload(observer, fileName)
 
-  expect(resumeMock).toHaveBeenCalled();
-});
+    expect(pauseMock).toHaveBeenCalled()
+  })
 
-it('should handle aborting a download correctly', () => {
-  const observer = jest.fn();
-  const fileName = process.platform === 'win32' ? 'C:\\path\\to\\file' : 'path/to/file';
+  it('should resume download correctly', () => {
+    const observer = jest.fn()
+    const fileName = process.platform === 'win32' ? 'C:\\path\\to\\file' : 'path/to/file'
 
-  const downloader = new Downloader(observer);
-  const abortMock = jest.fn();
-  DownloadManager.instance.networkRequests[fileName] = { abort: abortMock };
+    const downloader = new Downloader(observer)
+    const resumeMock = jest.fn()
+    DownloadManager.instance.networkRequests[fileName] = { resume: resumeMock }
 
-  downloader.abortDownload(observer, fileName);
+    downloader.resumeDownload(observer, fileName)
 
-  expect(abortMock).toHaveBeenCalled();
-  expect(observer).toHaveBeenCalledWith(DownloadEvent.onFileDownloadError, expect.objectContaining({
-    error: 'aborted'
-  }));
-});
+    expect(resumeMock).toHaveBeenCalled()
+  })
+
+  it('should handle aborting a download correctly', () => {
+    const observer = jest.fn()
+    const fileName = process.platform === 'win32' ? 'C:\\path\\to\\file' : 'path/to/file'
+
+    const downloader = new Downloader(observer)
+    const abortMock = jest.fn()
+    DownloadManager.instance.networkRequests[fileName] = { abort: abortMock }
+
+    downloader.abortDownload(observer, fileName)
+
+    expect(abortMock).toHaveBeenCalled()
+    expect(observer).toHaveBeenCalledWith(
+      DownloadEvent.onFileDownloadError,
+      expect.objectContaining({
+        error: 'aborted',
+      })
+    )
+  })
+
+  it('should handle download fail correctly', () => {
+    const observer = jest.fn()
+    const fileName = process.platform === 'win32' ? 'C:\\path\\to\\file' : 'path/to/file.gguf'
+
+    const downloader = new Downloader(observer)
+
+    downloader.downloadFile(observer, {
+      localPath: fileName,
+      url: 'http://127.0.0.1',
+    })
+    expect(observer).toHaveBeenCalledWith(
+      DownloadEvent.onFileDownloadError,
+      expect.objectContaining({
+        error: expect.anything(),
+      })
+    )
+  })
+})

--- a/core/src/node/api/processors/download.ts
+++ b/core/src/node/api/processors/download.ts
@@ -100,18 +100,20 @@ export class Downloader implements Processor {
       })
       .on('end', () => {
         const currentDownloadState = DownloadManager.instance.downloadProgressMap[modelId]
-        if (currentDownloadState && DownloadManager.instance.networkRequests[normalizedPath]) {
-          if (DownloadManager.instance.downloadProgressMap[modelId]?.downloadState !== 'error') {
-            // Finished downloading, rename temp file to actual file
-            renameSync(downloadingTempFile, destination)
-            const downloadState: DownloadState = {
-              ...currentDownloadState,
-              fileName: fileName,
-              downloadState: 'end',
-            }
-            observer?.(DownloadEvent.onFileDownloadSuccess, downloadState)
-            DownloadManager.instance.downloadProgressMap[modelId] = downloadState
+        if (
+          currentDownloadState &&
+          DownloadManager.instance.networkRequests[normalizedPath] &&
+          DownloadManager.instance.downloadProgressMap[modelId]?.downloadState !== 'error'
+        ) {
+          // Finished downloading, rename temp file to actual file
+          renameSync(downloadingTempFile, destination)
+          const downloadState: DownloadState = {
+            ...currentDownloadState,
+            fileName: fileName,
+            downloadState: 'end',
           }
+          observer?.(DownloadEvent.onFileDownloadSuccess, downloadState)
+          DownloadManager.instance.downloadProgressMap[modelId] = downloadState
         }
       })
       .pipe(createWriteStream(downloadingTempFile))

--- a/core/src/node/api/processors/download.ts
+++ b/core/src/node/api/processors/download.ts
@@ -101,15 +101,17 @@ export class Downloader implements Processor {
       .on('end', () => {
         const currentDownloadState = DownloadManager.instance.downloadProgressMap[modelId]
         if (currentDownloadState && DownloadManager.instance.networkRequests[normalizedPath]) {
-          // Finished downloading, rename temp file to actual file
-          renameSync(downloadingTempFile, destination)
-          const downloadState: DownloadState = {
-            ...currentDownloadState,
-            fileName: fileName,
-            downloadState: 'end',
+          if (DownloadManager.instance.downloadProgressMap[modelId]?.downloadState !== 'error') {
+            // Finished downloading, rename temp file to actual file
+            renameSync(downloadingTempFile, destination)
+            const downloadState: DownloadState = {
+              ...currentDownloadState,
+              fileName: fileName,
+              downloadState: 'end',
+            }
+            observer?.(DownloadEvent.onFileDownloadSuccess, downloadState)
+            DownloadManager.instance.downloadProgressMap[modelId] = downloadState
           }
-          observer?.(DownloadEvent.onFileDownloadSuccess, downloadState)
-          DownloadManager.instance.downloadProgressMap[modelId] = downloadState
         }
       })
       .pipe(createWriteStream(downloadingTempFile))


### PR DESCRIPTION
## Describe Your Changes

- This PR addresses an issue where a model download failure still allows usage.

Root cause: The `request-progress` event fires `end` after the `error` event is emitted, toggling the download status back to succeed.

### Describe the Bug
Models occasionally do not download correctly, but still report a "use" button, indicating that it was downloaded successfully, but the models can not be ran.

### Steps to Reproduce
1. Open Jan
2. Attempt to download a model from the Hub
3. Use an app blocking software like glasswire to block the access to jan, simulating a loss of internet connection
4. Model will report as a failed or cancelled download in the top right
5. Model will show as downloaded and have a "use" button
6. Attempt to run the model, it will fail, sometimes with no error message

## Fixes Issues
- Fixes #3727

## Changes made

### `download.test.ts`
- **New Test Added**:
  - `should handle download fail correctly`: This test involves mocking out the file download process and verifying that the test observer catches the download failure.
  
- **Mocking Improvements**:
  - Mocks are put in place for modules `helper`, `helper/path`, `request`, `fs`, and `request-progress`. The mocks return specific values or behaviors to simulate particular application states or errors.
  - Previously, some modules were mocked implicitly, but now explicit mocks are defined at the top of the test file, making the code more organized and easier to understand.

### `download.ts`
- **Additional Conditions in 'end' Event Handler**:
  - The `end` event handler in the `Downloader` class has undergone a modification. Now, besides checking if a download state exists (`currentDownloadState`) and if there is a network request in the progress map (`DownloadManager.instance.networkRequests[normalizedPath]`), it also cross-checks if the `downloadState` is not `'error'`. 
  - If all these conditions pass, the code assumes the download has finished successfully and will then rename the temporary download file to the destination file.
