### PR TITLE
fix: disabled shortcut create new thread on starter screen

### DIFF
--- a/web/containers/Providers/KeyListener.tsx
+++ b/web/containers/Providers/KeyListener.tsx
@@ -8,6 +8,8 @@ import { MainViewState } from '@/constants/screens'
 
 import { useCreateNewThread } from '@/hooks/useCreateNewThread'
 
+import { useStarterScreen } from '@/hooks/useStarterScreen'
+
 import {
   mainViewStateAtom,
   showLeftPanelAtom,
@@ -32,6 +34,7 @@ export default function KeyListener({ children }: Props) {
   const assistants = useAtomValue(assistantsAtom)
   const activeThread = useAtomValue(activeThreadAtom)
   const setModalActionThread = useSetAtom(modalActionThreadAtom)
+  const { isShowStarterScreen } = useStarterScreen()
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
@@ -60,7 +63,7 @@ export default function KeyListener({ children }: Props) {
         return
       }
 
-      if (e.code === 'KeyN' && prefixKey) {
+      if (e.code === 'KeyN' && prefixKey && !isShowStarterScreen) {
         if (mainViewState !== MainViewState.Thread) return
         requestCreateNewThread(assistants[0])
         setMainViewState(MainViewState.Thread)
@@ -82,6 +85,7 @@ export default function KeyListener({ children }: Props) {
   }, [
     activeThread,
     assistants,
+    isShowStarterScreen,
     mainViewState,
     requestCreateNewThread,
     setMainViewState,


### PR DESCRIPTION
## Describe Your Changes

The Git diff shows that there have been some modifications made to the `KeyListener.tsx` file located in the `web/containers/Providers` directory. Here's a detailed description of the changes:

1. **Import Statement**:
   - A new import statement for `useStarterScreen` has been added from '@/hooks/useStarterScreen'.

2. **Variable Declaration**:
   - A new variable `isShowStarterScreen` is declared by destructuring from the `useStarterScreen` hook.

3. **UseEffect Dependency Update**:
   - The dependency array of the `useEffect` hook has been updated to include the newly added `isShowStarterScreen`.

4. **Conditional Check in useEffect**:
   - Inside the `onKeyDown` event handler, there is a conditional check to ensure that the `isShowStarterScreen` is `false` before proceeding with certain actions.


## Fixes Issues

- Closes # https://github.com/janhq/jan/issues/4055#issuecomment-2490325564
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
