### PR TITLE
fix: update thread's title edge cases

### DIFF
--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -191,9 +191,11 @@ export const useCreateNewThread = () => {
     async (thread: Thread) => {
       updateThread(thread)
 
-      setActiveAssistant(thread.assistants[0])
       updateThreadCallback(thread)
-      updateAssistantCallback(thread.id, thread.assistants[0])
+      if (thread.assistants && thread.assistants?.length > 0) {
+        setActiveAssistant(thread.assistants[0])
+        updateAssistantCallback(thread.id, thread.assistants[0])
+      }
     },
     [
       updateThread,


### PR DESCRIPTION
## Describe Your Changes

- Fixed an issue where editing the titles of other threads might not work due to incorrect assistant accessibility for the thread.

## Self Checklist
This pull request includes a small but important change to the `useCreateNewThread` hook in the `web/hooks/useCreateNewThread.ts` file. The change ensures that the `setActiveAssistant` function is only called if the `thread.assistants` array is not empty, which prevents potential errors when the array is empty or undefined.

* [`web/hooks/useCreateNewThread.ts`](diffhunk://#diff-11adf34745ca476ecb45f143cb48d7ceb507793be060729acb9b0708ee3fd6ceL194-R198): Updated the `useCreateNewThread` hook to check if `thread.assistants` is non-empty before calling `setActiveAssistant` and `updateAssistantCallback`.
