### PR TITLE
fix: context length is reset while creating a new thread

### DIFF
--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -115,13 +115,15 @@ export const useCreateNewThread = () => {
     )
 
     const overriddenSettings = {
-      ctx_len: !isLocalEngine(model?.engine) ? undefined : defaultContextLength,
+      ctx_len: !isLocalEngine(defaultModel?.engine)
+        ? undefined
+        : defaultContextLength,
     }
 
     // Use ctx length by default
     const overriddenParameters = {
-      max_tokens: !isLocalEngine(model?.engine)
-        ? (model?.parameters.token_limit ?? 8192)
+      max_tokens: !isLocalEngine(defaultModel?.engine)
+        ? (defaultModel?.parameters.token_limit ?? 8192)
         : defaultContextLength,
     }
 


### PR DESCRIPTION
## Describe Your Changes

- Fixed an issue where app resets context length setting while creating a new thread due to undefined model selection value. Now should use default model value.

![CleanShot 2024-12-18 at 17 52 41](https://github.com/user-attachments/assets/8841c984-1148-430c-879e-dc0e5402d78d)


## Fixes Issues

- Closes #
- Closes #

## Code changes
The Git diff shows the following changes to the `useCreateNewThread.ts` file:

1. **Variable Renaming**:
   - The variable `model` is renamed to `defaultModel`. This change ensures that the function uses the default model settings consistently.

2. **Consistent Use of Default Model**:
   - In both `overriddenSettings` and `overriddenParameters`, the code now checks if the engine of `defaultModel` is local using `!isLocalEngine(defaultModel?.engine)`. This ensures that the settings are applied based on whether the model's engine is local or not, maintaining consistency.

3. **Token Limit Adjustment**:
   - The token limit in `overriddenParameters` now correctly uses `defaultModel?.parameters.token_limit ?? 8192`. This means that if `token_limit` is not defined for `defaultModel`, it defaults to 8192.

These changes make the code more consistent and clear, ensuring that model-specific settings are applied correctly based on whether the engine is local or not.
