### PR TITLE
fix: handle symlink model import failure - fallback to legacy model run

### DIFF
--- a/extensions/inference-cortex-extension/src/index.ts
+++ b/extensions/inference-cortex-extension/src/index.ts
@@ -100,12 +100,10 @@ export default class JanInferenceCortexExtension extends LocalOAIEngine {
       // Legacy chat model support
       model.settings = {
         ...model.settings,
-        llama_model_path: model.file_path
-          ? await joinPath([
-              await dirName(model.file_path),
-              model.settings.llama_model_path,
-            ])
-          : await getModelFilePath(model, model.settings.llama_model_path),
+        llama_model_path: await getModelFilePath(
+          model,
+          model.settings.llama_model_path
+        ),
       }
     } else {
       const { llama_model_path, ...settings } = model.settings
@@ -262,7 +260,7 @@ export default class JanInferenceCortexExtension extends LocalOAIEngine {
 
 /// Legacy
 const getModelFilePath = async (
-  model: Model,
+  model: Model & { file_path?: string },
   file: string
 ): Promise<string> => {
   // Symlink to the model file
@@ -271,6 +269,9 @@ const getModelFilePath = async (
     (await fs.existsSync(model.sources[0].url))
   ) {
     return model.sources[0]?.url
+  }
+  if (model.file_path) {
+    await joinPath([await dirName(model.file_path), file])
   }
   return joinPath([await getJanDataFolderPath(), 'models', model.id, file])
 }


### PR DESCRIPTION
## Describe Your Changes

This PR addresses a specific edge case where users could create a symlink to a model file located outside the data folder. This is done to fall back to legacy model run behavior in case model import fail due to potential issues like server API corruption, metadata extraction errors, or YAML parse errors.

To ensure a fallback to the legacy model run behavior, where it can be forced to run with llama_model_path.

In the screenshot, there are no models imported to cortex.cpp. Instead, there was a Test ID model that was symlinked by the model.json file (version 0.5.7 or lower). This model can still run as before the update.

![Screenshot 2024-11-19 at 22 42 28](https://github.com/user-attachments/assets/cc6620a0-bbc5-4751-a282-85f91754730e)


## Changes made
The provided `git diff` output shows changes made across three files. Here's a summary of the modifications:

1. **`extensions/inference-cortex-extension/src/index.ts`:**
   - Simplified the handling of the `llama_model_path`. Previously, it conditionally used either a constructed path or a function call to `getModelFilePath`. Now, it always calls `getModelFilePath`.
   - Modified the `getModelFilePath` function signature to include an optional `file_path` property in the `model` argument type.
   - Within `getModelFilePath`, included a new conditional that joins a path using `model.file_path` if it exists.

These changes appear to be refactoring or modifying the logic for model path handling and disabling an API method, with a minor formatting change in the hooks file.