### PR TITLE
fix: Optimize resource watching

### DIFF
--- a/web/containers/Layout/BottomPanel/SystemMonitor/SystemMonitor.test.tsx
+++ b/web/containers/Layout/BottomPanel/SystemMonitor/SystemMonitor.test.tsx
@@ -1,0 +1,86 @@
+import '@testing-library/jest-dom'
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import SystemMonitor from './index'
+import { useAtom, useAtomValue } from 'jotai'
+import {
+  cpuUsageAtom,
+  gpusAtom,
+  totalRamAtom,
+  usedRamAtom,
+} from '@/helpers/atoms/SystemBar.atom'
+
+// Mock dependencies
+jest.mock('jotai', () => ({
+  useAtomValue: jest.fn(),
+  useSetAtom: jest.fn(),
+  useAtom: jest.fn(),
+  atom: jest.fn(),
+}))
+
+// Mock the hooks and atoms
+jest.mock('@/hooks/useGetSystemResources', () => ({
+  __esModule: true,
+  default: () => ({ watch: jest.fn(), stopWatching: jest.fn() }),
+}))
+
+jest.mock('@/hooks/usePath', () => ({
+  usePath: () => ({ onRevealInFinder: jest.fn() }),
+}))
+
+jest.mock('@/helpers/atoms/App.atom', () => ({
+  showSystemMonitorPanelAtom: { init: false },
+}))
+
+jest.mock('@/helpers/atoms/Setting.atom', () => ({
+  reduceTransparentAtom: { init: false },
+}))
+
+jest.mock('@/helpers/atoms/SystemBar.atom', () => ({
+  totalRamAtom: { init: 16000000000 },
+  usedRamAtom: { init: 8000000000 },
+  cpuUsageAtom: { init: 50 },
+  gpusAtom: { init: [] },
+  ramUtilitizedAtom: { init: 50 },
+}))
+
+describe('SystemMonitor', () => {
+  beforeAll(() => {
+    jest.clearAllMocks()
+  })
+  it('renders without crashing', () => {
+    ;(useAtom as jest.Mock).mockReturnValue([false, jest.fn()])
+    render(<SystemMonitor />)
+    expect(screen.getByText('System Monitor')).toBeInTheDocument()
+  })
+
+  it('renders information on expand', () => {
+    const mockGpusAtom = jest.fn()
+    const mockShowPanel = jest.fn()
+    ;(useAtom as jest.Mock).mockImplementation(mockShowPanel)
+    // Mock Jotai hooks
+    ;(useAtomValue as jest.Mock).mockImplementation((atom) => {
+      switch (atom) {
+        case totalRamAtom:
+          return 16000000000
+        case usedRamAtom:
+          return 8000000000
+        case cpuUsageAtom:
+          return 30
+        case gpusAtom:
+          return mockGpusAtom
+        default:
+          return jest.fn()
+      }
+    })
+    mockGpusAtom.mockImplementation(() => [])
+    mockShowPanel.mockImplementation(() => [true, jest.fn()])
+
+    render(<SystemMonitor />)
+
+    expect(screen.getByText('Running Models')).toBeInTheDocument()
+    expect(screen.getByText('App Log')).toBeInTheDocument()
+    expect(screen.getByText('7.45/14.90 GB')).toBeInTheDocument()
+    expect(screen.getByText('30%')).toBeInTheDocument()
+  })
+})

