### PR TITLE
fix: Phi 3 Mini Instruct model download url replacement

### DIFF
--- a/extensions/inference-cortex-extension/package.json
+++ b/extensions/inference-cortex-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janhq/inference-cortex-extension",
   "productName": "Cortex Inference Engine",
-  "version": "1.0.21",
+  "version": "1.0.22",
   "description": "This extension embeds cortex.cpp, a lightweight inference engine written in C++. See https://jan.ai.\nAdditional dependencies could be installed to run without Cuda Toolkit installation.",
   "main": "dist/index.js",
   "node": "dist/node/index.cjs.js",

--- a/extensions/inference-cortex-extension/resources/models/phi3-3.8b/model.json
+++ b/extensions/inference-cortex-extension/resources/models/phi3-3.8b/model.json
@@ -1,8 +1,8 @@
 {
     "sources": [
       {
-        "url": "https://huggingface.co/cortexso/phi3/resolve/main/model.gguf",
-        "filename": "model.gguf"
+        "url": "https://huggingface.co/bartowski/Phi-3-mini-4k-instruct-GGUF/resolve/main/Phi-3-mini-4k-instruct-Q4_K_M.gguf",
+        "filename": "Phi-3-mini-4k-instruct-Q4_K_M.gguf"
       }
     ],
     "id": "phi3-3.8b",
@@ -14,7 +14,7 @@
     "settings": {
       "ctx_len": 4096,
       "prompt_template": "<|user|>\n{prompt}<|end|>\n<|assistant|>\n",
-      "llama_model_path": "model.gguf",
+      "llama_model_path": "Phi-3-mini-4k-instruct-Q4_K_M.gguf",
       "ngl": 33
     },
     "parameters": {

--- a/extensions/inference-cortex-extension/resources/models/phi3-medium/model.json
+++ b/extensions/inference-cortex-extension/resources/models/phi3-medium/model.json
@@ -1,8 +1,8 @@
 {
     "sources": [
       {
-        "url": "https://huggingface.co/bartowski/Phi-3-medium-128k-instruct-GGUF/resolve/main/Phi-3-medium-128k-instruct-Q4_K_M.gguf",
-        "filename": "Phi-3-medium-128k-instruct-Q4_K_M.gguf"
+        "url": "https://huggingface.co/bartowski/Phi-3-mini-4k-instruct-GGUF/resolve/main/Phi-3-mini-4k-instruct-Q4_K_M.gguf",
+        "filename": "Phi-3-mini-4k-instruct-Q4_K_M.gguf"
       }
     ],
     "id": "phi3-medium",
@@ -14,7 +14,7 @@
     "settings": {
       "ctx_len": 128000,
       "prompt_template": "<|user|> {prompt}<|end|><|assistant|>",
-      "llama_model_path": "Phi-3-medium-128k-instruct-Q4_K_M.gguf",
+      "llama_model_path": "Phi-3-mini-4k-instruct-Q4_K_M.gguf",
       "ngl": 33
     },
     "parameters": {

--- a/web/hooks/useModels.ts
+++ b/web/hooks/useModels.ts
@@ -89,7 +89,10 @@ const useModels = () => {
     const cachedModels = ModelManager.instance().models.values().toArray()
     const toUpdate = [
       ...downloadedModels,
-      ...cachedModels.filter((e) => !isLocalEngine(e.engine) && !downloadedModels.some((g: Model) => g.id === e.id)
+      ...cachedModels.filter(
+        (e) =>
+          !isLocalEngine(e.engine) &&
+          !downloadedModels.some((g: Model) => g.id === e.id)
       ),
     ]
 

--- a/web/hooks/useModels.ts
+++ b/web/hooks/useModels.ts
@@ -89,13 +89,13 @@ const useModels = () => {
     const cachedModels = ModelManager.instance().models.values().toArray()
     const toUpdate = [
       ...downloadedModels,
-      ...cachedModels.filter(
-        (e: Model) => !downloadedModels.some((g: Model) => g.id === e.id)
+      ...cachedModels.filter((e) => !isLocalEngine(e.engine) && !downloadedModels.some((g: Model) => g.id === e.id)
       ),
     ]
 
     setDownloadedModels(toUpdate)
-  }, [downloadedModels, setDownloadedModels])
+    setExtensionModels(cachedModels)
+  }, [downloadedModels, setDownloadedModels, setExtensionModels])
 
   const getModels = async (): Promise<Model[]> =>
     extensionManager


### PR DESCRIPTION
## Describe Your Changes

This PR is to correct the download URL of Phi 3 Mini 4k Instruct model. 

#[4073](https://github.com/janhq/jan/issues/4073)

The model can now be downloaded with proper metadata, including its size, name, and it runs properly.
<img width="1279" alt="Screenshot 2024-11-21 at 16 24 30" src="https://github.com/user-attachments/assets/28e27c6a-5311-4ba8-8b50-51d7540140f3">


Update:
This PR included a hot fix for Tensorrt-LL models listing

![image](https://github.com/user-attachments/assets/f68ff3f5-8c92-41a1-82a3-7d55cdb2fbe4)
