### PR TITLE
fix: thread error handling

### DIFF
--- a/web/containers/Providers/ModelHandler.tsx
+++ b/web/containers/Providers/ModelHandler.tsx
@@ -302,15 +302,10 @@ export default function ModelHandler() {
 
   const generateThreadTitle = (message: ThreadMessage, thread: Thread) => {
     // If this is the first ever prompt in the thread
-    if (
-      (thread.title ?? thread.metadata?.title)?.trim() !== defaultThreadTitle
-    ) {
+    if ((thread.title ?? thread.metadata?.title)?.trim() !== defaultThreadTitle)
       return
-    }
 
-    if (!activeModelRef.current) {
-      return
-    }
+    if (!activeModelRef.current) return
 
     // Check model engine; we don't want to generate a title when it's not a local engine. remote model using first promp
     if (!isLocalEngine(activeModelRef.current?.engine as InferenceEngine)) {
@@ -332,6 +327,7 @@ export default function ModelHandler() {
             ...updatedThread,
           })
         })
+        .catch(console.error)
     }
 
     // This is the first time message comes in on a new thread

--- a/web/hooks/useDeleteThread.ts
+++ b/web/hooks/useDeleteThread.ts
@@ -37,9 +37,16 @@ export default function useDeleteThread() {
     async (threadId: string) => {
       const thread = threads.find((c) => c.id === threadId)
       if (!thread) return
+      const availableThreads = threads.filter((c) => c.id !== threadId)
+      setThreads(availableThreads)
+
+      // delete the thread state
+      deleteThreadState(threadId)
+
       const assistantInfo = await extensionManager
         .get<ConversationalExtension>(ExtensionTypeEnum.Conversational)
         ?.getThreadAssistant(thread.id)
+        .catch(console.error)
 
       if (!assistantInfo) return
       const model = models.find((c) => c.id === assistantInfo?.model?.id)


### PR DESCRIPTION
## Describe Your Changes

Fixed the issue where cleaning the thread raises an error, preventing it from being cleaned.

## Changes made

The changes in this pull request involve the following updates:

### `ModelHandler.tsx`
1. Simplified the conditions in the `generateThreadTitle` function:
   - Removed unnecessary braces and reduced lines by combining conditions.
   - Added a `.catch(console.error)` to handle errors in a promise chain.

### `useDeleteThread.ts`
1. Updated the `useDeleteThread` function:
   - Added code to filter out the deleted thread and update the thread state accordingly.
   - Added a `.catch(console.error)` to handle errors in a promise chain.

These changes aim to streamline the code and improve error handling.
