### PR TITLE
fix: new thread isn't automatically created on factory reset

### DIFF
--- a/core/src/browser/extensions/engines/OAIEngine.ts
+++ b/core/src/browser/extensions/engines/OAIEngine.ts
@@ -71,7 +71,7 @@ export abstract class OAIEngine extends AIEngine {
       return
     }
 
-    const timestamp = Date.now()
+    const timestamp = Date.now() / 1000
     const message: ThreadMessage = {
       id: ulid(),
       thread_id: data.threadId,

--- a/extensions/assistant-extension/src/index.ts
+++ b/extensions/assistant-extension/src/index.ts
@@ -127,7 +127,7 @@ export default class JanAssistantExtension extends AssistantExtension {
     thread_location: undefined,
     id: 'jan',
     object: 'assistant',
-    created_at: Date.now(),
+    created_at: Date.now() / 1000,
     name: 'Jan',
     description: 'A default assistant that can use all downloaded models',
     model: '*',

--- a/web/containers/Providers/ModelHandler.tsx
+++ b/web/containers/Providers/ModelHandler.tsx
@@ -264,6 +264,9 @@ export default function ModelHandler() {
         if (updatedMessage) {
           deleteMessage(message.id)
           addNewMessage(updatedMessage)
+          setTokenSpeed((prev) =>
+            prev ? { ...prev, message: updatedMessage.id } : undefined
+          )
         }
       })()
 

--- a/web/helpers/atoms/Assistant.atom.ts
+++ b/web/helpers/atoms/Assistant.atom.ts
@@ -4,9 +4,15 @@ import { atomWithStorage } from 'jotai/utils'
 
 export const assistantsAtom = atom<Assistant[]>([])
 
+export const cachedAssistantAtom = atomWithStorage<
+  ThreadAssistantInfo | undefined
+>('activeAssistant', undefined, undefined, { getOnInit: true })
 /**
  * Get the current active assistant
  */
-export const activeAssistantAtom = atomWithStorage<
-  ThreadAssistantInfo | undefined
->('activeAssistant', undefined, undefined, { getOnInit: true })
+export const activeAssistantAtom = atom(
+  (get) => get(cachedAssistantAtom) ?? get(assistantsAtom)[0],
+  (_get, set, newAssistant: ThreadAssistantInfo) => {
+    set(cachedAssistantAtom, newAssistant)
+  }
+)

--- a/web/helpers/atoms/Assistant.atom.ts
+++ b/web/helpers/atoms/Assistant.atom.ts
@@ -4,15 +4,9 @@ import { atomWithStorage } from 'jotai/utils'
 
 export const assistantsAtom = atom<Assistant[]>([])
 
-export const cachedAssistantAtom = atomWithStorage<
-  ThreadAssistantInfo | undefined
->('activeAssistant', undefined, undefined, { getOnInit: true })
 /**
  * Get the current active assistant
  */
-export const activeAssistantAtom = atom(
-  (get) => get(cachedAssistantAtom) ?? get(assistantsAtom)[0],
-  (_get, set, newAssistant: ThreadAssistantInfo) => {
-    set(cachedAssistantAtom, newAssistant)
-  }
-)
+export const activeAssistantAtom = atomWithStorage<
+  ThreadAssistantInfo | undefined
+>('activeAssistant', undefined, undefined, { getOnInit: true })

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
@@ -88,9 +88,7 @@ const MessageContainer: React.FC<
         >
           {isUser
             ? props.role
-            : 'assistant_name' in activeAssistant
-              ? activeAssistant?.assistant_name
-              : props.role}
+            : (activeAssistant?.assistant_name ?? props.role)}
         </div>
         <p className="text-xs font-medium text-gray-400">
           {props.created_at && displayDate(props.created_at ?? new Date())}

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
@@ -88,7 +88,9 @@ const MessageContainer: React.FC<
         >
           {isUser
             ? props.role
-            : (activeAssistant?.assistant_name ?? props.role)}
+            : 'assistant_name' in activeAssistant
+              ? activeAssistant?.assistant_name
+              : props.role}
         </div>
         <p className="text-xs font-medium text-gray-400">
           {props.created_at && displayDate(props.created_at ?? new Date())}

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
@@ -91,7 +91,8 @@ const MessageContainer: React.FC<
             : (activeAssistant?.assistant_name ?? props.role)}
         </div>
         <p className="text-xs font-medium text-gray-400">
