### PR TITLE
fix: disabled native resize textarea when textarea autogrowing

### DIFF
--- a/joi/src/core/TextArea/index.tsx
+++ b/joi/src/core/TextArea/index.tsx
@@ -34,7 +34,11 @@ const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
     return (
       <div className="textarea__wrapper">
         <textarea
-          className={twMerge('textarea', className)}
+          className={twMerge(
+            'textarea',
+            className,
+            autoResize && 'resize-none'
+          )}
           ref={autoResize ? textareaRef : ref}
           {...props}
         />

--- a/web/screens/Thread/ThreadRightPanel/index.tsx
+++ b/web/screens/Thread/ThreadRightPanel/index.tsx
@@ -257,7 +257,7 @@ const ThreadRightPanel = () => {
                 id="assistant-instructions"
                 placeholder="Eg. You are a helpful assistant."
                 value={activeAssistant?.instructions ?? ''}
-                autoResize
+                // autoResize
                 onChange={onAssistantInstructionChanged}
               />
             </div>


### PR DESCRIPTION
## Describe Your Changes

- Disbaled resize native textarea when we use autogrowing

![CleanShot 2024-12-23 at 19 12 17](https://github.com/user-attachments/assets/245ffa92-6cc0-4fac-bb26-f838d207356c)

![CleanShot 2024-12-23 at 19 11 54](https://github.com/user-attachments/assets/47e25825-3bdc-4a58-9db1-b670ebbecacd)

## Fixes Issues

- Closes https://github.com/janhq/jan/issues/4291#issuecomment-2553433359
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
