### PR TITLE
fix: remove cuda toolkit error message and bring back incremental model import

### DIFF
--- a/web/hooks/useDropModelBinaries.ts
+++ b/web/hooks/useDropModelBinaries.ts
@@ -29,7 +29,7 @@ export default function useDropModelBinaries() {
       const importingModels: ImportingModel[] = supportedFiles.map((file) => ({
         importId: uuidv4(),
         modelId: undefined,
-        name: file.name.replace('.gguf', ''),
+        name: file.name.replace(/ /g, '').replace('.gguf', ''),
         description: '',
         path: file.path,
         tags: [],

--- a/web/hooks/useImportModel.ts
+++ b/web/hooks/useImportModel.ts
@@ -12,7 +12,7 @@ import {
   baseName,
 } from '@janhq/core'
 
-import { atom, useSetAtom } from 'jotai'
+import { atom, useAtomValue, useSetAtom } from 'jotai'
 
 import { v4 as uuidv4 } from 'uuid'
 
@@ -23,6 +23,7 @@ import { FilePathWithSize } from '@/utils/file'
 import { extensionManager } from '@/extension'
 import {
   addDownloadingModelAtom,
+  downloadedModelsAtom,
   importingModelsAtom,
   removeDownloadingModelAtom,
 } from '@/helpers/atoms/Model.atom'
@@ -58,11 +59,24 @@ const useImportModel = () => {
   const setImportingModels = useSetAtom(importingModelsAtom)
   const addDownloadingModel = useSetAtom(addDownloadingModelAtom)
   const removeDownloadingModel = useSetAtom(removeDownloadingModelAtom)
+  const downloadedModels = useAtomValue(downloadedModelsAtom)
+
+  const incrementalModelName = useCallback(
+    (name: string, startIndex: number = 0): string => {
+      const newModelName = startIndex ? `${name}-${startIndex}` : name
+      if (downloadedModels.some((model) => model.id === newModelName)) {
+        return incrementalModelName(name, startIndex + 1)
+      } else {
+        return newModelName
+      }
+    },
+    [downloadedModels]
+  )
 
   const importModels = useCallback(
     (models: ImportingModel[], optionType: OptionType) => {
       models.map(async (model) => {
-        const modelId = model.modelId ?? (await baseName(model.path))
+        const modelId = model.modelId ?? incrementalModelName(model.name)
         if (modelId) {
           addDownloadingModel(modelId)
           extensionManager
@@ -78,7 +92,7 @@ const useImportModel = () => {
         }
       })
     },
-    [addDownloadingModel, removeDownloadingModel]
+    [addDownloadingModel, incrementalModelName, removeDownloadingModel]
   )
 
   const updateModelInfo = useCallback(
@@ -100,7 +114,7 @@ const useImportModel = () => {
         ({ path, name, size }: FilePathWithSize) => ({
           importId: uuidv4(),
           modelId: undefined,
-          name: name.replace('.gguf', ''),
+          name: name.replace(/ /g, '').replace('.gguf', ''),
           description: '',
           path: path,
           tags: [],

--- a/web/screens/Thread/ThreadCenterPanel/LoadModelError/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/LoadModelError/index.tsx
@@ -64,49 +64,6 @@ const LoadModelError = () => {
           to continue using it.
         </p>
       )
-    } else if (
-      settings &&
-      settings.run_mode === 'gpu' &&
-      !settings.vulkan &&
-      (!settings.nvidia_driver?.exist || !settings.cuda?.exist)
-    ) {
-      return (
-        <>
-          {!settings?.cuda.exist ? (
-            <p>
-              The CUDA toolkit may be unavailable. Please use the{' '}
-              <span
-                className="cursor-pointer font-medium text-[hsla(var(--app-link))]"
-                onClick={() => {
-                  setMainState(MainViewState.Settings)
-                  if (activeThread?.assistants[0]?.model.engine) {
-                    const engine = EngineManager.instance().get(
-                      activeThread.assistants[0].model.engine
-                    )
-                    engine?.name && setSelectedSettingScreen(engine.name)
-                  }
-                }}
-              >
-                Install Additional Dependencies
-              </span>{' '}
-              setting to proceed with the download / installation process.
-            </p>
-          ) : (
-            <div>
-              Problem with Nvidia drivers. Please follow the{' '}
-              <a
-                className="font-medium text-[hsla(var(--app-link))]"
-                href="https://www.nvidia.com/Download/index.aspx"
-                target="_blank"
-              >
-                Nvidia Drivers guideline
-              </a>{' '}
-              to access installation instructions and ensure proper functioning
-              of the application.
-            </div>
-          )}
-        </>
-      )
     } else {
       return (
         <div>


### PR DESCRIPTION
## Describe Your Changes

This PR removes the irrelevant error message about missing CUDA toolkit dependencies since it’s now shipped by default. Bring back the legacy incremental model import naming convention.

## Changes made
**1. `useDropModelBinaries.ts`:**
- The name processing for file names was modified. Any spaces in the file name are now removed before the '.gguf' extension is stripped.

**2. `useImportModel.ts`:**
- Jotai's `useAtomValue` was imported to access the atom state.
- `downloadedModelsAtom` was added to the imports, which enables tracking of already downloaded models.
- A new utility function, `incrementalModelName`, was introduced to handle naming conflicts. This function ensures that any model name duplicates are resolved by appending a number to the model's name.
- The naming logic for models during import was updated to use `incrementalModelName` for unique identification.
- Similar name processing to `useDropModelBinaries.ts` was applied, where spaces in model names are removed.

**3. `LoadModelError/index.tsx`:**
- A substantial block of error-handling code related to GPU settings, CUDA toolkit, and Nvidia drivers was removed. This code was responsible for rendering specific error messages when issues were detected with the GPU runtime configuration.

Overall, these changes focus on ensuring unique model name identification, simplifying error handling by removing specific GPU-related messages, and cleaning up file name processing.
