### PR TITLE
fix: send message button state reset on stop

### DIFF
--- a/web/helpers/atoms/Thread.atom.ts
+++ b/web/helpers/atoms/Thread.atom.ts
@@ -174,6 +174,21 @@ export const updateThreadWaitingForResponseAtom = atom(
 )
 
 /**
+ * Reset the thread waiting for response state
+ */
+export const resetThreadWaitingForResponseAtom = atom(null, (get, set) => {
+  const currentState = { ...get(threadStatesAtom) }
+  Object.keys(currentState).forEach((threadId) => {
+    currentState[threadId] = {
+      ...currentState[threadId],
+      waitingForResponse: false,
+      error: undefined,
+    }
+  })
+  set(threadStatesAtom, currentState)
+})
+
+/**
  * Update the thread last message
  */
 export const updateThreadStateLastMessageAtom = atom(

--- a/web/hooks/useActiveModel.ts
+++ b/web/hooks/useActiveModel.ts
@@ -10,6 +10,10 @@ import { LAST_USED_MODEL_ID } from './useRecommendedModel'
 import { vulkanEnabledAtom } from '@/helpers/atoms/AppConfig.atom'
 import { activeAssistantAtom } from '@/helpers/atoms/Assistant.atom'
 import { downloadedModelsAtom } from '@/helpers/atoms/Model.atom'
+import {
+  isGeneratingResponseAtom,
+  resetThreadWaitingForResponseAtom,
+} from '@/helpers/atoms/Thread.atom'
 
 export const activeModelAtom = atom<Model | undefined>(undefined)
 export const loadModelErrorAtom = atom<string | undefined>(undefined)
@@ -34,6 +38,10 @@ export function useActiveModel() {
   const pendingModelLoad = useRef(false)
   const isVulkanEnabled = useAtomValue(vulkanEnabledAtom)
   const activeAssistant = useAtomValue(activeAssistantAtom)
+  const setGeneratingResponse = useSetAtom(isGeneratingResponseAtom)
+  const resetThreadWaitingForResponseState = useSetAtom(
+    resetThreadWaitingForResponseAtom
+  )
 
   const downloadedModelsRef = useRef<Model[]>([])
 
@@ -139,6 +147,8 @@ export function useActiveModel() {
         return
 
       const engine = EngineManager.instance().get(stoppingModel.engine)
+      setGeneratingResponse(false)
+      resetThreadWaitingForResponseState()
       return engine
         ?.unloadModel(stoppingModel)
         .catch((e) => console.error(e))
@@ -148,7 +158,14 @@ export function useActiveModel() {
           pendingModelLoad.current = false
         })
     },
-    [activeModel, setStateModel, setActiveModel, stateModel]
+    [
+      activeModel,
+      setStateModel,
+      setActiveModel,
+      stateModel,
+      setGeneratingResponse,
+      resetThreadWaitingForResponseState,
+    ]
   )
 
   const stopInference = useCallback(async () => {

--- a/web/hooks/useDeleteThread.ts
+++ b/web/hooks/useDeleteThread.ts
@@ -48,6 +48,7 @@ export default function useDeleteThread() {
         if (thread) {
           const updatedThread = {
             ...thread,
+            title: 'New Thread',
             metadata: {
               ...thread.metadata,
               title: 'New Thread',

--- a/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
@@ -302,9 +302,7 @@ const ChatInput = () => {
               </div>
             )}
 
-            {messages[messages.length - 1]?.status !== MessageStatus.Pending &&
-            !isGeneratingResponse &&
-            !isStreamingResponse ? (
+            {!isGeneratingResponse && !isStreamingResponse ? (
               <>
                 {currentPrompt.length !== 0 && (
                   <Button


### PR DESCRIPTION
## Describe Your Changes

This PR addresses the issue where stopping a model mid-generation can cause the stop button to remain in the generating state.

## Changes made
This pull request includes changes to improve the handling of thread states and model management in the application. The key changes involve adding a new atom to reset the thread waiting for response state and updating the `useActiveModel` hook to incorporate this reset functionality.

Improvements to thread state management:

* [`web/helpers/atoms/Thread.atom.ts`](diffhunk://#diff-4d7af9a9bba964e4d35729b2cdafe1ac8c4d6a7fd7eae7ed2c680f67bdc3a15cR176-R190): Added `resetThreadWaitingForResponseAtom` to reset the waiting for response state of threads.
* [`web/hooks/useActiveModel.ts`](diffhunk://#diff-3b4961cb78a2f54ecdeb49e921fd543e45ced1c8b5a12edc12e2c6f324f54d56R13-R16): Imported `resetThreadWaitingForResponseAtom` and used it in the `useActiveModel` hook to reset the thread waiting for response state when stopping a model. [[1]](diffhunk://#diff-3b4961cb78a2f54ecdeb49e921fd543e45ced1c8b5a12edc12e2c6f324f54d56R13-R16) [[2]](diffhunk://#diff-3b4961cb78a2f54ecdeb49e921fd543e45ced1c8b5a12edc12e2c6f324f54d56R41-R44) [[3]](diffhunk://#diff-3b4961cb78a2f54ecdeb49e921fd543e45ced1c8b5a12edc12e2c6f324f54d56R150-R151) [[4]](diffhunk://#diff-3b4961cb78a2f54ecdeb49e921fd543e45ced1c8b5a12edc12e2c6f324f54d56L151-R168)

UI updates:

* [`web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx`](diffhunk://#diff-6939e74c6339668f085c4edb1a90987fea21a6e5679fa3ff95495629ba249b4aL305-R305): Simplified the condition for displaying the chat input button by removing the check for the last message's status.