### PR TITLE
fix: model dropdown should show recommended models to download

### DIFF
--- a/web/helpers/atoms/Model.atom.test.ts
+++ b/web/helpers/atoms/Model.atom.test.ts
@@ -38,7 +38,7 @@ describe('Model.atom.ts', () => {
 
   describe('showEngineListModelAtom', () => {
     it('should initialize as an empty array', () => {
-      expect(ModelAtoms.showEngineListModelAtom.init).toEqual([])
+      expect(ModelAtoms.showEngineListModelAtom.init).toEqual(['nitro'])
     })
   })
 

--- a/web/helpers/atoms/Model.atom.ts
+++ b/web/helpers/atoms/Model.atom.ts
@@ -1,4 +1,4 @@
-import { ImportingModel, Model, ModelFile } from '@janhq/core'
+import { ImportingModel, InferenceEngine, Model, ModelFile } from '@janhq/core'
 import { atom } from 'jotai'
 
 export const stateModel = atom({ state: 'start', loading: false, model: '' })
@@ -133,4 +133,4 @@ export const updateImportingModelAtom = atom(
 
 export const selectedModelAtom = atom<ModelFile | undefined>(undefined)
 
-export const showEngineListModelAtom = atom<string[]>([])
+export const showEngineListModelAtom = atom<string[]>([InferenceEngine.nitro])


### PR DESCRIPTION
## Describe Your Changes

There was an issue where recommended models weren't expanding to download, and this PR is just to fix that. This will be changed to cortex after 0.5.5

## Screenshots

| Local models section is expanded by default |
|:-:|
|![21636](https://github.com/user-attachments/assets/df6782cf-6511-43c1-a99f-88afb70777d5)|

## Code changes
1. Model.atom.test.ts:
   - In the test for 'showEngineListModelAtom', the expected initial value has been changed from an empty array ([]) to an array containing 'nitro' (['nitro']).

2. Model.atom.ts:
   - The import statement has been updated to include 'InferenceEngine' from '@janhq/core'.
   - The 'showEngineListModelAtom' has been modified to initialize with [InferenceEngine.nitro] instead of an empty array.

These changes suggest that the 'showEngineListModelAtom' is now being initialized with a default value of 'nitro' as the inference engine, rather than starting empty. The test file has been updated to reflect this change in the expected initial state.