### PR TITLE
fix: crash markdown render code block without triple backtick

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -41,7 +41,6 @@
     "rehype-highlight": "^7.0.1",
     "rehype-highlight-code-lines": "^1.0.4",
     "rehype-katex": "^7.0.1",
-    "rehype-raw": "^7.0.0",
     "remark-math": "^6.0.0",
     "sass": "^1.69.4",
     "slate": "latest",

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx
@@ -7,8 +7,9 @@ import Markdown from 'react-markdown'
 
 import rehypeHighlight from 'rehype-highlight'
 import rehypeHighlightCodeLines from 'rehype-highlight-code-lines'
+
 import rehypeKatex from 'rehype-katex'
-import rehypeRaw from 'rehype-raw'
+
 import remarkMath from 'remark-math'
 
 import 'katex/dist/katex.min.css'
@@ -198,12 +199,10 @@ export const MarkdownTextMessage = memo(
           remarkPlugins={[remarkMath]}
           rehypePlugins={[
             [rehypeKatex, { throwOnError: false }],
-            rehypeRaw,
             rehypeHighlight,
             [rehypeHighlightCodeLines, { showLineNumbers: true }],
             wrapCodeBlocksWithoutVisit,
           ]}
-          skipHtml={true}
         >
           {text}
         </Markdown>


### PR DESCRIPTION
## Describe Your Changes

case is user write codeblock without backtick 
The root cause is likely malformed Markdown content or the handling of raw HTML tags in the Markdown processor.

### Changes in `package.json`
- **Removed Dependency**: The package `rehype-raw` with version `^7.0.0` has been removed from the list of dependencies.

### Changes in `MarkdownTextMessage.tsx`
- **Import Removal**: The import statement for `rehypeRaw` has been deleted.
- **Plugin Removal**:
  - `rehypeRaw` has been removed from the `rehypePlugins` array.
- **Attribute Change**:
  - The `skipHtml` attribute, which was set to `true`, has been removed from the `<Markdown>` component.

Overall, the changes reflect the removal of the `rehype-raw` package and associated logic from the codebase, likely to improve security or simplify functionality by disallowing the use of raw HTML content in Markdown rendering.

## Fixes Issues

![CleanShot 2024-12-09 at 15 41 54](https://github.com/user-attachments/assets/64e78aa7-f997-4324-bb03-8c2c03938495)

- Closes #4247 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
