### PR TITLE
fix: 4209 - Inconsistent max tokens value persistence

### DIFF
--- a/web/containers/ModelDropdown/index.tsx
+++ b/web/containers/ModelDropdown/index.tsx
@@ -187,15 +187,19 @@ const ModelDropdown = ({
           ],
         })
 
-        const overriddenSettings =
-          model?.settings.ctx_len && model.settings.ctx_len > 4096
-            ? { ctx_len: 4096 }
-            : {}
+        const defaultContextLength = Math.min(
+          8192,
+          model?.settings.ctx_len ?? 8192
+        )
+        const overriddenParameters = {
+          ctx_len: Math.min(8192, model?.settings.ctx_len ?? 8192),
+          max_tokens: defaultContextLength,
+        }
 
         const modelParams = {
           ...model?.parameters,
           ...model?.settings,
-          ...overriddenSettings,
+          ...overriddenParameters,
         }
 
         // Update model parameter to the thread state

--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -105,14 +105,21 @@ export const useCreateNewThread = () => {
       enabled: true,
       settings: assistant.tools && assistant.tools[0].settings,
     }
-    const overriddenSettings =
-      defaultModel?.settings.ctx_len && defaultModel.settings.ctx_len > 2048
-        ? { ctx_len: 4096 }
-        : {}
 
-    const overriddenParameters = defaultModel?.parameters.max_tokens
-      ? { max_tokens: 4096 }
-      : {}
+    // Default context length is 8192
+    const defaultContextLength = Math.min(
+      8192,
+      defaultModel?.settings.ctx_len ?? 8192
+    )
+
+    const overriddenSettings = {
+      ctx_len: defaultContextLength,
+    }
+
+    // Use ctx length by default
+    const overriddenParameters = {
+      max_tokens: defaultContextLength,
+    }
 
     const createdAt = Date.now()
     let instructions: string | undefined = assistant.instructions


### PR DESCRIPTION
## Describe Your Changes

This PR addresses an issue where selecting the max_tokens parameter in the thread.json file doesn’t get updated when the model is changed.

![CleanShot 2024-12-04 at 12 35 38](https://github.com/user-attachments/assets/a6349159-ff28-4f2b-a724-f23c83ac6568)

## Fixes Issues

- #4209

## Changes made
The code change involves adjustments to how model parameters are handled in two different files: `ModelDropdown/index.tsx` and `useCreateNewThread.ts`.

1. **ModelDropdown/index.tsx Changes:**
   - The `overriddenSettings` logic is replaced with `overriddenParameters`.
   - A new `defaultContextLength` variable is defined, which chooses the minimum between 8192 and the model's `ctx_len` setting (defaulting to 8192 if not specified).
   - The `overriddenParameters` object now includes both `ctx_len` and `max_tokens`, both set to this new `defaultContextLength`.

2. **useCreateNewThread.ts Changes:**
   - Similar to the changes in `ModelDropdown`, a `defaultContextLength` variable is introduced.
   - The `overriddenSettings` object now consistently uses this `defaultContextLength` for `ctx_len`.
   - The `overriddenParameters` object is reconstructed to set `max_tokens` using the same `defaultContextLength`.

Overall, the changes standardize how `ctx_len` and `max_tokens` are determined and used, defaulting these settings to a maximum of 8192.