### PR TITLE
chore: refactor rerender components

### DIFF
--- a/electron/managers/window.ts
+++ b/electron/managers/window.ts
@@ -28,6 +28,7 @@ class WindowManager {
       ...mainWindowConfig,
       width: bounds.width,
       height: bounds.height,
+      show: false,
       x: bounds.x,
       y: bounds.y,
       webPreferences: {
@@ -77,6 +78,11 @@ class WindowManager {
         evt.preventDefault()
         windowManager.hideMainWindow()
       }
+    })
+
+    windowManager.mainWindow?.on('ready-to-show', function () {
+      // Feature Toggle for Quick Ask
+      windowManager.mainWindow?.show()
     })
   }
 

--- a/web/containers/Providers/DataLoader.tsx
+++ b/web/containers/Providers/DataLoader.tsx
@@ -2,7 +2,12 @@
 
 import { Fragment, ReactNode, useEffect } from 'react'
 
-import { AppConfiguration, getUserHomePath } from '@janhq/core'
+import {
+  AppConfiguration,
+  events,
+  getUserHomePath,
+  ModelEvent,
+} from '@janhq/core'
 import { useSetAtom } from 'jotai'
 
 import useAssistants from '@/hooks/useAssistants'
@@ -30,11 +35,18 @@ const DataLoader: React.FC<Props> = ({ children }) => {
   const setJanDefaultDataFolder = useSetAtom(defaultJanDataFolderAtom)
   const setJanSettingScreen = useSetAtom(janSettingScreenAtom)
 
-  useModels()
   useThreads()
   useAssistants()
   useGetSystemResources()
   useLoadTheme()
+
+  const { loadDataModel, isUpdated } = useModels()
+  useEffect(() => {
+    // Listen for model updates
+    if (isUpdated) {
+      loadDataModel()
+    }
+  }, [isUpdated, loadDataModel])
 
   useEffect(() => {
     window.core?.api


### PR DESCRIPTION
## Describe Your Changes

1. **electron/managers/window.ts**:
   - Added a new property `show: false` when creating the main window configuration.
   - Added an event listener for `'ready-to-show'` on the main window. This feature toggle controls whether to show the main window once it is ready to be displayed.

2. **web/containers/Providers/DataLoader.tsx**:
   - Imported additional functions and types from `@janhq/core`, including `events` and `ModelEvent`.
   - Introduced a new state variable `isUpdated` and an effect hook that listens for model updates using the `useModels` hook.
   - Inside this effect, it checks if `isUpdated` is true and then calls the `loadDataModel` function to reload the models.

3. **web/hooks/useModels.ts**:
   - Removed the local variable `isUpdated` as it was being used inconsistently throughout the file.
   - Introduced a return object from the `useModels` hook that includes both `loadDataModel` and `isUpdated`.
   - Updated the useEffect to listen for model updates only if `isUpdated` is true, ensuring that the models are reloaded only when necessary.

These changes primarily involve improving the window management in Electron and enhancing the data loading process in a React component by incorporating real-time updates based on model changes. The introduction of feature toggles (`show: false`) and conditional event listeners helps in managing the visibility and behavior of application components more effectively.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
