### PR TITLE
fix: error handling for model imports should be handled gracefully

### DIFF
--- a/extensions/model-extension/src/index.test.ts
+++ b/extensions/model-extension/src/index.test.ts
@@ -784,5 +784,63 @@ describe('JanModelExtension', () => {
         expect.anything()
       )
     })
+
+    it('should handle model with valid chat_template', async () => {
+      executeMock.mockResolvedValue('{prompt}')
+      ;(gguf as jest.Mock).mockResolvedValue({
+        metadata: {},
+      })
+      // @ts-ignore
+      global.NODE = 'node'
+      // @ts-ignore
+      global.DEFAULT_MODEL = {
+        parameters: { stop: [] },
+        settings: {
+          prompt_template: '<|im-start|>{prompt}<|im-end|>',
+        },
+      }
+
+      const result = await sut.retrieveGGUFMetadata({})
+
+      expect(result).toEqual({
+        parameters: {
+          stop: [],
+        },
+        settings: {
+          ctx_len: 4096,
+          ngl: 33,
+          prompt_template: '{prompt}',
+        },
+      })
+    })
+
+    it('should handle model without chat_template', async () => {
+      executeMock.mockRejectedValue({})
+      ;(gguf as jest.Mock).mockResolvedValue({
+        metadata: {},
+      })
+      // @ts-ignore
+      global.NODE = 'node'
+      // @ts-ignore
+      global.DEFAULT_MODEL = {
+        parameters: { stop: [] },
+        settings: {
+          prompt_template: '<|im-start|>{prompt}<|im-end|>',
+        },
+      }
+
+      const result = await sut.retrieveGGUFMetadata({})
+
+      expect(result).toEqual({
+        parameters: {
+          stop: [],
+        },
+        settings: {
+          ctx_len: 4096,
+          ngl: 33,
+          prompt_template: '<|im-start|>{prompt}<|im-end|>',
+        },
+      })
+    })
   })
 })

--- a/extensions/model-extension/src/index.ts
+++ b/extensions/model-extension/src/index.ts
@@ -577,7 +577,7 @@ export default class JanModelExtension extends ModelExtension {
         dirName,
         binaryFileName,
       ])
-    )
+    ).catch(() => undefined)
 
     const updatedModel = await this.retrieveGGUFMetadata(metadata)
 
@@ -877,8 +877,13 @@ export default class JanModelExtension extends ModelExtension {
    * @returns
    */
   async retrieveGGUFMetadata(metadata: any): Promise<Partial<Model>> {
-    const template = await executeOnMain(NODE, 'renderJinjaTemplate', metadata)
     const defaultModel = DEFAULT_MODEL as Model
+    var template = await executeOnMain(
+      NODE,
+      'renderJinjaTemplate',
+      metadata
+    ).catch(() => undefined)
+
     const eos_id = metadata['tokenizer.ggml.eos_token_id']
     const architecture = metadata['general.architecture']
 

--- a/extensions/model-extension/src/node/index.ts
+++ b/extensions/model-extension/src/node/index.ts
@@ -16,12 +16,7 @@ export const retrieveGGUFMetadata = async (ggufPath: string) => {
     // Parse metadata and tensor info
     const { metadata } = ggufMetadata(buffer.buffer)
 
-    // Parse jinja template
-    const renderedTemplate = renderJinjaTemplate(metadata)
-    return {
-      ...metadata,
-      parsed_chat_template: renderedTemplate,
-    }
+    return metadata
   } catch (e) {
     console.log('[MODEL_EXT]', e)
   }


### PR DESCRIPTION
## Describe Your Changes

There was an issue where the fix for #3708 attempted to retrieve metadata and the chat template from GGUF models, but models without a `chat_template` could throw an error. To address this, we added error handling to catch exceptions and fall back to the default chat template.

## Screenshots

|Import and HF Download Models|
|:-:|
| Mathstral |
|<img width="1206" alt="image" src="https://github.com/user-attachments/assets/c53196ef-74a4-4b72-811b-67b964295e06">|
| A random missing metadata model |
|<img width="1206" alt="image" src="https://github.com/user-attachments/assets/07b4b3a8-fd59-45ab-9e6c-d961237823dd">|
|With the correct model metadata imported|
|<img width="1206" alt="image" src="https://github.com/user-attachments/assets/bd51e942-2f2a-470e-ae79-a0123d070999">|
## Related Issues
- #3558 

## Changes have been made

1. In `index.test.ts`:
   - Two new test cases were added:
     a. Testing the handling of a model with a valid chat_template
     b. Testing the handling of a model without a chat_template

2. In `index.ts`:
   - The `retrieveGGUFMetadata` method was modified:
     - Added error handling for the `executeOnMain` function call
     - Changed how the template is retrieved, now using a try-catch block
   - In the `loadModel` method, error handling was added to the `executeOnMain` function call

3. In `node/index.ts`:
   - The `retrieveGGUFMetadata` function was simplified:
     - Removed the parsing of the Jinja template
     - Now only returns the metadata without additional processing

