### PR TITLE
fix: 3986 - invalid request should show clear error message

### DIFF
--- a/electron/tests/e2e/thread.e2e.spec.ts
+++ b/electron/tests/e2e/thread.e2e.spec.ts
@@ -25,9 +25,7 @@ test('Select GPT model from Hub and Chat with Invalid API Key', async ({
     { timeout: TIMEOUT }
   )
 
-  const APIKeyError = page.getByText(
-    `You didn't provide an API key. You need to provide your API key in an Authorization header using Bearer auth (i.e. Authorization: Bearer YOUR_KEY), or as the password field (with blank username) if you're accessing the API from your browser and are prompted for a username and password. You can obtain an API key from https://platform.openai.com/account/api-keys.`
-  )
+  const APIKeyError = page.getByTestId('passthrough-error-message')
   await expect(APIKeyError).toBeVisible({
     timeout: TIMEOUT,
   })

--- a/electron/tests/e2e/thread.e2e.spec.ts
+++ b/electron/tests/e2e/thread.e2e.spec.ts
@@ -25,7 +25,9 @@ test('Select GPT model from Hub and Chat with Invalid API Key', async ({
     { timeout: TIMEOUT }
   )
 
-  const APIKeyError = page.getByTestId('invalid-API-key-error')
+  const APIKeyError = page.getByText(
+    `You didn't provide an API key. You need to provide your API key in an Authorization header using Bearer auth (i.e. Authorization: Bearer YOUR_KEY), or as the password field (with blank username) if you're accessing the API from your browser and are prompted for a username and password. You can obtain an API key from https://platform.openai.com/account/api-keys.`
+  )
   await expect(APIKeyError).toBeVisible({
     timeout: TIMEOUT,
   })

--- a/web/containers/ErrorMessage/index.test.tsx
+++ b/web/containers/ErrorMessage/index.test.tsx
@@ -49,11 +49,7 @@ describe('ErrorMessage Component', () => {
 
     render(<ErrorMessage message={message} />)
 
-    expect(
-      screen.getByText(
-        `You didn't provide an API key. You need to provide your API key in an Authorization header using Bearer auth (i.e. Authorization: Bearer YOUR_KEY), or as the password field (with blank username) if you're accessing the API from your browser and are prompted for a username and password. You can obtain an API key from https://platform.openai.com/account/api-keys.`
-      )
-    ).toBeInTheDocument()
+    expect(screen.getByTestId('invalid-API-key-error')).toBeInTheDocument()
     expect(screen.getByText('Settings')).toBeInTheDocument()
   })
 

--- a/web/containers/ErrorMessage/index.test.tsx
+++ b/web/containers/ErrorMessage/index.test.tsx
@@ -49,7 +49,11 @@ describe('ErrorMessage Component', () => {
 
     render(<ErrorMessage message={message} />)
 
-    expect(screen.getByTestId('invalid-API-key-error')).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        `You didn't provide an API key. You need to provide your API key in an Authorization header using Bearer auth (i.e. Authorization: Bearer YOUR_KEY), or as the password field (with blank username) if you're accessing the API from your browser and are prompted for a username and password. You can obtain an API key from https://platform.openai.com/account/api-keys.`
+      )
+    ).toBeInTheDocument()
     expect(screen.getByText('Settings')).toBeInTheDocument()
   })
 

--- a/web/containers/ErrorMessage/index.tsx
+++ b/web/containers/ErrorMessage/index.tsx
@@ -52,7 +52,7 @@ const ErrorMessage = ({ message }: { message: ThreadMessage }) => {
         )
       default:
         return (
-          <p>
+          <p data-testid="passthrough-error-message">
             {message.content[0]?.text?.value && (
               <AutoLink text={message.content[0].text.value} />
             )}

--- a/web/containers/ErrorMessage/index.tsx
+++ b/web/containers/ErrorMessage/index.tsx
@@ -29,7 +29,6 @@ const ErrorMessage = ({ message }: { message: ThreadMessage }) => {
     switch (message.error_code) {
       case ErrorCode.InvalidApiKey:
       case ErrorCode.AuthenticationError:
-      case ErrorCode.InvalidRequestError:
         return (
           <span data-testid="invalid-API-key-error">
             Invalid API key. Please check your API key from{' '}


### PR DESCRIPTION
## Describe Your Changes

The error message for an invalid request is not handled correctly. Instead of displaying a clear error message from the provider, it prompts users about an invalid API key error.

## Fixes Issues

- #3986

## Changes made

The provided `git diff` shows a modification in the `index.tsx` file located in the `web/containers/ErrorMessage` directory. Specifically, the change involves removing a single case from a switch statement. The case that has been removed is:

```typescript
case ErrorCode.InvalidRequestError:
```

This change means that the `ErrorMessage` component will no longer handle the `InvalidRequestError` by displaying a specific error message (i.e., an invalid API key error), which was part of the switch statement before this modification.
