### PR TITLE
fix: 4086 - editing message should not send follow-up messages

### DIFF
--- a/web/hooks/useSendChatMessage.ts
+++ b/web/hooks/useSendChatMessage.ts
@@ -135,7 +135,10 @@ export default function useSendChatMessage() {
     sendChatMessage(toSendMessage.content[0]?.text.value)
   }
 
-  const sendChatMessage = async (message: string) => {
+  const sendChatMessage = async (
+    message: string,
+    messages?: ThreadMessage[]
+  ) => {
     if (!message || message.trim().length === 0) return
 
     if (!activeThreadRef.current) {
@@ -187,7 +190,7 @@ export default function useSendChatMessage() {
         parameters: runtimeParams,
       },
       activeThreadRef.current,
-      currentMessages
+      messages ?? currentMessages
     ).addSystemMessage(activeThreadRef.current.assistants[0].instructions)
 
     requestBuilder.pushMessage(prompt, base64Blob, fileUpload[0]?.type)

--- a/web/screens/Thread/ThreadCenterPanel/EditChatInput/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/EditChatInput/index.tsx
@@ -90,7 +90,7 @@ const EditChatInput: React.FC<Props> = ({ message }) => {
           newMessages
         )
         .then(() => {
-          sendChatMessage(editPrompt)
+          sendChatMessage(editPrompt, newMessages)
         })
     }
   }


### PR DESCRIPTION
## Describe Your Changes

When editing a message, for instance, "A of A _ B _C," it sends "A B C A" instead of just "A."

![CleanShot 2024-11-25 at 17 32 16@2x](https://github.com/user-attachments/assets/71cf8a63-e353-4bd4-a464-5d50b69e3d90)

## Fixes Issues

- #4086

## Changes made

1. **`useSendChatMessage.ts`:**
   - The `sendChatMessage` function's signature has been updated to accept an optional `messages` parameter of type `ThreadMessage[]`.
   - When calling `requestBuilder.requestThread`, if `messages` is provided, it will be used; otherwise, `currentMessages` will be used as before.

2. **`index.tsx`:**
   - Within the `EditChatInput` component, the call to `sendChatMessage` has been updated to pass `newMessages` as the second argument, matching the updated function signature.

These changes likely aim to provide more flexibility when sending chat messages by allowing an optional thread message array to be passed to the `sendChatMessage` function.