### PR TITLE
fix: inconsistent model dropdown list and my models

### DIFF
--- a/core/src/node/api/processors/download.ts
+++ b/core/src/node/api/processors/download.ts
@@ -1,6 +1,6 @@
 import { resolve, sep } from 'path'
 import { DownloadEvent } from '../../../types/api'
-import { normalizeFilePath, validatePath } from '../../helper/path'
+import { normalizeFilePath } from '../../helper/path'
 import { getJanDataFolderPath } from '../../helper'
 import { DownloadManager } from '../../helper/download'
 import { createWriteStream, renameSync } from 'fs'
@@ -37,7 +37,6 @@ export class Downloader implements Processor {
     const modelId = downloadRequest.modelId ?? array.pop() ?? ''
 
     const destination = resolve(getJanDataFolderPath(), normalizedPath)
-    validatePath(destination)
     const rq = request({ url, strictSSL, proxy })
 
     // Put request to download manager instance

--- a/core/src/node/api/processors/fs.ts
+++ b/core/src/node/api/processors/fs.ts
@@ -1,5 +1,5 @@
 import { join, resolve } from 'path'
-import { normalizeFilePath, validatePath } from '../../helper/path'
+import { normalizeFilePath } from '../../helper/path'
 import { getJanDataFolderPath } from '../../helper'
 import { Processor } from './Processor'
 import fs from 'fs'
@@ -36,7 +36,6 @@ export class FileSystem implements Processor {
               return path
             }
             const absolutePath = resolve(path)
-            validatePath(absolutePath)
             return absolutePath
           })
         )
@@ -55,7 +54,6 @@ export class FileSystem implements Processor {
     }
 
     const absolutePath = resolve(path)
-    validatePath(absolutePath)
 
     return new Promise((resolve, reject) => {
       fs.rm(absolutePath, { recursive: true, force: true }, (err) => {
@@ -79,7 +77,6 @@ export class FileSystem implements Processor {
     }
 
     const absolutePath = resolve(path)
-    validatePath(absolutePath)
 
     return new Promise((resolve, reject) => {
       fs.mkdir(absolutePath, { recursive: true }, (err) => {

--- a/core/src/node/api/processors/fsExt.ts
+++ b/core/src/node/api/processors/fsExt.ts
@@ -1,6 +1,6 @@
 import { basename, join } from 'path'
 import fs, { readdirSync } from 'fs'
-import { appResourcePath, normalizeFilePath, validatePath } from '../../helper/path'
+import { appResourcePath, normalizeFilePath } from '../../helper/path'
 import { defaultAppConfig, getJanDataFolderPath, getJanDataFolderPath as getPath } from '../../helper'
 import { Processor } from './Processor'
 import { FileStat } from '../../../types'
@@ -61,7 +61,6 @@ export class FSExt implements Processor {
       
       const dataBuffer = Buffer.from(data, 'base64')
       const writePath = join(getJanDataFolderPath(), normalizedPath)
-      validatePath(writePath)
       fs.writeFileSync(writePath, dataBuffer)
     } catch (err) {
       console.error(`writeFile ${path} result: ${err}`)
@@ -69,7 +68,6 @@ export class FSExt implements Processor {
   }
 
   copyFile(src: string, dest: string): Promise<void> {
-    validatePath(dest)
     return new Promise((resolve, reject) => {
       fs.copyFile(src, dest, (err) => {
         if (err) {

--- a/core/src/node/helper/path.ts
+++ b/core/src/node/helper/path.ts
@@ -35,17 +35,3 @@ export function appResourcePath() {
   // server
   return join(global.core.appPath(), '../../..')
 }
-
-export function validatePath(path: string) {
-  const appDataFolderPath = getJanDataFolderPath()
-  const resourcePath = appResourcePath()
-  const applicationSupportPath = global.core?.appPath() ?? resourcePath
-  const absolutePath = resolve(__dirname, path)
-  if (
-    ![appDataFolderPath, resourcePath, applicationSupportPath].some((whiteListedPath) =>
-      absolutePath.startsWith(whiteListedPath)
-    )
-  ) {
-    throw new Error(`Invalid path: ${absolutePath}`)
-  }
-}

--- a/extensions/model-extension/src/index.ts
+++ b/extensions/model-extension/src/index.ts
@@ -179,8 +179,8 @@ export default class JanModelExtension extends ModelExtension {
     if (toImportModels.length > 0) {
       // Import models
       await Promise.all(
-        toImportModels.map(async (model: Model & { file_path: string }) =>
-          this.importModel(
+        toImportModels.map(async (model: Model & { file_path: string }) => {
+          return this.importModel(
             model.id,
             model.sources[0].url.startsWith('http') ||
               !(await fs.existsSync(model.sources[0].url))
@@ -200,7 +200,7 @@ export default class JanModelExtension extends ModelExtension {
               ...model.parameters,
             } as Partial<Model>)
           })
-        )
+        })
       )
 
       return currentModels

--- a/web/containers/ModelDropdown/index.tsx
+++ b/web/containers/ModelDropdown/index.tsx
@@ -108,6 +108,11 @@ const ModelDropdown = ({
   const filteredDownloadedModels = useMemo(
     () =>
       configuredModels
+        .concat(
+          downloadedModels.filter(
+            (e) => !configuredModels.some((x) => x.id === e.id)
+          )
+        )
         .filter((e) =>
           e.name.toLowerCase().includes(searchText.toLowerCase().trim())
         )

--- a/web/screens/Settings/SelectingModelModal/index.tsx
+++ b/web/screens/Settings/SelectingModelModal/index.tsx
@@ -21,7 +21,7 @@ const SelectingModelModal = () => {
 
   const onSelectFileClick = useCallback(async () => {
     const platform = (await systemInformation()).osInfo?.platform
-    if (platform === 'win32') {
+    if (platform !== 'darwin') {
       setImportModelStage('CHOOSE_WHAT_TO_IMPORT')
       return
     }


### PR DESCRIPTION
## Describe Your Changes

- Fixed inconsistent model list across components.
- Fixed import of gguf files on Linux (file picker).
- Fixed importing symlinked models to files outside the app folder.

Notes: 
Path validation is no longer needed since now
1. App does not expose FS APIs to external sources
2. Shifting those to cortex.cpp

## Changes made
### `download.ts`
- Removed usage of `validatePath` imported from `../../helper/path`.
- The function is no longer called to validate the path before processing file operations.

### `fs.ts`
- Instances of `validatePath` were removed when resolving paths for various file operations, such as directory removal and creation.

### `fsExt.ts`
- The `validatePath` function call was removed before writing a file and copying a file.
  
### `path.ts`
- The `validatePath` function was removed entirely. It was responsible for ensuring paths were whitelisted, with some application-specific logic.
  
### `index.ts` (in `model-extension`)
- Updated the promise handling in `toImportModels` processing to include a return statement within a map function, improving readability and potentially fixing a promise handling bug.

### `ModelDropdown/index.tsx`
- The code now ensures all unique `downloadedModels` that are not already in `configuredModels` are concatenated to `configuredModels` before filtering for search text. This enhances the model list displayed based on search criteria.

### `SelectingModelModal/index.tsx`
- Adjusted platform-specific logic to handle non-`darwin` systems uniformly, which likely changes the behavior of the model selection process for different operating systems.

These changes collectively focus on removing unnecessary path validation logic, improving asynchronous promise handling, and fixing platform-specific conditions in the UI component logic.