-          {props.created_at && displayDate(props.created_at ?? new Date())}
+          {props.created_at &&
+            displayDate(props.created_at ?? Date.now() / 1000)}
         </p>
       </div>
 

--- a/web/screens/Thread/ThreadLeftPanel/index.tsx
+++ b/web/screens/Thread/ThreadLeftPanel/index.tsx
@@ -71,7 +71,6 @@ const ThreadLeftPanel = () => {
   useEffect(() => {
     if (
       threadDataReady &&
-      activeAssistant &&
       assistants.length > 0 &&
       threads.length === 0 &&
       downloadedModels.length > 0
@@ -81,7 +80,9 @@ const ThreadLeftPanel = () => {
       )
       const selectedModel = model[0] || recommendedModel
       requestCreateNewThread(
-        { ...assistants[0], ...activeAssistant },
+        activeAssistant
+          ? { ...assistants[0], ...activeAssistant }
+          : assistants[0],
         selectedModel
       )
     } else if (threadDataReady && !activeThreadId) {

--- a/web/utils/datetime.test.ts
+++ b/web/utils/datetime.test.ts
@@ -4,11 +4,7 @@ import { isToday } from './datetime'
 test("should return only time for today's timestamp", () => {
   const today = new Date()
   const timestamp = today.getTime()
-  const expectedTime = `${today.toLocaleDateString(undefined, {
-    day: '2-digit',
-    month: 'short',
-    year: 'numeric',
-  })}, ${today.toLocaleTimeString(undefined, {
+  const expectedTime = `${today.toLocaleTimeString(undefined, {
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',
@@ -24,5 +20,5 @@ test('should return N/A for undefined timestamp', () => {
 test("should return true for today's timestamp", () => {
   const today = new Date()
   const timestamp = today.setHours(0, 0, 0, 0)
-  expect(isToday(timestamp)).toBe(true)
+  expect(isToday(timestamp / 1000)).toBe(true)
 })

--- a/web/utils/datetime.ts
+++ b/web/utils/datetime.ts
@@ -1,6 +1,9 @@
 export const isToday = (timestamp: number) => {
   const today = new Date()
-  return today.setHours(0, 0, 0, 0) === new Date(timestamp).setHours(0, 0, 0, 0)
+  return (
+    today.setHours(0, 0, 0, 0) ===
+    new Date(timestamp * 1000).setHours(0, 0, 0, 0)
+  )
 }
 
 export const displayDate = (timestamp?: string | number | Date) => {

--- a/web/utils/messageRequestBuilder.ts
+++ b/web/utils/messageRequestBuilder.ts
@@ -15,7 +15,7 @@ import { ulid } from 'ulidx'
 
 import { Stack } from '@/utils/Stack'
 
-import { FileInfo, FileType } from '@/types/file'
+import { FileInfo } from '@/types/file'
 
 export class MessageRequestBuilder {
   msgId: string

--- a/web/utils/threadMessageBuilder.ts
+++ b/web/utils/threadMessageBuilder.ts
@@ -22,7 +22,7 @@ export class ThreadMessageBuilder {
   }
 
   build(): ThreadMessage {
-    const timestamp = Date.now()
+    const timestamp = Date.now() / 1000
     return {
       id: this.messageRequest.msgId,
       thread_id: this.messageRequest.thread.id,


### PR DESCRIPTION
## Describe Your Changes

This PR fixes the issue where the app doesn't automatically create a new thread after downloading a model from the welcome screen.

![CleanShot 2024-12-19 at 11 43 12](https://github.com/user-attachments/assets/da0e6bf4-3f6c-4dac-a086-e68bfadc69c5)


## Changes made
The changes in this PR include modifications to the following files:

- `core/src/browser/extensions/engines/OAIEngine.ts`: Adjusted timestamp to use seconds.
- `extensions/assistant-extension/src/index.ts`: Adjusted timestamp to use seconds.
- `web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx`: Adjusted timestamp to use seconds.
- `web/screens/Thread/ThreadLeftPanel/index.tsx`: Changed logic for creating new thread with default assistant.
- `web/utils/datetime.ts`: Adjusted timestamp handling to use seconds.
- `web/utils/messageRequestBuilder.ts`: Removed unused import.
- `web/utils/threadMessageBuilder.ts`: Adjusted timestamp to use seconds.