### PR TITLE
feat: stop word model setting

### DIFF
--- a/core/src/types/setting/settingComponent.ts
+++ b/core/src/types/setting/settingComponent.ts
@@ -12,7 +12,7 @@ export type SettingComponentProps = {
 
 export type ConfigType = 'runtime' | 'setting'
 
-export type ControllerType = 'slider' | 'checkbox' | 'input'
+export type ControllerType = 'slider' | 'checkbox' | 'input' | 'tag'
 
 export type InputType = 'password' | 'text' | 'email' | 'number' | 'tel' | 'url'
 
@@ -22,7 +22,7 @@ export type InputAction = InputActionsTuple[number]
 
 export type InputComponentProps = {
   placeholder: string
-  value: string
+  value: string | string[]
   type?: InputType
   textAlign?: 'left' | 'right'
   inputActions?: InputAction[]

--- a/web/containers/EngineSetting/index.tsx
+++ b/web/containers/EngineSetting/index.tsx
@@ -4,7 +4,10 @@ import SettingComponentBuilder from '@/containers/ModelSetting/SettingComponent'
 
 type Props = {
   componentData: SettingComponentProps[]
-  onValueChanged: (key: string, value: string | number | boolean) => void
+  onValueChanged: (
+    key: string,
+    value: string | number | boolean | string[]
+  ) => void
   disabled?: boolean
 }
 

--- a/web/containers/ModelConfigInput/index.tsx
+++ b/web/containers/ModelConfigInput/index.tsx
@@ -19,28 +19,30 @@ const ModelConfigInput = ({
   description,
   placeholder,
   onValueChanged,
-}: Props) => (
-  <div className="flex flex-col">
-    <div className="mb-2 flex items-center gap-x-2">
-      <p className="font-medium">{title}</p>
-      <Tooltip
-        trigger={
-          <InfoIcon
-            size={16}
-            className="flex-shrink-0 text-[hsla(var(--text-secondary))]"
-          />
-        }
-        content={description}
+}: Props) => {
+  return (
+    <div className="flex flex-col">
+      <div className="mb-2 flex items-center gap-x-2">
+        <p className="font-medium">{title}</p>
+        <Tooltip
+          trigger={
+            <InfoIcon
+              size={16}
+              className="flex-shrink-0 text-[hsla(var(--text-secondary))]"
+            />
+          }
+          content={description}
+        />
+      </div>
+      <TextArea
+        placeholder={placeholder}
+        onChange={(e) => onValueChanged?.(e.target.value)}
+        autoResize
+        value={value}
+        disabled={disabled}
       />
     </div>
-    <TextArea
-      placeholder={placeholder}
-      onChange={(e) => onValueChanged?.(e.target.value)}
-      autoResize
-      value={value}
-      disabled={disabled}
-    />
-  </div>
-)
+  )
+}
 
 export default ModelConfigInput

