### PR TITLE
chore: proxies Jan APIs to cortex.cpp

### DIFF
--- a/core/src/node/api/restful/common.ts
+++ b/core/src/node/api/restful/common.ts
@@ -10,6 +10,7 @@ import {
   getMessages,
   retrieveMessage,
   updateThread,
+  getModels,
 } from './helper/builder'
 
 import { JanApiRouteConfiguration } from './helper/configuration'
@@ -26,9 +27,12 @@ export const commonRouter = async (app: HttpServer) => {
   // Common Routes
   // Read & Delete :: Threads | Models | Assistants
   Object.keys(JanApiRouteConfiguration).forEach((key) => {
-    app.get(`/${key}`, async (_request) =>
-      getBuilder(JanApiRouteConfiguration[key]).then(normalizeData)
-    )
+    app.get(`/${key}`, async (_req, _res) => {
+      if (key === 'models') {
+        return getModels(_req, _res)
+      }
+      return getBuilder(JanApiRouteConfiguration[key]).then(normalizeData)
+    })
 
     app.get(`/${key}/:id`, async (request: any) =>
       retrieveBuilder(JanApiRouteConfiguration[key], request.params.id)

--- a/core/src/node/api/restful/common.ts
+++ b/core/src/node/api/restful/common.ts
@@ -10,7 +10,7 @@ import {
   getMessages,
   retrieveMessage,
   updateThread,
-  getModels,
+  models,
 } from './helper/builder'
 
 import { JanApiRouteConfiguration } from './helper/configuration'
@@ -29,7 +29,7 @@ export const commonRouter = async (app: HttpServer) => {
   Object.keys(JanApiRouteConfiguration).forEach((key) => {
     app.get(`/${key}`, async (_req, _res) => {
       if (key === 'models') {
-        return getModels(_req, _res)
+        return models(_req, _res)
       }
       return getBuilder(JanApiRouteConfiguration[key]).then(normalizeData)
     })

--- a/core/src/node/api/restful/helper/builder.test.ts
+++ b/core/src/node/api/restful/helper/builder.test.ts
@@ -220,22 +220,6 @@ describe('builder helper functions', () => {
   })
 
   describe('chatCompletions', () => {
-    it('should return an error if model is not found', async () => {
-      const request = { body: { model: 'nonexistentModel' } }
-      const reply = { code: jest.fn().mockReturnThis(), send: jest.fn() }
-
-      await chatCompletions(request, reply)
-      expect(reply.code).toHaveBeenCalledWith(404)
-      expect(reply.send).toHaveBeenCalledWith({
-        error: {
-          message: 'The model nonexistentModel does not exist',
-          type: 'invalid_request_error',
-          param: null,
-          code: 'model_not_found',
-        },
-      })
-    })
-
     it('should return the error on status not ok', async () => {
       const request = { body: { model: 'model1' } }
       const mockSend = jest.fn()

--- a/core/src/node/api/restful/helper/builder.ts
+++ b/core/src/node/api/restful/helper/builder.ts
@@ -302,14 +302,14 @@ export const downloadModel = async (
  * @param request
  * @param reply
  */
-export const getModels = async (request: any, reply: any) => {
+export const models = async (request: any, reply: any) => {
   const fetch = require('node-fetch')
   const headers: Record<string, any> = {
     'Content-Type': 'application/json',
   }
 
   const response = await fetch(`${CORTEX_API_URL}/models`, {
-    method: 'GET',
+    method: request.method,
     headers: headers,
     body: JSON.stringify(request.body),
   })

--- a/core/src/node/api/restful/helper/consts.ts
+++ b/core/src/node/api/restful/helper/consts.ts
@@ -6,4 +6,4 @@ export const LOCAL_HOST = '127.0.0.1'
 
 export const SUPPORTED_MODEL_FORMAT = '.gguf'
 
-export const DEFAULT_CHAT_COMPLETION_URL = `http://${LOCAL_HOST}:${CORTEX_DEFAULT_PORT}/v1/chat/completions` // default nitro url
+export const CORTEX_API_URL = `http://${LOCAL_HOST}:${CORTEX_DEFAULT_PORT}/v1` // default nitro url

--- a/core/src/node/api/restful/helper/consts.ts
+++ b/core/src/node/api/restful/helper/consts.ts
@@ -1,9 +1,7 @@
-// The PORT to use for the Nitro subprocess
 export const CORTEX_DEFAULT_PORT = 39291
 
-// The HOST address to use for the Nitro subprocess
 export const LOCAL_HOST = '127.0.0.1'
 
 export const SUPPORTED_MODEL_FORMAT = '.gguf'
 
-export const CORTEX_API_URL = `http://${LOCAL_HOST}:${CORTEX_DEFAULT_PORT}/v1` // default nitro url
+export const CORTEX_API_URL = `http://${LOCAL_HOST}:${CORTEX_DEFAULT_PORT}/v1`


### PR DESCRIPTION
## Describe Your Changes

This PR makes Jan /models and /chat_completions proxies to cortex.cpp.

NOTES: This removed the OpenAI proxy due to poor implementation and missing features. It would be better for cortex.cpp to support this more soon.

## Changes made

1. **Proxying /models Route:**
   - The `getModels` function was introduced in `helper/builder.ts`. It is designed to proxy requests to the `/models` endpoint of the Cortex API.
   - In `common.ts`, the `/models` route handling in the `commonRouter` was modified to use the new `getModels` function.

2. **Refactoring chatCompletions:**
   - Removed retrieval of model details and configuration for the chatCompletions logic.
   - The `chatCompletions` function no longer fetches model configurations or dynamically constructs the API URL based on a model ID. Instead, it directly calls the Cortex endpoint.

3. **Constants Refactoring:**
   - The constant `DEFAULT_CHAT_COMPLETION_URL` was renamed to `CORTEX_API_URL`.
   - Its value was modified to be more generic, ending with `/v1`, without the `/chat/completions` path.

4. **HTTP Request Handling:**
   - Both `getModels` and `chatCompletions` now utilize `node-fetch` for making HTTP requests to the Cortex API. 
   - The functions include enhanced error handling by forwarding error responses from the Cortex API back to the client.
   - For successful response handling, models and completions now pipe the API's response directly to the client for efficiency.

5. **Minor Adjustments:**
   - Removal of imports for unused variables like `getEngineConfiguration`, `Model`, and `DEFAULT_CHAT_COMPLETION_URL`.
   - Headers setup both in `getModels` and `chatCompletions` include standard HTTP content-type and CORS headers. 

These changes collectively refactor the route handling to externalize model and completion logic directly to Cortex, suggesting potentially improved separation of concerns and reduced internal processing complexity.
