### PR TITLE
fix: improper line break on response message

### DIFF
--- a/web/screens/Thread/ThreadCenterPanel/SimpleTextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/SimpleTextMessage/index.tsx
@@ -383,7 +383,7 @@ const SimpleTextMessage: React.FC<ThreadMessage> = (props) => {
           ) : (
             <div
               className={twMerge(
-                'message max-width-[100%] flex flex-col gap-y-2 overflow-auto leading-relaxed	'
+                'message max-width-[100%] flex flex-col gap-y-2 overflow-auto leading-relaxed'
               )}
               dir="ltr"
             >

--- a/web/screens/Thread/ThreadCenterPanel/SimpleTextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/SimpleTextMessage/index.tsx
@@ -383,7 +383,7 @@ const SimpleTextMessage: React.FC<ThreadMessage> = (props) => {
           ) : (
             <div
               className={twMerge(
-                'message max-width-[100%] flex flex-col gap-y-2 overflow-auto break-all leading-relaxed	'
+                'message max-width-[100%] flex flex-col gap-y-2 overflow-auto leading-relaxed	'
               )}
               dir="ltr"
             >


### PR DESCRIPTION
## Describe Your Changes

Before
<img width="553" alt="Screenshot 2024-11-18 at 17 45 57" src="https://github.com/user-attachments/assets/7d5ba573-b4a0-4d77-9ba7-ad4b7b275d8d">

After
<img width="567" alt="Screenshot 2024-11-18 at 17 46 14" src="https://github.com/user-attachments/assets/67c9b684-8521-43ab-833a-68f355b210e0">


## Fixes Issues

- Closes #4039 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