--- a/web/containers/ModelSetting/SettingComponent.tsx
+++ b/web/containers/ModelSetting/SettingComponent.tsx
@@ -8,11 +8,15 @@ import {
 import Checkbox from '@/containers/Checkbox'
 import ModelConfigInput from '@/containers/ModelConfigInput'
 import SliderRightPanel from '@/containers/SliderRightPanel'
+import TagInput from '@/containers/TagInput'
 
 type Props = {
   componentProps: SettingComponentProps[]
   disabled?: boolean
-  onValueUpdated: (key: string, value: string | number | boolean) => void
+  onValueUpdated: (
+    key: string,
+    value: string | number | boolean | string[]
+  ) => void
 }
 
 const SettingComponent: React.FC<Props> = ({
@@ -53,7 +57,24 @@ const SettingComponent: React.FC<Props> = ({
             name={data.key}
             description={data.description}
             placeholder={placeholder}
-            value={textValue}
+            value={textValue as string}
+            onValueChanged={(value) => onValueUpdated(data.key, value)}
+          />
+        )
+      }
+
+      case 'tag': {
+        const { placeholder, value: textValue } =
+          data.controllerProps as InputComponentProps
+        return (
+          <TagInput
+            title={data.title}
+            disabled={disabled}
+            key={data.key}
+            name={data.key}
+            description={data.description}
+            placeholder={placeholder}
+            value={textValue as string[]}
             onValueChanged={(value) => onValueUpdated(data.key, value)}
           />
         )

--- a/web/containers/ModelSetting/index.tsx
+++ b/web/containers/ModelSetting/index.tsx
@@ -6,7 +6,10 @@ import SettingComponentBuilder from './SettingComponent'
 
 type Props = {
   componentProps: SettingComponentProps[]
-  onValueChanged: (key: string, value: string | number | boolean) => void
+  onValueChanged: (
+    key: string,
+    value: string | number | boolean | string[]
+  ) => void
   disabled?: boolean
 }
 

--- a/web/containers/TagInput/index.test.tsx
+++ b/web/containers/TagInput/index.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+import TagInput from './index' // Adjust the import path as necessary
+import '@testing-library/jest-dom'
+
+describe('TagInput Component', () => {
+  let props: any
+
+  beforeEach(() => {
+    props = {
+      title: 'Tags',
+      name: 'tag-input',
+      description: 'Add your tags',
+      placeholder: 'Enter a tag',
+      value: ['tag1', 'tag2'],
+      onValueChanged: jest.fn(),
+    }
+  })
+
+  it('renders correctly', () => {
+    const { getByText, getByPlaceholderText } = render(<TagInput {...props} />)
+    expect(getByText('Tags')).toBeInTheDocument()
+    expect(getByText('tag1')).toBeInTheDocument()
+    expect(getByText('tag2')).toBeInTheDocument()
+    expect(getByPlaceholderText('Enter a tag')).toBeInTheDocument()
+  })
+
+  it('calls onValueChanged when a new tag is added', () => {
+    const { getByPlaceholderText } = render(<TagInput {...props} />)
+    const input = getByPlaceholderText('Enter a tag')
+
+    fireEvent.change(input, { target: { value: 'tag3' } })
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' })
+
+    expect(props.onValueChanged).toHaveBeenCalledWith(
+      expect.arrayContaining(['tag1', 'tag2', 'tag3'])
+    )
+  })
+
+  it('calls onValueChanged when a tag is removed', () => {
+    const { getAllByRole } = render(<TagInput {...props} />)
+    const removeButton = getAllByRole('button')[0] // Click on the first remove button
+
+    fireEvent.click(removeButton)
+
+    expect(props.onValueChanged).toHaveBeenCalledWith(
+      expect.arrayContaining(['tag2'])
+    )
+  })
+})

--- a/web/containers/TagInput/index.tsx
+++ b/web/containers/TagInput/index.tsx
@@ -59,23 +59,25 @@ const TagInput = ({
           }
         }}
       />
-      <div className="mt-2 flex min-h-[2.5rem] flex-wrap items-center gap-2 overflow-y-auto">
-        {value.map((item, idx) => (
-          <Badge key={idx} theme="secondary">
-            {item}
-            <button
-              type="button"
-              className="ml-1.5 w-3 bg-transparent"
-              onClick={() => {
-                onValueChanged &&
-                  onValueChanged(value.filter((i) => i !== item))
-              }}
-            >
-              <XIcon className="w-3" />
-            </button>
-          </Badge>
-        ))}
-      </div>
+      {value.length > 0 && (
+        <div className="mt-2 flex min-h-[2.5rem] flex-wrap items-center gap-2 overflow-y-auto">
+          {value.map((item, idx) => (
+            <Badge key={idx} theme="secondary">
+              {item}
+              <button
+                type="button"
+                className="ml-1.5 w-3 bg-transparent"
+                onClick={() => {
+                  onValueChanged &&
+                    onValueChanged(value.filter((i) => i !== item))
+                }}
+              >
+                <XIcon className="w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
     </div>
   )
 }

--- a/web/containers/TagInput/index.tsx
+++ b/web/containers/TagInput/index.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react'
+
+import { Badge, Input, Tooltip } from '@janhq/joi'
+
+import { InfoIcon, XIcon } from 'lucide-react'
+
+type Props = {
+  title: string
+  disabled?: boolean
+  name: string
+  description: string
+  placeholder: string
+  value: string[]
+  onValueChanged?: (e: string | number | boolean | string[]) => void
+}
+
+const TagInput = ({
+  title,
+  disabled = false,
+  value,
+  description,
+  placeholder,
+  onValueChanged,
+}: Props) => {
+  const [pendingDataPoint, setPendingDataPoint] = useState('')
+
+  const addPendingDataPoint = () => {
+    if (pendingDataPoint) {
+      const newDataPoints = new Set([...value, pendingDataPoint])
+      onValueChanged && onValueChanged(Array.from(newDataPoints))
+      setPendingDataPoint('')
+    }
+  }
+
+  return (
+    <div className="flex flex-col">
+      <div className="mb-2 flex items-center gap-x-2">
+        <p className="font-medium">{title}</p>
+        <Tooltip
+          trigger={
+            <InfoIcon
+              size={16}
+              className="flex-shrink-0 text-[hsla(var(--text-secondary))]"
+            />
+          }
+          content={description}
+        />
+      </div>
+      <Input
+        value={pendingDataPoint}
+        disabled={disabled}
+        onChange={(e) => setPendingDataPoint(e.target.value)}
+        placeholder={placeholder}
+        className="w-full"
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === 'Tab') {
+            e.preventDefault()
+            addPendingDataPoint()
+          }
+        }}
+      />
+      <div className="mt-2 flex min-h-[2.5rem] flex-wrap items-center gap-2 overflow-y-auto">
+        {value.map((item, idx) => (
+          <Badge key={idx} theme="secondary">
+            {item}
+            <button
+              type="button"
+              className="ml-1.5 w-3 bg-transparent"
+              onClick={() => {
+                onValueChanged &&
+                  onValueChanged(value.filter((i) => i !== item))
+              }}
+            >
+              <XIcon className="w-3" />
+            </button>
+          </Badge>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export default TagInput

--- a/web/screens/LocalServer/LocalServerRightPanel/index.tsx
+++ b/web/screens/LocalServer/LocalServerRightPanel/index.tsx
@@ -86,7 +86,7 @@ const LocalServerRightPanel = () => {
   }, [currentModelSettingParams, setLocalAPIserverModelParams])
 
   const onValueChanged = useCallback(
-    (key: string, value: string | number | boolean) => {
+    (key: string, value: string | number | boolean | string[]) => {
       setCurrentModelSettingParams((prevParams) => ({
         ...prevParams,
         [key]: value,

--- a/web/screens/Settings/ExtensionSetting/index.tsx
+++ b/web/screens/Settings/ExtensionSetting/index.tsx
@@ -44,7 +44,7 @@ const ExtensionSetting = () => {
 
   const onValueChanged = async (
     key: string,
-    value: string | number | boolean
+    value: string | number | boolean | string[]
   ) => {
     // find the key in settings state, update it and set the state back
     const newSettings = settings.map((setting) => {

--- a/web/screens/Settings/SettingDetail/SettingDetailItem/SettingDetailTextInputItem/index.tsx
+++ b/web/screens/Settings/SettingDetail/SettingDetailItem/SettingDetailTextInputItem/index.tsx
@@ -51,7 +51,7 @@ const SettingDetailTextInputItem = ({
   }, [])
 
   const copy = useCallback(() => {
-    navigator.clipboard.writeText(value)
+    navigator.clipboard.writeText(value as string)
     if (value.length > 0) {
       setCopied(true)
     }

--- a/web/screens/Settings/SettingDetail/SettingDetailItem/index.tsx
+++ b/web/screens/Settings/SettingDetail/SettingDetailItem/index.tsx
@@ -5,7 +5,10 @@ import SettingDetailToggleItem from './SettingDetailToggleItem'
 
 type Props = {
   componentProps: SettingComponentProps[]
-  onValueUpdated: (key: string, value: string | number | boolean) => void
+  onValueUpdated: (
+    key: string,
+    value: string | number | boolean | string[]
+  ) => void
 }
 
 const SettingDetailItem = ({ componentProps, onValueUpdated }: Props) => {

--- a/web/screens/Thread/ThreadCenterPanel/AssistantSetting/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/AssistantSetting/index.tsx
@@ -24,7 +24,7 @@ const AssistantSetting: React.FC<Props> = ({ componentData }) => {
   const setEngineParamsUpdate = useSetAtom(engineParamsUpdateAtom)
 
   const onValueChanged = useCallback(
-    (key: string, value: string | number | boolean) => {
+    (key: string, value: string | number | boolean | string[]) => {
       if (!activeThread) return
       const shouldReloadModel =
         componentData.find((x) => x.key === key)?.requireModelReload ?? false

--- a/web/screens/Thread/ThreadRightPanel/PromptTemplateSetting/index.tsx
+++ b/web/screens/Thread/ThreadRightPanel/PromptTemplateSetting/index.tsx
@@ -26,7 +26,7 @@ const PromptTemplateSetting: React.FC<Props> = ({ componentData }) => {
 
   const setEngineParamsUpdate = useSetAtom(engineParamsUpdateAtom)
   const onValueChanged = useCallback(
-    (key: string, value: string | number | boolean) => {
+    (key: string, value: string | number | boolean | string[]) => {
       if (!activeThread) return
 
       setEngineParamsUpdate(true)

--- a/web/screens/Thread/ThreadRightPanel/index.tsx
+++ b/web/screens/Thread/ThreadRightPanel/index.tsx
@@ -173,7 +173,7 @@ const ThreadRightPanel = () => {
   }, 300)
 
   const onValueChanged = useCallback(
-    (key: string, value: string | number | boolean) => {
+    (key: string, value: string | number | boolean | string[]) => {
       if (!activeThread) {
         return
       }

--- a/web/utils/componentSettings.ts
+++ b/web/utils/componentSettings.ts
@@ -60,11 +60,14 @@ export const getConfigurationsData = (
         componentSetting.controllerProps.placeholder = placeholder
     } else if ('checkbox' === componentSetting.controllerType) {
       const checked = keySetting as boolean
-
       if ('value' in componentSetting.controllerProps)
         componentSetting.controllerProps.value = checked
+    } else if ('tag' === componentSetting.controllerType) {
+      if ('value' in componentSetting.controllerProps)
+        componentSetting.controllerProps.value = keySetting as string
     }
     componentData.push(componentSetting)
   })
+
   return componentData
 }

--- a/web/utils/predefinedComponent.ts
+++ b/web/utils/predefinedComponent.ts
@@ -17,10 +17,10 @@ export const presetConfiguration: Record<string, SettingComponentProps> = {
     key: 'stop',
     title: 'Stop',
     description: `Defines specific tokens or phrases that signal the model to stop producing further output, allowing you to control the length and coherence of the output.`,
-    controllerType: 'input',
+    controllerType: 'tag',
     controllerProps: {
-      placeholder: 'Stop',
-      value: '',
+      placeholder: 'Enter stop words',
+      value: [''],
     },
     requireModelReload: false,
     configType: 'runtime',


### PR DESCRIPTION
## Describe Your Changes

Type Modifications:

In settingComponent.ts, the `ControllerType` type now includes 'tag' as a possible value. The `InputComponentProps` type has been adjusted to allow value to be either string or string[].
`ModelConfigInput` Component:

The code in `ModelConfigInput/index.tsx` has been refactored to use a return statement with curly brackets {} instead of an implicit return, although its logic remains largely unchanged.
`SettingComponent` Component:

In ModelSetting/SettingComponent.tsx, added support for the 'tag' controller type, including handling for the value to be string[] and modifying the `onValueUpdated` function to handle arrays of strings.
`ModelSetting` Component:

In ModelSetting/index.tsx, the onValueChanged function signature was updated to accept string[].
TagInput Component:

A new component `TagInput` was created in `TagInput/index.tsx`. It provides the ability to enter tag-like data, allowing users to add strings to an array and render them as badges with an option to remove them.
`ThreadRightPanel` Component:

In `ThreadRightPanel/index.tsx`, the `onValueChanged` function now supports receiving `string[]` values.

Component Utilities:
In `componentSettings.ts`, support was added for the 'tag' controller type, setting its value from `keySetting`.
In `predefinedComponent.ts`, the existing 'stop' setting was switched from an input type to a tag type, with a default value of an empty string array and a new placeholder.

## Fixes Issues

default 
<img width="1095" alt="Screenshot 2024-11-25 at 15 13 14" src="https://github.com/user-attachments/assets/f007acbe-41c2-47f5-ab16-aee40ed307f6">

adding custom 
<img width="1089" alt="Screenshot 2024-11-25 at 15 24 33" src="https://github.com/user-attachments/assets/e42ec1e1-d7cb-450d-8658-72ca3e910881">

Thread json
![Screenshot 2024-11-25 at 15 24 27](https://github.com/user-attachments/assets/16b2adf9-502c-4e37-afdd-875654cfed16)

No Stop word
<img width="1092" alt="Screenshot 2024-11-25 at 15 27 04" src="https://github.com/user-attachments/assets/50bc93c3-8bed-4514-ae69-7da060c60bc7">


- Closes #4088 
- Closes #3536 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
