### PR TITLE
fix: 4165 - Refactor message builder to avoid sending empty messages

### DIFF
--- a/web/hooks/useSendChatMessage.ts
+++ b/web/hooks/useSendChatMessage.ts
@@ -10,7 +10,6 @@ import {
   ConversationalExtension,
   EngineManager,
   ToolManager,
-  ChatCompletionMessage,
 } from '@janhq/core'
 import { extractInferenceParams, extractModelLoadParams } from '@janhq/core'
 import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai'
@@ -21,7 +20,6 @@ import {
   fileUploadAtom,
 } from '@/containers/Providers/Jotai'
 
-import { Stack } from '@/utils/Stack'
 import { compressImage, getBase64 } from '@/utils/base64'
 import { MessageRequestBuilder } from '@/utils/messageRequestBuilder'
 
@@ -85,33 +83,6 @@ export default function useSendChatMessage() {
   useEffect(() => {
     selectedModelRef.current = selectedModel
   }, [selectedModel])
-
-  const normalizeMessages = (
-    messages: ChatCompletionMessage[]
-  ): ChatCompletionMessage[] => {
-    const stack = new Stack<ChatCompletionMessage>()
-    for (const message of messages) {
-      if (stack.isEmpty()) {
-        stack.push(message)
-        continue
-      }
-      const topMessage = stack.peek()
-
-      if (message.role === topMessage.role) {
-        // add an empty message
-        stack.push({
-          role:
-            topMessage.role === ChatCompletionRole.User
-              ? ChatCompletionRole.Assistant
-              : ChatCompletionRole.User,
-          content: '.', // some model requires not empty message
-        })
-      }
-      stack.push(message)
-    }
-
-    return stack.reverseOutput()
-  }
 
   const resendChatMessage = async (currentMessage: ThreadMessage) => {
     // Delete last response before regenerating
@@ -247,7 +218,6 @@ export default function useSendChatMessage() {
         (assistant) => assistant.tools ?? []
       ) ?? []
     )
-    request.messages = normalizeMessages(request.messages ?? [])
 
     // Request for inference
     EngineManager.instance()


### PR DESCRIPTION
## Describe Your Changes

- I’ve resolved the issue where the app could include empty messages, which caused problems with a few remote providers. There was a case where message pushing could include an empty message in case of an error.

![CleanShot 2024-12-03 at 15 20 51](https://github.com/user-attachments/assets/cea07977-34a3-4900-814d-032f1dac8a69)

## Fixes Issues

- #4165

## Self Checklist

The code changes involve refactoring the function `normalizeMessages` and its integration within the system:

1. **Removal from `useSendChatMessage.ts`:**
   - The `normalizeMessages` function and the `Stack` import were removed from `useSendChatMessage.ts`. This function was previously responsible for ensuring consecutive messages from the same role (e.g., User or Assistant) were separated by an empty message. The feature was meant to meet specific requirements of some models.
   - The call to `normalizeMessages` was also removed from the `resendChatMessage` function, meaning normalization is no longer performed directly there.

2. **Integration into `messageRequestBuilder.ts`:**
   - `normalizeMessages` was moved into `MessageRequestBuilder` class in `messageRequestBuilder.ts`. This function maintains the same logic to avoid consecutive messages of the same role by inserting a dummy message.
   - The normalization process is now applied during the `build()` function call, ensuring the message list is normalized whenever a `MessageRequest` is built.
   - The Stack utility was imported to support this functionality.

By consolidating the `normalizeMessages` logic within the `MessageRequestBuilder`, the process of managing message roles is now contained within the request-building phase, promoting better cohesion and separability within the codebase.