### PR TITLE
fix: 4162 - Graceful Openrouter error handling

### DIFF
--- a/core/src/browser/extensions/engines/OAIEngine.ts
+++ b/core/src/browser/extensions/engines/OAIEngine.ts
@@ -132,9 +132,6 @@ export abstract class OAIEngine extends AIEngine {
         events.emit(MessageEvent.OnMessageUpdate, message)
       },
       error: async (err: any) => {
-        console.debug('inference url: ', this.inferenceUrl)
-        console.debug('header: ', header)
-        console.error(`Inference error:`, JSON.stringify(err))
         if (this.isCancelled || message.content.length) {
           message.status = MessageStatus.Stopped
           events.emit(MessageEvent.OnMessageUpdate, message)

--- a/core/src/browser/extensions/engines/helpers/sse.ts
+++ b/core/src/browser/extensions/engines/helpers/sse.ts
@@ -77,6 +77,11 @@ export function requestInference(
                   const toParse = cachedLines + line
                   if (!line.includes('data: [DONE]')) {
                     const data = JSON.parse(toParse.replace('data: ', ''))
+                    if ('error' in data) {
+                      subscriber.error(data.error)
+                      subscriber.complete()
+                      return
+                    }
                     content += data.choices[0]?.delta?.content ?? ''
                     if (content.startsWith('assistant: ')) {
                       content = content.replace('assistant: ', '')


### PR DESCRIPTION
## Describe Your Changes

This PR aims to handle error messages returned by OpenRouter gracefully. Unlike others, it doesn’t return JSON but a stream message.

![CleanShot 2024-12-03 at 15 59 57](https://github.com/user-attachments/assets/95ecabbb-263a-471f-a0b9-758d83ce03df)
![CleanShot 2024-12-03 at 15 59 50](https://github.com/user-attachments/assets/df058684-5141-453a-883e-e9ae5bb45925)


## Fixes Issues

- #4162

## Changes made
The code changes remove certain debug logging statements and add error handling logic:

1. **OAIEngine.ts:**
   - Removed debug statements that logged the inference URL, headers, and the inference error as a JSON string.

2. **sse.ts:**
   - Added logic to handle errors received in the SSE data. If the parsed data contains an `error`, it triggers the error handling in the subscriber, marks the stream as complete, and exits early to prevent further processing.

These changes improve error handling and reduce unnecessary logging output.
