### PR TITLE
chore: replace windows codesign cert

### DIFF
--- a/.github/workflows/template-build-windows-x64.yml
+++ b/.github/workflows/template-build-windows-x64.yml
@@ -113,7 +113,7 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          AZURE_CERT_NAME: ${{ secrets.AZURE_CERT_NAME }}
+          AZURE_CERT_NAME: homebrewltd
           AWS_ACCESS_KEY_ID: ${{ secrets.DELTA_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.DELTA_AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
@@ -132,7 +132,7 @@ jobs:
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          AZURE_CERT_NAME: ${{ secrets.AZURE_CERT_NAME }}
+          AZURE_CERT_NAME: homebrewltd
 
       - name: Upload Artifact
         if: inputs.public_provider != 'github'


### PR DESCRIPTION
## Describe Your Changes

- chore: replace windows codesign cert

## Fixes Issues

- Related issue #3801 
- Closes #

## To test updating the app from the old codesign version to the new codesign version, follow these steps:

- Step 1: Download the Jan Windows version with the old codesign of the beta version (this is a test version, and we haven't notified users about it yet; I will remove it later). You can download it here: https://github.com/janhq/jan/releases/download/v0.5.7-rc1-beta/jan-beta-win-x64-0.5.7-rc1-beta.exe. After downloading, you can verify that this version is signed with Jan's certificate.
  ![image](https://github.com/user-attachments/assets/9b7b0266-6019-4b6c-a2fe-0f548b8c861e)

- Step 2: Install the app. After installation, you will see a notification that a new version (v0.5.7-rc2-beta) is available for update. Click to update it, and then restart the app => you update app successfully

- Step 3: You can download the Windows file for v0.5.7-rc2-beta here: https://github.com/janhq/jan/releases/download/v0.5.7-rc2-beta/jan-beta-win-x64-0.5.7-rc2-beta.exe and verify that it is signed with the Homebrew certificate.
  ![image](https://github.com/user-attachments/assets/0f6a62c8-4b48-4ca9-aaba-c1518e9f8f3a)

