### PR TITLE
Fix: Fix issue with duplicate events on Enter key press during CJK character composition in chat input

### DIFF
--- a/web/screens/Thread/ThreadCenterPanel/ChatInput/RichTextEditor.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatInput/RichTextEditor.tsx
@@ -225,7 +225,11 @@ const RichTextEditor = ({
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
-      if (event.key === 'Enter' && !event.shiftKey && event.nativeEvent.isComposing === false) {
+      if (
+        event.key === 'Enter' &&
+        !event.shiftKey &&
+        event.nativeEvent.isComposing === false
+      ) {
         event.preventDefault()
         if (messages[messages.length - 1]?.status !== MessageStatus.Pending) {
           sendChatMessage(currentPrompt)

--- a/web/screens/Thread/ThreadCenterPanel/ChatInput/RichTextEditor.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatInput/RichTextEditor.tsx
@@ -314,7 +314,7 @@ const RichTextEditor = ({
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
-      if (event.key === 'Enter' && !event.shiftKey) {
+      if (event.key === 'Enter' && !event.shiftKey && event.nativeEvent.isComposing === false) {
         event.preventDefault()
         if (messages[messages.length - 1]?.status !== MessageStatus.Pending) {
           sendChatMessage(currentPrompt)


### PR DESCRIPTION
## Describe Your Changes
- Resolve problem where pressing Enter triggers events twice: once for the composed string and once for the composing character.
- Ensure proper handling of composition events for Chinese, Japanese, and Korean input.

## Fixes Issues

- #4267

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
