### PR TITLE
fix: update the payload transform for OpenAI preview models

### DIFF
--- a/extensions/inference-openai-extension/src/index.ts
+++ b/extensions/inference-openai-extension/src/index.ts
@@ -70,16 +70,17 @@ export default class JanInferenceOpenAIExtension extends RemoteOAIEngine {
    * Tranform the payload before sending it to the inference endpoint.
    * The new preview models such as o1-mini and o1-preview replaced max_tokens by max_completion_tokens parameter.
    * Others do not.
-   * @param payload 
-   * @returns 
+   * @param payload
+   * @returns
    */
   transformPayload = (payload: OpenAIPayloadType): OpenAIPayloadType => {
     // Transform the payload for preview models
     if (this.previewModels.includes(payload.model)) {
-      const { max_tokens, ...params } = payload
+      const { max_tokens, temperature, top_p, stop, ...params } = payload
       return {
         ...params,
         max_completion_tokens: max_tokens,
+        stream: false // o1 only support stream = false
       }
     }
     // Pass through for non-preview models


### PR DESCRIPTION
## Describe Your Changes

- A follow-up PR of #3728 to update transform payload to support o1 preview models

## Fixes Issues

- #3771 

## Self Checklist

The code changes in the Git diff involve a modification to the `transformPayload` function within a TypeScript file, specifically `src/index.ts`.

1. **Comment Formatting**: There were minor formatting changes to remove extra spaces in the comments.

2. **Function Logic**:
   - The `transformPayload` function originally extracted the `max_tokens` from the `payload` and passed the rest of the parameters through.
   - Now, it also extracts `temperature`, `top_p`, and `stop` parameters along with `max_tokens`, and the remaining parameters (`params`) are spread into the new object.
   - The key `max_completion_tokens` is set with the value of `max_tokens`.
   - A new property `stream` is added to the returned payload with a value of `false`, as `o1` models only support `stream = false`.

These changes effectively modify the transformation logic to accommodate additional parameters and ensure the correct `stream` setting for specific models.