### PR TITLE
fix: factory reset hang on wiping data

### DIFF
--- a/extensions/inference-cortex-extension/src/index.ts
+++ b/extensions/inference-cortex-extension/src/index.ts
@@ -83,11 +83,11 @@ export default class JanInferenceCortexExtension extends LocalOAIEngine {
     })
   }
 
-  onUnload(): void {
+  async onUnload() {
     console.log('Clean up cortex.cpp services')
     this.shouldReconnect = false
     this.clean()
-    executeOnMain(NODE, 'dispose')
+    await executeOnMain(NODE, 'dispose')
     super.onUnload()
   }
 

--- a/extensions/inference-cortex-extension/src/node/cpuInfo.ts
+++ b/extensions/inference-cortex-extension/src/node/cpuInfo.ts
@@ -1,0 +1,27 @@
+import { cpuInfo } from 'cpu-instructions'
+
+// Check the CPU info and determine the supported instruction set
+const info = cpuInfo.cpuInfo().some((e) => e.toUpperCase() === 'AVX512')
+  ? 'avx512'
+  : cpuInfo.cpuInfo().some((e) => e.toUpperCase() === 'AVX2')
+    ? 'avx2'
+    : cpuInfo.cpuInfo().some((e) => e.toUpperCase() === 'AVX')
+      ? 'avx'
+      : 'noavx'
+
+// Send the result and wait for confirmation before exiting
+new Promise<void>((resolve, reject) => {
+  // @ts-ignore
+  process.send(info, (error: Error | null) => {
+    if (error) {
+      reject(error)
+    } else {
+      resolve()
+    }
+  })
+})
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error('Failed to send info:', error)
+    process.exit(1)
+  })

--- a/web/hooks/useFactoryReset.test.ts
+++ b/web/hooks/useFactoryReset.test.ts
@@ -17,6 +17,14 @@ jest.mock('@janhq/core', () => ({
   fs: {
     rm: jest.fn(),
   },
+  EngineManager: {
+    instance: jest.fn().mockReturnValue({
+      get: jest.fn(),
+      engines: {
+        values: jest.fn().mockReturnValue([])
+      }
+    }),
+  },
 }))
 
 describe('useFactoryReset', () => {

--- a/web/hooks/useFactoryReset.ts
+++ b/web/hooks/useFactoryReset.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react'
 
-import { fs, AppConfiguration } from '@janhq/core'
+import { fs, AppConfiguration, EngineManager } from '@janhq/core'
 import { atom, useAtomValue, useSetAtom } from 'jotai'
 
 import { useActiveModel } from './useActiveModel'
@@ -37,6 +37,15 @@ export default function useFactoryReset() {
       // 1: Stop running model
       setFactoryResetState(FactoryResetState.StoppingModel)
       await stopModel()
+
+      await Promise.all(
+        EngineManager.instance()
+          .engines.values()
+          .map(async (engine) => {
+            await engine.onUnload()
+          })
+      )
+
       await new Promise((resolve) => setTimeout(resolve, 4000))
 
       // 2: Delete the old jan data folder


### PR DESCRIPTION
## Describe Your Changes

- This resolves the issue where the app hangs during a factory reset. The root cause is that some dependencies are loaded onto the JavaScript VM and hold the process.

To resolve this issue, we can fork the dependency execution to a separate process and terminate it once its execution is complete.

## Fixes Issues

- [#4001](https://github.com/janhq/jan/issues/4001)

## Changes made

### Summary of Changes:

1. **asynchronous OnUnload Method**:
   - Changed the `onUnload` method in `JanInferenceCortexExtension` to be asynchronous and added an `await` before calling `executeOnMain`.

2. **New File for CPU Information**:
   - Added a new file `cpuInfo.ts` that uses the `cpu-instructions` package to check CPU features (`avx512`, `avx2`, `avx`, or `noavx`) and sends this information back to the parent process using inter-process communication.

3. **CPU Instructions Logic Update**:
   - Updated the `cpuInstructions` function in `execute.ts` to run as an asynchronous function.
   - Uses a child process (fork) to get CPU instruction capabilities instead of directly using the `cpu-instructions` package.

4. **Engine Variant Function**:
   - Made the `engineVariant` function asynchronous to accommodate for the asynchronous nature of retrieving CPU instructions.
   - Added logging to indicate the detected CPU instruction set.

5. **Mocking in Tests**:
   - Added a Jest mock for `EngineManager` in `useFactoryReset.test.ts`, providing mock implementations and default returns for methods.

6. **Factory Reset Enhancements**:
   - Updated `useFactoryReset.ts` to include logic for stopping engines through `EngineManager`'s `onUnload` method using `Promise.all` for concurrent processing.
   - Introduced a wait period after stopping engines to ensure proper cleanup.

These changes enhance CPU feature detection, modify engine lifecycle management, and extend test coverage for the new logic.