### PR TITLE
chore: correct scrollview thumb style

### DIFF
--- a/joi/src/core/ScrollArea/styles.scss
+++ b/joi/src/core/ScrollArea/styles.scss
@@ -66,4 +66,5 @@
 }
 ::-webkit-scrollbar-thumb {
   background: hsla(var(--scrollbar-thumb));
+  border-radius: 20px;
 }

--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
@@ -88,7 +88,7 @@ const ChatBody = memo(
     }
 
     return (
-      <div className="flex h-full w-full flex-col overflow-x-hidden">
+      <div className="scroll-area flex h-full w-full flex-col overflow-x-hidden">
         <div
           ref={parentRef}
           className="List"


### PR DESCRIPTION
## Describe Your Changes

This is to fix the scrollview's thumb CSS

![CleanShot 2024-12-02 at 18 18 35](https://github.com/user-attachments/assets/31e2e9da-6269-45f6-9855-b8433a976282)

## Self Checklist

The code changes include:

1. **SCSS File (`styles.scss`):**
   - Added a `border-radius` of `20px` to the scrollbar thumb to give it rounded edges in the scroll area.

2. **React Component (`index.tsx`):**
   - Added a new class name `scroll-area` to the `div` enclosing the chat body layout. This class is likely added to apply specific styling or features to that `div`, possibly related to the modified scrollbar thumb style.
