### PR TITLE
chore: add NGL settings for vision models

### DIFF
--- a/extensions/inference-cortex-extension/package.json
+++ b/extensions/inference-cortex-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janhq/inference-cortex-extension",
   "productName": "Cortex Inference Engine",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "This extension embeds cortex.cpp, a lightweight inference engine written in C++. See https://jan.ai.\nAdditional dependencies could be installed to run without Cuda Toolkit installation.",
   "main": "dist/index.js",
   "node": "dist/node/index.cjs.js",

--- a/extensions/inference-cortex-extension/resources/models/bakllava-1/model.json
+++ b/extensions/inference-cortex-extension/resources/models/bakllava-1/model.json
@@ -21,7 +21,8 @@
     "ctx_len": 4096,
     "prompt_template": "\n### Instruction:\n{prompt}\n### Response:\n",
     "llama_model_path": "ggml-model-q5_k.gguf",
-    "mmproj": "mmproj-model-f16.gguf"
+    "mmproj": "mmproj-model-f16.gguf",
+    "ngl": 33
   },
   "parameters": {
     "max_tokens": 4096

--- a/extensions/inference-cortex-extension/resources/models/llava-13b/model.json
+++ b/extensions/inference-cortex-extension/resources/models/llava-13b/model.json
@@ -21,7 +21,8 @@
     "ctx_len": 4096,
     "prompt_template": "\n### Instruction:\n{prompt}\n### Response:\n",
     "llama_model_path": "llava-v1.6-vicuna-13b.Q4_K_M.gguf",
-    "mmproj": "mmproj-model-f16.gguf"
+    "mmproj": "mmproj-model-f16.gguf",
+    "ngl": 33
   },
   "parameters": {
     "max_tokens": 4096,

--- a/extensions/inference-cortex-extension/resources/models/llava-7b/model.json
+++ b/extensions/inference-cortex-extension/resources/models/llava-7b/model.json
@@ -21,7 +21,8 @@
     "ctx_len": 4096,
     "prompt_template": "\n### Instruction:\n{prompt}\n### Response:\n",
     "llama_model_path": "llava-v1.6-mistral-7b.Q4_K_M.gguf",
-    "mmproj": "mmproj-model-f16.gguf"
+    "mmproj": "mmproj-model-f16.gguf",
+    "ngl": 33
   },
   "parameters": {
     "max_tokens": 4096,


### PR DESCRIPTION
## Describe Your Changes

It’s an update to add new NGL settings for the llava model.json files. It’s a minor update for predefined models, but there should be a correct update from cortex.cpp to import vision models.

## Related Issues

[- #1763](https://github.com/janhq/cortex.cpp/issues/1763)

## Changes made 

The changes in the code are as follows:

1. **package.json**:
   - The version of the package `@janhq/inference-cortex-extension` has been updated from "1.0.23" to "1.0.24".

2. **model.json files**:
   - Changes were made to three different model JSON files located in different subdirectories: `bakllava-1`, `llava-13b`, and `llava-7b`.
   - For each of these models, an additional property `"ngl": 33` was added to the "model" key.
   - This update is consistent across all model files, suggesting a related change or parameter update applicable to multiple model configurations.
