### PR TITLE
fix: wrong component wrapping and state handling cause excessive app re-render

### DIFF
--- a/web/app/search/layout.tsx
+++ b/web/app/search/layout.tsx
@@ -52,9 +52,8 @@ export default function RootLayout() {
       <body className="font-sans antialiased">
         <JotaiWrapper>
           <ThemeWrapper>
-            <ClipboardListener>
-              <Search />
-            </ClipboardListener>
+            <ClipboardListener />
+            <Search />
           </ThemeWrapper>
         </JotaiWrapper>
       </body>

--- a/web/containers/ListContainer/index.tsx
+++ b/web/containers/ListContainer/index.tsx
@@ -1,12 +1,8 @@
-import { ReactNode, useCallback, useEffect, useRef } from 'react'
+import { PropsWithChildren, useCallback, useEffect, useRef } from 'react'
 
 import { ScrollArea } from '@janhq/joi'
 
-type Props = {
-  children: ReactNode
-}
-
-const ListContainer = ({ children }: Props) => {
+const ListContainer = ({ children }: PropsWithChildren) => {
   const listRef = useRef<HTMLDivElement>(null)
   const prevScrollTop = useRef(0)
   const isUserManuallyScrollingUp = useRef(false)

--- a/web/containers/ModelConfigInput/index.test.tsx
+++ b/web/containers/ModelConfigInput/index.test.tsx
@@ -2,7 +2,6 @@ import '@testing-library/jest-dom'
 import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
 import ModelConfigInput from './index'
-import { Tooltip } from '@janhq/joi'
 
 // Mocking the Tooltip component to simplify testing
 jest.mock('@janhq/joi', () => ({

--- a/web/containers/Providers/AppUpdateListener.tsx
+++ b/web/containers/Providers/AppUpdateListener.tsx
@@ -1,4 +1,4 @@
-import { Fragment, PropsWithChildren, useEffect } from 'react'
+import { Fragment, useEffect } from 'react'
 
 import { AppUpdateInfo } from '@janhq/core'
 import { useSetAtom } from 'jotai'
@@ -8,7 +8,7 @@ import {
   updateVersionErrorAtom,
 } from '@/helpers/atoms/App.atom'
 
-const AppUpdateListener = ({ children }: PropsWithChildren) => {
+const AppUpdateListener = () => {
   const setProgress = useSetAtom(appDownloadProgressAtom)
   const setUpdateVersionError = useSetAtom(updateVersionErrorAtom)
 
@@ -39,7 +39,7 @@ const AppUpdateListener = ({ children }: PropsWithChildren) => {
     }
   }, [setProgress, setUpdateVersionError])
 
-  return <Fragment>{children}</Fragment>
+  return <Fragment></Fragment>
 }
 
 export default AppUpdateListener

--- a/web/containers/Providers/ClipboardListener.tsx
+++ b/web/containers/Providers/ClipboardListener.tsx
@@ -1,10 +1,10 @@
-import { Fragment, PropsWithChildren } from 'react'
+import { Fragment } from 'react'
 
 import { useSetAtom } from 'jotai'
 
 import { selectedTextAtom } from './Jotai'
 
-const ClipboardListener = ({ children }: PropsWithChildren) => {
+const ClipboardListener = () => {
   const setSelectedText = useSetAtom(selectedTextAtom)
 
   if (typeof window !== 'undefined') {
@@ -13,7 +13,7 @@ const ClipboardListener = ({ children }: PropsWithChildren) => {
     })
   }
 
-  return <Fragment>{children}</Fragment>
+  return <Fragment></Fragment>
 }
 
 export default ClipboardListener

--- a/web/containers/Providers/DataLoader.tsx
+++ b/web/containers/Providers/DataLoader.tsx
@@ -1,13 +1,12 @@
 'use client'
 
-import { Fragment, ReactNode, useEffect } from 'react'
+import { Fragment, useEffect } from 'react'
 
 import { AppConfiguration, getUserHomePath } from '@janhq/core'
 import { useSetAtom } from 'jotai'
 
 import useAssistants from '@/hooks/useAssistants'
 import useGetSystemResources from '@/hooks/useGetSystemResources'
-import { useLoadTheme } from '@/hooks/useLoadTheme'
 import useModels from '@/hooks/useModels'
 import useThreads from '@/hooks/useThreads'
 
@@ -20,27 +19,20 @@ import {
 } from '@/helpers/atoms/AppConfig.atom'
 import { janSettingScreenAtom } from '@/helpers/atoms/Setting.atom'
 
-type Props = {
-  children: ReactNode
-}
-
-const DataLoader: React.FC<Props> = ({ children }) => {
+const DataLoader: React.FC = () => {
   const setJanDataFolderPath = useSetAtom(janDataFolderPathAtom)
   const setQuickAskEnabled = useSetAtom(quickAskEnabledAtom)
   const setJanDefaultDataFolder = useSetAtom(defaultJanDataFolderAtom)
   const setJanSettingScreen = useSetAtom(janSettingScreenAtom)
-  const { loadDataModel, configurePullOptions } = useModels()
+  const { getData: loadModels } = useModels()
 
   useThreads()
   useAssistants()
   useGetSystemResources()
-  useLoadTheme()
 
   useEffect(() => {
     // Load data once
-    loadDataModel()
-    // Configure pull options once
-    configurePullOptions()
+    loadModels()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -71,7 +63,7 @@ const DataLoader: React.FC<Props> = ({ children }) => {
 
   console.debug('Load Data...')
 
-  return <Fragment>{children}</Fragment>
+  return <Fragment></Fragment>
 }
 
 export default DataLoader

--- a/web/containers/Providers/DeepLinkListener.tsx
+++ b/web/containers/Providers/DeepLinkListener.tsx
@@ -1,4 +1,4 @@
-import { Fragment, ReactNode } from 'react'
+import { Fragment } from 'react'
 
 import { useSetAtom } from 'jotai'
 
@@ -13,11 +13,8 @@ import {
   importHuggingFaceModelStageAtom,
   importingHuggingFaceRepoDataAtom,
 } from '@/helpers/atoms/HuggingFace.atom'
-type Props = {
-  children: ReactNode
-}
 
-const DeepLinkListener: React.FC<Props> = ({ children }) => {
+const DeepLinkListener: React.FC = () => {
   const { getHfRepoData } = useGetHFRepoData()
   const setLoadingInfo = useSetAtom(loadingModalInfoAtom)
   const setImportingHuggingFaceRepoData = useSetAtom(
@@ -69,7 +66,7 @@ const DeepLinkListener: React.FC<Props> = ({ children }) => {
     handleDeepLinkAction(action)
   })
 
-  return <Fragment>{children}</Fragment>
+  return <Fragment></Fragment>
 }
 
 type DeepLinkAction = {

--- a/web/containers/Providers/EventListener.tsx
+++ b/web/containers/Providers/EventListener.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren, useCallback, useEffect } from 'react'
+import { useCallback, useEffect } from 'react'
 
 import React from 'react'
 
@@ -23,7 +23,7 @@ import { toaster } from '../Toast'
 
 import AppUpdateListener from './AppUpdateListener'
 import ClipboardListener from './ClipboardListener'
-import EventHandler from './EventHandler'
+import ModelHandler from './ModelHandler'
 
 import ModelImportListener from './ModelImportListener'
 import QuickAskListener from './QuickAskListener'
@@ -39,7 +39,7 @@ import {
   removeDownloadingModelAtom,
 } from '@/helpers/atoms/Model.atom'
 
-const EventListenerWrapper = ({ children }: PropsWithChildren) => {
+const EventListener = () => {
   const setDownloadState = useSetAtom(setDownloadStateAtom)
   const setInstallingExtension = useSetAtom(setInstallingExtensionAtom)
   const removeInstallingExtension = useSetAtom(removeInstallingExtensionAtom)
@@ -156,16 +156,14 @@ const EventListenerWrapper = ({ children }: PropsWithChildren) => {
   ])
 
   return (
-    <AppUpdateListener>
-      <ClipboardListener>
-        <ModelImportListener>
-          <QuickAskListener>
-            <EventHandler>{children}</EventHandler>
-          </QuickAskListener>
-        </ModelImportListener>
-      </ClipboardListener>
-    </AppUpdateListener>
+    <>
+      <AppUpdateListener />
+      <ClipboardListener />
+      <ModelImportListener />
+      <QuickAskListener />
+      <ModelHandler />
+    </>
   )
 }
 
-export default EventListenerWrapper
+export default EventListener

--- a/web/containers/Providers/Jotai.tsx
+++ b/web/containers/Providers/Jotai.tsx
@@ -1,12 +1,8 @@
 'use client'
 
-import { ReactNode } from 'react'
+import { PropsWithChildren } from 'react'
 
 import { Provider, atom } from 'jotai'
-
-type Props = {
-  children: ReactNode
-}
 
 export const editPromptAtom = atom<string>('')
 export const currentPromptAtom = atom<string>('')
@@ -16,7 +12,7 @@ export const searchAtom = atom<string>('')
 
 export const selectedTextAtom = atom('')
 
-export default function JotaiWrapper({ children }: Props) {
+export default function JotaiWrapper({ children }: PropsWithChildren) {
   return <Provider>{children}</Provider>
 }
 

--- a/web/containers/Providers/KeyListener.tsx
+++ b/web/containers/Providers/KeyListener.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Fragment, ReactNode, useEffect } from 'react'
+import { Fragment, useEffect } from 'react'
 
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 
@@ -22,11 +22,7 @@ import {
   ThreadModalAction,
 } from '@/helpers/atoms/Thread.atom'
 
-type Props = {
-  children: ReactNode
-}
-
-export default function KeyListener({ children }: Props) {
+export default function KeyListener() {
   const setShowLeftPanel = useSetAtom(showLeftPanelAtom)
   const setShowRightPanel = useSetAtom(showRightPanelAtom)
   const [mainViewState, setMainViewState] = useAtom(mainViewStateAtom)
@@ -94,5 +90,5 @@ export default function KeyListener({ children }: Props) {
     setShowRightPanel,
   ])
 
-  return <Fragment>{children}</Fragment>
+  return <Fragment></Fragment>
 }

--- a/web/containers/Providers/ModelHandler.tsx
+++ b/web/containers/Providers/ModelHandler.tsx
@@ -1,4 +1,4 @@
-import { Fragment, ReactNode, useCallback, useEffect, useRef } from 'react'
+import { Fragment, useCallback, useEffect, useRef } from 'react'
 
 import {
   ChatCompletionMessage,
@@ -43,7 +43,7 @@ import {
 const maxWordForThreadTitle = 10
 const defaultThreadTitle = 'New Thread'
 
-export default function EventHandler({ children }: { children: ReactNode }) {
+export default function ModelHandler() {
   const messages = useAtomValue(getCurrentChatMessagesAtom)
   const addNewMessage = useSetAtom(addNewMessageAtom)
   const updateMessage = useSetAtom(updateMessageAtom)
@@ -333,5 +333,5 @@ export default function EventHandler({ children }: { children: ReactNode }) {
     }
   }, [onNewMessageResponse, onMessageResponseUpdate, onModelStopped])
 
-  return <Fragment>{children}</Fragment>
+  return <Fragment></Fragment>
 }

--- a/web/containers/Providers/ModelImportListener.tsx
+++ b/web/containers/Providers/ModelImportListener.tsx
@@ -1,4 +1,4 @@
-import { Fragment, PropsWithChildren, useCallback, useEffect } from 'react'
+import { Fragment, useCallback, useEffect } from 'react'
 
 import {
   ImportingModel,
@@ -17,7 +17,7 @@ import {
   updateImportingModelProgressAtom,
 } from '@/helpers/atoms/Model.atom'
 
-const ModelImportListener = ({ children }: PropsWithChildren) => {
+const ModelImportListener = () => {
   const updateImportingModelProgress = useSetAtom(
     updateImportingModelProgressAtom
   )
@@ -103,7 +103,7 @@ const ModelImportListener = ({ children }: PropsWithChildren) => {
     onImportModelFailed,
   ])
 
-  return <Fragment>{children}</Fragment>
+  return <Fragment></Fragment>
 }
 
 export default ModelImportListener

--- a/web/containers/Providers/QuickAskListener.tsx
+++ b/web/containers/Providers/QuickAskListener.tsx
@@ -1,4 +1,4 @@
-import { Fragment, ReactNode } from 'react'
+import { Fragment } from 'react'
 
 import { useSetAtom } from 'jotai'
 
@@ -10,11 +10,7 @@ import useSendChatMessage from '@/hooks/useSendChatMessage'
 
 import { mainViewStateAtom } from '@/helpers/atoms/App.atom'
 
-type Props = {
-  children: ReactNode
-}
-
-const QuickAskListener: React.FC<Props> = ({ children }) => {
+const QuickAskListener: React.FC = () => {
   const { sendChatMessage } = useSendChatMessage()
   const setMainState = useSetAtom(mainViewStateAtom)
 
@@ -27,7 +23,7 @@ const QuickAskListener: React.FC<Props> = ({ children }) => {
     debounced(input)
   })
 
-  return <Fragment>{children}</Fragment>
+  return <Fragment></Fragment>
 }
 
 export default QuickAskListener

--- a/web/containers/Providers/Responsive.tsx
+++ b/web/containers/Providers/Responsive.tsx
@@ -1,11 +1,11 @@
-import { Fragment, PropsWithChildren, useEffect, useRef } from 'react'
+import { Fragment, useEffect, useRef } from 'react'
 
 import { useMediaQuery } from '@janhq/joi'
 import { useAtom } from 'jotai'
 
 import { showLeftPanelAtom, showRightPanelAtom } from '@/helpers/atoms/App.atom'
 
-const Responsive = ({ children }: PropsWithChildren) => {
+const Responsive = () => {
   const matches = useMediaQuery('(max-width: 880px)')
   const [showLeftPanel, setShowLeftPanel] = useAtom(showLeftPanelAtom)
   const [showRightPanel, setShowRightPanel] = useAtom(showRightPanelAtom)
@@ -30,7 +30,7 @@ const Responsive = ({ children }: PropsWithChildren) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [matches, setShowLeftPanel, setShowRightPanel])
 
-  return <Fragment>{children}</Fragment>
+  return <Fragment></Fragment>
 }
 
 export default Responsive

--- a/web/containers/Providers/SettingsHandler.tsx
+++ b/web/containers/Providers/SettingsHandler.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useEffect } from 'react'
+
+import { useConfigurations } from '@/hooks/useConfigurations'
+import { useLoadTheme } from '@/hooks/useLoadTheme'
+
+const SettingsHandler: React.FC = () => {
+  useLoadTheme()
+
+  const { configurePullOptions } = useConfigurations()
+
+  useEffect(() => {
+    configurePullOptions()
+  }, [configurePullOptions])
+
+  return <></>
+}
+
+export default SettingsHandler

--- a/web/containers/Providers/index.tsx
+++ b/web/containers/Providers/index.tsx
@@ -5,7 +5,7 @@ import { PropsWithChildren, useCallback, useEffect, useState } from 'react'
 import { Toaster } from 'react-hot-toast'
 
 import Loader from '@/containers/Loader'
-import EventListenerWrapper from '@/containers/Providers/EventListener'
+import EventListener from '@/containers/Providers/EventListener'
 import JotaiWrapper from '@/containers/Providers/Jotai'
 
 import ThemeWrapper from '@/containers/Providers/Theme'
@@ -23,6 +23,8 @@ import DataLoader from './DataLoader'
 import DeepLinkListener from './DeepLinkListener'
 import KeyListener from './KeyListener'
 import Responsive from './Responsive'
+
+import SettingsHandler from './SettingsHandler'
 
 import { extensionManager } from '@/extension'
 
@@ -76,16 +78,14 @@ const Providers = ({ children }: PropsWithChildren) => {
         {settingUp && <Loader description="Preparing Update..." />}
         {setupCore && activated && (
           <>
-            <Responsive>
-              <KeyListener>
-                <EventListenerWrapper>
-                  <DataLoader>
-                    <DeepLinkListener>{children}</DeepLinkListener>
-                  </DataLoader>
-                </EventListenerWrapper>
-                <Toaster />
-              </KeyListener>
-            </Responsive>
+            <Responsive />
+            <KeyListener />
+            <EventListener />
+            <DataLoader />
+            <SettingsHandler />
+            <DeepLinkListener />
+            <Toaster />
+            {children}
           </>
         )}
       </JotaiWrapper>

--- a/web/hooks/useConfigurations.ts
+++ b/web/hooks/useConfigurations.ts
@@ -1,0 +1,41 @@
+import { useCallback, useEffect } from 'react'
+
+import { ExtensionTypeEnum, ModelExtension } from '@janhq/core'
+import { useAtomValue } from 'jotai'
+
+import { extensionManager } from '@/extension'
+import {
+  ignoreSslAtom,
+  proxyAtom,
+  proxyEnabledAtom,
+} from '@/helpers/atoms/AppConfig.atom'
+
+export const useConfigurations = () => {
+  const proxyEnabled = useAtomValue(proxyEnabledAtom)
+  const proxyUrl = useAtomValue(proxyAtom)
+  const proxyIgnoreSSL = useAtomValue(ignoreSslAtom)
+
+  const configurePullOptions = useCallback(() => {
+    extensionManager
+      .get<ModelExtension>(ExtensionTypeEnum.Model)
+      ?.configurePullOptions(
+        proxyEnabled
+          ? {
+              proxy_url: proxyUrl,
+              verify_peer_ssl: !proxyIgnoreSSL,
+            }
+          : {
+              proxy_url: '',
+              verify_peer_ssl: false,
+            }
+      )
+  }, [proxyEnabled, proxyUrl, proxyIgnoreSSL])
+
+  useEffect(() => {
+    configurePullOptions()
+  }, [])
+
+  return {
+    configurePullOptions,
+  }
+}

--- a/web/screens/Settings/Advanced/index.tsx
+++ b/web/screens/Settings/Advanced/index.tsx
@@ -25,7 +25,7 @@ import { useDebouncedCallback } from 'use-debounce'
 import { snackbar, toaster } from '@/containers/Toast'
 
 import { useActiveModel } from '@/hooks/useActiveModel'
-import useModels from '@/hooks/useModels'
+import { useConfigurations } from '@/hooks/useConfigurations'
 import { useSettings } from '@/hooks/useSettings'
 
 import DataFolder from './DataFolder'
@@ -68,7 +68,7 @@ const Advanced = () => {
   const [dropdownOptions, setDropdownOptions] = useState<HTMLDivElement | null>(
     null
   )
-  const { configurePullOptions } = useModels()
+  const { configurePullOptions } = useConfigurations()
 
   const [toggle, setToggle] = useState<HTMLDivElement | null>(null)
 


### PR DESCRIPTION
## Describe Your Changes

This PR is to refactor bad components structure and state handling across components. So many necessary nested component wrapping might cause performance issues later on. 

Should not wrap app component inside irrelevant parent wrappers where:
1.  It is not manipulated overtime, e.g. no data passed to children.
2. No parent domain is wrapped outside it when it goes through the wrapper (HOC)
3. No provider setup on parent component and context access from children.

Before: Too many attempts to load data
![CleanShot 2024-11-27 at 18 12 48@2x](https://github.com/user-attachments/assets/364ab949-ceba-430d-acc8-766007bd31a1)

After: Necessary attempts are made only
![CleanShot 2024-11-27 at 18 12 17@2x](https://github.com/user-attachments/assets/b150befd-662f-4f60-b63d-688ff2113d23)

## Changes made

1. **Component Modifications**: 
   - Several components have been altered to remove `children` props where they were redundant. The components now return an empty `Fragment` instead of wrapping `children`.
   - The imports like `ReactNode` or `PropsWithChildren` have been removed from several components, indicating a shift away from passing children props.
   - Components including `AppUpdateListener`, `ClipboardListener`, and others have been updated to function without internal or external content consumption, simplifying their interfaces.

4. **Hooks and Configurations**:
   - A new custom hook, `useConfigurations`, is introduced to manage configuration settings, primarily related to proxy settings, which was previously handled inside `useModels`.
   - This change externalizes the setup logic into `useConfigurations`, making `useModels` lighter and focused on data loading and state updating.

5. **File Renaming**:
   - There is a file renaming from `EventHandler` to `ModelHandler` to better reflect its purpose post-refactoring.

6. **Providers Component**:
   - The `Providers` component in `index.tsx` has been streamlined. Instead of wrapping the rendered structure within specific component wrappers, components are now rendered independently, simplifying the composition.
   - `SettingsHandler` has been introduced and is included in the main provider setup.

7. **Settings Screen**:
   - The `Advanced` settings screen now uses the `useConfigurations` hook instead of importing `useModels` for configuring pull options.

8. **Dependency and Unused Code Removal**:
   - Unused imports, such as `Tooltip` in the test files, have been removed, and there is a general cleanup of redundant code across files.

9. **Fragment Usage**:
   - Components returning `<Fragment>{children}</Fragment>` have been changed to simply return `<Fragment></Fragment>`, reflecting the removal of logic that conditionally rendered children.

Overall, these changes improve code modularity, decrease complexity in component interfaces, and enhance maintainability.