### PR TITLE
fix: escape heading on user message item

### DIFF
--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx
@@ -19,8 +19,14 @@ import { useClipboard } from '@/hooks/useClipboard'
 import { getLanguageFromExtension } from '@/utils/codeLanguageExtension'
 
 export const MarkdownTextMessage = memo(
-  ({ text }: { id: string; text: string }) => {
+  ({ text, isUser }: { id: string; text: string; isUser: boolean }) => {
     const clipboard = useClipboard({ timeout: 1000 })
+
+    // Escapes headings
+    function preprocessMarkdown(text: string): string {
+      if (!isUser) return text
+      return text.replace(/^#{1,6} /gm, (match) => `\\${match}`)
+    }
 
     function extractCodeLines(node: { children: { children: any[] }[] }) {
       const codeLines: any[] = []
@@ -204,7 +210,7 @@ export const MarkdownTextMessage = memo(
             wrapCodeBlocksWithoutVisit,
           ]}
         >
-          {text}
+          {preprocessMarkdown(text)}
         </Markdown>
       </>
     )

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
@@ -141,7 +141,11 @@ const MessageContainer: React.FC<
                 )}
                 dir="ltr"
               >
-                <MarkdownTextMessage id={props.id} text={text} />
+                <MarkdownTextMessage
+                  id={props.id}
+                  text={text}
+                  isUser={isUser}
+                />
               </div>
             )}
           </>


### PR DESCRIPTION
## Describe Your Changes

The changes in the provided `git diff` involve two TypeScript files and focus on modifying how markdown text is processed and rendered. Here's a breakdown of what has been changed:

1. **MarkdownTextMessage.tsx:**
   - **Function Parameter Modification:**
     - The `MarkdownTextMessage` component's props have been modified to include an `isUser` boolean property alongside the existing `id` and `text` properties. This is indicated by the change to the function signature from:
       ```typescript
       ({ text }: { id: string; text: string })
       ```
       to:
       ```typescript
       ({ text, isUser }: { id: string; text: string; isUser: boolean })
       ```

   - **Markdown Preprocessing:**
     - Introduced a new function `preprocessMarkdown` to modify the markdown text if the `isUser` flag is `true`. The function escapes markdown headings by prefixing them with a backslash. This is done using a `replace` method:
       ```typescript
       text.replace(/^#{1,6} /gm, (match) => `\\${match}`)
       ```
     - Condition: The preprocessing only occurs if the `isUser` prop is `true`.

   - **Markdown Component Usage:**
     - The markdown content now uses the preprocessed markdown text:
       ```javascript
       {preprocessMarkdown(text)}
       ```
     - Replacing the previous direct usage of `text`:
       ```javascript
       {text}
       ```

2. **index.tsx:**
   - **Props Update in Component Usage:**
     - Updated the `MarkdownTextMessage` component instantiation to include the `isUser` prop:
       ```typescript
       <MarkdownTextMessage
         id={props.id}
         text={text}
         isUser={isUser}
       />
       ```
     - Previously, it was:
       ```typescript
       <MarkdownTextMessage id={props.id} text={text} />
       ```

In summary, these changes introduce a conditional preprocessing of markdown messages based on the user context (`isUser`), specifically to escape headings in markdown content originating from users.

## Fixes Issues

![CleanShot 2024-12-19 at 21 33 56](https://github.com/user-attachments/assets/3a8586ea-2a21-4007-97f0-efaacb89e612)

![CleanShot 2024-12-19 at 21 33 53](https://github.com/user-attachments/assets/6c6f266e-4d4d-4e3f-93b0-1dc4f88e5ee7)

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
