### PR TITLE
feat: update Jan’s client request to adapt API changes from Cortex

### DIFF
--- a/extensions/inference-cortex-extension/src/index.ts
+++ b/extensions/inference-cortex-extension/src/index.ts
@@ -70,7 +70,7 @@ export default class JanInferenceCortexExtension extends LocalOAIEngine {
     super.onLoad()
 
     this.queue.add(() => this.clean())
-    
+
     // Run the process watchdog
     const systemInfo = await systemInformation()
     this.queue.add(() => executeOnMain(NODE, 'run', systemInfo))
@@ -180,12 +180,20 @@ export default class JanInferenceCortexExtension extends LocalOAIEngine {
       'engineVariant',
       systemInfo.gpuSetting
     )
-    return ky
-      .post(
-        `${CORTEX_API_URL}/v1/engines/${InferenceEngine.cortex_llamacpp}/default?version=${CORTEX_ENGINE_VERSION}&variant=${variant}`,
-        { json: {} }
-      )
-      .then(() => {})
+    return (
+      ky
+        // Fallback support for legacy API
+        .post(
+          `${CORTEX_API_URL}/v1/engines/${InferenceEngine.cortex_llamacpp}/default?version=${CORTEX_ENGINE_VERSION}&variant=${variant}`,
+          {
+            json: {
+              version: CORTEX_ENGINE_VERSION,
+              variant,
+            },
+          }
+        )
+        .then(() => {})
+    )
   }
 
   /**


### PR DESCRIPTION
## Describe Your Changes

This PR aims to update the cortex API request regarding the default engine variant. Previously, the settings payload was included in the search parameters, but it’s now correct to include it in the body of the request.

## Fixes Issues

- #4123

## Changes made

1. **API Request Changes**:
   - Added explicit JSON payload (`version`, `variant`) while posting to the `ky.post` method to support a legacy API.

2. **Test Enhancements**:
   - **Imports**: Added import for `fork` from the `child_process` module.
   - **Mocks**: Implemented a mock for `child_process.fork` to simulate child process behavior.
   - **Test Cases**: 
     - Updated test descriptions for more clarity.
     - Used `mockFork` to define behavior for `fork` mock, especially handling messages for CPU instruction sets.
     - Changed test assertions to use `resolves.toEqual` or `resolves.toBe` to handle asynchronous operations with promises.
     - Duplication of logic was reduced by introducing modular mock process handling.

3. **General Formatting**:
   - Minor string formatting adjustments (e.g., consistent use of single quotes).

These changes focus on improving API interaction robustness and enhancing test reliability through better simulation of asynchronous operations.