### PR TITLE
fix: change theme settings do not work after relocated data folder

### DIFF
--- a/web/helpers/atoms/Setting.atom.ts
+++ b/web/helpers/atoms/Setting.atom.ts
@@ -20,12 +20,7 @@ export const CHAT_WIDTH = 'chatWidth'
 export const themesOptionsAtom = atomWithStorage<
   { name: string; value: string }[]
 >(THEME_OPTIONS, [], undefined, { getOnInit: true })
-export const janThemesPathAtom = atomWithStorage<string | undefined>(
-  THEME_PATH,
-  undefined,
-  undefined,
-  { getOnInit: true }
-)
+
 export const selectedThemeIdAtom = atomWithStorage<string>(
   THEME,
   '',

--- a/web/screens/Settings/Appearance/index.tsx
+++ b/web/screens/Settings/Appearance/index.tsx
@@ -8,9 +8,10 @@ import { useAtom, useAtomValue } from 'jotai'
 
 import { twMerge } from 'tailwind-merge'
 
+import { janDataFolderPathAtom } from '@/helpers/atoms/AppConfig.atom'
+
 import {
   chatWidthAtom,
-  janThemesPathAtom,
   reduceTransparentAtom,
   selectedThemeIdAtom,
   spellCheckAtom,
@@ -21,8 +22,8 @@ import {
 export default function AppearanceOptions() {
   const [selectedIdTheme, setSelectedIdTheme] = useAtom(selectedThemeIdAtom)
   const themeOptions = useAtomValue(themesOptionsAtom)
+  const janDataFolderPath = useAtomValue(janDataFolderPathAtom)
   const { setTheme, theme } = useTheme()
-  const janThemesPath = useAtomValue(janThemesPathAtom)
   const [themeData, setThemeData] = useAtom(themeDataAtom)
   const [reduceTransparent, setReduceTransparent] = useAtom(
     reduceTransparentAtom
@@ -48,6 +49,7 @@ export default function AppearanceOptions() {
   const handleClickTheme = useCallback(
     async (e: string) => {
       setSelectedIdTheme(e)
+      const janThemesPath = await joinPath([janDataFolderPath, 'themes'])
       const filePath = await joinPath([`${janThemesPath}/${e}`, `theme.json`])
       const theme: Theme = JSON.parse(await fs.readFileSync(filePath, 'utf-8'))
       setThemeData(theme)
@@ -59,7 +61,7 @@ export default function AppearanceOptions() {
       }
     },
     [
-      janThemesPath,
+      janDataFolderPath,
       reduceTransparent,
       setReduceTransparent,
       setSelectedIdTheme,


### PR DESCRIPTION
## Describe Your Changes

- Fixed an issue where changing the theme did not work after relocating the data folder. Theme settings were cached to avoid glitches during app launch, but the settings page used unnecessary cached states.

## Fixes Issues

- #4291

## Changes made

This pull request includes several changes to the theme loading functionality in the project. The main changes involve the removal of the `janThemesPathAtom` and the introduction of a new `applyTheme` function to streamline the application of theme variables. Below are the most important changes grouped by theme.

### Removal of `janThemesPathAtom`:

* [`web/helpers/atoms/Setting.atom.ts`](diffhunk://#diff-fe970dc673b247de554e793d3e1a453f1456278107ae53a390229595621c4384L23-R23): Removed the `janThemesPathAtom` export.
* [`web/hooks/useLoadTheme.ts`](diffhunk://#diff-ebfeebc079f299318f7ca32d33c9a99115774693cde0aa06ec9d6ef6ea97177aL13): Removed references to `janThemesPathAtom` in the `useLoadTheme` hook. [[1]](diffhunk://#diff-ebfeebc079f299318f7ca32d33c9a99115774693cde0aa06ec9d6ef6ea97177aL13) [[2]](diffhunk://#diff-ebfeebc079f299318f7ca32d33c9a99115774693cde0aa06ec9d6ef6ea97177aL24) [[3]](diffhunk://#diff-ebfeebc079f299318f7ca32d33c9a99115774693cde0aa06ec9d6ef6ea97177aL62) [[4]](diffhunk://#diff-ebfeebc079f299318f7ca32d33c9a99115774693cde0aa06ec9d6ef6ea97177aL84-R99)
* [`web/screens/Settings/Appearance/index.tsx`](diffhunk://#diff-bef365c7204ef5ec9137caff2e9d85a8fbf5a4b9629387968612b3bb84ea9e1bR11-L13): Removed references to `janThemesPathAtom` and replaced it with `janDataFolderPathAtom`. [[1]](diffhunk://#diff-bef365c7204ef5ec9137caff2e9d85a8fbf5a4b9629387968612b3bb84ea9e1bR11-L13) [[2]](diffhunk://#diff-bef365c7204ef5ec9137caff2e9d85a8fbf5a4b9629387968612b3bb84ea9e1bR25-L25) [[3]](diffhunk://#diff-bef365c7204ef5ec9137caff2e9d85a8fbf5a4b9629387968612b3bb84ea9e1bL62-R64)

### Introduction of `applyTheme` function:

* [`web/hooks/useLoadTheme.ts`](diffhunk://#diff-ebfeebc079f299318f7ca32d33c9a99115774693cde0aa06ec9d6ef6ea97177aR42-R49): Added a new `applyTheme` function to handle the application of CSS variables for themes, replacing inline code with a function call. [[1]](diffhunk://#diff-ebfeebc079f299318f7ca32d33c9a99115774693cde0aa06ec9d6ef6ea97177aR42-R49) [[2]](diffhunk://#diff-ebfeebc079f299318f7ca32d33c9a99115774693cde0aa06ec9d6ef6ea97177aL71-R76) [[3]](diffhunk://#diff-ebfeebc079f299318f7ca32d33c9a99115774693cde0aa06ec9d6ef6ea97177aL84-R99)

These changes improve the maintainability and readability of the theme loading code by removing redundant atoms and encapsulating theme application logic within a dedicated function.