### PR TITLE
fix: export PATH env to engine destination folder to have additional dlls scoped

### DIFF
--- a/extensions/inference-cortex-extension/download.bat
+++ b/extensions/inference-cortex-extension/download.bat
@@ -7,7 +7,7 @@ set /p CORTEX_VERSION=<./bin/version.txt
 set VERSION=v0.1.35
 set DOWNLOAD_URL=https://github.com/janhq/cortex.llamacpp/releases/download/%VERSION%/cortex.llamacpp-0.1.35-windows-amd64
 set CUDA_DOWNLOAD_URL=https://github.com/janhq/cortex.llamacpp/releases/download/%VERSION%
-set SUBFOLDERS=win-cuda-12-0 win-cuda-11-7 win-noavx win-avx win-avx2 win-avx512 win-vulkan
+set SUBFOLDERS=noavx-cuda-12-0 noavx-cuda-11-7 avx2-cuda-12-0 avx2-cuda-11-7 noavx avx avx2 avx512 vulkan
 
 call .\node_modules\.bin\download -e --strip 1 -o %BIN_PATH% https://github.com/janhq/cortex/releases/download/v%CORTEX_VERSION%/cortex-%CORTEX_VERSION%-windows-amd64.tar.gz
 call .\node_modules\.bin\download %DOWNLOAD_URL%-avx2-cuda-12-0.tar.gz -e --strip 1 -o %BIN_PATH%/avx2-cuda-12-0/engines/cortex.llamacpp

