### PR TITLE
fix: syntax highlight configurations that made everything dark

### DIFF
--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx
@@ -5,14 +5,14 @@ import React, { memo } from 'react'
 
 import Markdown from 'react-markdown'
 
-import latex from 'highlight.js/lib/languages/latex'
 import rehypeHighlight from 'rehype-highlight'
 import rehypeHighlightCodeLines from 'rehype-highlight-code-lines'
 import rehypeKatex from 'rehype-katex'
 import rehypeRaw from 'rehype-raw'
 import remarkMath from 'remark-math'
-import 'katex/dist/katex.min.css'
 
+import 'katex/dist/katex.min.css'
+import 'highlight.js/styles/atom-one-dark.css'
 import { useClipboard } from '@/hooks/useClipboard'
 
 import { getLanguageFromExtension } from '@/utils/codeLanguageExtension'
@@ -199,16 +199,7 @@ export const MarkdownTextMessage = memo(
           rehypePlugins={[
             [rehypeKatex, { throwOnError: false }],
             rehypeRaw,
-            [
-              // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-              // @ts-ignore
-              rehypeHighlight,
-              {
-                languages: { latex },
-                subset: false,
-                plainText: ['txt', 'text'],
-              },
-            ],
+            rehypeHighlight,
             [rehypeHighlightCodeLines, { showLineNumbers: true }],
             wrapCodeBlocksWithoutVisit,
           ]}


### PR DESCRIPTION
## Describe Your Changes

![CleanShot 2024-12-05 at 08 50 40](https://github.com/user-attachments/assets/8fd6d591-41e0-4ad5-a81e-8ad960cf9eec)

![CleanShot 2024-12-05 at 09 16 28](https://github.com/user-attachments/assets/43a382dc-7251-4225-8e77-1b61f0920e2b)


## Changes made

The given `git diff` shows changes made to the `MarkdownTextMessage.tsx` component. Here's a summary of the modifications:

1. **Import Statements**:
    - The `latex` language import from `highlight.js` has been removed.
    - The CSS import for `katex` has been rearranged, but it's effectively unchanged.
    - A new CSS import for `highlight.js` styles (`atom-one-dark.css`) has been added, which implies a change in the highlighted code's visual appearance.

2. **Rehype Plugins Configuration**:
    - The configuration for `rehypeHighlight` has been simplified. The previous custom configuration that included the `latex` language, no subset, and plain text options has been replaced with a default setup by removing the custom configuration object.

These changes likely simplify the markdown rendering logic and improve code syntax highlighting by using the default language setup and adding dark-themed styling for code blocks.
