### PR TITLE
fix: 4155 - Queue up health check on server restarting

### DIFF
--- a/extensions/inference-cortex-extension/src/index.ts
+++ b/extensions/inference-cortex-extension/src/index.ts
@@ -334,13 +334,22 @@ export default class JanInferenceCortexExtension extends LocalOAIEngine {
             }
           })
 
+          /**
+           * This is to handle the server segfault issue
+           */
           this.socket.onclose = (event) => {
             console.log('WebSocket closed:', event)
+            // Notify app to update model running state
             events.emit(ModelEvent.OnModelStopped, {})
+
+            // Reconnect to the /events websocket
             if (this.shouldReconnect) {
               console.log(`Attempting to reconnect...`)
               setTimeout(() => this.subscribeToEvents(), 1000)
             }
+
+            // Queue up health check
+            this.queue.add(() => this.healthz())
           }
 
           resolve()


### PR DESCRIPTION
## Describe Your Changes

- This fixes the issue where users force-kill the Cortex process in Windows Task Manager and immediately try to send a message in Jan's UI, they receive a "failed to fetch" error. This indicates that Jan is not gracefully handling cases where the Cortex process is terminated unexpectedly.

![CleanShot 2024-12-03 at 16 16 25](https://github.com/user-attachments/assets/03387d68-67fc-4169-a879-96365d5dc5ad)


## Fixes Issues

- #4155

## Changes made

The code modification introduces several updates within the `onclose` event handler for a WebSocket connection:

1. **Comment Addition**: A comment explaining the server segfault issue handling has been added.

2. **Event Emission**: Before attempting to reconnect, the code now emits a `ModelEvent.OnModelStopped` event to notify the application about a model's stopped state.

3. **Health Check**: After attempting to reconnect, the code queues up a health check call (`this.healthz()`) using the `this.queue` mechanism to ensure the system's health is verified.
