### PR TITLE
fix: 4012 - active model should be gone as soon as cortex.cpp server is killed

### DIFF
--- a/extensions/inference-cortex-extension/src/index.ts
+++ b/extensions/inference-cortex-extension/src/index.ts
@@ -70,7 +70,7 @@ export default class JanInferenceCortexExtension extends LocalOAIEngine {
     super.onLoad()
 
     this.queue.add(() => this.clean())
-    
+
     // Run the process watchdog
     const systemInfo = await systemInformation()
     this.queue.add(() => executeOnMain(NODE, 'run', systemInfo))
@@ -251,6 +251,7 @@ export default class JanInferenceCortexExtension extends LocalOAIEngine {
 
           this.socket.onclose = (event) => {
             console.log('WebSocket closed:', event)
+            events.emit(ModelEvent.OnModelStopped, {})
             if (this.shouldReconnect) {
               console.log(`Attempting to reconnect...`)
               setTimeout(() => this.subscribeToEvents(), 1000)


### PR DESCRIPTION
## Describe Your Changes

This PR addresses an issue where the app frontend displays an active running model even after the user forcefully terminates the cortex-server.cpp process through the activity monitor.

Before killing the process
![CleanShot 2024-11-26 at 19 02 05](https://github.com/user-attachments/assets/60774420-a8af-4ca3-8144-73a6169f6f47)

After killing the process
![CleanShot 2024-11-26 at 19 02 20](https://github.com/user-attachments/assets/c57f249d-4720-4471-a022-f2ebc2fc7b17)

## Fixes Issues

- #4012


1. **Whitespace Adjustment:**  
   - A line containing only whitespace was modified. An unnecessary trailing whitespace was removed on line 71.

2. **Event Emission on WebSocket Closure:**  

   - A new line was added after the `console.log('WebSocket closed:', event)` within the `this.socket.onclose` function. The new line emits an event `ModelEvent.OnModelStopped` with an empty object (`{}`) as the payload. This likely triggers logic elsewhere in the application when a WebSocket connection is closed.
