### PR TITLE
fix: app picks model automatically edge cases

### DIFF
--- a/web/containers/ModelDropdown/index.tsx
+++ b/web/containers/ModelDropdown/index.tsx
@@ -183,10 +183,7 @@ const ModelDropdown = ({
     if (!activeThread) return
     const modelId = activeAssistant?.model?.id
 
-    let model = downloadedModels.find((model) => model.id === modelId)
-    if (!model) {
-      model = undefined
-    }
+    const model = downloadedModels.find((model) => model.id === modelId)
     setSelectedModel(model)
   }, [
     recommendedModel,

--- a/web/hooks/useDeleteThread.ts
+++ b/web/hooks/useDeleteThread.ts
@@ -8,6 +8,8 @@ import { currentPromptAtom } from '@/containers/Providers/Jotai'
 
 import { toaster } from '@/containers/Toast'
 
+import useSetActiveThread from './useSetActiveThread'
+
 import { extensionManager } from '@/extension/ExtensionManager'
 
 import { deleteChatMessageAtom as deleteChatMessagesAtom } from '@/helpers/atoms/ChatMessage.atom'
@@ -27,6 +29,7 @@ export default function useDeleteThread() {
   const deleteMessages = useSetAtom(deleteChatMessagesAtom)
 
   const deleteThreadState = useSetAtom(deleteThreadStateAtom)
+  const { setActiveThread } = useSetActiveThread()
 
   const cleanThread = useCallback(
     async (threadId: string) => {
@@ -86,7 +89,7 @@ export default function useDeleteThread() {
       type: 'success',
     })
     if (availableThreads.length > 0) {
-      setActiveThreadId(availableThreads[0].id)
+      setActiveThread(availableThreads[0])
     } else {
       setActiveThreadId(undefined)
     }

--- a/web/screens/Thread/ThreadRightPanel/Tools/index.tsx
+++ b/web/screens/Thread/ThreadRightPanel/Tools/index.tsx
@@ -32,12 +32,9 @@ const Tools = () => {
 
   useEffect(() => {
     if (!activeThread) return
-    let model = downloadedModels.find(
+    const model = downloadedModels.find(
       (model) => model.id === activeAssistant?.model.id
     )
-    if (!model) {
-      model = recommendedModel
-    }
     setSelectedModel(model)
   }, [
     recommendedModel,


### PR DESCRIPTION
## Describe Your Changes

Fixed an issue where deleted models were not handled gracefully. However, there are still edge cases where users could change tool settings or delete a new thread, causing the app to automatically assign a new model to older threads with deleted models.

![CleanShot 2024-12-23 at 15 19 28](https://github.com/user-attachments/assets/aba98564-03cc-45c6-bdae-9b12f53d06e0)

## Fixes Issues

- #4291

## Changes made

This pull request includes several changes to improve the handling of model selection and thread management in the web application. The most important changes include refactoring the code to simplify model selection and updating the thread deletion logic to use a new hook.

Improvements to model selection:

* [`web/containers/ModelDropdown/index.tsx`](diffhunk://#diff-897fe0e9366de0fa6ec9428b1423439aaab3dee774cea4b7efd6401a42fb00fbL186-R186): Simplified the logic for finding and setting the selected model by removing unnecessary conditional checks.
* [`web/screens/Thread/ThreadRightPanel/Tools/index.tsx`](diffhunk://#diff-0386ee47e96749a416392d0b8170050daae8d8af497fb09cb15cbe413cfa9c5aL35-L40): Refactored the model selection logic to directly set the selected model without additional checks.

Enhancements to thread management:

* [`web/hooks/useDeleteThread.ts`](diffhunk://#diff-3ffd0d3a7599a887a37bf1c222a222baf9f5e45c473d12711a7831272f92b254R11-R12): Added `useSetActiveThread` hook to manage the active thread state and updated the `cleanThread` function to use this new hook. [[1]](diffhunk://#diff-3ffd0d3a7599a887a37bf1c222a222baf9f5e45c473d12711a7831272f92b254R11-R12) [[2]](diffhunk://#diff-3ffd0d3a7599a887a37bf1c222a222baf9f5e45c473d12711a7831272f92b254R32) [[3]](diffhunk://#diff-3ffd0d3a7599a887a37bf1c222a222baf9f5e45c473d12711a7831272f92b254L89-R92)
