### PR TITLE
fix: model import edge cases

### DIFF
--- a/extensions/model-extension/src/legacy/delete.ts
+++ b/extensions/model-extension/src/legacy/delete.ts
@@ -1,10 +1,12 @@
-import { fs, joinPath } from '@janhq/core'
+import { dirName, fs } from '@janhq/core'
+import { scanModelsFolder } from './model-json'
 
 export const deleteModelFiles = async (id: string) => {
   try {
-    const dirPath = await joinPath(['file://models', id])
+    const models = await scanModelsFolder()
+    const dirPath = models.find((e) => e.id === id)?.file_path
     // remove model folder directory
-    await fs.rm(dirPath)
+    if (dirPath) await fs.rm(await dirName(dirPath))
   } catch (err) {
     console.error(err)
   }

--- a/extensions/model-extension/src/legacy/model-json.ts
+++ b/extensions/model-extension/src/legacy/model-json.ts
@@ -12,7 +12,9 @@ const LocalEngines = [
  * Scan through models folder and return downloaded models
  * @returns
  */
-export const scanModelsFolder = async (): Promise<Model[]> => {
+export const scanModelsFolder = async (): Promise<
+  (Model & { file_path?: string })[]
+> => {
   const _homeDir = 'file://models'
   try {
     if (!(await fs.existsSync(_homeDir))) {
@@ -37,7 +39,7 @@ export const scanModelsFolder = async (): Promise<Model[]> => {
 
       const jsonPath = await getModelJsonPath(folderFullPath)
 
-      if (await fs.existsSync(jsonPath)) {
+      if (jsonPath && (await fs.existsSync(jsonPath))) {
         // if we have the model.json file, read it
         let model = await fs.readFileSync(jsonPath, 'utf-8')
 
@@ -83,7 +85,10 @@ export const scanModelsFolder = async (): Promise<Model[]> => {
                   file.toLowerCase().endsWith('.gguf') || // GGUF
                   file.toLowerCase().endsWith('.engine') // Tensort-LLM
                 )
-              })?.length >= (model.engine === InferenceEngine.nitro_tensorrt_llm ? 1 : (model.sources?.length ?? 1))
+              })?.length >=
+                (model.engine === InferenceEngine.nitro_tensorrt_llm
+                  ? 1
+                  : (model.sources?.length ?? 1))
             )
           })
 

--- a/web/hooks/useModels.ts
+++ b/web/hooks/useModels.ts
@@ -34,7 +34,7 @@ const useModels = () => {
     const getDownloadedModels = async () => {
       const localModels = (await getModels()).map((e) => ({
         ...e,
-        name: ModelManager.instance().models.get(e.id)?.name ?? e.id,
+        name: ModelManager.instance().models.get(e.id)?.name ?? e.name ?? e.id,
         metadata:
           ModelManager.instance().models.get(e.id)?.metadata ?? e.metadata,
       }))
@@ -92,7 +92,8 @@ const useModels = () => {
   const getModels = async (): Promise<Model[]> =>
     extensionManager
       .get<ModelExtension>(ExtensionTypeEnum.Model)
-      ?.getModels() ?? []
+      ?.getModels()
+      .catch(() => []) ?? []
 
   useEffect(() => {
     // Listen for model updates


### PR DESCRIPTION
## Describe Your Changes

This PR added a few changes that handle edge cases of models import, such as:
1. The model import and run fail due to a mismatch between the folder name and the model ID.
2. Model deletion failed due to a mismatch between folder name and model ID.
3. The model wouldn’t be automatically reimported if the user deleted the same model before.
4. The model display name is incorrect, it’s displaying the model’s ID instead.
5. A broken import process could block the model listing process

| This screenshot shows a case where users have a self-crafted model.json folder named "test" with a model ID of "this-is-test-model".` |
|:-:|
|![Screenshot 2024-11-19 at 11 47 16](https://github.com/user-attachments/assets/85119219-4a47-4163-9306-aa6eaf8eb5a2)|
|![Screenshot 2024-11-19 at 11 57 04](https://github.com/user-attachments/assets/c0f20c3e-00be-4f10-8c15-e83226fcef43)|



## Fixes Issues

- #4015 

## Changes made

The changes in the `git diff` include:

1. **`inference-cortex-extension/src/index.ts`:**
   - Added `dirName` import from `@janhq/core`.
   - Updated handling of `llama_model_path` using `model.file_path` to conditionally join paths or fetch model file path.
   - Re-formatted the `setDefaultEngine` function for better readability.

2. **`model-extension/src/index.ts`:**
   - Removed unused `ExtensionEnum`.
   - Simplified `getModels` function by directly using `legacyModels` instead of handling local storage retrieval.
   - Streamlined model import logic and added error handling with `.catch` to log potential errors.

6. **`model-extension/src/legacy/delete.ts`:**
   - Modified `deleteModelFiles` to find model directory path using `scanModelsFolder` and check for `file_path`.
   - Adjusted file removal logic to account for the directory path existence.

7. **`model-extension/src/legacy/model-json.ts`:**
   - Updated `scanModelsFolder` function to redefine the return type to include optional `file_path`.
   - Added a check to ensure `jsonPath` exists before reading the model JSON file.
   - Indented condition logic for clarity.

8. **`web/hooks/useModels.ts`:**
   - Modified logic in `getDownloadedModels` to use `e.name` as a fallback when accessing model names.
   - Added error handling to `getModels` to return an empty array in case of a promise rejection.

9. **Final Change in `model-extension/src/index.ts`:**
   - Updated `importModel` method to always reject the promise, implying a possible temporary disabling of model import functionality.

Overall, the changes mainly focus on optimization, error handling improvements, code refactoring for clarity, and handling model paths more robustly.
