### PR TITLE
chore: 4244 - deprecate groq llama 3.1 70B Versatile

### DIFF
--- a/extensions/inference-groq-extension/resources/models.json
+++ b/extensions/inference-groq-extension/resources/models.json
@@ -67,37 +67,6 @@
         "url": "https://groq.com"
       }
     ],
-    "id": "llama-3.1-70b-versatile",
-    "object": "model",
-    "name": "Groq Llama 3.1 70b Versatile",
-    "version": "1.1",
-    "description": "Groq Llama 3.1 70b Versatile with supercharged speed!",
-    "format": "api",
-    "settings": {},
-    "parameters": {
-      "max_tokens": 8000,
-      "temperature": 0.7,
-      "top_p": 0.95,
-      "stream": true,
-      "stop": [],
-      "frequency_penalty": 0,
-      "presence_penalty": 0
-    },
-    "metadata": {
-      "author": "Meta",
-      "tags": [
-        "General",
-        "Big Context Length"
-      ]
-    },
-    "engine": "groq"
-  },
-  {
-    "sources": [
-      {
-        "url": "https://groq.com"
-      }
-    ],
     "id": "llama-3.1-8b-instant",
     "object": "model",
     "name": "Groq Llama 3.1 8b Instant",


### PR DESCRIPTION
## Describe Your Changes

- This PR is to remove deprecated groq model Llama 3.1 70B Versatile

## Fixes Issues

- #4244

### Code Changes Summary

The following changes were made to the `models.json` file:

- **Removed a Model Entry**: The model entry with the id `"llama-3.1-70b-versatile"` was completely removed. This model had the name "Groq Llama 3.1 70b Versatile" and was described as having "supercharged speed." It included various configurations such as:
  - Maximum tokens: 8000
  - Temperature: 0.7
  - Top_p: 0.95
  - Streaming enabled
  - Tags including "General" and "Big Context Length"

The rest of the models in the file remain unchanged.
