### PR TITLE
enhancement: default open Jan Input Box Settings and Right panel

### DIFF
--- a/web/containers/Providers/Responsive.tsx
+++ b/web/containers/Providers/Responsive.tsx
@@ -11,15 +11,14 @@ const Responsive = () => {
   const [showRightPanel, setShowRightPanel] = useAtom(showRightPanelAtom)
 
   // Refs to store the last known state of the panels
-  const lastLeftPanelState = useRef<boolean>(true)
-  const lastRightPanelState = useRef<boolean>(true)
+  const lastLeftPanelState = useRef<boolean>(showLeftPanel)
+  const lastRightPanelState = useRef<boolean>(showRightPanel)
 
   useEffect(() => {
     if (matches) {
       // Store the last known state before closing the panels
       lastLeftPanelState.current = showLeftPanel
       lastRightPanelState.current = showRightPanel
-
       setShowLeftPanel(false)
       setShowRightPanel(false)
     } else {

--- a/web/helpers/atoms/App.atom.ts
+++ b/web/helpers/atoms/App.atom.ts
@@ -15,7 +15,9 @@ export const showLeftPanelAtom = atom<boolean>(true)
 
 export const showRightPanelAtom = atomWithStorage<boolean>(
   SHOW_RIGHT_PANEL,
-  false
+  false,
+  undefined,
+  { getOnInit: true }
 )
 
 export const showSystemMonitorPanelAtom = atom<boolean>(false)

--- a/web/helpers/atoms/App.atom.ts
+++ b/web/helpers/atoms/App.atom.ts
@@ -1,14 +1,23 @@
 import { atom } from 'jotai'
 
+import { atomWithStorage } from 'jotai/utils'
+
 import { MainViewState } from '@/constants/screens'
 
 export const mainViewStateAtom = atom<MainViewState>(MainViewState.Thread)
 
 export const defaultJanDataFolderAtom = atom<string>('')
 
+const SHOW_RIGHT_PANEL = 'showRightPanel'
+
 // Store panel atom
 export const showLeftPanelAtom = atom<boolean>(true)
-export const showRightPanelAtom = atom<boolean>(true)
+
+export const showRightPanelAtom = atomWithStorage<boolean>(
+  SHOW_RIGHT_PANEL,
+  false
+)
+
 export const showSystemMonitorPanelAtom = atom<boolean>(false)
 export const appDownloadProgressAtom = atom<number>(-1)
 export const updateVersionErrorAtom = atom<string | undefined>(undefined)

--- a/web/helpers/atoms/Thread.atom.ts
+++ b/web/helpers/atoms/Thread.atom.ts
@@ -207,7 +207,7 @@ export const setThreadModelParamsAtom = atom(
  */
 export const activeSettingInputBoxAtom = atomWithStorage<boolean>(
   ACTIVE_SETTING_INPUT_BOX,
-  false,
+  true,
   undefined,
   { getOnInit: true }
 )


### PR DESCRIPTION
## Describe Your Changes

changes made to three files in a codebase: `Responsive.tsx`, `App.atom.ts`, and `Thread.atom.ts`. Here's a summary of each change:

1. **Responsive.tsx**:
   - The initial values for the refs `lastLeftPanelState` and `lastRightPanelState` have been modified. Previously, these refs were initialized as `true` for both, but now they are initialized using the current state values of `showLeftPanel` and `showRightPanel`.
   - This change ensures that when switching to a state where the panels should close, their last states are known from the outset.

2. **App.atom.ts**:
   - An import of `atomWithStorage` from `jotai/utils` was added, which allows creating a persistent atom.
   - `showRightPanelAtom` is modified to use `atomWithStorage`, meaning it will now persist the panel's state using local storage under the key `SHOW_RIGHT_PANEL`. The default state of this atom is changed from `true` to `false`.
   - This change persists the panel's open/close state even after the application reloads, with the state being initially closed by default.

3. **Thread.atom.ts**:
   - The default value of `activeSettingInputBoxAtom` was changed from `false` to `true`.
   - This change sets the active setting input box state to be `true` by default, which means the input box might now be in the active/open state when the application loads.

These changes generally deal with the default states and durability (persistent state) of UI components and user inputs.

Screen when fresh install

![CleanShot 2024-12-05 at 15 55 42](https://github.com/user-attachments/assets/2c550e40-0345-4944-bfdd-ae9b8729440e)

Create new thread
![CleanShot 2024-12-05 at 15 56 10](https://github.com/user-attachments/assets/e9a95369-d08e-42e5-9867-f393f69512f3)

Create new thread when rightpanel open

![CleanShot 2024-12-05 at 15 56 29](https://github.com/user-attachments/assets/6dfffb4c-3681-4335-8838-2564ca367818)

When create new thread Right panel and Chat input box setting will depends on local storage





## Fixes Issues

- Closes #4117 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
