### PR TITLE
fix: cleaning a thread should just clear out messages

### DIFF
--- a/extensions/conversational-extension/src/index.ts
+++ b/extensions/conversational-extension/src/index.ts
@@ -147,7 +147,9 @@ export default class CortexConversationalExtension extends ConversationalExtensi
    */
   async getThreadAssistant(threadId: string): Promise<ThreadAssistantInfo> {
     return this.queue.add(() =>
-      ky.get(`${API_URL}/v1/assistants/${threadId}?limit=-1`).json<ThreadAssistantInfo>()
+      ky
+        .get(`${API_URL}/v1/assistants/${threadId}?limit=-1`)
+        .json<ThreadAssistantInfo>()
     ) as Promise<ThreadAssistantInfo>
   }
   /**
@@ -188,7 +190,7 @@ export default class CortexConversationalExtension extends ConversationalExtensi
    * Do health check on cortex.cpp
    * @returns
    */
-  healthz(): Promise<void> {
+  async healthz(): Promise<void> {
     return ky
       .get(`${API_URL}/healthz`, {
         retry: { limit: 20, delay: () => 500, methods: ['get'] },

--- a/web/helpers/atoms/Thread.atom.ts
+++ b/web/helpers/atoms/Thread.atom.ts
@@ -126,6 +126,26 @@ export const waitingToSendMessage = atom<boolean | undefined>(undefined)
 export const isGeneratingResponseAtom = atom<boolean | undefined>(undefined)
 
 /**
+ * Create a new thread and add it to the thread list
+ */
+export const createNewThreadAtom = atom(null, (get, set, newThread: Thread) => {
+  // create thread state for this new thread
+  const currentState = { ...get(threadStatesAtom) }
+
+  const threadState: ThreadState = {
+    hasMore: false,
+    waitingForResponse: false,
+    lastMessage: undefined,
+  }
+  currentState[newThread.id] = threadState
+  set(threadStatesAtom, currentState)
+
+  // add the new thread on top of the thread list to the state
+  const threads = get(threadsAtom)
+  set(threadsAtom, [newThread, ...threads])
+})
+
+/**
  * Remove a thread state from the atom
  */
 export const deleteThreadStateAtom = atom(

--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -33,28 +33,11 @@ import { activeAssistantAtom } from '@/helpers/atoms/Assistant.atom'
 import { selectedModelAtom } from '@/helpers/atoms/Model.atom'
 import {
   threadsAtom,
-  threadStatesAtom,
   updateThreadAtom,
   setThreadModelParamsAtom,
   isGeneratingResponseAtom,
+  createNewThreadAtom,
 } from '@/helpers/atoms/Thread.atom'
-
-const createNewThreadAtom = atom(null, (get, set, newThread: Thread) => {
-  // create thread state for this new thread
-  const currentState = { ...get(threadStatesAtom) }
-
-  const threadState: ThreadState = {
-    hasMore: false,
-    waitingForResponse: false,
-    lastMessage: undefined,
-  }
-  currentState[newThread.id] = threadState
-  set(threadStatesAtom, currentState)
-
-  // add the new thread on top of the thread list to the state
-  const threads = get(threadsAtom)
-  set(threadsAtom, [newThread, ...threads])
-})
 
 export const useCreateNewThread = () => {
   const createNewThread = useSetAtom(createNewThreadAtom)

--- a/web/hooks/useDeleteThread.test.ts
+++ b/web/hooks/useDeleteThread.test.ts
@@ -55,17 +55,21 @@ describe('useDeleteThread', () => {
     const mockCleanMessages = jest.fn()
     ;(useSetAtom as jest.Mock).mockReturnValue(() => mockCleanMessages)
     ;(useAtomValue as jest.Mock).mockReturnValue(['thread 1'])
-    const mockCreateNewThread = jest.fn()
-    ;(useCreateNewThread as jest.Mock).mockReturnValue({
-      requestCreateNewThread: mockCreateNewThread,
-    })
 
     const mockSaveThread = jest.fn()
-    const mockDeleteThread = jest.fn().mockResolvedValue({})
+    const mockDeleteMessage = jest.fn().mockResolvedValue({})
+    const mockModifyThread = jest.fn().mockResolvedValue({})
     extensionManager.get = jest.fn().mockReturnValue({
       saveThread: mockSaveThread,
       getThreadAssistant: jest.fn().mockResolvedValue({}),
-      deleteThread: mockDeleteThread,
+      listMessages: jest.fn().mockResolvedValue([
+        {
+          id: 'message1',
+          text: 'Message 1',
+        },
+      ]),
+      deleteMessage: mockDeleteMessage,
+      modifyThread: mockModifyThread,
     })
 
     const { result } = renderHook(() => useDeleteThread())
@@ -74,8 +78,8 @@ describe('useDeleteThread', () => {
       await result.current.cleanThread('thread1')
     })
 
-    expect(mockDeleteThread).toHaveBeenCalled()
-    expect(mockCreateNewThread).toHaveBeenCalled()
+    expect(mockDeleteMessage).toHaveBeenCalled()
+    expect(mockModifyThread).toHaveBeenCalled()
   })
 
   it('should handle errors when deleting a thread', async () => {

--- a/web/hooks/useDeleteThread.ts
+++ b/web/hooks/useDeleteThread.ts
@@ -2,19 +2,15 @@ import { useCallback } from 'react'
 
 import { ExtensionTypeEnum, ConversationalExtension } from '@janhq/core'
 
-import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { useAtom, useSetAtom } from 'jotai'
 
 import { currentPromptAtom } from '@/containers/Providers/Jotai'
 
 import { toaster } from '@/containers/Toast'
 
-import { useCreateNewThread } from './useCreateNewThread'
-
 import { extensionManager } from '@/extension/ExtensionManager'
 
-import { assistantsAtom } from '@/helpers/atoms/Assistant.atom'
 import { deleteChatMessageAtom as deleteChatMessagesAtom } from '@/helpers/atoms/ChatMessage.atom'
-import { downloadedModelsAtom } from '@/helpers/atoms/Model.atom'
 import {
   threadsAtom,
   setActiveThreadIdAtom,


### PR DESCRIPTION
## Describe Your Changes

- Fixed an issue where the legacy implementation of thread cleaning no longer worked. Now, cleaning a thread clears messages and resets its metadata.

![CleanShot 2024-12-23 at 11 38 43](https://github.com/user-attachments/assets/fb900cce-f57c-4adb-9146-721b2d3f477b)


## Fixes Issues

- #4291
## Changes made
The code changes in the pull request include the following updates:

1. **`extensions/conversational-extension/src/index.ts`**:
   - Reformatted the code for better readability by splitting a chained method call across multiple lines.
   - Changed the `healthz` method to be `async`.

2. **`web/helpers/atoms/Thread.atom.ts`**:
   - Added a new atom `createNewThreadAtom` for creating a new thread and adding it to the thread list.

3. **`web/hooks/useCreateNewThread.ts`**:
   - Removed the inline definition of `createNewThreadAtom` and imported it from `Thread.atom.ts`.

4. **`web/hooks/useDeleteThread.test.ts`**:
   - Updated mock functions to reflect changes in the actual code.
   - Renamed `mockDeleteThread` to `mockDeleteMessage` and added `mockModifyThread`.

5. **`web/hooks/useDeleteThread.ts`**:
   - Replaced the deletion of entire thread states with deletion of individual messages within threads.
   - Added logic to update thread metadata and use the `modifyThread` method instead of `deleteThread`.

These changes improve code organization, enhance readability, and adjust the logic for handling threads and messages.
