### PR TITLE
fix: Line-number and border color code block UI

### DIFF
--- a/web/screens/Thread/ThreadCenterPanel/SimpleTextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/SimpleTextMessage/index.tsx
@@ -133,7 +133,7 @@ const SimpleTextMessage: React.FC<ThreadMessage> = (props) => {
                     tagName: 'div',
                     properties: {
                       className:
-                        'code-header bg-[hsla(var(--app-code-block))] flex justify-between items-center py-2 px-3 border-b border-[hsla(var(--app-border))] rounded-t-lg',
+                        'code-header bg-[hsla(var(--app-code-block))] flex justify-between items-center py-2 px-3 code-header--border rounded-t-lg',
                     },
                     children: [
                       {

--- a/web/styles/components/code-block.scss
+++ b/web/styles/components/code-block.scss
@@ -159,8 +159,13 @@ span.code-line {
   margin-right: 16px;
   width: 1.2rem;
   font-size: 12px;
-  color: hsla(var(--text-tertiary));
+  color: rgba($color: #fff, $alpha: 0.4);
   text-align: right;
-
   display: inline-block;
+}
+
+.code-header {
+  &--border {
+    border-bottom: 1px solid rgba($color: #fff, $alpha: 0.1);
+  }
 }


### PR DESCRIPTION
## Describe Your Changes

Missing border color and line number color when code block render on Jan light theme

## Fixes Issues

Dark dimmed
<img width="712" alt="Screenshot 2024-11-23 at 16 43 04" src="https://github.com/user-attachments/assets/e1259a9c-89ef-4bb3-97f4-47ccf71baa75">

Dark
<img width="727" alt="Screenshot 2024-11-23 at 16 42 42" src="https://github.com/user-attachments/assets/c142cc30-dfba-47a2-a356-ca7128654025">


Light 
<img width="817" alt="Screenshot 2024-11-23 at 16 42 32" src="https://github.com/user-attachments/assets/a297f1cd-d7df-4abe-8a3a-a9a6c34a3f5f">

Night Blue
<img width="724" alt="Screenshot 2024-11-23 at 16 42 54" src="https://github.com/user-attachments/assets/3b35ce17-b5f0-44ff-b55f-115190b4111c">


- Closes #4103 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
