### PR TITLE
fix: issue ellipsis text on model selector and loader model start

### DIFF
--- a/web/containers/Loader/ModelStart.tsx
+++ b/web/containers/Loader/ModelStart.tsx
@@ -36,13 +36,13 @@ export default function ModelStart() {
 
   return (
     <div className=" mb-1 mt-2 py-2 text-center">
-      <div className="relative inline-block overflow-hidden rounded-lg bg-[hsla(var(--loader-bg))] px-4 py-2 font-semibold text-[hsla(var(--loader-fg))] shadow-lg">
+      <div className="relative inline-block max-w-[300px] overflow-hidden text-ellipsis whitespace-nowrap rounded-lg bg-[hsla(var(--loader-bg))] px-4 py-2 font-semibold text-[hsla(var(--loader-fg))] shadow-lg">
         <div
           className="absolute left-0 top-0 h-full bg-[hsla(var(--loader-active-bg))]"
           style={{ width: `${loader}%` }}
           data-testid="model-loader"
         />
-        <span className="relative z-10 line-clamp-1 max-w-[300px]">
+        <span className="relative z-10">
           {stateModel.state === 'start' ? 'Starting' : 'Stopping'}
           &nbsp;model&nbsp;
           {stateModel.model?.id}

--- a/web/containers/ModelDropdown/index.tsx
+++ b/web/containers/ModelDropdown/index.tsx
@@ -313,14 +313,12 @@ const ModelDropdown = ({
             theme="secondary"
             variant={open ? 'solid' : 'outline'}
             className={twMerge(
-              'cursor-pointer',
+              'inline-block max-w-[200px] cursor-pointer overflow-hidden text-ellipsis whitespace-nowrap',
               open && 'border border-transparent'
             )}
             onClick={() => setOpen(!open)}
           >
-            <span className="line-clamp-1 max-w-[286px]">
-              {selectedModel?.name}
-            </span>
+            <span>{selectedModel?.name}</span>
           </Badge>
         ) : (
           <Input


### PR DESCRIPTION
## Describe Your Changes

#### File: `web/containers/Loader/ModelStart.tsx`

- **Styling**: These changes enhance the visual presentation by ensuring that the loader and state text do not overflow beyond 300 pixels in width. Truncation with an ellipsis prevents content from stretching unnecessarily.
- **Readability**: The removal of `line-clamp` means the full text is now visible if it fits within the container, which might improve readability for longer model IDs.

#### File: `web/containers/ModelDropdown/index.tsx`

- **Styling**: These changes enhance the visual presentation by ensuring that the model name does not overflow beyond 200 pixels in width. Truncation with an ellipsis prevents content from stretching unnecessarily.
- **Readability**: The removal of `line-clamp` means the full text is now visible if it fits within the container, which might improve readability for longer model names.

#### Summary:

The changes made to both files aim to improve the visual presentation by controlling the width of elements that could potentially grow large, ensuring they do not overflow their containers. This helps in maintaining a cleaner and more consistent layout across different screen sizes and content lengths.

## Fixes Issues

<img width="968" alt="Screenshot 2024-10-15 at 11 24 43" src="https://github.com/user-attachments/assets/54634fa4-bee2-4e37-a61f-87d3323b9a3e">

- Closes #3759 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
