### PR TITLE
chore: remove deprecated warning from build project joi

### DIFF
--- a/joi/rollup.config.mjs
+++ b/joi/rollup.config.mjs
@@ -38,7 +38,11 @@ export default [
       postcss({
         plugins: [autoprefixer(), tailwindcss(tailwindConfig)],
         sourceMap: true,
-        use: ['sass'],
+        use: {
+          sass: {
+            silenceDeprecations: ['legacy-js-api'],
+          },
+        },
         minimize: true,
         extract: 'main.css',
       }),


### PR DESCRIPTION
## Issue 
![Screenshot 2024-10-28 at 13 15 25](https://github.com/user-attachments/assets/d32140e6-6359-403d-805e-519b1f2933bb)

## Describe Your Changes
Update `rollup` config to use option sass `silenceDeprecations`

## Fixes Issues
![Screenshot 2024-10-28 at 13 19 38](https://github.com/user-attachments/assets/7c05c13a-7c5f-4b84-9a80-651672259f03)

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
