### PR TITLE
fix: empty tooltip on attachment icon, also fix z-index

### DIFF
--- a/web/screens/Hub/ModelList/ModelHeader/index.tsx
+++ b/web/screens/Hub/ModelList/ModelHeader/index.tsx
@@ -71,7 +71,6 @@ const ModelItemHeader = ({ model, onClick, open }: Props) => {
 
   let downloadButton = (
     <Button
-      className="z-50"
       onClick={(e) => {
         e.stopPropagation()
         onDownloadClick()

--- a/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
@@ -94,9 +94,9 @@ const ChatInput = () => {
     stopInference()
   }
 
-  const isModelSupportRagAndTools =
-    selectedModel?.engine === InferenceEngine.openai ||
-    isLocalEngine(selectedModel?.engine as InferenceEngine)
+  const isModelSupportRagAndTools = isLocalEngine(
+    selectedModel?.engine as InferenceEngine
+  )
 
   /**
    * Handles the change event of the extension file input element by setting the file name state.
@@ -182,7 +182,7 @@ const ChatInput = () => {
               </Button>
             }
             disabled={
-              isModelSupportRagAndTools &&
+              !isModelSupportRagAndTools &&
               activeAssistant?.tools &&
               activeAssistant?.tools[0]?.enabled
             }
@@ -231,7 +231,8 @@ const ChatInput = () => {
                   <li
                     className={twMerge(
                       'text-[hsla(var(--text-secondary)] hover:bg-secondary flex w-full items-center space-x-2 px-4 py-2 hover:bg-[hsla(var(--dropdown-menu-hover-bg))]',
-                      activeAssistant?.model.settings?.vision_model
+                      activeAssistant?.model.settings?.vision_model ||
+                        isModelSupportRagAndTools
                         ? 'cursor-pointer'
                         : 'cursor-not-allowed opacity-50'
                     )}
@@ -255,11 +256,15 @@ const ChatInput = () => {
                   <li
                     className={twMerge(
                       'text-[hsla(var(--text-secondary)] hover:bg-secondary flex w-full cursor-pointer items-center space-x-2 px-4 py-2 hover:bg-[hsla(var(--dropdown-menu-hover-bg))]',
-                      'cursor-pointer'
+                      isModelSupportRagAndTools
+                        ? 'cursor-pointer'
+                        : 'cursor-not-allowed opacity-50'
                     )}
                     onClick={() => {
-                      fileInputRef.current?.click()
-                      setShowAttacmentMenus(false)
+                      if (isModelSupportRagAndTools) {
+                        fileInputRef.current?.click()
+                        setShowAttacmentMenus(false)
+                      }
                     }}
                   >
                     <FileTextIcon size={16} />


### PR DESCRIPTION
## Describe Your Changes

1. **In `web/screens/Hub/ModelList/ModelHeader/index.tsx`:**
   - The `z-50` class was removed from the `Button` component. This class might have been related to the z-index, and its removal suggests a possible simplification or a fix for a styling issue.

2. **In `web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx`:**
   - The `isModelSupportRagAndTools` constant has been refined to focus solely on the result of `isLocalEngine(selectedModel?.engine as InferenceEngine)`. Previously, it also checked if `selectedModel?.engine === InferenceEngine.openai`.
   - The logic for the `disabled` property of certain elements has been updated to disable the button if `!isModelSupportRagAndTools` instead of `isModelSupportRagAndTools`.
   - The text list item’s className logic was updated to disable user interaction with a "cursor-not-allowed opacity-50" class when `isModelSupportRagAndTools` is `false`, reflecting conditions under which interaction should be permissible.
   - For handling file input clicks, the code now checks if `isModelSupportRagAndTools` is `true` before executing the file input click and closing the attachment menus. This check prevents actions when the conditions do not support them.

These changes aim to clean up the code, refactor conditions for clarity, and ensure user interfaces respond correctly to model support conditions.

## Fixes Issues

![CleanShot 2024-12-18 at 15 13 00](https://github.com/user-attachments/assets/e101e0af-7d1e-46f0-9727-117cf3f55ec4)
![CleanShot 2024-12-18 at 15 12 44](https://github.com/user-attachments/assets/0e3c7df4-768c-422d-be00-6845ce07ed75)

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
