### PR TITLE
fix: threads sorting order after updated

### DIFF
--- a/web/helpers/atoms/Thread.atom.ts
+++ b/web/helpers/atoms/Thread.atom.ts
@@ -200,12 +200,12 @@ export const updateThreadAtom = atom(
     )
 
     // sort new threads based on updated at
-    threads.sort((thread1, thread2) => {
-      const aDate = new Date(thread1.updated ?? 0)
-      const bDate = new Date(thread2.updated ?? 0)
-      return bDate.getTime() - aDate.getTime()
+    threads.sort((a, b) => {
+      return ((a.metadata?.updated_at as number) ?? 0) >
+        ((b.metadata?.updated_at as number) ?? 0)
+        ? -1
+        : 1
     })
-
     set(threadsAtom, threads)
   }
 )


### PR DESCRIPTION
## Describe Your Changes

This PR fixed an issue where threads are sorted incorrectly after updated a certain thread.

![CleanShot 2024-12-23 at 13 26 12](https://github.com/user-attachments/assets/06805503-6626-4094-89ce-9ae129d7c2dd)


## Fixes Issues

- #4291
## Changes made
This pull request includes various updates across multiple files to enhance the functionality and maintainability of the project. The most significant changes include modifications to API requests, updates to the model configurations, improvements to the thread handling logic, and adjustments to the theme management.

### API Request Updates:
* [`extensions/conversational-extension/src/index.ts`](diffhunk://#diff-8556eacb45b5ef692a9d500744d6cacad5f2660bc457a83281b79eb9cb3751cbL43-R43): Updated API requests to include a `limit=-1` parameter for fetching threads, messages, and assistant info. [[1]](diffhunk://#diff-8556eacb45b5ef692a9d500744d6cacad5f2660bc457a83281b79eb9cb3751cbL43-R43) [[2]](diffhunk://#diff-8556eacb45b5ef692a9d500744d6cacad5f2660bc457a83281b79eb9cb3751cbL136-R136) [[3]](diffhunk://#diff-8556eacb45b5ef692a9d500744d6cacad5f2660bc457a83281b79eb9cb3751cbL150-R152)
* [`extensions/model-extension/src/cortex.ts`](diffhunk://#diff-a69fb65b826c2074b66e3cf3c814dbec098b3af170a1cc487336300be17b5db5L56-R56): Added `limit=-1` parameter to the `getModels` API request.

### Model Configuration:
* [`extensions/inference-openai-extension/resources/models.json`](diffhunk://#diff-6be9f295baf83d9d549776e1c581e62f24fb48c3bbb0d2c9b6231e0d913b214bR88-R144): Added new models "OpenAI GPT 4o-mini" and "OpenAI o1" with their respective configurations.

### Thread Handling Improvements:
* [`web/helpers/atoms/Thread.atom.ts`](diffhunk://#diff-4d7af9a9bba964e4d35729b2cdafe1ac8c4d6a7fd7eae7ed2c680f67bdc3a15cR128-R147): Introduced `createNewThreadAtom` to manage the creation of new threads.
* [`web/hooks/useCreateNewThread.ts`](diffhunk://#diff-11adf34745ca476ecb45f143cb48d7ceb507793be060729acb9b0708ee3fd6ceL36-L58): Refactored to utilize the new `createNewThreadAtom` for thread creation. [[1]](diffhunk://#diff-11adf34745ca476ecb45f143cb48d7ceb507793be060729acb9b0708ee3fd6ceL36-L58) [[2]](diffhunk://#diff-11adf34745ca476ecb45f143cb48d7ceb507793be060729acb9b0708ee3fd6ceR139)
* [`web/hooks/useDeleteThread.ts`](diffhunk://#diff-3ffd0d3a7599a887a37bf1c222a222baf9f5e45c473d12711a7831272f92b254L5-R23): Updated the thread deletion logic to handle messages and modify threads instead of deleting them outright. [[1]](diffhunk://#diff-3ffd0d3a7599a887a37bf1c222a222baf9f5e45c473d12711a7831272f92b254L5-R23) [[2]](diffhunk://#diff-3ffd0d3a7599a887a37bf1c222a222baf9f5e45c473d12711a7831272f92b254L38-R63)

### Theme Management:
* [`web/hooks/useLoadTheme.ts`](diffhunk://#diff-ebfeebc079f299318f7ca32d33c9a99115774693cde0aa06ec9d6ef6ea97177aL13): Removed `janThemesPathAtom` and refactored theme application logic into a separate `applyTheme` function. [[1]](diffhunk://#diff-ebfeebc079f299318f7ca32d33c9a99115774693cde0aa06ec9d6ef6ea97177aL13) [[2]](diffhunk://#diff-ebfeebc079f299318f7ca32d33c9a99115774693cde0aa06ec9d6ef6ea97177aL24) [[3]](diffhunk://#diff-ebfeebc079f299318f7ca32d33c9a99115774693cde0aa06ec9d6ef6ea97177aR42-R49) [[4]](diffhunk://#diff-ebfeebc079f299318f7ca32d33c9a99115774693cde0aa06ec9d6ef6ea97177aL62) [[5]](diffhunk://#diff-ebfeebc079f299318f7ca32d33c9a99115774693cde0aa06ec9d6ef6ea97177aL71-R76) [[6]](diffhunk://#diff-ebfeebc079f299318f7ca32d33c9a99115774693cde0aa06ec9d6ef6ea97177aL84-R99)

### Miscellaneous:
* [`web/containers/ModelDropdown/index.tsx`](diffhunk://#diff-897fe0e9366de0fa6ec9428b1423439aaab3dee774cea4b7efd6401a42fb00fbL381-R388): Updated placeholder text to "Select a model".
* [`web/hooks/useThreads.ts`](diffhunk://#diff-a74fcb0fca997e136784a396ad1cb028d85ade9e7a91ee336ba78abc52c32989L29-R34): Sorted threads by `updated_at` metadata.
* [`web/package.json`](diffhunk://#diff-b861012a5dd72b8a9f3281b7cf09f5a779c98569d040b1bbc1db50f1b15e7cceL3-R3): Bumped version from 0.5.11 to 0.5.12.