--- a/web/containers/Layout/BottomPanel/SystemMonitor/SystemMonitor.test.tsx
+++ b/web/containers/Layout/BottomPanel/SystemMonitor/SystemMonitor.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import SystemMonitor from './index'
 import { useAtom, useAtomValue } from 'jotai'
 import {
@@ -9,6 +9,7 @@ import {
   totalRamAtom,
   usedRamAtom,
 } from '@/helpers/atoms/SystemBar.atom'
+import useGetSystemResources from '@/hooks/useGetSystemResources'
 
 // Mock dependencies
 jest.mock('jotai', () => ({
@@ -19,10 +20,7 @@ jest.mock('jotai', () => ({
 }))
 
 // Mock the hooks and atoms
-jest.mock('@/hooks/useGetSystemResources', () => ({
-  __esModule: true,
-  default: () => ({ watch: jest.fn(), stopWatching: jest.fn() }),
-}))
+jest.mock('@/hooks/useGetSystemResources')
 
 jest.mock('@/hooks/usePath', () => ({
   usePath: () => ({ onRevealInFinder: jest.fn() }),
@@ -45,8 +43,14 @@ jest.mock('@/helpers/atoms/SystemBar.atom', () => ({
 }))
 
 describe('SystemMonitor', () => {
+  const mockWatch = jest.fn()
+  const mockStopWatching = jest.fn()
   beforeAll(() => {
     jest.clearAllMocks()
+    ;(useGetSystemResources as jest.Mock).mockReturnValue({
+      watch: mockWatch,
+      stopWatching: mockStopWatching,
+    })
   })
   it('renders without crashing', () => {
     ;(useAtom as jest.Mock).mockReturnValue([false, jest.fn()])
@@ -82,5 +86,39 @@ describe('SystemMonitor', () => {
     expect(screen.getByText('App Log')).toBeInTheDocument()
     expect(screen.getByText('7.45/14.90 GB')).toBeInTheDocument()
     expect(screen.getByText('30%')).toBeInTheDocument()
+  })
+
+  it('it should not request system resource on close', async () => {
+    const mockGpusAtom = jest.fn()
+    const mockShowPanel = jest.fn()
+    ;(useAtom as jest.Mock).mockImplementation(mockShowPanel)
+
+    // Mock Jotai hooks
+    ;(useAtomValue as jest.Mock).mockImplementation((atom) => {
+      switch (atom) {
+        case totalRamAtom:
+          return 16000000000
+        case usedRamAtom:
+          return 8000000000
+        case cpuUsageAtom:
+          return 30
+        case gpusAtom:
+          return mockGpusAtom
+        default:
+          return jest.fn()
+      }
+    })
+    mockGpusAtom.mockImplementation(() => [])
+    mockShowPanel.mockImplementation(() => [true, jest.fn()])
+
+    await waitFor(async () => {
+      await render(<SystemMonitor />)
+
+      const toggle = screen.getByTestId('system-monitoring')
+      toggle.click()
+    })
+
+    expect(mockWatch).not.toHaveBeenCalled()
+    expect(mockStopWatching).toHaveBeenCalled()
   })
 })

--- a/web/containers/Layout/BottomPanel/SystemMonitor/index.tsx
+++ b/web/containers/Layout/BottomPanel/SystemMonitor/index.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useState } from 'react'
+import { Fragment, useCallback, useState } from 'react'
 
 import { Progress } from '@janhq/joi'
 import { useClickOutside } from '@janhq/joi'
@@ -51,24 +51,27 @@ const SystemMonitor = () => {
   const reduceTransparent = useAtomValue(reduceTransparentAtom)
 
   const { watch, stopWatching } = useGetSystemResources()
+
   useClickOutside(
     () => {
-      setShowSystemMonitorPanel(false)
+      toggleShowSystemMonitorPanel(false)
       setShowFullScreen(false)
     },
     null,
     [control, elementExpand]
   )
 
-  useEffect(() => {
-    // Watch for resource update
-    watch()
-
-    return () => {
-      stopWatching()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  const toggleShowSystemMonitorPanel = useCallback(
+    (isShow: boolean) => {
+      setShowSystemMonitorPanel(isShow)
+      if (isShow) {
+        watch()
+      } else {
+        stopWatching()
+      }
+    },
+    [setShowSystemMonitorPanel, stopWatching, watch]
+  )
 
   return (
     <Fragment>
@@ -79,7 +82,7 @@ const SystemMonitor = () => {
           showSystemMonitorPanel && 'bg-[hsla(var(--secondary-bg))]'
         )}
         onClick={() => {
-          setShowSystemMonitorPanel(!showSystemMonitorPanel)
+          toggleShowSystemMonitorPanel(!showSystemMonitorPanel)
           setShowFullScreen(false)
         }}
       >
@@ -123,7 +126,7 @@ const SystemMonitor = () => {
                 size={16}
                 className="text-[hsla(var(--text-secondary))]"
                 onClick={() => {
-                  setShowSystemMonitorPanel(false)
+                  toggleShowSystemMonitorPanel(false)
                   setShowFullScreen(false)
                 }}
               />

--- a/web/containers/Layout/BottomPanel/SystemMonitor/index.tsx
+++ b/web/containers/Layout/BottomPanel/SystemMonitor/index.tsx
@@ -77,6 +77,7 @@ const SystemMonitor = () => {
     <Fragment>
       <div
         ref={setControl}
+        data-testid="system-monitoring"
         className={twMerge(
           'flex cursor-pointer items-center gap-x-1 rounded px-1 py-0.5 hover:bg-[hsla(var(--secondary-bg))]',
           showSystemMonitorPanel && 'bg-[hsla(var(--secondary-bg))]'


### PR DESCRIPTION
## Describe Your Changes

Currently, the System Monitoring component continuously requests information from the hardware's endpoints to retrieve resource details. However, it could be improved by sending requests only when the system monitoring bar is shown. When it's closed, it should stop requesting.

Also added tests to the component.

## Code changes

1. A new test file `SystemMonitor.test.tsx` has been added:
   - It includes unit tests for the SystemMonitor component
   - Mocks dependencies and hooks used by the component
   - Tests basic rendering and expanded view scenarios

2. Changes to the existing `index.tsx` file:
   - Imports have been updated, removing `useEffect` and adding `useCallback`
   - A new `toggleShowSystemMonitorPanel` function has been introduced using `useCallback`
   - The `useEffect` hook for watching resources has been removed
   - The resource watching logic is now integrated into the `toggleShowSystemMonitorPanel` function
   - All instances of `setShowSystemMonitorPanel` have been replaced with `toggleShowSystemMonitorPanel`

The main changes focus on improving the component's performance and testability by:
- Moving the resource watching logic into a callback function
- Ensuring that resources are only watched when the panel is shown
- Adding unit tests to verify the component's behavior

These changes should make the component more efficient and easier to maintain.
