### PR TITLE
fix: scroll to bottom issue

### DIFF
--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
@@ -57,9 +57,10 @@ const ChatBody = memo(
     loadModelError?: string
   }) => {
     // The scrollable element for your list
-    const parentRef = useRef(null)
+    const parentRef = useRef<HTMLDivElement>(null)
     const prevScrollTop = useRef(0)
     const isUserManuallyScrollingUp = useRef(false)
+    const currentThread = useAtomValue(activeThreadAtom)
 
     const count = useMemo(
       () => (messages?.length ?? 0) + (loadModelError ? 1 : 0),
@@ -73,20 +74,18 @@ const ChatBody = memo(
       estimateSize: () => 35,
       overscan: 5,
     })
-    useEffect(() => {
-      if (isUserManuallyScrollingUp.current === true || !parentRef.current)
-        return
 
-      if (count > 0 && messages && virtualizer) {
-        virtualizer.scrollToIndex(count - 1)
+    useEffect(() => {
+      // Delay the scroll until the DOM is updated
+      if (parentRef.current) {
+        requestAnimationFrame(() => {
+          if (parentRef.current) {
+            parentRef.current.scrollTo({ top: parentRef.current.scrollHeight })
+            virtualizer.scrollToIndex(count - 1)
+          }
+        })
       }
-    }, [
-      count,
-      virtualizer,
-      messages,
-      loadModelError,
-      isUserManuallyScrollingUp,
-    ])
+    }, [count, currentThread?.id, virtualizer])
 
     const items = virtualizer.getVirtualItems()
 


### PR DESCRIPTION
## Describe Your Changes

1. **TypeScript Type Annotation**: The `useRef` hook for `parentRef` is updated from `useRef(null)` to `useRef<HTMLDivElement>(null)`, providing a type annotation to specify that the ref should point to a `HTMLDivElement`.

2. **New State Addition**: A new state `currentThread` is introduced, which uses the `useAtomValue` hook to retrieve the value from `activeThreadAtom`.

3. **Refactoring useEffect Hook**: 
   - The existing `useEffect` hook is refactored to:
     - Remove the check for `isUserManuallyScrollingUp` and `!parentRef.current`.
     - Add a `requestAnimationFrame` call to delay scrolling until the DOM updates. This ensures smoother behavior when scrolling to the last index of messages.
     - Update the dependencies of the `useEffect` to include `currentThread?.id` and remove unused dependencies like `messages`, `loadModelError`, and `isUserManuallyScrollingUp`.

4. **Removed Logical Checks**: The logical checks within the previous `useEffect` have been refactored to ensure the scroll actions are executed efficiently in the newly structured `useEffect`.

## Fixes Issues

https://github.com/user-attachments/assets/73aa002f-437d-4c74-934b-f2bae5a8367e


- Closes #4253 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
