### PR TITLE
fix: edge case tiny chat input box show randomly

### DIFF
--- a/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
@@ -123,9 +123,8 @@ const ChatInput = () => {
 
   return (
     <div className="relative p-4 pb-2">
-      <div className="relative flex w-full flex-col">
+      <div className="relative block">
         {renderPreview(fileUpload)}
-
         <RichTextEditor
           className={twMerge(
             'relative mb-1 max-h-[400px] resize-none rounded-lg border border-[hsla(var(--app-border))] p-3 pr-20',
@@ -141,7 +140,7 @@ const ChatInput = () => {
           disabled={stateModel.loading || !activeThread}
         />
         <TextArea
-          className="absolute inset-0 top-14 h-0 w-0"
+          className="sr-only"
           data-testid="txt-input-chat"
           onChange={(e) => setCurrentPrompt(e.target.value)}
         />

--- a/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
@@ -123,7 +123,7 @@ const ChatInput = () => {
 
   return (
     <div className="relative p-4 pb-2">
-      <div className="relative block">
+      <div className="relative flex w-full flex-col">
         {renderPreview(fileUpload)}
         <RichTextEditor
           className={twMerge(


### PR DESCRIPTION
## Issue

https://discord.com/channels/1107178041848909847/1149558035971321886/1299591685667553290

- Issue edge case show tiny chat input box
- copy and paste text below to input chat box

```
Hi mew,


asdf awef 


afsdfawef
asdf awe f 



    
```

## Describe Your Changes

- Hides elements from visual users but makes them available to screen readers

## Fixes Issues

<img width="1046" alt="Screenshot 2024-10-27 at 06 39 18" src="https://github.com/user-attachments/assets/105a30bc-646f-42b2-b48f-3a5af75d6881">

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
