### PR TITLE
fix: hide Vulkan option for users who don't have GPU

### DIFF
--- a/web/containers/Providers/Jotai.tsx
+++ b/web/containers/Providers/Jotai.tsx
@@ -4,6 +4,8 @@ import { PropsWithChildren } from 'react'
 
 import { Provider, atom } from 'jotai'
 
+import { FileInfo } from '@/types/file'
+
 export const editPromptAtom = atom<string>('')
 export const currentPromptAtom = atom<string>('')
 export const fileUploadAtom = atom<FileInfo[]>([])
@@ -14,11 +16,4 @@ export const selectedTextAtom = atom('')
 
 export default function JotaiWrapper({ children }: PropsWithChildren) {
   return <Provider>{children}</Provider>
-}
-
-export type FileType = 'image' | 'pdf'
-
-export type FileInfo = {
-  file: File
-  type: FileType
 }

--- a/web/screens/Settings/Advanced/index.tsx
+++ b/web/screens/Settings/Advanced/index.tsx
@@ -436,7 +436,7 @@ const Advanced = () => {
         )}
 
         {/* Vulkan for AMD GPU/ APU and Intel Arc GPU */}
-        {!isMac && experimentalEnabled && (
+        {!isMac && gpuList.length && experimentalEnabled && (
           <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">
             <div className="space-y-1">
               <div className="flex gap-x-2">

--- a/web/screens/Settings/Advanced/index.tsx
+++ b/web/screens/Settings/Advanced/index.tsx
@@ -436,7 +436,7 @@ const Advanced = () => {
         )}
 
         {/* Vulkan for AMD GPU/ APU and Intel Arc GPU */}
-        {!isMac && gpuList.length && experimentalEnabled && (
+        {!isMac && gpuList.length > 0 && experimentalEnabled && (
           <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">
             <div className="space-y-1">
               <div className="flex gap-x-2">

--- a/web/types/file.d.ts
+++ b/web/types/file.d.ts
@@ -1,0 +1,6 @@
+export type FileType = 'image' | 'pdf'
+
+export type FileInfo = {
+  file: File
+  type: FileType
+}

--- a/web/utils/messageRequestBuilder.ts
+++ b/web/utils/messageRequestBuilder.ts
@@ -13,9 +13,9 @@ import {
 } from '@janhq/core'
 import { ulid } from 'ulidx'
 
-import { FileType } from '@/containers/Providers/Jotai'
-
 import { Stack } from '@/utils/Stack'
+
+import { FileType } from '@/types/file'
 
 export class MessageRequestBuilder {
   msgId: string

--- a/web/utils/threadMessageBuilder.ts
+++ b/web/utils/threadMessageBuilder.ts
@@ -6,9 +6,9 @@ import {
   ThreadMessage,
 } from '@janhq/core'
 
-import { FileInfo } from '@/containers/Providers/Jotai'
-
 import { MessageRequestBuilder } from './messageRequestBuilder'
+
+import { FileInfo } from '@/types/file'
 
 export class ThreadMessageBuilder {
   messageRequest: MessageRequestBuilder


### PR DESCRIPTION
## Describe Your Changes

This minor fix aims to hide Vulkan settings in case the system doesn’t detect a GPU.

## Screenshots
![CleanShot 2024-12-05 at 17 26 52@2x](https://github.com/user-attachments/assets/73b2362a-120e-4d36-8274-4297fa0ce682)

## Fixes Issues

- #4093

## Changes made

The code change is in the `index.tsx` file located at `web/screens/Settings/Advanced/`. Here's a summary of the modification:

- **Conditional Rendering Update**: The condition for rendering a specific `<div>` component has been modified.
- **Old Condition**: The component was rendered based on the condition `!isMac && experimentalEnabled`.
- **New Condition**: The component will now be rendered if `!isMac && gpuList.length && experimentalEnabled`, meaning it adds a check that requires `gpuList` to have a non-zero length (i.e., it is not empty).

This change introduces a dependency on `gpuList.length` as an additional condition for rendering, which implies that the display of this section is contingent upon the existence of GPU entries in `gpuList`.
