### PR TITLE
fix: performance issue with atom storage persistence

### DIFF
--- a/web/helpers/atoms/ChatMessage.atom.ts
+++ b/web/helpers/atoms/ChatMessage.atom.ts
@@ -6,7 +6,7 @@ import {
 } from '@janhq/core'
 import { atom } from 'jotai'
 
-import { atomWithStorage, createJSONStorage } from 'jotai/utils'
+import { atomWithStorage } from 'jotai/utils'
 
 import {
   getActiveThreadIdAtom,
@@ -16,17 +16,23 @@ import {
 import { TokenSpeed } from '@/types/token'
 
 const CHAT_MESSAGE_NAME = 'chatMessages'
-const storage = createJSONStorage<Record<string, ThreadMessage[]>>(
-  () => sessionStorage
-)
 /**
  * Stores all chat messages for all threads
  */
-export const chatMessages = atomWithStorage<Record<string, ThreadMessage[]>>(
-  CHAT_MESSAGE_NAME,
-  {},
-  storage,
-  { getOnInit: true }
+export const chatMessagesStorage = atomWithStorage<
+  Record<string, ThreadMessage[]>
+>(CHAT_MESSAGE_NAME, {}, undefined, { getOnInit: true })
+
+export const cachedMessages = atom<Record<string, ThreadMessage[]>>()
+/**
+ * Retrieve chat messages for all threads
+ */
+export const chatMessages = atom(
+  (get) => get(cachedMessages) ?? get(chatMessagesStorage),
+  (_get, set, newValue: Record<string, ThreadMessage[]>) => {
+    set(cachedMessages, newValue)
+    ;(() => set(chatMessagesStorage, newValue))()
+  }
 )
 
 /**


### PR DESCRIPTION
## Describe Your Changes

This PR fixes the message rendering issue when caching it with jotai local storage,  using composed atom of cache and storage

## Summary of Code Changes
The Git diff shows the following changes to the `ChatMessage.atom.ts` file:

1. **Import Statement**: The import statement for `createJSONStorage` is removed.
2. **Type Annotation**: A type annotation for `chatMessagesStorage` is added.
3. **Atom Creation**:
   - `chatMessagesStorage` is created using `atomWithStorage`.
   - `cachedMessages` is defined as an atom to store cached chat messages.
   - `chatMessages` is modified to first read from `cachedMessages`. If `cachedMessages` has no value, it reads from `chatMessagesStorage`.
   - The setter for `chatMessages` now sets both `cachedMessages` and `chatMessagesStorage`.

The overall goal seems to be improving the efficiency of accessing chat messages by caching them locally in addition to storing them persistently.
