### PR TITLE
fix: app re-render issues caused by bad state handling

### DIFF
--- a/web/containers/Layout/index.tsx
+++ b/web/containers/Layout/index.tsx
@@ -1,10 +1,8 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 
-import { motion as m } from 'framer-motion'
-
-import { useAtom, useAtomValue } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 
 import { twMerge } from 'tailwind-merge'
 
@@ -36,7 +34,7 @@ import { mainViewStateAtom } from '@/helpers/atoms/App.atom'
 import { reduceTransparentAtom } from '@/helpers/atoms/Setting.atom'
 
 const BaseLayout = () => {
-  const [mainViewState, setMainViewState] = useAtom(mainViewStateAtom)
+  const setMainViewState = useSetAtom(mainViewStateAtom)
   const importModelStage = useAtomValue(getImportModelStageAtom)
   const reduceTransparent = useAtomValue(reduceTransparentAtom)
 
@@ -68,24 +66,7 @@ const BaseLayout = () => {
       <TopPanel />
       <div className="relative top-9 flex h-[calc(100vh-(36px+36px))] w-screen">
         <RibbonPanel />
-        <div className={twMerge('relative flex w-full')}>
-          <div className="w-full">
-            <m.div
-              key={mainViewState}
-              initial={{ opacity: 0, y: -8 }}
-              className="h-full"
-              animate={{
-                opacity: 1,
-                y: 0,
-                transition: {
-                  duration: 0.5,
-                },
-              }}
-            >
-              <MainViewContainer />
-            </m.div>
-          </div>
-        </div>
+        <MainViewContainer />
         <LoadingModal />
         {importModelStage === 'SELECTING_MODEL' && <SelectingModelModal />}
         {importModelStage === 'MODEL_SELECTED' && <ImportModelOptionModal />}

--- a/web/containers/MainViewContainer/index.tsx
+++ b/web/containers/MainViewContainer/index.tsx
@@ -1,4 +1,9 @@
+import { memo } from 'react'
+
+import { motion as m } from 'framer-motion'
 import { useAtomValue } from 'jotai'
+
+import { twMerge } from 'tailwind-merge'
 
 import { MainViewState } from '@/constants/screens'
 
@@ -31,7 +36,26 @@ const MainViewContainer = () => {
       break
   }
 
-  return children
+  return (
+    <div className={twMerge('relative flex w-full')}>
+      <div className="w-full">
+        <m.div
+          key={mainViewState}
+          initial={{ opacity: 0, y: -8 }}
+          className="h-full"
+          animate={{
+            opacity: 1,
+            y: 0,
+            transition: {
+              duration: 0.25,
+            },
+          }}
+        >
+          {children}
+        </m.div>
+      </div>
+    </div>
+  )
 }
 
-export default MainViewContainer
+export default memo(MainViewContainer)

--- a/web/containers/Providers/CoreConfigurator.tsx
+++ b/web/containers/Providers/CoreConfigurator.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { PropsWithChildren, useCallback, useEffect, useState } from 'react'
+
+import Loader from '@/containers/Loader'
+
+import { setupCoreServices } from '@/services/coreService'
+import {
+  isCoreExtensionInstalled,
+  setupBaseExtensions,
+} from '@/services/extensionService'
+
+import { extensionManager } from '@/extension'
+
+export const CoreConfigurator = ({ children }: PropsWithChildren) => {
+  const [setupCore, setSetupCore] = useState(false)
+  const [activated, setActivated] = useState(false)
+  const [settingUp, setSettingUp] = useState(false)
+
+  const setupExtensions = useCallback(async () => {
+    // Register all active extensions
+    await extensionManager.registerActive()
+
+    setTimeout(async () => {
+      if (!isCoreExtensionInstalled()) {
+        setSettingUp(true)
+        await setupBaseExtensions()
+        return
+      }
+
+      extensionManager.load()
+      setSettingUp(false)
+      setActivated(true)
+    }, 500)
+  }, [])
+
+  // Services Setup
+  useEffect(() => {
+    setupCoreServices()
+    setSetupCore(true)
+    return () => {
+      extensionManager.unload()
+    }
+  }, [])
+
+  useEffect(() => {
+    if (setupCore) {
+      // Electron
+      if (window && window.core?.api) {
+        setupExtensions()
+      } else {
+        // Host
+        setActivated(true)
+      }
+    }
+  }, [setupCore, setupExtensions])
+
+  return (
+    <>
+      {settingUp && <Loader description="Preparing Update..." />}
+      {setupCore && activated && <>{children}</>}
+    </>
+  )
+}

--- a/web/containers/Providers/index.tsx
+++ b/web/containers/Providers/index.tsx
@@ -1,23 +1,17 @@
 'use client'
 
-import { PropsWithChildren, useCallback, useEffect, useState } from 'react'
+import { PropsWithChildren } from 'react'
 
 import { Toaster } from 'react-hot-toast'
 
-import Loader from '@/containers/Loader'
 import EventListener from '@/containers/Providers/EventListener'
 import JotaiWrapper from '@/containers/Providers/Jotai'
 
 import ThemeWrapper from '@/containers/Providers/Theme'
 
-import { setupCoreServices } from '@/services/coreService'
-import {
-  isCoreExtensionInstalled,
-  setupBaseExtensions,
-} from '@/services/extensionService'
-
 import Umami from '@/utils/umami'
 
+import { CoreConfigurator } from './CoreConfigurator'
 import DataLoader from './DataLoader'
 
 import DeepLinkListener from './DeepLinkListener'
@@ -26,57 +20,12 @@ import Responsive from './Responsive'
 
 import SettingsHandler from './SettingsHandler'
 
-import { extensionManager } from '@/extension'
-
 const Providers = ({ children }: PropsWithChildren) => {
-  const [setupCore, setSetupCore] = useState(false)
-  const [activated, setActivated] = useState(false)
-  const [settingUp, setSettingUp] = useState(false)
-
-  const setupExtensions = useCallback(async () => {
-    // Register all active extensions
-    await extensionManager.registerActive()
-
-    setTimeout(async () => {
-      if (!isCoreExtensionInstalled()) {
-        setSettingUp(true)
-        await setupBaseExtensions()
-        return
-      }
-
-      extensionManager.load()
-      setSettingUp(false)
-      setActivated(true)
-    }, 500)
-  }, [])
-
-  // Services Setup
-  useEffect(() => {
-    setupCoreServices()
-    setSetupCore(true)
-    return () => {
-      extensionManager.unload()
-    }
-  }, [])
-
-  useEffect(() => {
-    if (setupCore) {
-      // Electron
-      if (window && window.core?.api) {
-        setupExtensions()
-      } else {
-        // Host
-        setActivated(true)
-      }
-    }
-  }, [setupCore, setupExtensions])
-
   return (
     <ThemeWrapper>
       <JotaiWrapper>
         <Umami />
-        {settingUp && <Loader description="Preparing Update..." />}
-        {setupCore && activated && (
+        <CoreConfigurator>
           <>
             <Responsive />
             <KeyListener />
@@ -87,7 +36,7 @@ const Providers = ({ children }: PropsWithChildren) => {
             <Toaster />
             {children}
           </>
-        )}
+        </CoreConfigurator>
       </JotaiWrapper>
     </ThemeWrapper>
   )

--- a/web/helpers/atoms/AppConfig.atom.ts
+++ b/web/helpers/atoms/AppConfig.atom.ts
@@ -12,14 +12,35 @@ export const janDataFolderPathAtom = atom('')
 
 export const experimentalFeatureEnabledAtom = atomWithStorage(
   EXPERIMENTAL_FEATURE,
-  false
+  false,
+  undefined,
+  { getOnInit: true }
 )
 
-export const proxyEnabledAtom = atomWithStorage(PROXY_FEATURE_ENABLED, false)
-export const proxyAtom = atomWithStorage(HTTPS_PROXY_FEATURE, '')
+export const proxyEnabledAtom = atomWithStorage(
+  PROXY_FEATURE_ENABLED,
+  false,
+  undefined,
+  { getOnInit: true }
+)
+export const proxyAtom = atomWithStorage(HTTPS_PROXY_FEATURE, '', undefined, {
+  getOnInit: true,
+})
 
-export const ignoreSslAtom = atomWithStorage(IGNORE_SSL, false)
-export const vulkanEnabledAtom = atomWithStorage(VULKAN_ENABLED, false)
-export const quickAskEnabledAtom = atomWithStorage(QUICK_ASK_ENABLED, false)
+export const ignoreSslAtom = atomWithStorage(IGNORE_SSL, false, undefined, {
+  getOnInit: true,
+})
+export const vulkanEnabledAtom = atomWithStorage(
+  VULKAN_ENABLED,
+  false,
+  undefined,
+  { getOnInit: true }
+)
+export const quickAskEnabledAtom = atomWithStorage(
+  QUICK_ASK_ENABLED,
+  false,
+  undefined,
+  { getOnInit: true }
+)
 
 export const hostAtom = atom('http://localhost:1337/')

--- a/web/helpers/atoms/Model.atom.ts
+++ b/web/helpers/atoms/Model.atom.ts
@@ -16,7 +16,9 @@ enum ModelStorageAtomKeys {
  */
 export const downloadedModelsAtom = atomWithStorage<Model[]>(
   ModelStorageAtomKeys.DownloadedModels,
-  []
+  [],
+  undefined,
+  { getOnInit: true }
 )
 
 /**
@@ -25,7 +27,9 @@ export const downloadedModelsAtom = atomWithStorage<Model[]>(
  */
 export const configuredModelsAtom = atomWithStorage<Model[]>(
   ModelStorageAtomKeys.AvailableModels,
-  []
+  [],
+  undefined,
+  { getOnInit: true }
 )
 
 export const removeDownloadedModelAtom = atom(

--- a/web/helpers/atoms/Setting.atom.ts
+++ b/web/helpers/atoms/Setting.atom.ts
@@ -13,10 +13,22 @@ export const REDUCE_TRANSPARENT = 'reduceTransparent'
 export const SPELL_CHECKING = 'spellChecking'
 export const themesOptionsAtom = atom<{ name: string; value: string }[]>([])
 export const janThemesPathAtom = atom<string | undefined>(undefined)
-export const selectedThemeIdAtom = atomWithStorage<string>(THEME, '')
+export const selectedThemeIdAtom = atomWithStorage<string>(
+  THEME,
+  '',
+  undefined,
+  { getOnInit: true }
+)
 export const themeDataAtom = atom<Theme | undefined>(undefined)
 export const reduceTransparentAtom = atomWithStorage<boolean>(
   REDUCE_TRANSPARENT,
-  false
+  false,
+  undefined,
+  { getOnInit: true }
 )
-export const spellCheckAtom = atomWithStorage<boolean>(SPELL_CHECKING, false)
+export const spellCheckAtom = atomWithStorage<boolean>(
+  SPELL_CHECKING,
+  false,
+  undefined,
+  { getOnInit: true }
+)

--- a/web/helpers/atoms/Thread.atom.ts
+++ b/web/helpers/atoms/Thread.atom.ts
@@ -207,7 +207,9 @@ export const setThreadModelParamsAtom = atom(
  */
 export const activeSettingInputBoxAtom = atomWithStorage<boolean>(
   ACTIVE_SETTING_INPUT_BOX,
-  false
+  false,
+  undefined,
+  { getOnInit: true }
 )
 
 /**

--- a/web/hooks/useStarterScreen.ts
+++ b/web/hooks/useStarterScreen.ts
@@ -1,22 +1,20 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 
-import { useAtomValue, useSetAtom } from 'jotai'
+import { useAtomValue } from 'jotai'
 
 import { isLocalEngine } from '@/utils/modelEngine'
 
 import { extensionManager } from '@/extension'
-import {
-  downloadedModelsAtom,
-  selectedModelAtom,
-} from '@/helpers/atoms/Model.atom'
+import { downloadedModelsAtom } from '@/helpers/atoms/Model.atom'
 import { threadsAtom } from '@/helpers/atoms/Thread.atom'
 
 export function useStarterScreen() {
   const downloadedModels = useAtomValue(downloadedModelsAtom)
   const threads = useAtomValue(threadsAtom)
-  const setSelectedModel = useSetAtom(selectedModelAtom)
-  const isDownloadALocalModel = downloadedModels.some((x) =>
-    isLocalEngine(x.engine)
+
+  const isDownloadALocalModel = useMemo(
+    () => downloadedModels.some((x) => isLocalEngine(x.engine)),
+    [downloadedModels]
   )
 
   const [extensionHasSettings, setExtensionHasSettings] = useState<
@@ -24,9 +22,6 @@ export function useStarterScreen() {
   >([])
 
   useEffect(() => {
-    if (isDownloadALocalModel) {
-      setSelectedModel(downloadedModels[0])
-    }
     const getAllSettings = async () => {
       const extensionsMenu: {
         name?: string
@@ -66,12 +61,16 @@ export function useStarterScreen() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const isAnyRemoteModelConfigured = extensionHasSettings.some(
-    (x) => x.apiKey.length > 1
+  const isAnyRemoteModelConfigured = useMemo(
+    () => extensionHasSettings.some((x) => x.apiKey.length > 1),
+    [extensionHasSettings]
   )
 
-  const isShowStarterScreen =
-    !isAnyRemoteModelConfigured && !isDownloadALocalModel && !threads.length
+  const isShowStarterScreen = useMemo(
+    () =>
+      !isAnyRemoteModelConfigured && !isDownloadALocalModel && !threads.length,
+    [isAnyRemoteModelConfigured, isDownloadALocalModel, threads]
+  )
 
   return {
     extensionHasSettings,

--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/OnDeviceStarterScreen/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/OnDeviceStarterScreen/index.tsx
@@ -24,6 +24,8 @@ import useDownloadModel from '@/hooks/useDownloadModel'
 
 import { modelDownloadStateAtom } from '@/hooks/useDownloadState'
 
+import { useStarterScreen } from '@/hooks/useStarterScreen'
+
 import { formatDownloadPercentage, toGibibytes } from '@/utils/converter'
 import {
   getLogoEngine,
@@ -38,16 +40,8 @@ import {
 } from '@/helpers/atoms/Model.atom'
 import { selectedSettingAtom } from '@/helpers/atoms/Setting.atom'
 
-type Props = {
-  extensionHasSettings: {
-    name?: string
-    setting: string
-    apiKey: string
-    provider: string
-  }[]
-}
-
-const OnDeviceStarterScreen = ({ extensionHasSettings }: Props) => {
+const OnDeviceStarterScreen = () => {
+  const { extensionHasSettings } = useStarterScreen()
   const [searchValue, setSearchValue] = useState('')
   const [isOpen, setIsOpen] = useState(Boolean(searchValue.length))
   const downloadingModels = useAtomValue(getDownloadingModelAtom)

--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
@@ -1,3 +1,5 @@
+import { memo } from 'react'
+
 import { MessageStatus } from '@janhq/core'
 
 import { useAtomValue } from 'jotai'
@@ -44,4 +46,4 @@ const ChatBody = () => {
   )
 }
 
-export default ChatBody
+export default memo(ChatBody)

--- a/web/screens/Thread/ThreadCenterPanel/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
-import { useEffect, useState } from 'react'
+import { memo, useEffect, useState } from 'react'
 
 import { Accept, useDropzone } from 'react-dropzone'
 
@@ -232,4 +232,4 @@ const ThreadCenterPanel = () => {
   )
 }
 
-export default ThreadCenterPanel
+export default memo(ThreadCenterPanel)

--- a/web/screens/Thread/index.tsx
+++ b/web/screens/Thread/index.tsx
@@ -1,3 +1,5 @@
+import { memo } from 'react'
+
 import { useStarterScreen } from '@/hooks/useStarterScreen'
 
 import ThreadLeftPanel from '@/screens/Thread/ThreadLeftPanel'
@@ -9,19 +11,31 @@ import ModalDeleteThread from './ThreadLeftPanel/ModalDeleteThread'
 import ModalEditTitleThread from './ThreadLeftPanel/ModalEditTitleThread'
 import ThreadRightPanel from './ThreadRightPanel'
 
+type Props = {
+  isShowStarterScreen: boolean
+}
+
+const ThreadPanels = memo(({ isShowStarterScreen }: Props) => {
+  return isShowStarterScreen ? (
+    <OnDeviceStarterScreen />
+  ) : (
+    <>
+      <ThreadLeftPanel />
+      <ThreadCenterPanel />
+      <ThreadRightPanel />
+    </>
+  )
+})
+
+const WelcomeController = () => {
+  const { isShowStarterScreen } = useStarterScreen()
+  return <ThreadPanels isShowStarterScreen={isShowStarterScreen} />
+}
+
 const ThreadScreen = () => {
-  const { extensionHasSettings, isShowStarterScreen } = useStarterScreen()
   return (
     <div className="relative flex h-full w-full flex-1 overflow-x-hidden">
-      {isShowStarterScreen ? (
-        <OnDeviceStarterScreen extensionHasSettings={extensionHasSettings} />
-      ) : (
-        <>
-          <ThreadLeftPanel />
-          <ThreadCenterPanel />
-          <ThreadRightPanel />
-        </>
-      )}
+      <WelcomeController />
 
       {/* Showing variant modal action for thread screen */}
       <ModalEditTitleThread />
@@ -31,4 +45,4 @@ const ThreadScreen = () => {
   )
 }
 
-export default ThreadScreen
+export default memo(ThreadScreen)


### PR DESCRIPTION
## Describe Your Changes

Re-rendering across components in the app caused poor performance. This PR addresses numerous instances of poor state handling that lead to this issue.

JotaiProvider and ThemeProvider now load only once, which also the same issue before. These providers hold the main app states and themes, which could lead to unforeseen performance problems.

App appearance, theme, and show welcome screen toggle once on launch, causing screens to flash (attempt to display then disappear) due to initial storage state settings. These settings should persist on load.

Previously, the thread screen re-renders 16 times on launch
![CleanShot 2024-11-27 at 22 53 45](https://github.com/user-attachments/assets/ab6b6a2d-8658-4fdc-b9c0-42dedab97948)

Now it renders once (plus one due to Strict React debugging).
![CleanShot 2024-11-27 at 22 47 42](https://github.com/user-attachments/assets/4535140b-16ae-4029-9fed-6f63d22edf8d)

## Changes made
1. **Component Refactoring**:
   - `MainViewContainer`: Moved the `framer-motion` animation logic from `Layout` to `MainViewContainer` and added `memo` for performance optimization.
   - `ThreadScreen`: Introduced `ThreadPanels` as a memoized component that conditionally renders `OnDeviceStarterScreen` or the thread panel components. Also, added `WelcomeController` to utilize the `useStarterScreen` hook.
   - Various components (`ChatBody`, `ThreadCenterPanel`, `Thread`) were memoized for performance optimization.

2. **Simplification and Separation**:
   - `CoreConfigurator`: Created a new component to handle core and extension setup logic, migrating this functionality from `Providers`.
   - The configuration and setup logic in `Providers` was moved to `CoreConfigurator`.

3. **State Management Changes**:
   - Replaced `useAtom` with `useSetAtom` in certain places, such as for setting state in `Layout`.
   - Implemented `useMemo` to optimize the computation of derived state, such as checking if any remote models are configured.

4. **Jotai Atom Enhancements**:
   - Modified the `atomWithStorage` to include an `onInit` option for certain atoms across multiple files, ensuring initial state setup is handled correctly.

5. **Component Logic Adjustments**:
   - `OnDeviceStarterScreen`: Removed the explicit props passing of `extensionHasSettings` and is now integrated with `useStarterScreen`.
   - Updated `useStarterScreen` to use `useMemo` for calculating `isDownloadALocalModel` and `isShowStarterScreen` flags, promoting efficient calculations and re-renders.

6. **Miscellaneous**:
   - Imports and hooks were adjusted to ensure all components and logic are encapsulated appropriately.
   - Simplified some method calls and hooks usage that involves the Jotai state management.

Overall, these changes focus on enhancing performance by using React's memoization patterns, refactoring for better code organization, and improving the management of component state and data flow.
