### PR TITLE
chore: support customized OpenAI model.json

### DIFF
--- a/extensions/model-extension/src/legacy/model-json.ts
+++ b/extensions/model-extension/src/legacy/model-json.ts
@@ -1,5 +1,13 @@
 import { InferenceEngine, Model, fs, joinPath } from '@janhq/core'
 //// LEGACY MODEL FOLDER ////
+const LocalEngines = [
+  InferenceEngine.cortex,
+  InferenceEngine.cortex_llamacpp,
+  InferenceEngine.cortex_tensorrtllm,
+  InferenceEngine.cortex_onnx,
+  InferenceEngine.nitro_tensorrt_llm,
+  InferenceEngine.nitro,
+]
 /**
  * Scan through models folder and return downloaded models
  * @returns
@@ -57,7 +65,11 @@ export const scanModelsFolder = async (): Promise<Model[]> => {
               !source.url.startsWith(`https://`)
           )
         )
-        if (existFiles.every((exist) => exist)) return model
+        if (
+          !LocalEngines.includes(model.engine) ||
+          existFiles.every((exist) => exist)
+        )
+          return model
 
         const result = await fs
           .readdirSync(await joinPath([_homeDir, dirName]))

--- a/web/hooks/useModels.ts
+++ b/web/hooks/useModels.ts
@@ -43,7 +43,13 @@ const useModels = () => {
         .models.values()
         .toArray()
         .filter((e) => !isLocalEngine(e.engine))
-      const toUpdate = [...localModels, ...remoteModels]
+      const toUpdate = [
+        ...localModels,
+        ...remoteModels.filter(
+          (e: Model) => !localModels.some((g: Model) => g.id === e.id)
+        ),
+      ]
+
       setDownloadedModels(toUpdate)
 
       let isUpdated = false


### PR DESCRIPTION
## Describe Your Changes

This PR allows users to customize model.json to point to a compatible OpenAI endpoint. It applies the legacy model scanning for these cases.

![Screenshot 2024-11-06 at 16 47 15](https://github.com/user-attachments/assets/d2686fec-2309-4174-bdcd-ae140814fbf1)

## Changes made

The `git diff` highlights the following changes in the `model-json.ts` file:

1. **Added Local Engines Array:**
   - A new constant array `LocalEngines` has been added. It contains specific inference engines from the `InferenceEngine` enum: `cortex`, `cortex_llamacpp`, `cortex_tensorrtllm`, `cortex_onnx`, `nitro_tensorrt_llm`, and `nitro`.

2. **Modified Conditional Logic:**
   - The conditional check within the `scanModelsFolder` function was altered.
   - Previously, the code returned the `model` if all `existFiles` evaluated to true.
   - Now, the code checks if the model's engine is *not* in the `LocalEngines` list or if all `existFiles` are true before returning the `model`. If either of these conditions is met, the model is returned.

These changes adjust how models are processed based on their engine type and the existence of corresponding files.
