### PR TITLE
fix: react-markdown crash on code highlighting - threads switching do not take effect sometime

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -38,7 +38,7 @@
     "react-icons": "^4.12.0",
     "react-markdown": "^9.0.1",
     "react-toastify": "^9.1.3",
-    "rehype-highlight": "^6.0.0",
+    "rehype-highlight": "^7.0.1",
     "rehype-highlight-code-lines": "^1.0.4",
     "rehype-katex": "^7.0.1",
     "rehype-raw": "^7.0.0",

--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
@@ -14,9 +14,11 @@ import LoadModelError from '../LoadModelError'
 import EmptyThread from './EmptyThread'
 
 import { getCurrentChatMessagesAtom } from '@/helpers/atoms/ChatMessage.atom'
+import { activeThreadAtom } from '@/helpers/atoms/Thread.atom'
 
 const ChatConfigurator = memo(() => {
   const messages = useAtomValue(getCurrentChatMessagesAtom)
+  const currentThread = useAtomValue(activeThreadAtom)
 
   const [current, setCurrent] = useState<ThreadMessage[]>([])
   const loadModelError = useAtomValue(loadModelErrorAtom)
@@ -31,12 +33,12 @@ const ChatConfigurator = memo(() => {
 
   useEffect(() => {
     if (
-      messages?.length !== current?.length ||
-      !isMessagesIdentificial(messages, current)
+      !isMessagesIdentificial(messages, current) ||
+      messages.some((e) => e.thread_id !== currentThread?.id)
     ) {
       setCurrent(messages)
     }
-  }, [messages, current, loadModelError])
+  }, [messages, current, loadModelError, currentThread])
 
   if (!messages.length) return <EmptyThread />
   return (
@@ -119,7 +121,7 @@ const ChatBody = memo(
             >
               {items.map((virtualRow) => (
                 <div
-                  key={virtualRow.key}
+                  key={messages[virtualRow.index]?.id}
                   data-index={virtualRow.index}
                   ref={virtualizer.measureElement}
                 >


### PR DESCRIPTION
## Describe Your Changes

This PR addresses an issue where ReactMarkdown could crash due to unsupported languages in code highlighting. This has been resolved in the newer version of the dependency.

Also fixed the issue where switching between new threads (very shorts) would not take effect


![CleanShot 2024-12-04 at 16 51 53](https://github.com/user-attachments/assets/a2a654a7-2d40-498b-83df-d454cfc2a952)

![CleanShot 2024-12-04 at 16 52 23](https://github.com/user-attachments/assets/831dbbb3-7b27-4e0e-afd2-beaaf5a73563)

## Fixes Issues

- #4205
- #4215

## Changes made
The changes in the `git diff` are as follows:

1. **`package.json` Update:**
   - The version of the `rehype-highlight` package was updated from `^6.0.0` to `^7.0.1` in the project's dependencies.

2. **`index.tsx` Code Modifications:**
   - **Import Changes:**
     - Added a new import: `import { activeThreadAtom } from '@/helpers/atoms/Thread.atom'`.

   - **State and Effect Hook Adjustments:**
     - Introduced a new state variable `currentThread` using `useAtomValue` to get the value of `activeThreadAtom`.
     - Updated the `useEffect` dependency and logic to include `currentThread`. This ensures that `setCurrent` is called if any message's `thread_id` does not match `currentThread?.id`.

   - **Virtual Row Key Adjustment:**
     - Changed the key for each `virtualRow` from `virtualRow.key` to `messages[virtualRow.index]?.id`. This provides a more consistent and relevant key based on the message ID. 

These changes aim to improve thread handling and ensure correct rendering of chat messages in the component.
