### PR TITLE
chore: display error message from response

### DIFF
--- a/web/containers/ModelSearch/index.tsx
+++ b/web/containers/ModelSearch/index.tsx
@@ -46,8 +46,7 @@ const ModelSearch = ({ onSearchLocal }: Props) => {
         errMessage = err.message
       }
       toaster({
-        title: 'Oops, you may be rate limited, give it a bit more time',
-        description: errMessage,
+        title: errMessage,
         type: 'error',
       })
       console.error(err)

--- a/web/utils/huggingface.test.ts
+++ b/web/utils/huggingface.test.ts
@@ -64,7 +64,7 @@ describe('huggingface utils', () => {
       })
 
       await expect(fetchHuggingFaceRepoData('user/repo')).rejects.toThrow(
-        'user/repo is not supported. Only GGUF models are supported.'
+        'Only GGUF models are currently supported.'
       )
     })
 

--- a/web/utils/huggingface.ts
+++ b/web/utils/huggingface.ts
@@ -34,9 +34,7 @@ export const fetchHuggingFaceRepoData = async (
   const data = response as HuggingFaceRepoData
 
   if (data.tags.indexOf('gguf') === -1) {
-    throw new Error(
-      `${repoId} is not supported. Only GGUF models are supported.`
-    )
+    throw new Error(`Only GGUF models are currently supported.`)
   }
 
   // fetching file sizes


### PR DESCRIPTION
## Describe Your Changes

This PR corrects the error message to display the correct error from the response.

![image](https://github.com/user-attachments/assets/d191f858-0227-4d7d-92c8-4869ed7d0551)

## Changes made
The changes in the code are in the `ModelSearch` component, specifically in the error handling section. The `toaster` function call has been modified:

- The `title` previously had a static message: "Oops, you may be rate limited, give it a bit more time".
- Now, the `title` is set to the value of `errMessage`, which dynamically contains the error message.
- The `description` property, which used to contain `errMessage`, has been removed.

This change means that the error message displayed will now be more specific to the error encountered, as the exact error message will be shown in the title.
