### PR TITLE
fix: context length input value isn't update 

### DIFF
--- a/web/containers/ModelSetting/SettingComponent.tsx
+++ b/web/containers/ModelSetting/SettingComponent.tsx
@@ -25,6 +25,7 @@ const SettingComponent: React.FC<Props> = ({
       case 'slider': {
         const { min, max, step, value } =
           data.controllerProps as SliderComponentProps
+
         return (
           <SliderRightPanel
             key={data.key}

--- a/web/containers/SliderRightPanel/index.tsx
+++ b/web/containers/SliderRightPanel/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { Slider, Input, Tooltip } from '@janhq/joi'
 
@@ -31,6 +31,10 @@ const SliderRightPanel = ({
   const [val, setVal] = useState(value.toString())
 
   useClickOutside(() => setShowTooltip({ max: false, min: false }), null, [])
+
+  useEffect(() => {
+    setVal(value.toString())
+  }, [value])
 
   return (
     <div className="flex flex-col">


### PR DESCRIPTION
## Describe Your Changes

To make val always stay in sync with `value.toString()` in React, you need to update val whenever value changes. we need using the `useEffect` hook, which will listen for changes in value and update val accordingly.


## Fixes Issues

- Closes #3842 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
