### PR TITLE
fix: convo component re-render every single token yield

### DIFF
--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
@@ -1,6 +1,6 @@
-import { memo } from 'react'
+import { memo, useEffect, useState } from 'react'
 
-import { MessageStatus } from '@janhq/core'
+import { MessageStatus, ThreadMessage } from '@janhq/core'
 
 import { useAtomValue } from 'jotai'
 
@@ -17,33 +17,67 @@ import EmptyThread from './EmptyThread'
 
 import { getCurrentChatMessagesAtom } from '@/helpers/atoms/ChatMessage.atom'
 
-const ChatBody = () => {
+const ChatConfigurator = memo(() => {
   const messages = useAtomValue(getCurrentChatMessagesAtom)
+
+  const [current, setCurrent] = useState<ThreadMessage[]>([])
+
+  const isMessagesIdentificial = (
+    arr1: ThreadMessage[],
+    arr2: ThreadMessage[]
+  ): boolean => {
+    if (arr1.length !== arr2.length) return false
+    return arr1.every((item, index) => item.id === arr2[index].id)
+  }
+
+  useEffect(() => {
+    if (
+      messages.length !== current.length ||
+      !isMessagesIdentificial(messages, current)
+    ) {
+      setCurrent(messages)
+    }
+  }, [messages, current])
 
   const loadModelError = useAtomValue(loadModelErrorAtom)
 
   if (!messages.length) return <EmptyThread />
-
   return (
-    <ListContainer>
-      {messages.map((message, index) => (
-        <div key={message.id}>
-          {message.status !== MessageStatus.Error &&
-            message.content.length > 0 && (
+    <div className="flex h-full w-full flex-col">
+      <ChatBody loadModelError={loadModelError} messages={current} />
+    </div>
+  )
+})
+
+const ChatBody = memo(
+  ({
+    messages,
+    loadModelError,
+  }: {
+    messages: ThreadMessage[]
+    loadModelError?: string
+  }) => {
+    return (
+      <ListContainer>
+        {messages.map((message, index) => (
+          <div key={message.id}>
+            {message.status !== MessageStatus.Error && (
               <ChatItem {...message} key={message.id} />
             )}
 
-          {!loadModelError &&
-            index === messages.length - 1 &&
-            message.status !== MessageStatus.Pending &&
-            message.status !== MessageStatus.Ready && (
-              <ErrorMessage message={message} />
-            )}
-        </div>
-      ))}
-      {loadModelError && <LoadModelError />}
-    </ListContainer>
-  )
-}
+            {!loadModelError &&
+              index === messages.length - 1 &&
+              message.status !== MessageStatus.Pending &&
+              message.status !== MessageStatus.Ready && (
+                <ErrorMessage message={message} />
+              )}
+          </div>
+        ))}
 
-export default memo(ChatBody)
+        {loadModelError && <LoadModelError />}
+      </ListContainer>
+    )
+  }
+)
+
+export default memo(ChatConfigurator)

--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
@@ -61,16 +61,12 @@ const ChatBody = memo(
       <ListContainer>
         {messages.map((message, index) => (
           <div key={message.id}>
-            {message.status !== MessageStatus.Error && (
-              <ChatItem {...message} key={message.id} />
-            )}
-
-            {!loadModelError &&
-              index === messages.length - 1 &&
-              message.status !== MessageStatus.Pending &&
-              message.status !== MessageStatus.Ready && (
-                <ErrorMessage message={message} />
-              )}
+            <ChatItem
+              {...message}
+              key={message.id}
+              loadModelError={loadModelError}
+              isCurrentMessage={index === messages.length - 1}
+            />
           </div>
         ))}
 

--- a/web/screens/Thread/ThreadCenterPanel/ChatItem/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatItem/index.tsx
@@ -8,20 +8,38 @@ import {
   ThreadMessage,
 } from '@janhq/core'
 
+import ErrorMessage from '@/containers/ErrorMessage'
+
 import SimpleTextMessage from '../SimpleTextMessage'
 
 type Ref = HTMLDivElement
 
-const ChatItem = forwardRef<Ref, ThreadMessage>((message, ref) => {
+type Props = {
+  loadModelError?: string
+  isCurrentMessage?: boolean
+} & ThreadMessage
+
+const ChatItem = forwardRef<Ref, Props>((message, ref) => {
   const [content, setContent] = useState<ThreadContent[]>(message.content)
   const [status, setStatus] = useState<MessageStatus>(message.status)
+  const [errorMessage, setErrorMessage] = useState<ThreadMessage | undefined>(
+    message.isCurrentMessage && message.status === MessageStatus.Error
+      ? message
+      : undefined
+  )
 
   function onMessageUpdate(data: ThreadMessage) {
     if (data.id === message.id) {
       setContent(data.content)
       if (data.status !== status) setStatus(data.status)
+      if (data.status === MessageStatus.Error && message.isCurrentMessage)
+        setErrorMessage(data)
     }
   }
+
+  useEffect(() => {
+    if (!message.isCurrentMessage && errorMessage) setErrorMessage(undefined)
+  }, [message, errorMessage])
 
   useEffect(() => {
     if (message.status === MessageStatus.Pending)
@@ -33,9 +51,16 @@ const ChatItem = forwardRef<Ref, ThreadMessage>((message, ref) => {
   }, [])
 
   return (
-    <div ref={ref} className="relative">
-      <SimpleTextMessage {...message} content={content} status={status} />
-    </div>
+    <>
+      {status !== MessageStatus.Error && content.length > 0 && (
+        <div ref={ref} className="relative">
+          <SimpleTextMessage {...message} content={content} status={status} />
+        </div>
+      )}
+      {errorMessage && !message.loadModelError && (
+        <ErrorMessage message={errorMessage} />
+      )}
+    </>
   )
 })
 

--- a/web/screens/Thread/ThreadCenterPanel/ChatItem/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatItem/index.tsx
@@ -1,15 +1,42 @@
-import React, { forwardRef } from 'react'
+import React, { forwardRef, useEffect, useState } from 'react'
 
-import { ThreadMessage } from '@janhq/core'
+import {
+  events,
+  MessageEvent,
+  MessageStatus,
+  ThreadContent,
+  ThreadMessage,
+} from '@janhq/core'
 
 import SimpleTextMessage from '../SimpleTextMessage'
 
 type Ref = HTMLDivElement
 
-const ChatItem = forwardRef<Ref, ThreadMessage>((message, ref) => (
-  <div ref={ref} className="relative">
-    <SimpleTextMessage {...message} />
-  </div>
-))
+const ChatItem = forwardRef<Ref, ThreadMessage>((message, ref) => {
+  const [content, setContent] = useState<ThreadContent[]>(message.content)
+  const [status, setStatus] = useState<MessageStatus>(message.status)
+
+  function onMessageUpdate(data: ThreadMessage) {
+    if (data.id === message.id) {
+      setContent(data.content)
+      if (data.status !== status) setStatus(data.status)
+    }
+  }
+
+  useEffect(() => {
+    if (message.status === MessageStatus.Pending)
+      events.on(MessageEvent.OnMessageUpdate, onMessageUpdate)
+    return () => {
+      events.off(MessageEvent.OnMessageUpdate, onMessageUpdate)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <div ref={ref} className="relative">
+      <SimpleTextMessage {...message} content={content} status={status} />
+    </div>
+  )
+})
 
 export default ChatItem


### PR DESCRIPTION
## Describe Your Changes

Re-rendering the entire messages list on every token yield causes poor performance. This is to address the issue of the convo component where it should not re-render on message update, but the message component re-render itself instead.

On mount, the convo component should render the initial messages list only, then listening for new message arrival. And pending update message component will listen to new message update event and re-render itself.

In the recorded video, in case there is a re-render attempt on convo component (messages list), it would console log a message "re-render".

![CleanShot 2024-11-28 at 12 38 34](https://github.com/user-attachments/assets/d32526df-b618-4bba-b0ec-aa8cdbe680c9)

## Changes made

1. **`ChatBody` Component:**
   - `ChatBody` has been renamed to `ChatConfigurator`, and the former `ChatBody` logic has been encapsulated inside a new `ChatBody` component that's utilized within `ChatConfigurator`.
   - Imports `useEffect` and `useState` from React for managing component state and side effects.
   - Introduces a state, `current`, to track the current messages, and a comparison function `isMessagesIdentificial` to check if the messages have changed.
   - Uses `useEffect` to update `current` messages if they differ from the received `messages`.
   - Conditionally renders `ChatBody` which is responsible for rendering `messages`.
   - Added a `Test` component for debug logging on rerenders.
   
2. **`ChatItem` Component:**
   - Additional imports from `@janhq/core` for handling message events.
   - State hooks are used to manage `content` and `status` for a `ThreadMessage`.
   - Introduced `onMessageUpdate` function to update `content` and `status` when a message changes, based on event listeners.
   - Utilizes `useEffect` to attach and detach `onMessageUpdate` event listeners for `MessageEvent.OnMessageUpdate`.

These changes introduce more responsive updates for chat messages and modularize the chat components for better maintainability and potential testing.
