### PR TITLE
fix: model params settings local api server

### DIFF
--- a/joi/src/core/Slider/index.tsx
+++ b/joi/src/core/Slider/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import * as SliderPrimitive from '@radix-ui/react-slider'
+import { twMerge } from 'tailwind-merge'
 
 import './styles.scss'
 
@@ -25,7 +26,7 @@ const Slider = ({
   disabled,
 }: Props) => (
   <SliderPrimitive.Root
-    className="slider"
+    className={twMerge('slider', disabled && 'slider--disabled')}
     name={name}
     min={min}
     max={max}

--- a/joi/src/core/Slider/styles.scss
+++ b/joi/src/core/Slider/styles.scss
@@ -6,6 +6,11 @@
   touch-action: none;
   height: 16px;
 
+  &--disabled {
+    cursor: not-allowed;
+    opacity: 0.2;
+  }
+
   &__track {
     background-color: hsla(var(--slider-track-bg));
     position: relative;

--- a/web/helpers/atoms/LocalServer.atom.ts
+++ b/web/helpers/atoms/LocalServer.atom.ts
@@ -1,3 +1,5 @@
 import { atom } from 'jotai'
 
 export const serverEnabledAtom = atom<boolean>(false)
+
+export const LocalAPIserverModelParamsAtom = atom()

--- a/web/screens/LocalServer/LocalServerLeftPanel/index.tsx
+++ b/web/screens/LocalServer/LocalServerLeftPanel/index.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useCallback, useState } from 'react'
 
+import { EngineManager, Model, ModelSettingParams } from '@janhq/core'
 import { Button, Tooltip, Select, Input, Checkbox } from '@janhq/joi'
 
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
@@ -22,7 +23,10 @@ import {
   hostOptions,
 } from '@/helpers/atoms/ApiServer.atom'
 
-import { serverEnabledAtom } from '@/helpers/atoms/LocalServer.atom'
+import {
+  LocalAPIserverModelParamsAtom,
+  serverEnabledAtom,
+} from '@/helpers/atoms/LocalServer.atom'
 import { selectedModelAtom } from '@/helpers/atoms/Model.atom'
 
 const LocalServerLeftPanel = () => {
@@ -31,7 +35,7 @@ const LocalServerLeftPanel = () => {
   const [serverEnabled, setServerEnabled] = useAtom(serverEnabledAtom)
   const [isLoading, setIsLoading] = useState(false)
 
-  const { startModel, stateModel } = useActiveModel()
+  const { stateModel } = useActiveModel()
   const selectedModel = useAtomValue(selectedModelAtom)
 
   const [isCorsEnabled, setIsCorsEnabled] = useAtom(apiServerCorsEnabledAtom)
@@ -42,8 +46,20 @@ const LocalServerLeftPanel = () => {
   const [port, setPort] = useAtom(apiServerPortAtom)
   const [prefix, setPrefix] = useAtom(apiServerPrefix)
   const setLoadModelError = useSetAtom(loadModelErrorAtom)
-
+  const localAPIserverModelParams = useAtomValue(LocalAPIserverModelParamsAtom)
   const FIRST_TIME_VISIT_API_SERVER = 'firstTimeVisitAPIServer'
+
+  const model: Model | undefined = selectedModel
+    ? {
+        ...selectedModel,
+        object: selectedModel.object || '',
+        settings: {
+          ...(typeof localAPIserverModelParams === 'object'
+            ? { ...(localAPIserverModelParams as ModelSettingParams) }
+            : { ...selectedModel.settings }),
+        } as ModelSettingParams,
+      }
+    : undefined
 
   const [firstTimeVisitAPIServer, setFirstTimeVisitAPIServer] =
     useState<boolean>(false)
@@ -80,7 +96,9 @@ const LocalServerLeftPanel = () => {
         localStorage.setItem(FIRST_TIME_VISIT_API_SERVER, 'false')
         setFirstTimeVisitAPIServer(false)
       }
-      startModel(selectedModel.id, false).catch((e) => console.error(e))
+      const engine = EngineManager.instance().get((model as Model).engine)
+      engine?.loadModel(model as Model)
+      // startModel(selectedModel.id, false).catch((e) => console.error(e))
       setIsLoading(false)
     } catch (e) {
       console.error(e)

--- a/web/screens/LocalServer/LocalServerLeftPanel/index.tsx
+++ b/web/screens/LocalServer/LocalServerLeftPanel/index.tsx
@@ -53,11 +53,9 @@ const LocalServerLeftPanel = () => {
     ? {
         ...selectedModel,
         object: selectedModel.object || '',
-        settings: {
-          ...(typeof localAPIserverModelParams === 'object'
-            ? { ...(localAPIserverModelParams as ModelSettingParams) }
-            : { ...selectedModel.settings }),
-        } as ModelSettingParams,
+        settings: (typeof localAPIserverModelParams === 'object'
+          ? { ...(localAPIserverModelParams as ModelSettingParams) }
+          : { ...selectedModel.settings }) as ModelSettingParams,
       }
     : undefined
 


### PR DESCRIPTION
## Describe Your Changes

1. **Slider Component Enhancements**:
   - Added `twMerge` from `tailwind-merge` to conditionally apply Tailwind CSS classes.
   - Modified the `className` prop of the `SliderPrimitive.Root` component to use `twMerge` for dynamic class names based on whether the slider is disabled.

2. **Slider Styles**:
   - Added styles for a disabled state in `styles.scss`, making the cursor unavailable and reducing opacity when the slider is disabled.

3. **Atom Updates**:
   - Added a new atom `LocalAPIserverModelParamsAtom` in `LocalServer.atom.ts`.
   - Updated imports and uses of `serverEnabledAtom` and `selectedModelAtom` across various components to ensure consistency and access to these atoms.

4. **Left Panel Enhancements**:
   - Imported necessary types from `@janhq/core` for better type safety.
   - Used `EngineManager` and `Model` to manage model loading more effectively.
   - Enhanced the logic to handle overridden settings, specifically setting `ctx_len` to 4096 if it's greater than 2048.

5. **Right Panel Enhancements**:
   - Added a new state management function `onUpdateParams` to update the `LocalAPIserverModelParamsAtom`.
   - Ensured that the `disabled` prop is passed down to `ModelSetting` and `EngineSetting` components to reflect the server's enabled status.

These changes aim to improve the user interface, enhance type safety, and provide more dynamic control over model settings in a local server environment.

## Fixes Issues

<img width="1136" alt="Screenshot 2024-11-21 at 22 31 34" src="https://github.com/user-attachments/assets/3fb441d0-3783-4278-a527-2367ade2d3d5">


- Closes # https://github.com/janhq/jan/issues/4055#issuecomment-2490367191
- Closes # https://github.com/janhq/jan/issues/4055#issuecomment-2490412807

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
