### PR TITLE
feat: save instruction for new threads as a stable feature

### DIFF
--- a/web/hooks/useLoadTheme.ts
+++ b/web/hooks/useLoadTheme.ts
@@ -18,7 +18,7 @@ import {
 
 type NativeThemeProps = 'light' | 'dark'
 
-export const useLoadTheme = async () => {
+export const useLoadTheme = () => {
   const janDataFolderPath = useAtomValue(janDataFolderPathAtom)
   const setThemeOptions = useSetAtom(themesOptionsAtom)
   const setThemePath = useSetAtom(janThemesPathAtom)

--- a/web/package.json
+++ b/web/package.json
@@ -74,7 +74,6 @@
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-prettier": "^5.0.1",
     "eslint-plugin-react": "^7.34.0",
-    "eslint-plugin-react-hooks": "^4.6.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-runner": "^29.7.0",
     "prettier": "^3.0.3",

--- a/web/screens/Thread/ThreadRightPanel/index.tsx
+++ b/web/screens/Thread/ThreadRightPanel/index.tsx
@@ -251,7 +251,7 @@ const ThreadRightPanel = () => {
                 onChange={onAssistantInstructionChanged}
               />
             </div>
-            {experimentalFeature && <CopyOverInstruction />}
+            <CopyOverInstruction />
           </div>
         </TabsContent>
         <TabsContent value="model">


### PR DESCRIPTION
## Describe Your Changes

`ThreadRightPanel/index.tsx`

The condition checking for `experimentalFeature` before rendering <CopyOverInstruction /> has been removed. This means the component will always be rendered, regardless of whether the feature is experimental or not.

`eslint-plugin-react-hooks` has been removed for fix the `eslint` issue 

<img width="1276" alt="Screenshot 2024-10-14 at 22 44 41" src="https://github.com/user-attachments/assets/d4b9dc81-265e-4d5c-9dbf-594f60be35ff">

## Fixes Issues

- Closes #3704 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
