### PR TITLE
fix: memory leak when the code block response is too long

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -19,7 +19,7 @@
     "autoprefixer": "10.4.16",
     "class-variance-authority": "^0.7.0",
     "framer-motion": "^10.16.4",
-    "highlight.js": "^11.9.0",
+    "highlight.js": "^11.10.0",
     "jotai": "^2.6.0",
     "katex": "^0.16.10",
     "lodash": "^4.17.21",
@@ -83,5 +83,8 @@
     "rimraf": "^5.0.5",
     "ts-jest": "^29.2.5",
     "typescript": "^5.3.3"
+  },
+  "resolutions": {
+    "highlight.js": "11.10.0"
   }
 }


### PR DESCRIPTION
## Describe Your Changes

Update highlight.js version

https://github.com/user-attachments/assets/6b24cc4c-4d13-42a6-a344-5feba9bf589c


<img width="874" alt="Screenshot 2024-11-26 at 15 59 44" src="https://github.com/user-attachments/assets/6d666f6c-b006-48c7-b675-b4e39c237532">

issue on highlight.js 

reference:
- https://github.com/wooorm/lowlight/issues/60
- https://github.com/rehypejs/rehype-highlight/issues/31
- https://github.com/remarkjs/react-markdown/issues/791

## Fixes Issues

- Closes #4102 
- Closes #4124 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
