### PR TITLE
fix: handle case markdown value no space

### DIFF
--- a/web/styles/components/message.scss
+++ b/web/styles/components/message.scss
@@ -1,5 +1,6 @@
 .message {
   white-space: pre-line;
+  word-break: break-word;
   font-size: 16px;
   ul,
   ol {


### PR DESCRIPTION
## Describe Your Changes

- Cannot open right panel bc value content markdown no space, center panel will push out right panel

## Solution 
using `word-break: break-word`

## Fixes Issues
<img width="1277" alt="Screenshot 2024-11-24 at 15 45 52" src="https://github.com/user-attachments/assets/6f287704-b525-47d3-9c69-490360e6afbf">


- Closes #4090 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
