### PR TITLE
fix: 4208 - Empty title with special characters

### DIFF
--- a/web/containers/Providers/ModelHandler.tsx
+++ b/web/containers/Providers/ModelHandler.tsx
@@ -134,7 +134,7 @@ export default function ModelHandler() {
 
       // Remove non-alphanumeric characters
       const cleanedMessageContent = messageContent
-        .replace(/[^a-z0-9\s]/gi, '')
+        .replace(/[^\p{L}\s]+/gu, '')
         .trim()
 
       // Split the message into words
@@ -146,6 +146,9 @@ export default function ModelHandler() {
         )
         return
       }
+
+      // Do not persist empty message
+      if (!cleanedMessageContent.trim().length) return
 
       const updatedThread: Thread = {
         ...thread,


### PR DESCRIPTION
## Describe Your Changes

- This PR addressed an issue where thread title generation removed special characters that should also prevent multilingual support for that. Now it will remove only non-letter Unicode characters. 

![CleanShot 2024-12-04 at 11 41 10](https://github.com/user-attachments/assets/c5ab10bf-a858-4263-afac-b66095186cbe)

![CleanShot 2024-12-04 at 11 42 25@2x](https://github.com/user-attachments/assets/b0c63e50-6bc7-44d5-b084-9e166a46685a)


## Fixes Issues

- #4208

## Changes made

The code change in `ModelHandler.tsx` updates the `cleanedMessageContent` processing logic and adds validation. Specifically:

1. The regular expression used in `replace()` is modified to:
   - Before: `[^a-z0-9\s]`, which removes non-alphanumeric ASCII characters.
   - After: `[^\p{L}\s]+`, which removes non-letter Unicode characters using the Unicode property escapes.

2. A new validation step is introduced:
   - It checks if `cleanedMessageContent` is empty after trimming. If it is, the function exits early to avoid processing or persisting an empty message.
