### PR TITLE
fix: reorder alphabetical cloud model on starter screen

### DIFF
--- a/web/screens/Settings/Hotkeys/index.tsx
+++ b/web/screens/Settings/Hotkeys/index.tsx
@@ -39,14 +39,6 @@ const availableHotkeys = [
     combination: 'Shift Enter',
     description: 'Insert a new line (in input field)',
   },
-  {
-    combination: 'Arrow Up',
-    description: 'Navigate to previous option (within search dialog)',
-  },
-  {
-    combination: 'Arrow Down',
-    description: 'Navigate to next option (within search dialog)',
-  },
 ]
 
 const Hotkeys = () => {

--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/OnDeviceStarterScreen/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/OnDeviceStarterScreen/index.tsx
@@ -85,9 +85,9 @@ const OnDeviceStarterScreen = ({ extensionHasSettings }: Props) => {
 
   const remoteModelEngine = remoteModel.map((x) => x.engine)
 
-  const groupByEngine = remoteModelEngine
-    .filter((item, index) => remoteModelEngine.indexOf(item) === index)
-    .sort((a, b) => a.localeCompare(b))
+  const groupByEngine = remoteModelEngine.filter(function (item, index) {
+    if (remoteModelEngine.indexOf(item) === index) return item
+  })
 
   const itemsPerRow = 5
 
@@ -99,7 +99,10 @@ const OnDeviceStarterScreen = ({ extensionHasSettings }: Props) => {
     return rows
   }
 
-  const rows = getRows(groupByEngine, itemsPerRow)
+  const rows = getRows(
+    groupByEngine.sort((a, b) => a.localeCompare(b)),
+    itemsPerRow
+  )
 
   const refDropdown = useClickOutside(() => setIsOpen(false))
 

--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/OnDeviceStarterScreen/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/OnDeviceStarterScreen/index.tsx
@@ -85,9 +85,9 @@ const OnDeviceStarterScreen = ({ extensionHasSettings }: Props) => {
 
   const remoteModelEngine = remoteModel.map((x) => x.engine)
 
-  const groupByEngine = remoteModelEngine.filter(function (item, index) {
-    if (remoteModelEngine.indexOf(item) === index) return item
-  })
+  const groupByEngine = remoteModelEngine
+    .filter((item, index) => remoteModelEngine.indexOf(item) === index)
+    .sort((a, b) => a.localeCompare(b))
 
   const itemsPerRow = 5
 


### PR DESCRIPTION
## Describe Your Changes

<img width="1111" alt="Screenshot 2024-11-21 at 15 38 13" src="https://github.com/user-attachments/assets/3f3264b5-7c5b-4472-b386-59cf68ccc33b">

<br/>

Also fix for remove deprecated shortcut
https://github.com/janhq/jan/issues/4055#issuecomment-2490320629

<img width="1112" alt="Screenshot 2024-11-21 at 15 38 23" src="https://github.com/user-attachments/assets/cf031798-498f-42de-b9c4-b4d8b6eb6750">


## Fixes Issues

- Closes #4066 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
