### PR TITLE
fix: inconsistent error handling

### DIFF
--- a/web/hooks/useSendChatMessage.ts
+++ b/web/hooks/useSendChatMessage.ts
@@ -27,7 +27,7 @@ import { MessageRequestBuilder } from '@/utils/messageRequestBuilder'
 
 import { ThreadMessageBuilder } from '@/utils/threadMessageBuilder'
 
-import { loadModelErrorAtom, useActiveModel } from './useActiveModel'
+import { useActiveModel } from './useActiveModel'
 
 import { extensionManager } from '@/extension/ExtensionManager'
 import {
@@ -60,10 +60,8 @@ export default function useSendChatMessage() {
   const currentMessages = useAtomValue(getCurrentChatMessagesAtom)
   const selectedModel = useAtomValue(selectedModelAtom)
   const { activeModel, startModel } = useActiveModel()
-  const loadModelFailed = useAtomValue(loadModelErrorAtom)
 
   const modelRef = useRef<Model | undefined>()
-  const loadModelFailedRef = useRef<string | undefined>()
   const activeModelParams = useAtomValue(getActiveThreadModelParamsAtom)
   const engineParamsUpdate = useAtomValue(engineParamsUpdateAtom)
 
@@ -79,10 +77,6 @@ export default function useSendChatMessage() {
   useEffect(() => {
     modelRef.current = activeModel
   }, [activeModel])
-
-  useEffect(() => {
-    loadModelFailedRef.current = loadModelFailed
-  }, [loadModelFailed])
 
   useEffect(() => {
     activeThreadRef.current = activeThread

--- a/web/screens/Thread/ThreadCenterPanel/LoadModelError/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/LoadModelError/index.tsx
@@ -20,23 +20,8 @@ const LoadModelError = () => {
   const setSelectedSettingScreen = useSetAtom(selectedSettingAtom)
   const activeThread = useAtomValue(activeThreadAtom)
 
-  const PORT_NOT_AVAILABLE = 'PORT_NOT_AVAILABLE'
-
   const ErrorMessage = () => {
-    if (loadModelError === PORT_NOT_AVAILABLE) {
-      return (
-        <p>
-          Port 3928 is currently unavailable. Check for conflicting apps, or
-          access&nbsp;
-          <span
-            className="cursor-pointer text-[hsla(var(--app-link))]"
-            onClick={() => setModalTroubleShooting(true)}
-          >
-            troubleshooting assistance
-          </span>
-        </p>
-      )
-    } else if (
+    if (
       typeof loadModelError?.includes === 'function' &&
       loadModelError.includes('EXTENSION_IS_NOT_INSTALLED')
     ) {
@@ -63,10 +48,10 @@ const LoadModelError = () => {
       )
     } else {
       return (
-        <div>
-          Apologies, {`Something's wrong.`}.&nbsp;
+        <div className="mx-6 flex flex-col items-center space-y-2 text-center font-medium text-[hsla(var(--text-secondary))]">
+          {loadModelError && <p>{loadModelError}</p>}
           <p>
-            Access&nbsp;
+            {`Something's wrong.`}&nbsp;Access&nbsp;
             <span
               className="cursor-pointer text-[hsla(var(--app-link))]"
               onClick={() => setModalTroubleShooting(true)}


### PR DESCRIPTION
## Describe Your Changes
There’s an issue where the app displays two different user interfaces for error handling between Model Inference and Load. Additionally, this is being done to add the error information returned from cortex.cpp for improved error handling in the future.

| Model Load | Model Inference |
|:-:|:-:|
|![Screenshot 2024-11-19 at 23 17 57](https://github.com/user-attachments/assets/c64c22c5-0799-4957-b8bd-645b2a841aa8)|![image](https://github.com/user-attachments/assets/403d08b8-fa58-459a-9eff-0fcfbb5ff064)|

| Model Load with the fix - First error message is returned from cortex.cpp server |
|:-:|
|![Screenshot 2024-11-19 at 23 17 37](https://github.com/user-attachments/assets/72299dfc-9d61-4f51-a580-e824b39bf21b)|

This PR also eliminates the deprecated error handling scenario where the port number 3928 is unavailable for serving the server and unused variables.

## Changes made
1. **useActiveModel.ts**:
   - Removed the `pendingModelLoadAtom` for state management and replaced it with a `useRef` hook to track the `pendingModelLoad` state.
   - Updated related logic to use `pendingModelLoad.current` instead of atom-based state.
   - Simplified and adjusted hooks dependencies, removing `setPendingModelLoad` from dependencies.

2. **useSendChatMessage.ts**:
   - Removed the import and usage of `loadModelErrorAtom`.
   - Removed a reference to `loadModelFailedRef` and related effect since `loadModelErrorAtom` is no longer used.

3. **LoadModelError/index.tsx**:
   - Removed specific error handling for `PORT_NOT_AVAILABLE`.
   - Adjusted the user interface to ensure any `loadModelError` is displayed with a refined presentation, utilizing `loadModelError` directly in a conditional UI component.

Overall, the changes focus on refactoring state management from an atom-based system to React's `useRef`, simplifying the error management logic, and updating UI presentation for error handling. 
