### PR TITLE
Update broken/outdated hyperlink

### DIFF
--- a/extensions/inference-martian-extension/resources/settings.json
+++ b/extensions/inference-martian-extension/resources/settings.json
@@ -14,7 +14,7 @@
   {
     "key": "chat-completions-endpoint",
     "title": "Chat Completions Endpoint",
-    "description": "The endpoint to use for chat completions. See the [Martian API documentation](https://docs.withmartian.com/martian-model-router/api-reference/get-chat-completions) for more information.",
+    "description": "The endpoint to use for chat completions. See the [Martian API documentation](https://docs.withmartian.com/martian-model-router/getting-started/quickstart-integrating-martian-into-your-codebase) for more information.",
     "controllerType": "input",
     "controllerProps": {
       "placeholder": "https://withmartian.com/api/openai/v1/chat/completions",


### PR DESCRIPTION
## **Describe Your Changes**

- Updated the incorrect hyperlink for the **Martian** section under **Settings > Model Providers > Martian** to point to the correct documentation.
- Replaced the old link [https://docs.withmartian.com/martian-model-router/api-reference/get-chat-completions](https://docs.withmartian.com/martian-model-router/api-reference/get-chat-completions) with [https://docs.withmartian.com/martian-model-router/getting-started/quickstart-integrating-martian-into-your-codebase](https://docs.withmartian.com/martian-model-router/getting-started/quickstart-integrating-martian-into-your-codebase), which provides more accurate and up-to-date integration instructions for Martian.

---

## **Fixes Issues**

- Closes #3856 
---

## **Self Checklist**

- [ ] Added relevant comments, especially in complex areas.
- [x] Updated docs (for bug fixes / features).
- [ ] Created issues for follow-up changes or refactoring needed.