### PR TITLE
fix: migrate model settings and parameters but still allow model.yml editing

### DIFF
--- a/extensions/model-extension/src/cortex.ts
+++ b/extensions/model-extension/src/cortex.ts
@@ -123,10 +123,10 @@ export class CortexAPI implements ICortexAPI {
    * @param model
    * @returns
    */
-  updateModel(model: object): Promise<void> {
+  updateModel(model: Partial<Model>): Promise<void> {
     return this.queue.add(() =>
       ky
-        .patch(`${API_URL}/v1/models/${model}`, { json: { model } })
+        .patch(`${API_URL}/v1/models/${model.id}`, { json: { ...model } })
         .json()
         .then()
     )

--- a/extensions/model-extension/src/index.ts
+++ b/extensions/model-extension/src/index.ts
@@ -193,7 +193,13 @@ export default class JanModelExtension extends ModelExtension {
                 ]) // Copied models
               : model.sources[0].url, // Symlink models,
             model.name
-          )
+          ).then((e) => {
+            this.updateModel({
+              id: model.id,
+              ...model.settings,
+              ...model.parameters,
+            } as Partial<Model>)
+          })
         )
       )
 

--- a/web/hooks/useModels.ts
+++ b/web/hooks/useModels.ts
@@ -35,10 +35,6 @@ const useModels = () => {
       const localModels = (await getModels()).map((e) => ({
         ...e,
         name: ModelManager.instance().models.get(e.id)?.name ?? e.id,
-        settings:
-          ModelManager.instance().models.get(e.id)?.settings ?? e.settings,
-        parameters:
-          ModelManager.instance().models.get(e.id)?.parameters ?? e.parameters,
         metadata:
           ModelManager.instance().models.get(e.id)?.metadata ?? e.metadata,
       }))


### PR DESCRIPTION
## Describe Your Changes

- This PR addresses the major issue of migrating the Jan model.json to cortex.cpp model.yaml. Legacy model settings and parameters are not maintained during the transition because cortex.cpp attempts to extract metadata from the GGUF model file.

- As described in #3690, Jan will import all existing models to cortex.cpp, and new model download requests will be proxied to cortex.cpp. An idea came up to force the app to use model.json settings, but this created an issue where users could only change model settings through the GUI and not update model.yml.

- This PR updates model settings and parameters when transferring models to cortex.cpp, keeping all settings intact and allowing users to edit via model.yml.

| Gemma 2B uses a pre-defined prompt template not from gguf metadata |
|:-:|
|![Screenshot 2024-11-09 at 13 00 12](https://github.com/user-attachments/assets/07fc95a0-7f5a-43db-9dca-c20981078813)|

| Users manual update model.yaml (ngl: from 27 to 40) | 
|:-:|
|![Screenshot 2024-11-09 at 13 00 51](https://github.com/user-attachments/assets/f954df46-5701-4b33-b7e2-2fc20a395852)|
| It affects the app as expected |
| ![Screenshot 2024-11-09 at 13 00 46](https://github.com/user-attachments/assets/d7f0c9f8-43b8-4039-b84b-f6150c705fe3) |

The PR aims to complete the model management transition from Jan to cortex.cpp, maintaining the efforts of model.json while ensuring model.yml functions the same.

## Changes made

1. **CortexAPI Update:**
   - The signature of the `updateModel` method in `cortex.ts` was changed to accept a `Partial<Model>` instead of a general object. This allows optional properties of the `Model` type.
   - The API call within this method was updated to use `model.id` for the path and spread operator `{ ...model }` in the JSON body.

2. **JanModelExtension Changes:**
   - In `index.ts`, after certain operations, the `updateModel` method is now called. This method passes a `Partial<Model>` consisting of `model.id`, `model.settings`, and `model.parameters`.

3. **EventListener Update:**
   - In `EventListener.tsx`, additional imports were added for managing models.
   - In the `onFileDownloadSuccess` callback, the code checks if the file download is related to a model. If so, it updates the model metadata using the `extensionManager`.

4. **Removed Code in useModels:**
   - In `useModels.ts`, the properties `settings` and `parameters` have been removed from the mapped local models, implying reliance on other properties for these.

Overall, these changes seem focused on correctly handling the model data structure and ensuring model metadata is consistently updated across different components of the application.
