### PR TITLE
fix: wrong model download location when there is a mismatch model_id

### DIFF
--- a/core/src/node/api/processors/download.ts
+++ b/core/src/node/api/processors/download.ts
@@ -34,7 +34,7 @@ export class Downloader implements Processor {
     }
     const array = normalizedPath.split(sep)
     const fileName = array.pop() ?? ''
-    const modelId = array.pop() ?? ''
+    const modelId = downloadRequest.modelId ?? array.pop() ?? ''
 
     const destination = resolve(getJanDataFolderPath(), normalizedPath)
     validatePath(destination)

--- a/core/src/types/file/index.ts
+++ b/core/src/types/file/index.ts
@@ -40,6 +40,14 @@ export type DownloadRequest = {
    */
   extensionId?: string
 
+  /**
+   * The model ID of the model that initiated the download.
+   */
+  modelId?: string
+
+  /**
+   * The download type.
+   */
   downloadType?: DownloadType | string
 }
 

--- a/core/src/types/model/modelInterface.ts
+++ b/core/src/types/model/modelInterface.ts
@@ -12,7 +12,7 @@ export interface ModelInterface {
    * @returns A Promise that resolves when the model has been downloaded.
    */
   downloadModel(
-    model: Model,
+    model: ModelFile,
     gpuSettings?: GpuSetting,
     network?: { ignoreSSL?: boolean; proxy?: string }
   ): Promise<void>
@@ -35,11 +35,11 @@ export interface ModelInterface {
    * Gets a list of downloaded models.
    * @returns A Promise that resolves with an array of downloaded models.
    */
-  getDownloadedModels(): Promise<Model[]>
+  getDownloadedModels(): Promise<ModelFile[]>
 
   /**
    * Gets a list of configured models.
    * @returns A Promise that resolves with an array of configured models.
    */
-  getConfiguredModels(): Promise<Model[]>
+  getConfiguredModels(): Promise<ModelFile[]>
 }


### PR DESCRIPTION
## Description

There was an edge case where the model folder didn't match the model_id, leading to an issue where the app would download the local model to a cloned folder using the folder as its ID. This could result in an unwanted outcome, different from what the user had intended. 

We previously knew about an issue with the remote model, and now we've discovered an edge case for the local model folder.

This is a follow-up PR of #3476 

## Screenshots

| Correct download progress |
|:-:|
|![88332](https://github.com/user-attachments/assets/e105ce4a-a799-4ebf-aac6-61693b44e91f)| 
| GUGU is a copied model of Gemma - It handles the download accordingly instead of duplicated or stuck at 0% |


## Code changes

1. **download.ts** in **core/src/node/api/processors/**
   - The `modelId` variable now uses the `downloadRequest.modelId` if available, otherwise it falls back to the previous logic.

2. **index.ts** in **core/src/types/file/**
   - Added the `modelId` and `downloadType` fields to the `DownloadRequest` type.

3. **modelInterface.ts** in **core/src/types/model/**
   - Changed the return types of `getDownloadedModels` and `getConfiguredModels` from `Promise<Model[]>` to `Promise<ModelFile[]>`.

4. **index.test.ts** in **extensions/model-extension/src/**
   - Mocked and imported necessary modules.
   - Added several test cases to handle different scenarios in the `downloadModel` function, including:
     - Downloading a model with a valid ID.
     - Handling invalid model files.
     - Handling models with no sources.
     - Handling models with multiple sources.
     - Handling models with no `file_path`.
     - Handling models with an invalid `file_path`.

5. **index.ts** in **extensions/model-extension/src/**
   - Changed the `downloadModel` function to accept a `ModelFile` instead of a `Model`.
   - Adjusted logic to use the `file_path` from `ModelFile` if available, otherwise it falls back to the previous logic.

These changes are aimed at improving the functionality and robustness of the model download process, ensuring that the system can handle various edge cases and types of model configurations.
