### PR TITLE
fix: Glitch theme applies on launch

### DIFF
--- a/web/helpers/atoms/Setting.atom.ts
+++ b/web/helpers/atoms/Setting.atom.ts
@@ -11,15 +11,30 @@ export const janSettingScreenAtom = atom<SettingScreen[]>([])
 export const THEME = 'themeAppearance'
 export const REDUCE_TRANSPARENT = 'reduceTransparent'
 export const SPELL_CHECKING = 'spellChecking'
-export const themesOptionsAtom = atom<{ name: string; value: string }[]>([])
-export const janThemesPathAtom = atom<string | undefined>(undefined)
+export const THEME_DATA = 'themeData'
+export const THEME_OPTIONS = 'themeOptions'
+export const THEME_PATH = 'themePath'
+export const themesOptionsAtom = atomWithStorage<
+  { name: string; value: string }[]
+>(THEME_OPTIONS, [], undefined, { getOnInit: true })
+export const janThemesPathAtom = atomWithStorage<string | undefined>(
+  THEME_PATH,
+  undefined,
+  undefined,
+  { getOnInit: true }
+)
 export const selectedThemeIdAtom = atomWithStorage<string>(
   THEME,
   '',
   undefined,
   { getOnInit: true }
 )
-export const themeDataAtom = atom<Theme | undefined>(undefined)
+export const themeDataAtom = atomWithStorage<Theme | undefined>(
+  THEME_DATA,
+  undefined,
+  undefined,
+  { getOnInit: true }
+)
 export const reduceTransparentAtom = atomWithStorage<boolean>(
   REDUCE_TRANSPARENT,
   false,

--- a/web/hooks/useLoadTheme.test.ts
+++ b/web/hooks/useLoadTheme.test.ts
@@ -4,6 +4,11 @@ import { fs, joinPath } from '@janhq/core'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 
 import { useLoadTheme } from './useLoadTheme'
+import { janDataFolderPathAtom } from '@/helpers/atoms/AppConfig.atom'
+import {
+  selectedThemeIdAtom,
+  themeDataAtom,
+} from '@/helpers/atoms/Setting.atom'
 
 // Mock dependencies
 jest.mock('next-themes')
@@ -36,10 +41,25 @@ describe('useLoadTheme', () => {
 
   it('should load theme and set variables', async () => {
     // Mock Jotai hooks
-    ;(useAtomValue as jest.Mock).mockReturnValue(mockJanDataFolderPath)
+    ;(useAtomValue as jest.Mock).mockImplementation((atom) => {
+      switch (atom) {
+        case janDataFolderPathAtom:
+          return mockJanDataFolderPath
+        default:
+          return undefined
+      }
+    })
     ;(useSetAtom as jest.Mock).mockReturnValue(jest.fn())
-    ;(useAtom as jest.Mock).mockReturnValue([mockSelectedThemeId, jest.fn()])
-    ;(useAtom as jest.Mock).mockReturnValue([mockThemeData, jest.fn()])
+    ;(useAtom as jest.Mock).mockImplementation((atom) => {
+      switch (atom) {
+        case selectedThemeIdAtom:
+          return [mockSelectedThemeId, jest.fn()]
+        case themeDataAtom:
+          return [mockThemeData, jest.fn()]
+        default:
+          return [undefined, jest.fn()]
+      }
+    })
 
     // Mock fs and joinPath
     ;(fs.readdirSync as jest.Mock).mockResolvedValue(['joi-light', 'joi-dark'])


### PR DESCRIPTION
## Describe Your Changes

There’s an issue with an app where when the user launches the app with the first thread is a large one, it glitches the app’s theme a bit before the conversation is loaded. This results in a very ugly display, with only a border and a translucent background.

This fix intends to store the previously set settings in the localStorage., ensuring that themes are applied effectively without the need to load JSON files from the disk.

Before:
![CleanShot 2024-11-30 at 18 58 26](https://github.com/user-attachments/assets/e83a97e8-26b1-43b4-9887-745faa7fc832)

After:
![CleanShot 2024-11-30 at 19 02 36](https://github.com/user-attachments/assets/95213441-9042-4e1f-9738-399a13d6388a)

Notes: 
Ordered list offscreen issue is filed in another issue

## Changes made
This diff introduces several changes to the `Setting.atom.ts` and `useLoadTheme.ts` files, as follows:

### `Setting.atom.ts` Changes:
1. **Atoms and Constants Updates:**
   - New constants `THEME_DATA`, `THEME_OPTIONS`, and `THEME_PATH` are defined.
   - The `themesOptionsAtom`, `janThemesPathAtom`, and `themeDataAtom` are updated to use `atomWithStorage`, allowing them to persist in storage.
   - These atoms now have storage keys and enable the `getOnInit` option for initialization.

### `useLoadTheme.ts` Changes:
1. **Atom Imports:**
   - The import for `useSetAtom` from `jotai` is removed because it is no longer used.

2. **useLoadTheme Logic:**
   - The hook `useLoadTheme` has been refactored to use `useAtom` for `themeOptions` and `themePath` instead of `useSetAtom`.
   - A new `useCallback` hook, `applyTheme`, is introduced to handle theme application logic. It first checks if `themeData`, `themeOptions`, or `themePath` is missing - if so, it calls `getThemes`. Otherwise, it applies CSS variables through a style tag in the document's head.
   - The `useEffect` now relies on `applyTheme` instead of directly calling `getThemes`.

These changes primarily focus on improving theme persistence and application by leveraging `atomWithStorage` in Recoil Jotai and optimizing the effect hooks.