### PR TITLE
fix: correct OpenAI o1 model parameters

### DIFF
--- a/core/src/browser/extensions/engines/helpers/sse.ts
+++ b/core/src/browser/extensions/engines/helpers/sse.ts
@@ -45,7 +45,9 @@ export function requestInference(
           subscriber.complete()
           return
         }
-        if (model.parameters?.stream === false) {
+        // There could be overriden stream parameter in the model
+        // that is set in request body (transformed payload)
+        if (requestBody?.stream === false || model.parameters?.stream === false) {
           const data = await response.json()
           if (transformResponse) {
             subscriber.next(transformResponse(data))

--- a/extensions/inference-cortex-extension/src/index.ts
+++ b/extensions/inference-cortex-extension/src/index.ts
@@ -69,12 +69,13 @@ export default class JanInferenceCortexExtension extends LocalOAIEngine {
 
     super.onLoad()
 
-    await this.queue.add(() => this.clean())
-    this.queue.add(() => this.healthz())
-    this.queue.add(() => this.setDefaultEngine(systemInfo))
+    this.queue.add(() => this.clean())
+    
     // Run the process watchdog
     const systemInfo = await systemInformation()
-    await executeOnMain(NODE, 'run', systemInfo)
+    this.queue.add(() => executeOnMain(NODE, 'run', systemInfo))
+    this.queue.add(() => this.healthz())
+    this.queue.add(() => this.setDefaultEngine(systemInfo))
     this.subscribeToEvents()
 
     window.addEventListener('beforeunload', () => {

--- a/extensions/inference-openai-extension/resources/models.json
+++ b/extensions/inference-openai-extension/resources/models.json
@@ -97,11 +97,9 @@
     "format": "api",
     "settings": {},
     "parameters": {
-      "max_tokens": 4096,
-      "temperature": 0.7,
-      "top_p": 0.95,
-      "stream": true,
-      "stop": [],
+      "temperature": 1,
+      "top_p": 1,
+      "max_tokens": 32768,
       "frequency_penalty": 0,
       "presence_penalty": 0
     },
@@ -125,11 +123,9 @@
     "format": "api",
     "settings": {},
     "parameters": {
-      "max_tokens": 4096,
-      "temperature": 0.7,
-      "top_p": 0.95,
-      "stream": true,
-      "stop": [],
+      "temperature": 1,
+      "top_p": 1,
+      "max_tokens": 65536,
       "frequency_penalty": 0,
       "presence_penalty": 0
     },

--- a/extensions/inference-openai-extension/src/index.ts
+++ b/extensions/inference-openai-extension/src/index.ts
@@ -76,11 +76,11 @@ export default class JanInferenceOpenAIExtension extends RemoteOAIEngine {
   transformPayload = (payload: OpenAIPayloadType): OpenAIPayloadType => {
     // Transform the payload for preview models
     if (this.previewModels.includes(payload.model)) {
-      const { max_tokens, temperature, top_p, stop, ...params } = payload
+      const { max_tokens, stop, ...params } = payload
       return {
         ...params,
         max_completion_tokens: max_tokens,
-        stream: false // o1 only support stream = false
+        stream: false, // o1 only support stream = false
       }
     }
     // Pass through for non-preview models

--- a/extensions/model-extension/package.json
+++ b/extensions/model-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janhq/model-extension",
   "productName": "Model Management",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "description": "Model Management Extension provides model exploration and seamless downloads",
   "main": "dist/index.js",
   "author": "Jan <service@jan.ai>",

--- a/extensions/model-extension/src/index.ts
+++ b/extensions/model-extension/src/index.ts
@@ -143,7 +143,10 @@ export default class JanModelExtension extends ModelExtension {
      * There is no model to import
      * just return fetched models
      */
-    if (!toImportModels.length) return fetchedModels
+    if (!toImportModels.length)
+      return fetchedModels.concat(
+        legacyModels.filter((e) => e.settings?.vision_model)
+      )
 
     console.log('To import models:', toImportModels.length)
     /**


### PR DESCRIPTION
## Describe Your Changes

- As discussed in https://github.com/janhq/jan/issues/3745, there are fixed parameters from the endpoints of the o1 models. Therefore, the current model.json files should be updated accordingly.

- This PR aims to correct the transform payload to the models and also to return graceful error messages as soon as inference errors occur.

- A few unsupported parameters have been removed to prevent confusion.

![Screenshot 2024-11-19 at 22 08 41](https://github.com/user-attachments/assets/51cac0c4-c3d4-4ae8-b0a2-88a12bf1995c)
![Screenshot 2024-11-19 at 22 08 45](https://github.com/user-attachments/assets/0641fb4e-a42c-4716-9abd-cf7fa8d0071d)
![Screenshot 2024-11-19 at 22 09 11](https://github.com/user-attachments/assets/72253f13-b2a0-44ea-92b7-3d1e8a03f67d)


## Fixes Issues

- #3745
- #3771

## Changes made

This git diff summarizes a set of code changes across multiple files. Here's a concise breakdown:

1. **`sse.ts` (Helper for SSE requests):**
   - Added a check for an overridden `stream` parameter in the request body. If `stream` is false either in the request body or model parameters, it adjusts accordingly.

2. **`models.json` (Model Configuration File):**
   - Removed the `stream`, `stop`, and some other parameters from the model configurations.
   - Updated `max_tokens` values to significantly higher numbers (`32768` and `65536`).
   - Adjusted `temperature` to 1 and `top_p` to 1.

3. **`index.ts` (`inference-openai-extension`):**
   - Simplified the `transformPayload` function by removing unused destructured variables `temperature`, `top_p`, and `stop`.
   - Kept `stream: false` for handling specific models that only support non-streaming requests.

4. **`package.json` (Model Extension):**
   - Incremented the package version from `1.0.34` to `1.0.35`.

5. **`inference-cortex-extension/src/index.ts`:**
   - Reordered queue operations during the `onLoad` method of the `JanInferenceCortexExtension` class:
     - The call to `this.clean()` remains, but the surrounding queue structure is slightly rearranged.
     - The call to `executeOnMain` is now added to the queue using `this.queue.add()`.
     - The calls to `this.healthz()` and `this.setDefaultEngine(systemInfo)` are also added to the queue afterward.

6. **`model-extension/src/index.ts`:**
   - Modified the return logic for an empty `toImportModels` array in the `JanModelExtension` class:
     - Instead of immediately returning `fetchedModels`, the logic now concatenates `legacyModels` that have the `vision_model` setting with `fetchedModels`.

These changes include modifications to model configurations and payload transformation logic for specific model handling, package version bump.
