### PR TITLE
fix: 4238 - fix default max_tokens set on remote models

### DIFF
--- a/extensions/inference-openai-extension/resources/models.json
+++ b/extensions/inference-openai-extension/resources/models.json
@@ -99,10 +99,10 @@
     "format": "api",
     "settings": {},
     "parameters": {
+      "max_tokens": 32768,
       "temperature": 1,
       "top_p": 1,
       "stream": true,
-      "max_tokens": 32768,
       "frequency_penalty": 0,
       "presence_penalty": 0
     },
@@ -126,9 +126,9 @@
     "format": "api",
     "settings": {},
     "parameters": {
+      "max_tokens": 65536,
       "temperature": 1,
       "top_p": 1,
-      "max_tokens": 65536,
       "stream": true,
       "frequency_penalty": 0,
       "presence_penalty": 0

--- a/web/containers/ModelDropdown/index.tsx
+++ b/web/containers/ModelDropdown/index.tsx
@@ -192,8 +192,12 @@ const ModelDropdown = ({
           model?.settings.ctx_len ?? 8192
         )
         const overriddenParameters = {
-          ctx_len: Math.min(8192, model?.settings.ctx_len ?? 8192),
-          max_tokens: defaultContextLength,
+          ctx_len: !isLocalEngine(model?.engine)
+            ? undefined
+            : defaultContextLength,
+          max_tokens: !isLocalEngine(model?.engine)
+            ? (model?.parameters.max_tokens ?? 8192)
+            : defaultContextLength,
         }
 
         const modelParams = {

--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -17,6 +17,7 @@ import { fileUploadAtom } from '@/containers/Providers/Jotai'
 
 import { toaster } from '@/containers/Toast'
 
+import { isLocalEngine } from '@/utils/modelEngine'
 import { generateThreadId } from '@/utils/thread'
 
 import { useActiveModel } from './useActiveModel'
@@ -113,12 +114,14 @@ export const useCreateNewThread = () => {
     )
 
     const overriddenSettings = {
-      ctx_len: defaultContextLength,
+      ctx_len: !isLocalEngine(model?.engine) ? undefined : defaultContextLength,
     }
 
     // Use ctx length by default
     const overriddenParameters = {
-      max_tokens: defaultContextLength,
+      max_tokens: !isLocalEngine(model?.engine)
+        ? (model?.parameters.token_limit ?? 8192)
+        : defaultContextLength,
     }
 
     const createdAt = Date.now()

--- a/web/utils/modelEngine.ts
+++ b/web/utils/modelEngine.ts
@@ -38,7 +38,9 @@ export const getLogoEngine = (engine: InferenceEngine) => {
  * @param engine
  * @returns
  */
-export const isLocalEngine = (engine: string) => {
+export const isLocalEngine = (engine?: string) => {
+  if (!engine) return false
+
   const engineObj = EngineManager.instance().get(engine)
   if (!engineObj) return false
   return (


### PR DESCRIPTION
## Describe Your Changes

I've resolved the issue where it sets the default context_length as the first value for max_tokens.

![CleanShot 2024-12-12 at 13 16 28](https://github.com/user-attachments/assets/45b5f8a8-cd20-40d7-9fd3-0d2ef01ceed5)


## Fixes Issues

- #4238

## Changes made

1. **`models.json`:**
   - Moved the `max_tokens` parameter above the `temperature` parameter for better grouping in two sections of the file.

2. **`ModelDropdown/index.tsx`:**
   - Updated `overriddenParameters`:
     - Changed `ctx_len` to be `undefined` if `isLocalEngine` returns `false`, otherwise use `defaultContextLength`.
     - Changed `max_tokens` to use either the model's `max_tokens` or `defaultContextLength` based on whether `isLocalEngine` returns `false`.

3. **`useCreateNewThread.ts`:**
   - Updated imports to include `isLocalEngine`.
   - Modified `overriddenSettings` and `overriddenParameters`:
     - Changed `ctx_len` to behave similarly to the changes in `ModelDropdown/index.tsx`.
     - Changed `max_tokens` to use either the model's `token_limit` or `defaultContextLength` based on whether `isLocalEngine` returns `false`.

4. **`modelEngine.ts`:**
   - Made `isLocalEngine` handle an `undefined` `engine` by returning `false`, ensuring safety against calling the method with a `null` or undefined value.
