### PR TITLE
fix: 4094 - gpu mode toggle on by default but not affect for the first time launch

### DIFF
--- a/extensions/inference-cortex-extension/src/index.ts
+++ b/extensions/inference-cortex-extension/src/index.ts
@@ -89,7 +89,7 @@ export default class JanInferenceCortexExtension extends LocalOAIEngine {
       const systemInfo = await systemInformation()
       // Update run mode on settings update
       if (systemInfo.gpuSetting?.run_mode !== currentMode)
-        this.setDefaultEngine(systemInfo)
+        this.queue.add(() => this.setDefaultEngine(systemInfo))
     })
   }
 

--- a/extensions/monitoring-extension/src/index.ts
+++ b/extensions/monitoring-extension/src/index.ts
@@ -1,7 +1,9 @@
 import {
+  AppConfigurationEventName,
   GpuSetting,
   MonitoringExtension,
   OperatingSystemInfo,
+  events,
   executeOnMain,
 } from '@janhq/core'
 
@@ -37,6 +39,7 @@ export default class JanMonitoringExtension extends MonitoringExtension {
 
     // Attempt to fetch nvidia info
     await executeOnMain(NODE, 'updateNvidiaInfo')
+    events.emit(AppConfigurationEventName.OnConfigurationUpdate, {})
   }
 
   onSettingUpdate<T>(key: string, value: T): void {


### PR DESCRIPTION
## Describe Your Changes

This PR addresses an issue where the app fails to configure a new GPU variant update after detecting GPU information in the background during the first launch. The app still runs in CPU mode even when the GPU toggle is enabled in the settings.

## Fixes Issues

- #4094

The first attempt it sets CPU engine variant, then it switched to GPU engine variant
![image](https://github.com/user-attachments/assets/3ec0abdb-73c5-4f2e-979c-b1d643ae89a0)

GPU is used without additional settings
![image](https://github.com/user-attachments/assets/fed234ef-c5d2-4c25-a62a-e50bcfeaa67d)

## Changes made
The code changes introduce the following updates across multiple files:

1. **`inference-cortex-extension/src/index.ts`:**
   - Import `AppConfigurationEventName` from `@janhq/core`.
   - Added a new event listener for `AppConfigurationEventName.OnConfigurationUpdate` that updates the system's run mode when settings change.
   - Added an event emission `ModelEvent.OnModelStopped` when a WebSocket connection is closed.

2. **`monitoring-extension/src/index.ts`:**
   - Imported `AppConfigurationEventName` and `events` from `@janhq/core`.
   - Emitting `AppConfigurationEventName.OnConfigurationUpdate` from within the `onLoad` method to notify of configuration updates post Nvidia info update.
   
The main focus of the changes seems to be around monitoring and responding to configuration changes and handling WebSocket connectivity events more robustly.
