### PR TITLE
fix: list style off screen

### DIFF
--- a/web/styles/components/message.scss
+++ b/web/styles/components/message.scss
@@ -5,8 +5,9 @@
   ul,
   ol {
     list-style: auto;
-    padding-left: 24px;
+    padding-left: 16px;
     white-space: normal;
+    list-style-position: inside;
   }
 
   ul {


### PR DESCRIPTION
## Describe Your Changes

Changes made to the SCSS file located at `web/styles/components/message.scss`. Here's a summary of the changes:

1. **Padding Adjustment:**
   - The `padding-left` property for `ul` and `ol` elements has been changed from `24px` to `16px`. This reduces the left padding of list items.

2. **List Style Position Added:**
   - A new property, `list-style-position: inside;`, has been added to the `ul` and `ol` elements. This positions the bullet points or numbers inside the content flow of the list items, effectively aligning the text neatly with the bullets. 

![CleanShot 2024-12-05 at 14 31 30](https://github.com/user-attachments/assets/caed09e5-95cb-4b85-b2a8-1f76431ee22f)

![CleanShot 2024-12-05 at 14 31 38](https://github.com/user-attachments/assets/ff39c905-9b9b-4ea6-9b26-934d8bfcb803)

## Fixes Issues

- Closes #4169 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
