### PR TITLE
fix: conditional render model setting based on selected model

### DIFF
--- a/web/screens/Thread/ThreadRightPanel/index.tsx
+++ b/web/screens/Thread/ThreadRightPanel/index.tsx
@@ -268,34 +268,38 @@ const ThreadRightPanel = () => {
           <div className="flex flex-col gap-4 px-2 py-4">
             <ModelDropdown />
           </div>
-          <Accordion defaultValue={[]}>
-            {settings.runtimeSettings.length !== 0 && (
-              <AccordionItem
-                title={INFERENCE_SETTINGS}
-                value={INFERENCE_SETTINGS}
-              >
-                <ModelSetting
-                  componentProps={settings.runtimeSettings}
-                  onValueChanged={onValueChanged}
-                />
-              </AccordionItem>
-            )}
+          {selectedModel && (
+            <Accordion defaultValue={[]}>
+              {settings.runtimeSettings.length !== 0 && (
+                <AccordionItem
+                  title={INFERENCE_SETTINGS}
+                  value={INFERENCE_SETTINGS}
+                >
+                  <ModelSetting
+                    componentProps={settings.runtimeSettings}
+                    onValueChanged={onValueChanged}
+                  />
+                </AccordionItem>
+              )}
 
-            {promptTemplateSettings.length !== 0 && (
-              <AccordionItem title={MODEL_SETTINGS} value={MODEL_SETTINGS}>
-                <PromptTemplateSetting componentData={promptTemplateSettings} />
-              </AccordionItem>
-            )}
+              {promptTemplateSettings.length !== 0 && (
+                <AccordionItem title={MODEL_SETTINGS} value={MODEL_SETTINGS}>
+                  <PromptTemplateSetting
+                    componentData={promptTemplateSettings}
+                  />
+                </AccordionItem>
+              )}
 
-            {settings.engineSettings.length !== 0 && (
-              <AccordionItem title={ENGINE_SETTINGS} value={ENGINE_SETTINGS}>
-                <EngineSetting
-                  componentData={settings.engineSettings}
-                  onValueChanged={onValueChanged}
-                />
-              </AccordionItem>
-            )}
-          </Accordion>
+              {settings.engineSettings.length !== 0 && (
+                <AccordionItem title={ENGINE_SETTINGS} value={ENGINE_SETTINGS}>
+                  <EngineSetting
+                    componentData={settings.engineSettings}
+                    onValueChanged={onValueChanged}
+                  />
+                </AccordionItem>
+              )}
+            </Accordion>
+          )}
         </TabsContent>
         <TabsContent value="tools">
           <Tools />


### PR DESCRIPTION
## Describe Your Changes

The changes in the `ThreadRightPanel/index.tsx` file involve wrapping an `Accordion` component and its children with an additional conditional check to ensure that a `selectedModel` exists before rendering the `Accordion` and its `AccordionItem` children. Here's a summary of the modifications:

1. **Conditional Rendering**: Previously, the `Accordion` component and its `AccordionItem` components were rendered unconditionally. Now, they are only rendered if `selectedModel` is truthy.

2. **No Changes to Styling or Structure**: There are no changes to the styling (`className`) or the internal structure of the `Accordion` and `AccordionItem` components.

3. **Preservation of Existing Logic**: The logic inside `AccordionItem`s remains intact, including checks on the length of `settings.runtimeSettings`, `promptTemplateSettings`, and `settings.engineSettings`, as well as the handling of `onValueChanged` callbacks.

This change likely introduces a dependency on the `selectedModel` variable, ensuring that the settings sections are conditionally displayed only when a model is selected or defined.

## Fixes Issues

![CleanShot 2024-12-19 at 21 22 01](https://github.com/user-attachments/assets/3524dd11-9232-480d-bbd2-b076e5a7b2c6)


- Closes # [conv](https://discord.com/channels/1107178041848909847/1314078497441841182/1319265961265594432)
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
