### PR TITLE
fix: #3703 - Deepseek-Coder-33B-Instruct is incompatible

### DIFF
--- a/extensions/inference-nitro-extension/package.json
+++ b/extensions/inference-nitro-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janhq/inference-cortex-extension",
   "productName": "Cortex Inference Engine",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "This extension embeds cortex.cpp, a lightweight inference engine written in C++. See https://jan.ai.\nAdditional dependencies could be installed to run without Cuda Toolkit installation.",
   "main": "dist/index.js",
   "node": "dist/node/index.cjs.js",

--- a/extensions/inference-nitro-extension/resources/models/deepseek-coder-1.3b/model.json
+++ b/extensions/inference-nitro-extension/resources/models/deepseek-coder-1.3b/model.json
@@ -8,7 +8,7 @@
   "id": "deepseek-coder-1.3b",
   "object": "model",
   "name": "Deepseek Coder 1.3B Instruct Q8",
-  "version": "1.3",
+  "version": "1.4",
   "description": "Deepseek Coder excelled in project-level code completion with advanced capabilities across multiple programming languages.",
   "format": "gguf",
   "settings": {
@@ -22,13 +22,13 @@
     "top_p": 0.95,
     "stream": true,
     "max_tokens": 16384,
-    "stop": [],
+    "stop": ["<|EOT|>"],
     "frequency_penalty": 0,
     "presence_penalty": 0
   },
   "metadata": {
     "author": "Deepseek, The Bloke",
-    "tags": ["Tiny", "Foundational Model"],
+    "tags": ["Tiny"],
     "size": 1430000000
   },
   "engine": "nitro"

--- a/extensions/inference-nitro-extension/resources/models/deepseek-coder-34b/model.json
+++ b/extensions/inference-nitro-extension/resources/models/deepseek-coder-34b/model.json
@@ -2,13 +2,13 @@
   "sources": [
     {
       "filename": "deepseek-coder-33b-instruct.Q4_K_M.gguf",
-      "url": "https://huggingface.co/TheBloke/deepseek-coder-33B-instruct-GGUF/resolve/main/deepseek-coder-33b-instruct.Q4_K_M.gguf"
+      "url": "https://huggingface.co/mradermacher/deepseek-coder-33b-instruct-GGUF/resolve/main/deepseek-coder-33b-instruct.Q4_K_M.gguf"
     }
   ],
   "id": "deepseek-coder-34b",
   "object": "model",
   "name": "Deepseek Coder 33B Instruct Q4",
-  "version": "1.3",
+  "version": "1.4",
   "description": "Deepseek Coder excelled in project-level code completion with advanced capabilities across multiple programming languages.",
   "format": "gguf",
   "settings": {
@@ -22,13 +22,13 @@
     "top_p": 0.95,
     "stream": true,
     "max_tokens": 16384,
-    "stop": [],
+    "stop": ["<|EOT|>"],
     "frequency_penalty": 0,
     "presence_penalty": 0
   },
   "metadata": {
-    "author": "Deepseek, The Bloke",
-    "tags": ["34B", "Foundational Model"],
+    "author": "Deepseek",
+    "tags": ["33B"],
     "size": 19940000000
   },
   "engine": "nitro"


### PR DESCRIPTION
## Describe Your Changes

This PR updates the DeepSeek Coder 33B Instruct download URL to a working quantized version. Stop tokens have also been added, allowing the model to outputs properly.

<img width="1193" alt="Screenshot 2024-09-25 at 11 38 36" src="https://github.com/user-attachments/assets/63e5e2a6-4e62-4da0-9f99-e7bb7e85a8eb">

## Steps to Reproduce
1. Download Deepseek Coder 33B Instruct
2. Try to use it in threads

| Deepseek Coder 33B |
|:-:|
|![38183](https://github.com/user-attachments/assets/d770b360-d238-4c8a-8d3a-2c935d642bc7)|

## Fixes Issues

- Fixes #3703 

## Changes made

1. **`package.json` Updates:**
   - The version number of the package has been incremented from `1.0.17` to `1.0.18`.

2. **`model.json` Updates for `deepseek-coder-1.3b`:**
   - Version number incremented from `1.3` to `1.4`.
   - The array for `stop` is now explicitly set to `["<|EOT|>"]`, which defines the end-of-text token.
   - Tags have been modified to remove `"Foundational Model"`, leaving only `"Tiny"`.

3. **`model.json` Updates for `deepseek-coder-34b`:**
   - The download URL for the model file `deepseek-coder-33b-instruct.Q4_K_M.gguf` has been changed from `https://huggingface.co/TheBloke/deepseek-coder-33B-instruct-GGUF/resolve/main/deepseek-coder-33b-instruct.Q4_K_M.gguf` to `https://huggingface.co/mradermacher/deepseek-coder-33b-instruct-GGUF/resolve/main/deepseek-coder-33b-instruct.Q4_K_M.gguf`.
   - Version number incremented from `1.3` to `1.4`.
   - The array for `stop` is now explicitly set to `["<|EOT|>"]`.
   - Tags have been modified to remove `"Foundational Model"` and Updated `"34B"` to `"33B"`.
