### PR TITLE
fix: scroll bottom when generation text

### DIFF
--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
@@ -87,22 +87,16 @@ const ChatBody = memo(
 
     useEffect(() => {
       if (parentRef.current && isGeneratingResponse) {
-        requestAnimationFrame(() => {
-          if (parentRef.current) {
-            parentRef.current.scrollTo({ top: parentRef.current.scrollHeight })
-          }
-        })
+        parentRef.current.scrollTo({ top: parentRef.current.scrollHeight })
       }
-    }, [count, virtualizer, isGeneratingResponse])
+    }, [count, virtualizer, isGeneratingResponse, currentThread?.id])
 
     useEffect(() => {
       isUserManuallyScrollingUp.current = false
-      requestAnimationFrame(() => {
-        if (parentRef.current) {
-          parentRef.current.scrollTo({ top: parentRef.current.scrollHeight })
-          virtualizer.scrollToIndex(count - 1)
-        }
-      })
+      if (parentRef.current) {
+        parentRef.current.scrollTo({ top: parentRef.current.scrollHeight })
+        virtualizer.scrollToIndex(count - 1)
+      }
     }, [count, currentThread?.id, virtualizer])
 
     const items = virtualizer.getVirtualItems()

--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
@@ -88,6 +88,7 @@ const ChatBody = memo(
     useEffect(() => {
       if (parentRef.current && isGeneratingResponse) {
         parentRef.current.scrollTo({ top: parentRef.current.scrollHeight })
+        virtualizer.scrollToIndex(count - 1)
       }
     }, [count, virtualizer, isGeneratingResponse, currentThread?.id])
 

--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
@@ -86,6 +86,13 @@ const ChatBody = memo(
     })
 
     useEffect(() => {
+      if (parentRef.current) {
+        parentRef.current.scrollTo({ top: parentRef.current.scrollHeight })
+        virtualizer.scrollToIndex(count - 1)
+      }
+    }, [count, virtualizer, currentThread?.id])
+
+    useEffect(() => {
       if (parentRef.current && isGeneratingResponse) {
         parentRef.current.scrollTo({ top: parentRef.current.scrollHeight })
         virtualizer.scrollToIndex(count - 1)

--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
@@ -97,6 +97,13 @@ const ChatBody = memo(
         parentRef.current.scrollTo({ top: parentRef.current.scrollHeight })
         virtualizer.scrollToIndex(count - 1)
       }
+    }, [count, virtualizer, isGeneratingResponse])
+
+    useEffect(() => {
+      if (parentRef.current && isGeneratingResponse) {
+        parentRef.current.scrollTo({ top: parentRef.current.scrollHeight })
+        virtualizer.scrollToIndex(count - 1)
+      }
     }, [count, virtualizer, isGeneratingResponse, currentThread?.id])
 
     useEffect(() => {

--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
@@ -90,7 +90,7 @@ const ChatBody = memo(
         parentRef.current.scrollTo({ top: parentRef.current.scrollHeight })
         virtualizer.scrollToIndex(count - 1)
       }
-    }, [count, virtualizer, currentThread?.id])
+    }, [count, virtualizer])
 
     useEffect(() => {
       if (parentRef.current && isGeneratingResponse) {


### PR DESCRIPTION
## Describe Your Changes

The changes in this Git diff can be summarized as follows:

1. **Use of `requestAnimationFrame`:**
   - Removed the `requestAnimationFrame` calls from two places where scrolling is performed. This was used to schedule the scroll operation to occur optimally in the browser's next repaint cycle.

2. **Direct Scrolling:**
   - The code now directly calls `scrollTo` on `parentRef.current` without wrapping it in a `requestAnimationFrame`. This may have been done to simplify the logic or because the timing provided by `requestAnimationFrame` wasn't necessary.

3. **Dependency Array Modifications in `useEffect`:**
   - Added `currentThread?.id` to the dependency array of both `useEffect` hooks. This ensures that the effects are re-executed whenever `currentThread?.id` changes, which might be to ensure that the scrolling logic considers a change in the thread being viewed.

4. **Code Simplification:**
   - The changes result in simpler effect logic by removing the additional `requestAnimationFrame` wrapping, under the assumption that immediate execution provides the desired behavior without visual issues like jank.

Overall, these changes simplify the scrolling logic in the `ChatBody` component by removing unnecessary scheduling of the scroll operation and making the effects more responsive to changes in the `currentThread`.

## Fixes Issues

- Closes https://github.com/janhq/jan/issues/4291#issuecomment-2559059304
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
