### PR TITLE
fix: 4098 - factory reset closes the app & never opens again on Linux

### DIFF
--- a/core/src/types/api/index.ts
+++ b/core/src/types/api/index.ts
@@ -27,6 +27,7 @@ export enum NativeRoute {
 
   quickAskSizeUpdated = 'quickAskSizeUpdated',
   ackDeepLink = 'ackDeepLink',
+  factoryReset = 'factoryReset'
 }
 
 /**

--- a/electron/utils/migration.ts
+++ b/electron/utils/migration.ts
@@ -3,7 +3,6 @@ import { app } from 'electron'
 import { join } from 'path'
 import {
   rmdirSync,
-  readFileSync,
   existsSync,
   mkdirSync,
   readdirSync,

--- a/web/hooks/useFactoryReset.test.ts
+++ b/web/hooks/useFactoryReset.test.ts
@@ -21,8 +21,8 @@ jest.mock('@janhq/core', () => ({
     instance: jest.fn().mockReturnValue({
       get: jest.fn(),
       engines: {
-        values: jest.fn().mockReturnValue([])
-      }
+        values: jest.fn().mockReturnValue([]),
+      },
     }),
   },
 }))
@@ -45,6 +45,7 @@ describe('useFactoryReset', () => {
         getAppConfigurations: mockGetAppConfigurations,
         updateAppConfiguration: mockUpdateAppConfiguration,
         relaunch: mockRelaunch,
+        factoryReset: jest.fn(),
       },
     }
     mockGetAppConfigurations.mockResolvedValue({
@@ -80,7 +81,6 @@ describe('useFactoryReset', () => {
     expect(mockSetFactoryResetState).toHaveBeenCalledWith(
       FactoryResetState.ClearLocalStorage
     )
-    expect(mockRelaunch).toHaveBeenCalled()
   })
 
   it('should keep current folder when specified', async () => {

--- a/web/hooks/useFactoryReset.ts
+++ b/web/hooks/useFactoryReset.ts
@@ -62,13 +62,17 @@ export default function useFactoryReset() {
         await window.core?.api?.updateAppConfiguration(configuration)
       }
 
+      // Perform factory reset
+      await window.core?.api?.factoryReset()
+
       // 4: Clear app local storage
       setFactoryResetState(FactoryResetState.ClearLocalStorage)
       // reset the localStorage
       localStorage.clear()
 
+      window.core = undefined
       // 5: Relaunch the app
-      await window.core?.api?.relaunch()
+      window.location.reload()
     },
     [defaultJanDataFolder, stopModel, setFactoryResetState]
   )


### PR DESCRIPTION
## Describe Your Changes

This PR addresses an issue where the app requires a factory reset to relaunch. Now, it simply reloads the frontend to show the affected behavior.

## Fixes Issues

- #4098

## Changes made
This diff introduces several changes across multiple files:

1. **New IPC Route:**
   - A new `NativeRoute` named `factoryReset` is added to `core/src/types/api/index.ts`.

2. **Electron Handler Updates:**
   - The `electron/handlers/native.ts` file has been updated:
     - Added handling for the new `factoryReset` IPC, which clears imported modules, recreates user space, runs migrations, and sets up extensions.
     - Added documentation comments to various IPC handlers for clarity.

3. **Utils Cleanup:**
   - In `electron/utils/migration.ts`, the unused `readFileSync` import has been removed.

4. **Web Hook Modifications:**
   - In `web/hooks/useFactoryReset.ts`:
     - Before clearing local storage, there is now a call to `factoryReset` API for performing a complete factory reset.
     - After clearing local storage, `window.core` is set to `undefined`, and `window.location.reload()` is used instead of relaunching the application.

These changes collectively introduce functionality for performing a factory reset and improve code documentation and clarity.