--- a/extensions/inference-cortex-extension/src/index.ts
+++ b/extensions/inference-cortex-extension/src/index.ts
@@ -11,7 +11,6 @@ import {
   executeOnMain,
   systemInformation,
   joinPath,
-  dirName,
   LocalOAIEngine,
   InferenceEngine,
   getJanDataFolderPath,
@@ -97,7 +96,7 @@ export default class JanInferenceCortexExtension extends LocalOAIEngine {
       model.settings = settings
     }
 
-    return await ky
+    return await this.queue.add(() => ky
       .post(`${CORTEX_API_URL}/v1/models/start`, {
         json: {
           ...extractModelLoadParams(model.settings),
@@ -112,7 +111,7 @@ export default class JanInferenceCortexExtension extends LocalOAIEngine {
       .catch(async (e) => {
         throw (await e.response?.json()) ?? e
       })
-      .then()
+      .then())
   }
 
   override async unloadModel(model: Model): Promise<void> {

--- a/extensions/inference-cortex-extension/src/index.ts
+++ b/extensions/inference-cortex-extension/src/index.ts
@@ -15,6 +15,7 @@ import {
   InferenceEngine,
   getJanDataFolderPath,
   extractModelLoadParams,
+  fs,
 } from '@janhq/core'
 import PQueue from 'p-queue'
 import ky from 'ky'
@@ -96,22 +97,24 @@ export default class JanInferenceCortexExtension extends LocalOAIEngine {
       model.settings = settings
     }
 
-    return await this.queue.add(() => ky
-      .post(`${CORTEX_API_URL}/v1/models/start`, {
-        json: {
-          ...extractModelLoadParams(model.settings),
-          model: model.id,
-          engine:
-            model.engine === InferenceEngine.nitro // Legacy model cache
-              ? InferenceEngine.cortex_llamacpp
-              : model.engine,
-        },
-      })
-      .json()
-      .catch(async (e) => {
-        throw (await e.response?.json()) ?? e
-      })
-      .then())
+    return await this.queue.add(() =>
+      ky
+        .post(`${CORTEX_API_URL}/v1/models/start`, {
+          json: {
+            ...extractModelLoadParams(model.settings),
+            model: model.id,
+            engine:
+              model.engine === InferenceEngine.nitro // Legacy model cache
+                ? InferenceEngine.cortex_llamacpp
+                : model.engine,
+          },
+        })
+        .json()
+        .catch(async (e) => {
+          throw (await e.response?.json()) ?? e
+        })
+        .then()
+    )
   }
 
   override async unloadModel(model: Model): Promise<void> {
@@ -159,7 +162,10 @@ export const getModelFilePath = async (
   file: string
 ): Promise<string> => {
   // Symlink to the model file
-  if (!model.sources[0]?.url.startsWith('http')) {
+  if (
+    !model.sources[0]?.url.startsWith('http') &&
+    (await fs.existsSync(model.sources[0].url))
+  ) {
     return model.sources[0]?.url
   }
   return joinPath([await getJanDataFolderPath(), 'models', model.id, file])

--- a/extensions/inference-cortex-extension/src/node/index.ts
+++ b/extensions/inference-cortex-extension/src/node/index.ts
@@ -33,6 +33,11 @@ function run(systemInfo?: SystemInformation): Promise<any> {
     addEnvPaths(path.join(appResourcePath(), 'shared'))
     addEnvPaths(executableOptions.binPath)
     addEnvPaths(executableOptions.enginePath)
+    // Add the cortex.llamacpp path to the PATH and LD_LIBRARY_PATH
+    // This is required for the cortex engine to run for now since dlls are not moved to the root
+    addEnvPaths(
+      path.join(executableOptions.enginePath, 'engines', 'cortex.llamacpp')
+    )
 
     const dataFolderPath = getJanDataFolderPath()
     watchdog = new ProcessWatchdog(

--- a/extensions/model-extension/src/index.ts
+++ b/extensions/model-extension/src/index.ts
@@ -9,7 +9,7 @@ import {
   DownloadState,
   events,
   DownloadEvent,
-  OptionType
+  OptionType,
 } from '@janhq/core'
 import { CortexAPI } from './cortex'
 import { scanModelsFolder } from './legacy/model-json'
@@ -189,7 +189,8 @@ export default class JanModelExtension extends ModelExtension {
                     model.sources[0]?.url.split('/').pop() ??
                     model.id,
                 ]) // Copied models
-              : model.sources[0].url // Symlink models
+              : model.sources[0].url, // Symlink models,
+            model.name
           )
         )
       )

--- a/extensions/model-extension/src/index.ts
+++ b/extensions/model-extension/src/index.ts
@@ -4,6 +4,7 @@ import {
   InferenceEngine,
   joinPath,
   dirName,
+  fs,
   ModelManager,
   abortDownload,
   DownloadState,
@@ -181,7 +182,8 @@ export default class JanModelExtension extends ModelExtension {
         toImportModels.map(async (model: Model & { file_path: string }) =>
           this.importModel(
             model.id,
-            model.sources[0].url.startsWith('http')
+            model.sources[0].url.startsWith('http') ||
+              !(await fs.existsSync(model.sources[0].url))
               ? await joinPath([
                   await dirName(model.file_path),
                   model.sources[0]?.filename ??


### PR DESCRIPTION
## Describe Your Changes

This is to add engine destination into PATH so that the OS can scope the additional dlls in.

## Changes made

The given `git diff` shows changes made to the `index.ts` file in the `extensions/inference-cortex-extension/src/node/` directory. Here's a summary of the modifications:

- **Addition**: A new block of code has been added between existing lines (after line 33). This newly added block is responsible for adding the `cortex.llamacpp` path to both the `PATH` and `LD_LIBRARY_PATH` environment variables.
- **Context**: This addition is necessary for ensuring that the `cortex` engine executable and its dependencies (DLLs) can be found and executed correctly, as the required DLLs are not yet moved to a more accessible location within the system's root directories.
- **Impact**: By calling `addEnvPaths` with the path to the `cortex.llamacpp` directory, the program can successfully locate and execute necessary binaries and dynamic libraries at runtime.

Overall, these changes aim to improve the integration and execution environment configuration related to the `cortex` engine within the application.
