### PR TITLE
fix: Model import name and ID are incorrect on Windows

### DIFF
--- a/electron/utils/migration.ts
+++ b/electron/utils/migration.ts
@@ -61,6 +61,9 @@ async function checkAndMigrateTheme(
   )
   if (existingTheme) {
     const desTheme = join(janDataThemesFolder, existingTheme)
+    if (!lstatSync(desTheme).isDirectory()) {
+      return
+    }
     console.debug('Updating theme', existingTheme)
     rmdirSync(desTheme, { recursive: true })
     cpSync(sourceThemePath, join(janDataThemesFolder, sourceThemeName), {

--- a/web/hooks/useImportModel.ts
+++ b/web/hooks/useImportModel.ts
@@ -9,7 +9,7 @@ import {
   OptionType,
   events,
   fs,
-  baseName
+  baseName,
 } from '@janhq/core'
 
 import { atom, useSetAtom } from 'jotai'
@@ -62,7 +62,7 @@ const useImportModel = () => {
   const importModels = useCallback(
     (models: ImportingModel[], optionType: OptionType) => {
       models.map(async (model) => {
-        const modelId = model.modelId ?? await baseName(model.path)
+        const modelId = model.modelId ?? (await baseName(model.path))
         if (modelId) {
           addDownloadingModel(modelId)
           extensionManager

--- a/web/hooks/useImportModel.ts
+++ b/web/hooks/useImportModel.ts
@@ -5,11 +5,11 @@ import {
   ImportingModel,
   LocalImportModelEvent,
   Model,
-  ModelEvent,
   ModelExtension,
   OptionType,
   events,
   fs,
+  baseName
 } from '@janhq/core'
 
 import { atom, useSetAtom } from 'jotai'
@@ -61,8 +61,8 @@ const useImportModel = () => {
 
   const importModels = useCallback(
     (models: ImportingModel[], optionType: OptionType) => {
-      models.map((model) => {
-        const modelId = model.modelId ?? model.path.split('/').pop()
+      models.map(async (model) => {
+        const modelId = model.modelId ?? await baseName(model.path)
         if (modelId) {
           addDownloadingModel(modelId)
           extensionManager

--- a/web/package.json
+++ b/web/package.json
@@ -38,7 +38,7 @@
     "react": "18.2.0",
     "react-circular-progressbar": "^2.1.0",
     "react-dom": "18.2.0",
-    "react-dropzone": "^14.2.3",
+    "react-dropzone": "14.2.3",
     "react-hook-form": "^7.47.0",
     "react-hot-toast": "^2.4.1",
     "react-icons": "^4.12.0",

--- a/web/screens/Settings/Advanced/index.tsx
+++ b/web/screens/Settings/Advanced/index.tsx
@@ -306,7 +306,7 @@ const Advanced = () => {
                           })
                         }
                         // Stop any running model to apply the changes
-                        if (e.target.checked !== gpuEnabled) stopModel()
+                        if (e.target.checked !== gpuEnabled) stopModel().then(() => window.core?.api?.relaunch())
                       }}
                     />
                   }

--- a/web/screens/Settings/Advanced/index.tsx
+++ b/web/screens/Settings/Advanced/index.tsx
@@ -306,7 +306,8 @@ const Advanced = () => {
                           })
                         }
                         // Stop any running model to apply the changes
-                        if (e.target.checked !== gpuEnabled) stopModel().then(() => window.core?.api?.relaunch())
+                        if (e.target.checked !== gpuEnabled)
+                          stopModel().then(() => window.core?.api?.relaunch())
                       }}
                     />
                   }


### PR DESCRIPTION
## Describe Your Changes

- This PR addresses the issue of app importing models as full paths on model ID windows.

## Fixes Issues

- #3911 

## Changes made

1. **Imports:**
   - The import for `ModelEvent` was removed.
   - A new import `baseName` was added from `@janhq/core`.

2. **Function Changes:**
   - Inside the `importModels` function:
     - The `.map()` method on `models` was changed to be `async`.
     - The `modelId` assignment now uses `await baseName(model.path)` instead of `model.path.split('/').pop()` to extract the base name of the path.
