### PR TITLE
fix: starter screen layout

### DIFF
--- a/web/containers/CenterPanelContainer/index.tsx
+++ b/web/containers/CenterPanelContainer/index.tsx
@@ -18,19 +18,24 @@ import {
 } from '@/helpers/atoms/App.atom'
 import { reduceTransparentAtom } from '@/helpers/atoms/Setting.atom'
 
-const CenterPanelContainer = ({ children }: PropsWithChildren) => {
+type Props = {
+  isShowStarterScreen?: boolean
+} & PropsWithChildren
+
+const CenterPanelContainer = ({ children, isShowStarterScreen }: Props) => {
   const reduceTransparent = useAtomValue(reduceTransparentAtom)
   const matches = useMediaQuery('(max-width: 880px)')
   const showLeftPanel = useAtomValue(showLeftPanelAtom)
   const showRightPanel = useAtomValue(showRightPanelAtom)
   const mainViewState = useAtomValue(mainViewStateAtom)
+
   return (
     <div
       className={twMerge('flex h-full w-full')}
       style={{
         maxWidth: matches
           ? '100%'
-          : mainViewState === MainViewState.Thread
+          : mainViewState === MainViewState.Thread && !isShowStarterScreen
             ? `calc(100% - (${showRightPanel ? Number(localStorage.getItem(RIGHT_PANEL_WIDTH)) : 0}px + ${showLeftPanel ? Number(localStorage.getItem(LEFT_PANEL_WIDTH)) : 0}px))`
             : '100%',
       }}

--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/OnDeviceStarterScreen/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/OnDeviceStarterScreen/index.tsx
@@ -40,7 +40,11 @@ import {
 } from '@/helpers/atoms/Model.atom'
 import { selectedSettingAtom } from '@/helpers/atoms/Setting.atom'
 
-const OnDeviceStarterScreen = () => {
+type Props = {
+  isShowStarterScreen?: boolean
+}
+
+const OnDeviceStarterScreen = ({ isShowStarterScreen }: Props) => {
   const { extensionHasSettings } = useStarterScreen()
   const [searchValue, setSearchValue] = useState('')
   const [isOpen, setIsOpen] = useState(Boolean(searchValue.length))
@@ -103,7 +107,7 @@ const OnDeviceStarterScreen = () => {
   const [visibleRows, setVisibleRows] = useState(1)
 
   return (
-    <CenterPanelContainer>
+    <CenterPanelContainer isShowStarterScreen={isShowStarterScreen}>
       <ScrollArea className="flex h-full w-full items-center">
         <div className="relative mt-4 flex h-full w-full flex-col items-center justify-center">
           <div className="mx-auto flex h-full w-3/4 flex-col items-center justify-center py-16 text-center">

--- a/web/screens/Thread/index.tsx
+++ b/web/screens/Thread/index.tsx
@@ -17,7 +17,7 @@ type Props = {
 
 const ThreadPanels = memo(({ isShowStarterScreen }: Props) => {
   return isShowStarterScreen ? (
-    <OnDeviceStarterScreen />
+    <OnDeviceStarterScreen isShowStarterScreen={isShowStarterScreen} />
   ) : (
     <>
       <ThreadLeftPanel />


### PR DESCRIPTION
## Describe Your Changes

Before
![CleanShot 2024-12-17 at 09 46 55](https://github.com/user-attachments/assets/cb03a6ad-ccb2-40b7-b113-25ce1938b317)

After
![CleanShot 2024-12-17 at 09 47 10](https://github.com/user-attachments/assets/d7064308-7781-4762-921f-4e873f27154d)



1. **CenterPanelContainer Component**:
   - A new type `Props` is introduced to include an optional property `isShowStarterScreen`, in addition to `PropsWithChildren`.
   - The `CenterPanelContainer` function is updated to accept `isShowStarterScreen` as a prop.
   - The inline styling for the `div` element is updated to account for `isShowStarterScreen`. The condition for `maxWidth` now additionally checks if `!isShowStarterScreen`.

2. **OnDeviceStarterScreen Component**:
   - A new type `Props` is introduced with an optional property `isShowStarterScreen`.
   - The `OnDeviceStarterScreen` function is updated to accept `isShowStarterScreen` as a prop.
   - The `CenterPanelContainer` component within the `OnDeviceStarterScreen` component is now called with the `isShowStarterScreen` prop passed down to it.

3. **Thread Component**:
   - The `OnDeviceStarterScreen` is now called with the `isShowStarterScreen` prop passed to it, ensuring that the state is appropriately passed downstream when `ThreadPanels` is memoized and rendered based on the `isShowStarterScreen` condition. 

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
