### PR TITLE
fix: 4096 - failed to get huggingface models

### DIFF
--- a/core/src/browser/core.test.ts
+++ b/core/src/browser/core.test.ts
@@ -3,7 +3,6 @@ import { joinPath } from './core'
 import { openFileExplorer } from './core'
 import { getJanDataFolderPath } from './core'
 import { abortDownload } from './core'
-import { getFileSize } from './core'
 import { executeOnMain } from './core'
 
 describe('test core apis', () => {
@@ -64,18 +63,6 @@ describe('test core apis', () => {
     const result = await abortDownload(fileName)
     expect(globalThis.core.api.abortDownload).toHaveBeenCalledWith(fileName)
     expect(result).toBe('aborted')
-  })
-
-  it('should get file size', async () => {
-    const url = 'http://example.com/file'
-    globalThis.core = {
-      api: {
-        getFileSize: jest.fn().mockResolvedValue(1024),
-      },
-    }
-    const result = await getFileSize(url)
-    expect(globalThis.core.api.getFileSize).toHaveBeenCalledWith(url)
-    expect(result).toBe(1024)
   })
 
   it('should execute function on main process', async () => {

--- a/core/src/browser/core.ts
+++ b/core/src/browser/core.ts
@@ -29,15 +29,6 @@ const downloadFile: (downloadRequest: DownloadRequest, network?: NetworkConfig) 
 ) => globalThis.core?.api?.downloadFile(downloadRequest, network)
 
 /**
- * Get unit in bytes for a remote file.
- *
- * @param url - The url of the file.
- * @returns {Promise<number>} - A promise that resolves with the file size.
- */
-const getFileSize: (url: string) => Promise<number> = (url: string) =>
-  globalThis.core.api?.getFileSize(url)
-
-/**
  * Aborts the download of a specific file.
  * @param {string} fileName - The name of the file whose download is to be aborted.
  * @returns {Promise<any>} A promise that resolves when the download has been aborted.
@@ -167,7 +158,6 @@ export {
   getUserHomePath,
   systemInformation,
   showToast,
-  getFileSize,
   dirName,
   FileStat,
 }

--- a/core/src/node/api/processors/download.test.ts
+++ b/core/src/node/api/processors/download.test.ts
@@ -23,6 +23,11 @@ jest.mock('fs', () => ({
   createWriteStream: jest.fn(),
 }))
 
+const requestMock = jest.fn((options, callback) => {
+  callback(new Error('Test error'), null)
+})
+jest.mock('request', () => requestMock)
+
 jest.mock('request-progress', () => {
   return jest.fn().mockImplementation(() => {
     return {
@@ -53,18 +58,6 @@ jest.mock('request-progress', () => {
 describe('Downloader', () => {
   beforeEach(() => {
     jest.resetAllMocks()
-  })
-  it('should handle getFileSize errors correctly', async () => {
-    const observer = jest.fn()
-    const url = 'http://example.com/file'
-
-    const downloader = new Downloader(observer)
-    const requestMock = jest.fn((options, callback) => {
-      callback(new Error('Test error'), null)
-    })
-    jest.mock('request', () => requestMock)
-
-    await expect(downloader.getFileSize(observer, url)).rejects.toThrow('Test error')
   })
 
   it('should pause download correctly', () => {

--- a/core/src/node/api/processors/download.ts
+++ b/core/src/node/api/processors/download.ts
@@ -135,25 +135,4 @@ export class Downloader implements Processor {
   pauseDownload(_observer: any, fileName: any) {
     DownloadManager.instance.networkRequests[fileName]?.pause()
   }
-
-  async getFileSize(_observer: any, url: string): Promise<number> {
-    return new Promise((resolve, reject) => {
-      const request = require('request')
-      request(
-        {
-          url,
-          method: 'HEAD',
-        },
-        function (err: any, response: any) {
-          if (err) {
-            console.error('Getting file size failed:', err)
-            reject(err)
-          } else {
-            const size: number = response.headers['content-length'] ?? -1
-            resolve(size)
-          }
-        }
-      )
-    })
-  }
 }

--- a/core/src/types/api/index.ts
+++ b/core/src/types/api/index.ts
@@ -65,7 +65,6 @@ export enum DownloadRoute {
   pauseDownload = 'pauseDownload',
   resumeDownload = 'resumeDownload',
   getDownloadProgress = 'getDownloadProgress',
-  getFileSize = 'getFileSize',
 }
 
 export enum DownloadEvent {

--- a/web/containers/ModelSearch/index.tsx
+++ b/web/containers/ModelSearch/index.tsx
@@ -46,7 +46,7 @@ const ModelSearch = ({ onSearchLocal }: Props) => {
         errMessage = err.message
       }
       toaster({
-        title: 'Failed to get Hugging Face models',
+        title: 'Oops, you may be rate limited, give it a bit more time',
         description: errMessage,
         type: 'error',
       })

--- a/web/utils/huggingface.test.ts
+++ b/web/utils/huggingface.test.ts
@@ -3,11 +3,8 @@ import {
   toHuggingFaceUrl,
   InvalidHostError,
 } from './huggingface'
-import { getFileSize } from '@janhq/core'
 
-// Mock the getFileSize function
 jest.mock('@janhq/core', () => ({
-  getFileSize: jest.fn(),
   AllQuantizations: ['q4_0', 'q4_1', 'q5_0', 'q5_1', 'q8_0'],
 }))
 
@@ -38,9 +35,15 @@ describe('huggingface utils', () => {
       }
 
       ;(global.fetch as jest.Mock).mockResolvedValue({
-        json: jest.fn().mockResolvedValue(mockResponse),
+        json: jest
+          .fn()
+          .mockResolvedValueOnce(mockResponse)
+          .mockResolvedValueOnce([{
+            path: 'model-q4_0.gguf', size: 1000000,
+          },{
+            path: 'model-q4_0.gguf', size: 2000
+          }]),
       })
-      ;(getFileSize as jest.Mock).mockResolvedValue(1000000)
 
       const result = await fetchHuggingFaceRepoData('user/repo')
 

--- a/web/utils/huggingface.ts
+++ b/web/utils/huggingface.ts
@@ -1,4 +1,4 @@
-import { AllQuantizations, getFileSize, HuggingFaceRepoData } from '@janhq/core'
+import { AllQuantizations, HuggingFaceRepoData } from '@janhq/core'
 
 /**
  * Fetches data from a Hugging Face repository.
@@ -39,21 +39,19 @@ export const fetchHuggingFaceRepoData = async (
     )
   }
 
-  const promises: Promise<number>[] = []
-
   // fetching file sizes
   const url = new URL(sanitizedUrl)
   const paths = url.pathname.split('/').filter((e) => e.trim().length > 0)
 
+  const repoTree: { path: string; size: number }[] = await fetch(
+    `https://huggingface.co/api/models/${paths[2]}/${paths[3]}/tree/main`
+  ).then((res) => res.json())
+
   for (const sibling of data.siblings) {
     const downloadUrl = `https://huggingface.co/${paths[2]}/${paths[3]}/resolve/main/${sibling.rfilename}`
     sibling.downloadUrl = downloadUrl
-    promises.push(getFileSize(downloadUrl))
-  }
-
-  const result = await Promise.all(promises)
-  for (let i = 0; i < data.siblings.length; i++) {
-    data.siblings[i].fileSize = result[i]
+    sibling.fileSize =
+      repoTree.find((file) => file.path === sibling.rfilename)?.size ?? 0
   }
 
   AllQuantizations.forEach((quantization) => {


### PR DESCRIPTION
## Describe Your Changes

- Fix a bad implementation that fetches the Huggingface repository N + 1 times, where N = repo file list sizes. It’s easy to reach the limit rate issue by doing that, where it should make only one request to get all the file sizes information. Also, waiting N requests would cause a bad UX where users have to wait for a long time, it hits all the model download endpoints.

Results
- Fast model repo information display, consistent from repo to repo
![CleanShot 2024-11-27 at 00 09 52](https://github.com/user-attachments/assets/1120b5ad-f48e-4363-b59c-2a2ee575b247)

- Only 1 request sent to get all file sizes
![CleanShot 2024-11-27 at 00 10 08](https://github.com/user-attachments/assets/8eaee2ae-323b-4b0b-82be-d4fc81dcaaaa)


## Fixes Issues

- #4096

## Changes made
The code changes involve the removal and refactoring of the `getFileSize` function across the codebase:

1. **Tests**:
   - Removed the `getFileSize` unit test from `core.test.ts` and `download.test.ts`.

2. **Core Functionality**:
   - Deleted the `getFileSize` function definition from `core.ts` and its export statement. The associated API endpoint reference in the `DownloadRoute` enum has also been removed.
  
3. **Downloader Class**:
   - The `getFileSize` method in `download.ts` has been removed. Previously, it used the `request` library to fetch file sizes using HTTP HEAD requests.

4. **Hugging Face Integration**:
   - The import of `getFileSize` in `huggingface.ts` and its related mock in `huggingface.test.ts` have been removed.
   - File size determination now uses the Hugging Face repository's API through an additional `fetch` call to retrieve the file tree, including sizes, instead of individually calling `getFileSize`.

5. **UI Messaging**:
   - Updated the toaster message for failing to get Hugging Face models in `ModelSearch/index.tsx`, providing more user-friendly feedback regarding potential rate limiting.

Overall, the refactor centralizes file size retrieval to a single network call using existing repository data, reducing reliance on redundant and potentially heavy individual requests.
