### PR TITLE
feat: expand the clickable areas ribbon panel

### DIFF
--- a/web/containers/Layout/RibbonPanel/index.tsx
+++ b/web/containers/Layout/RibbonPanel/index.tsx
@@ -95,10 +95,11 @@ export default function RibbonPanel() {
         return (
           <div
             className={twMerge(
-              'relative my-0.5 flex h-8 w-8 items-center justify-center rounded-md hover:bg-[hsla(var(--ribbon-panel-icon-hover))]',
+              'relative my-0.5 flex h-8 w-8 cursor-pointer items-center justify-center rounded-md hover:bg-[hsla(var(--ribbon-panel-icon-hover))]',
               i === 1 && 'mb-auto'
             )}
             key={i}
+            onClick={() => onMenuClick(menu.state)}
           >
             <Tooltip
               side="right"
@@ -112,7 +113,6 @@ export default function RibbonPanel() {
                       isActive &&
                         'z-10 text-[hsla(var(--ribbon-panel-icon-active))]'
                     )}
-                    onClick={() => onMenuClick(menu.state)}
                   >
                     {menu.icon}
                   </div>


### PR DESCRIPTION
## Describe Your Changes

Adding `onClick` to the outer `div`:
A new `onClick` attribute was added to the outer div, which calls the `onMenuClick(menu.state)` function when clicked. This change ensures that clicking on the entire menu item triggers the `onMenuClick` function, rather than just the icon.

## Fixes Issues

- Closes #3885 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
