### PR TITLE
fix: correct eos token of llava models

### DIFF
--- a/extensions/inference-nitro-extension/package.json
+++ b/extensions/inference-nitro-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janhq/inference-cortex-extension",
   "productName": "Cortex Inference Engine",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "This extension embeds cortex.cpp, a lightweight inference engine written in C++. See https://jan.ai.\nAdditional dependencies could be installed to run without Cuda Toolkit installation.",
   "main": "dist/index.js",
   "node": "dist/node/index.cjs.js",

--- a/extensions/inference-nitro-extension/resources/models/llava-13b/model.json
+++ b/extensions/inference-nitro-extension/resources/models/llava-13b/model.json
@@ -12,7 +12,7 @@
   "id": "llava-13b",
   "object": "model",
   "name": "LlaVa 13B Q4",
-  "version": "1.1",
+  "version": "1.2",
   "description": "LlaVa can bring vision understanding to Jan",
   "format": "gguf",
   "settings": {
@@ -24,7 +24,8 @@
     "mmproj": "mmproj-model-f16.gguf"
   },
   "parameters": {
-    "max_tokens": 4096
+    "max_tokens": 4096,
+    "stop": ["</s>"]
   },
   "metadata": {
     "author": "liuhaotian",

--- a/extensions/inference-nitro-extension/resources/models/llava-7b/model.json
+++ b/extensions/inference-nitro-extension/resources/models/llava-7b/model.json
@@ -12,7 +12,7 @@
   "id": "llava-7b",
   "object": "model",
   "name": "LlaVa 7B",
-  "version": "1.1",
+  "version": "1.2",
   "description": "LlaVa can bring vision understanding to Jan",
   "format": "gguf",
   "settings": {
@@ -24,7 +24,8 @@
     "mmproj": "mmproj-model-f16.gguf"
   },
   "parameters": {
-    "max_tokens": 4096
+    "max_tokens": 4096,
+    "stop": ["</s>"]
   },
   "metadata": {
     "author": "liuhaotian",


### PR DESCRIPTION
# Update LLaVa model configurations

## Changes

 Updated LLaVa model configurations:
   - For both LLaVa 13B and LLaVa 7B models:
     - Bumped version from 1.1 to 1.2
     - Added a "stop" parameter with the value ["</s>"]

## Rationale

This PR includes a minor version bump for the Cortex Inference Engine extension, likely to reflect the changes made to the LLaVa model configurations.

The updates to the LLaVa models (both 13B and 7B versions) introduce a "stop" parameter, which can help control the model's output by specifying when to stop generating text. This can potentially improve the quality and relevance of the model's responses.

## Testing

The LLaVa models (13B and 7B) function as expected with the new configuration, particularly checking if the "stop" parameter is properly recognized and applied during inference.
