### PR TITLE
fix: Inconsistent model hub and download bar

### DIFF
--- a/core/src/node/api/processors/download.ts
+++ b/core/src/node/api/processors/download.ts
@@ -50,11 +50,6 @@ export class Downloader implements Processor {
     const initialDownloadState: DownloadState = {
       modelId,
       fileName,
-      time: {
-        elapsed: 0,
-        remaining: 0,
-      },
-      speed: 0,
       percent: 0,
       size: {
         total: 0,

--- a/core/src/types/file/index.ts
+++ b/core/src/types/file/index.ts
@@ -6,8 +6,8 @@ export type FileStat = {
 export type DownloadState = {
   modelId: string // TODO: change to download id
   fileName: string
-  time: DownloadTime
-  speed: number
+  time?: DownloadTime
+  speed?: number
 
   percent: number
   size: DownloadSize

--- a/web/containers/Layout/BottomPanel/DownloadingState/index.tsx
+++ b/web/containers/Layout/BottomPanel/DownloadingState/index.tsx
@@ -2,15 +2,19 @@ import { Fragment } from 'react'
 
 import { Progress, Modal, Button } from '@janhq/joi'
 
-import { useAtomValue } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 
 import useDownloadModel from '@/hooks/useDownloadModel'
-import { modelDownloadStateAtom } from '@/hooks/useDownloadState'
+import {
+  modelDownloadStateAtom,
+  removeDownloadStateAtom,
+} from '@/hooks/useDownloadState'
 
 import { formatDownloadPercentage } from '@/utils/converter'
 
 export default function DownloadingState() {
   const downloadStates = useAtomValue(modelDownloadStateAtom)
+  const removeDownloadState = useSetAtom(removeDownloadStateAtom)
   const { abortModelDownload } = useDownloadModel()
 
   const totalCurrentProgress = Object.values(downloadStates)
@@ -73,6 +77,7 @@ export default function DownloadingState() {
                       theme="destructive"
                       onClick={() => {
                         if (item?.modelId) {
+                          removeDownloadState(item?.modelId)
                           abortModelDownload(item?.modelId)
                         }
                       }}

--- a/web/containers/ModalCancelDownload/index.tsx
+++ b/web/containers/ModalCancelDownload/index.tsx
@@ -8,11 +8,12 @@ import { useAtomValue, useSetAtom } from 'jotai'
 
 import useDownloadModel from '@/hooks/useDownloadModel'
 
-import { modelDownloadStateAtom } from '@/hooks/useDownloadState'
+import {
+  modelDownloadStateAtom,
+  removeDownloadStateAtom,
+} from '@/hooks/useDownloadState'
 
 import { formatDownloadPercentage } from '@/utils/converter'
-
-import { removeDownloadingModelAtom } from '@/helpers/atoms/Model.atom'
 
 type Props = {
   model: Model
@@ -21,16 +22,16 @@ type Props = {
 
 const ModalCancelDownload = ({ model, isFromList }: Props) => {
   const { abortModelDownload } = useDownloadModel()
-  const removeModelDownload = useSetAtom(removeDownloadingModelAtom)
+  const removeDownloadState = useSetAtom(removeDownloadStateAtom)
   const allDownloadStates = useAtomValue(modelDownloadStateAtom)
   const downloadState = allDownloadStates[model.id]
 
   const cancelText = `Cancel ${formatDownloadPercentage(downloadState?.percent ?? 0)}`
 
   const onAbortDownloadClick = useCallback(() => {
-    removeModelDownload(model.id)
+    removeDownloadState(model.id)
     abortModelDownload(downloadState?.modelId ?? model.id)
-  }, [downloadState, abortModelDownload, removeModelDownload, model])
+  }, [downloadState, abortModelDownload, removeDownloadState, model])
 
   return (
     <Modal

--- a/web/hooks/useDownloadModel.ts
+++ b/web/hooks/useDownloadModel.ts
@@ -6,6 +6,8 @@ import { useSetAtom } from 'jotai'
 
 import { toaster } from '@/containers/Toast'
 
+import { setDownloadStateAtom } from './useDownloadState'
+
 import { extensionManager } from '@/extension/ExtensionManager'
 
 import {
@@ -16,10 +18,21 @@ import {
 export default function useDownloadModel() {
   const removeDownloadingModel = useSetAtom(removeDownloadingModelAtom)
   const addDownloadingModel = useSetAtom(addDownloadingModelAtom)
+  const setDownloadStates = useSetAtom(setDownloadStateAtom)
 
   const downloadModel = useCallback(
     async (model: string, id?: string, name?: string) => {
       addDownloadingModel(id ?? model)
+      setDownloadStates({
+        modelId: id ?? model,
+        downloadState: 'downloading',
+        fileName: id ?? model,
+        size: {
+          total: 0,
+          transferred: 0,
+        },
+        percent: 0,
+      })
       downloadLocalModel(model, id, name).catch((error) => {
         if (error.message) {
           toaster({
@@ -32,7 +45,7 @@ export default function useDownloadModel() {
         removeDownloadingModel(model)
       })
     },
-    [removeDownloadingModel, addDownloadingModel]
+    [removeDownloadingModel, addDownloadingModel, setDownloadStates]
   )
 
   const abortModelDownload = useCallback(async (model: string) => {

--- a/web/hooks/useDownloadState.ts
+++ b/web/hooks/useDownloadState.ts
@@ -10,8 +10,18 @@ import {
 } from '@/helpers/atoms/Model.atom'
 
 // download states
+
 export const modelDownloadStateAtom = atom<Record<string, DownloadState>>({})
 
+/**
+ * Remove a download state for a particular model.
+ */
+export const removeDownloadStateAtom = atom(null, (get, set, id: string) => {
+  const currentState = { ...get(modelDownloadStateAtom) }
+  delete currentState[id]
+  set(modelDownloadStateAtom, currentState)
+  set(removeDownloadingModelAtom, id)
+})
 /**
  * Used to set the download state for a particular model.
  */

--- a/web/screens/Settings/MyModels/MyModelList/index.tsx
+++ b/web/screens/Settings/MyModels/MyModelList/index.tsx
@@ -1,6 +1,6 @@
 import { memo, useState } from 'react'
 
-import { InferenceEngine, Model } from '@janhq/core'
+import { Model } from '@janhq/core'
 import { Badge, Button, Tooltip, useClickOutside } from '@janhq/joi'
 import { useAtom } from 'jotai'
 import {


### PR DESCRIPTION
## Describe Your Changes

- There was an issue where cortex.cpp does not support simultaneous downloads. Therefore, Jan should show the model download at 0 percent as a download bar.

<img width="1365" alt="Screenshot 2024-11-06 at 09 08 14" src="https://github.com/user-attachments/assets/8d7c0305-febb-4d98-8670-b7b43a426366">

## Changes made

1. **`download.ts`:**  
   - Removed `time` and `speed` from the initial download state definition, reflecting these as optional in the `DownloadState` type.

2. **`file/index.ts`:**  
   - Modified the `DownloadState` type to make `time` and `speed` optional.

3. **`DownloadingState/index.tsx`:**  
   - Added the `removeDownloadStateAtom` to handle the removal of download states.
   - Enhanced the abort logic to also remove the download state when an abort is initiated.

4. **`ModalCancelDownload/index.tsx`:**  
   - Similar updates as in `DownloadingState`, using `removeDownloadStateAtom` to remove download states upon abort.

5. **`useDownloadModel.ts`:**  
   - Implemented `setDownloadStateAtom` to update the download state when a model download is initiated.
   - Updated dependency arrays for `useCallback`.

6. **`useDownloadState.ts`:**  
   - Introduced `removeDownloadStateAtom` to allow state removal for a specific model, complementing existing download state management functions.

7. **`MyModelList/index.tsx`:**  
   - Removed unused `InferenceEngine` import.

This overall diff handles refactoring of download management to streamline state updates and cleanup, especially focusing on how abort operations are handled in a more coherent manner with the updated state management logic.