### PR TITLE
fix: api local server max ctx len not update when switch model

### DIFF
--- a/web/screens/LocalServer/LocalServerRightPanel/index.tsx
+++ b/web/screens/LocalServer/LocalServerRightPanel/index.tsx
@@ -72,8 +72,6 @@ const LocalServerRightPanel = () => {
     [componentDataEngineSetting]
   )
 
-  console.log(engineSettings)
-
   const modelSettings = useMemo(() => {
     return componentDataRuntimeSetting.filter(
       (x) => x.key !== 'prompt_template'

--- a/web/screens/LocalServer/LocalServerRightPanel/index.tsx
+++ b/web/screens/LocalServer/LocalServerRightPanel/index.tsx
@@ -19,8 +19,10 @@ import { getConfigurationsData } from '@/utils/componentSettings'
 
 import { serverEnabledAtom } from '@/helpers/atoms/LocalServer.atom'
 import { selectedModelAtom } from '@/helpers/atoms/Model.atom'
+import { getActiveThreadModelParamsAtom } from '@/helpers/atoms/Thread.atom'
 
 const LocalServerRightPanel = () => {
+  const activeModelParams = useAtomValue(getActiveThreadModelParamsAtom)
   const loadModelError = useAtomValue(loadModelErrorAtom)
   const serverEnabled = useAtomValue(serverEnabledAtom)
   const setModalTroubleShooting = useSetAtom(modalTroubleShootingAtom)
@@ -48,8 +50,17 @@ const LocalServerRightPanel = () => {
     selectedModel
   )
 
+  const modelEngineParams = extractModelLoadParams(
+    {
+      ...selectedModel?.settings,
+      ...activeModelParams,
+    },
+    selectedModel?.settings
+  )
+
   const componentDataEngineSetting = getConfigurationsData(
-    currentModelSettingParams
+    modelEngineParams,
+    selectedModel
   )
 
   const engineSettings = useMemo(
@@ -57,8 +68,11 @@ const LocalServerRightPanel = () => {
       componentDataEngineSetting.filter(
         (x) => x.key !== 'prompt_template' && x.key !== 'embedding'
       ),
+
     [componentDataEngineSetting]
   )
+
+  console.log(engineSettings)
 
   const modelSettings = useMemo(() => {
     return componentDataRuntimeSetting.filter(


### PR DESCRIPTION
## Describe Your Changes

Issue when on local API server page Jan App, switch model not update max `ctx-len`



## Fixes Issues
<img width="1035" alt="Screenshot 2024-11-15 at 15 20 10" src="https://github.com/user-attachments/assets/8f693fc9-c9fe-4497-96da-c08f6834785f">

<img width="1037" alt="Screenshot 2024-11-15 at 15 20 00" src="https://github.com/user-attachments/assets/89c7e7ea-6358-457f-8dfd-f5cc9b0fd569">

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
