### PR TITLE
fix: edge cases highlight codeblock

### DIFF
--- a/web/screens/Thread/ThreadCenterPanel/ChatInput/RichTextEditor.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatInput/RichTextEditor.tsx
@@ -69,6 +69,9 @@ const RichTextEditor = ({
 }: RichTextEditorProps) => {
   const [editor] = useState(() => withHistory(withReact(createEditor())))
   const currentLanguage = useRef<string>('plaintext')
+  const hasStartBackticks = useRef<boolean>(false)
+  const hasEndBackticks = useRef<boolean>(false)
+
   const [currentPrompt, setCurrentPrompt] = useAtom(currentPromptAtom)
   const textareaRef = useRef<HTMLDivElement>(null)
   const activeThreadId = useAtomValue(getActiveThreadIdAtom)
@@ -133,20 +136,31 @@ const RichTextEditor = ({
         node.children.forEach((child: { text: any }, childIndex: number) => {
           const text = child.text
 
+          const codeBlockStartRegex = /```(\w*)/g
+          const matches = [...currentPrompt.matchAll(codeBlockStartRegex)]
+
+          if (matches.length % 2 !== 0) {
+            hasEndBackticks.current = false
+          }
+
           // Match code block start and end
-          const startMatch = text.match(/^```(\w*)$/)
+          const lang = text.match(/^```(\w*)$/)
           const endMatch = text.match(/^```$/)
 
-          if (startMatch) {
+          if (lang) {
             // If it's the start of a code block, store the language
-            currentLanguage.current = startMatch[1] || 'plaintext'
+            currentLanguage.current = lang[1] || 'plaintext'
           } else if (endMatch) {
             // Reset language when code block ends
             currentLanguage.current = 'plaintext'
-          } else if (currentLanguage.current !== 'plaintext') {
+          } else if (
+            hasStartBackticks.current &&
+            hasEndBackticks.current &&
+            currentLanguage.current !== 'plaintext'
+          ) {
             // Highlight entire code line if in a code block
-            const leadingSpaces = text.match(/^\s*/)?.[0] ?? '' // Capture leading spaces
-            const codeContent = text.trimStart() // Remove leading spaces for highlighting
+
+            const codeContent = text.trim() // Remove leading spaces for highlighting
 
             let highlighted = ''
             highlighted = hljs.highlightAuto(codeContent).value
@@ -168,21 +182,9 @@ const RichTextEditor = ({
 
             let slateTextIndex = 0
 
-            // Adjust to include leading spaces in the ranges and preserve formatting
-            ranges.push({
-              anchor: { path: [...path, childIndex], offset: 0 },
-              focus: {
-                path: [...path, childIndex],
-                offset: slateTextIndex,
-              },
-              type: 'code',
-              code: true,
-              language: currentLanguage.current,
-              className: '', // No class for leading spaces
-            })
-
             doc.body.childNodes.forEach((childNode) => {
               const childText = childNode.textContent || ''
+
               const length = childText.length
               const className =
                 childNode.nodeType === Node.ELEMENT_NODE
@@ -192,11 +194,11 @@ const RichTextEditor = ({
               ranges.push({
                 anchor: {
                   path: [...path, childIndex],
-                  offset: slateTextIndex + leadingSpaces.length,
+                  offset: slateTextIndex,
                 },
                 focus: {
                   path: [...path, childIndex],
-                  offset: slateTextIndex + leadingSpaces.length + length,
+                  offset: slateTextIndex + length,
                 },
                 type: 'code',
                 code: true,
@@ -220,7 +222,7 @@ const RichTextEditor = ({
 
       return ranges
     },
-    [editor]
+    [currentPrompt, editor]
   )
 
   // RenderLeaf applies the decoration styles
@@ -340,9 +342,20 @@ const RichTextEditor = ({
           currentLanguage.current = 'plaintext'
         }
         const hasCodeBlockStart = combinedText.match(/^```(\w*)/m)
+        const hasCodeBlockEnd = combinedText.match(/^```$/m)
+
         // Set language to plaintext if no code block with language identifier is found
         if (!hasCodeBlockStart) {
           currentLanguage.current = 'plaintext'
+          hasStartBackticks.current = false
+        } else {
+          hasStartBackticks.current = true
+        }
+        if (!hasCodeBlockEnd) {
+          currentLanguage.current = 'plaintext'
+          hasEndBackticks.current = false
+        } else {
+          hasEndBackticks.current = true
         }
       }}
     >


### PR DESCRIPTION
## Describe Your Changes

Enforce strict code block rules, 

- The code block should start with triple backticks followed by a file extension `(```css)`, and end with triple backticks `(```)`.
This ensures that the code block is correctly defined with both the opening and closing triple backticks, with an optional file extension immediately after the opening backticks.

<img width="457" alt="Screenshot 2024-11-10 at 17 06 30" src="https://github.com/user-attachments/assets/923827ae-154a-440d-b65e-38939cae98bc">

- Multiple code blocks may impact each other. For example, if one of the code blocks is missing a formatting rule (e.g., missing the closing backticks), none of the code blocks will be highlighted

<img width="459" alt="Screenshot 2024-11-10 at 17 10 06" src="https://github.com/user-attachments/assets/74c46809-35c6-4a3a-ae8e-09a18e02d581">


## Fixes Issues

- Closes #3884 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
