### PR TITLE
chore: Refactor thread state management

### DIFF
--- a/web/containers/Providers/ModelHandler.tsx
+++ b/web/containers/Providers/ModelHandler.tsx
@@ -56,7 +56,7 @@ export default function ModelHandler() {
   const activeModel = useAtomValue(activeModelAtom)
   const setActiveModel = useSetAtom(activeModelAtom)
   const setStateModel = useSetAtom(stateModelAtom)
-  const [subscribedGeneratingMessage, setSubscribedGeneratingMessage] = useAtom(
+  const subscribedGeneratingMessage = useAtomValue(
     subscribedGeneratingMessageAtom
   )
   const activeThread = useAtomValue(activeThreadAtom)

--- a/web/helpers/atoms/Thread.atom.ts
+++ b/web/helpers/atoms/Thread.atom.ts
@@ -1,7 +1,7 @@
 import { Thread, ThreadContent, ThreadState } from '@janhq/core'
 
 import { atom } from 'jotai'
-import { atomWithStorage } from 'jotai/utils'
+import { atomWithStorage, selectAtom } from 'jotai/utils'
 
 import { ModelParams } from '@/types/model'
 
@@ -32,6 +32,22 @@ enum ThreadStorageAtomKeys {
 export const threadStatesAtom = atomWithStorage<Record<string, ThreadState>>(
   ThreadStorageAtomKeys.ThreadStates,
   {}
+)
+
+/**
+ * Returns whether there is a thread waiting for response or not
+ */
+const isWaitingForResponseAtom = selectAtom(threadStatesAtom, (threads) =>
+  Object.values(threads).some((t) => t.waitingForResponse)
+)
+
+/**
+ * Combine 2 states to reduce rerender
+ * 1. isWaitingForResponse
+ * 2. isGenerating
+ */
+export const isBlockingSendAtom = atom(
+  (get) => get(isWaitingForResponseAtom) || get(isGeneratingResponseAtom)
 )
 
 /**

--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
@@ -16,8 +16,7 @@ import EmptyThread from './EmptyThread'
 import { getCurrentChatMessagesAtom } from '@/helpers/atoms/ChatMessage.atom'
 import {
   activeThreadAtom,
-  isGeneratingResponseAtom,
-  threadStatesAtom,
+  isBlockingSendAtom,
 } from '@/helpers/atoms/Thread.atom'
 
 const ChatConfigurator = memo(() => {
@@ -65,12 +64,7 @@ const ChatBody = memo(
     const prevScrollTop = useRef(0)
     const isUserManuallyScrollingUp = useRef(false)
     const currentThread = useAtomValue(activeThreadAtom)
-    const threadStates = useAtomValue(threadStatesAtom)
-    const isGeneratingResponse = useAtomValue(isGeneratingResponseAtom)
-
-    const isStreamingResponse = Object.values(threadStates).some(
-      (threadState) => threadState.waitingForResponse
-    )
+    const isBlockingSend = useAtomValue(isBlockingSendAtom)
 
     const count = useMemo(
       () => (messages?.length ?? 0) + (loadModelError ? 1 : 0),
@@ -95,19 +89,19 @@ const ChatBody = memo(
 
     useEffect(() => {
       isUserManuallyScrollingUp.current = false
-      if (parentRef.current && isGeneratingResponse) {
+      if (parentRef.current && isBlockingSend) {
         parentRef.current.scrollTo({ top: parentRef.current.scrollHeight })
         virtualizer.scrollToIndex(count - 1)
       }
-    }, [count, virtualizer, isGeneratingResponse])
+    }, [count, virtualizer, isBlockingSend])
 
     useEffect(() => {
       isUserManuallyScrollingUp.current = false
-      if (parentRef.current && isGeneratingResponse) {
+      if (parentRef.current && isBlockingSend) {
         parentRef.current.scrollTo({ top: parentRef.current.scrollHeight })
         virtualizer.scrollToIndex(count - 1)
       }
-    }, [count, virtualizer, isGeneratingResponse, currentThread?.id])
+    }, [count, virtualizer, isBlockingSend, currentThread?.id])
 
     useEffect(() => {
       isUserManuallyScrollingUp.current = false
@@ -124,7 +118,7 @@ const ChatBody = memo(
       _,
       instance
     ) => {
-      if (isUserManuallyScrollingUp.current === true && isStreamingResponse)
+      if (isUserManuallyScrollingUp.current === true && isBlockingSend)
         return false
       return (
         // item.start < (instance.scrollOffset ?? 0) &&
@@ -136,7 +130,7 @@ const ChatBody = memo(
       (event: React.UIEvent<HTMLElement>) => {
         const currentScrollTop = event.currentTarget.scrollTop
 
-        if (prevScrollTop.current > currentScrollTop && isStreamingResponse) {
+        if (prevScrollTop.current > currentScrollTop && isBlockingSend) {
           isUserManuallyScrollingUp.current = true
         } else {
           const currentScrollTop = event.currentTarget.scrollTop
@@ -154,7 +148,7 @@ const ChatBody = memo(
         }
         prevScrollTop.current = currentScrollTop
       },
-      [isStreamingResponse]
+      [isBlockingSend]
     )
 
     return (

--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
@@ -81,35 +81,11 @@ const ChatBody = memo(
 
     useEffect(() => {
       isUserManuallyScrollingUp.current = false
-      if (parentRef.current) {
-        parentRef.current.scrollTo({ top: parentRef.current.scrollHeight })
-        virtualizer.scrollToIndex(count - 1)
-      }
-    }, [count, virtualizer])
-
-    useEffect(() => {
-      isUserManuallyScrollingUp.current = false
-      if (parentRef.current && isBlockingSend) {
-        parentRef.current.scrollTo({ top: parentRef.current.scrollHeight })
-        virtualizer.scrollToIndex(count - 1)
-      }
-    }, [count, virtualizer, isBlockingSend])
-
-    useEffect(() => {
-      isUserManuallyScrollingUp.current = false
       if (parentRef.current && isBlockingSend) {
         parentRef.current.scrollTo({ top: parentRef.current.scrollHeight })
         virtualizer.scrollToIndex(count - 1)
       }
     }, [count, virtualizer, isBlockingSend, currentThread?.id])
-
-    useEffect(() => {
-      isUserManuallyScrollingUp.current = false
-      if (parentRef.current) {
-        parentRef.current.scrollTo({ top: parentRef.current.scrollHeight })
-        virtualizer.scrollToIndex(count - 1)
-      }
-    }, [count, currentThread?.id, virtualizer])
 
     const items = virtualizer.getVirtualItems()
 

--- a/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
@@ -35,22 +35,19 @@ import RichTextEditor from './RichTextEditor'
 import { showRightPanelAtom } from '@/helpers/atoms/App.atom'
 import { experimentalFeatureEnabledAtom } from '@/helpers/atoms/AppConfig.atom'
 import { activeAssistantAtom } from '@/helpers/atoms/Assistant.atom'
-import { getCurrentChatMessagesAtom } from '@/helpers/atoms/ChatMessage.atom'
 import { selectedModelAtom } from '@/helpers/atoms/Model.atom'
 import { spellCheckAtom } from '@/helpers/atoms/Setting.atom'
 import {
   activeSettingInputBoxAtom,
   activeThreadAtom,
   getActiveThreadIdAtom,
-  isGeneratingResponseAtom,
-  threadStatesAtom,
+  isBlockingSendAtom,
 } from '@/helpers/atoms/Thread.atom'
 import { activeTabThreadRightPanelAtom } from '@/helpers/atoms/ThreadRightPanel.atom'
 
 const ChatInput = () => {
   const activeThread = useAtomValue(activeThreadAtom)
   const { stateModel } = useActiveModel()
-  const messages = useAtomValue(getCurrentChatMessagesAtom)
   const spellCheck = useAtomValue(spellCheckAtom)
 
   const [currentPrompt, setCurrentPrompt] = useAtom(currentPromptAtom)
@@ -67,18 +64,13 @@ const ChatInput = () => {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const imageInputRef = useRef<HTMLInputElement>(null)
   const experimentalFeature = useAtomValue(experimentalFeatureEnabledAtom)
-  const isGeneratingResponse = useAtomValue(isGeneratingResponseAtom)
-  const threadStates = useAtomValue(threadStatesAtom)
+  const isBlockingSend = useAtomValue(isBlockingSendAtom)
   const activeAssistant = useAtomValue(activeAssistantAtom)
   const { stopInference } = useActiveModel()
 
   const upload = uploader()
   const [activeTabThreadRightPanel, setActiveTabThreadRightPanel] = useAtom(
     activeTabThreadRightPanelAtom
-  )
-
-  const isStreamingResponse = Object.values(threadStates).some(
-    (threadState) => threadState.waitingForResponse
   )
 
   const refAttachmentMenus = useClickOutside(() => setShowAttacmentMenus(false))
@@ -302,7 +294,7 @@ const ChatInput = () => {
               </div>
             )}
 
-            {!isGeneratingResponse && !isStreamingResponse ? (
+            {!isBlockingSend ? (
               <>
                 {currentPrompt.length !== 0 && (
                   <Button

--- a/web/screens/Thread/ThreadCenterPanel/MessageToolbar/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/MessageToolbar/index.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/helpers/atoms/ChatMessage.atom'
 import {
   activeThreadAtom,
+  isBlockingSendAtom,
   updateThreadAtom,
   updateThreadStateLastMessageAtom,
 } from '@/helpers/atoms/Thread.atom'
@@ -43,6 +44,7 @@ const MessageToolbar = ({ message }: { message: ThreadMessage }) => {
   const clipboard = useClipboard({ timeout: 1000 })
   const updateThreadLastMessage = useSetAtom(updateThreadStateLastMessageAtom)
   const updateThread = useSetAtom(updateThreadAtom)
+  const isBlockingSend = useAtomValue(isBlockingSendAtom)
 
   const onDeleteClick = useCallback(async () => {
     deleteMessage(message.id ?? '')
@@ -91,7 +93,8 @@ const MessageToolbar = ({ message }: { message: ThreadMessage }) => {
     <div className="flex flex-row items-center">
       <div className="flex gap-1 bg-[hsla(var(--app-bg))]">
         {message.role === ChatCompletionRole.User &&
-          message.content[0]?.type === ContentType.Text && (
+          message.content[0]?.type === ContentType.Text &&
+          !isBlockingSend && (
             <div
               className="cursor-pointer rounded-lg border border-[hsla(var(--app-border))] p-2"
               onClick={onEditClick}
@@ -110,7 +113,8 @@ const MessageToolbar = ({ message }: { message: ThreadMessage }) => {
 
         {message.id === messages[messages.length - 1]?.id &&
           !messages[messages.length - 1]?.metadata?.error &&
-          !messages[messages.length - 1].attachments?.length && (
+          !messages[messages.length - 1].attachments?.length &&
+          !isBlockingSend && (
             <div
               className="cursor-pointer rounded-lg border border-[hsla(var(--app-border))] p-2"
               onClick={resendChatMessage}


### PR DESCRIPTION
## Describe Your Changes

• Combined isGeneratingResponseAtom & isWaitingForResponse with isBlockingSendAtom 
• Update dependencies in ChatBody, ChatInput, and MessageToolbar components 
• Remove unused code and variables
• Avoid unnecessary rerendering

![CleanShot 2024-12-29 at 22 44 08](https://github.com/user-attachments/assets/f9238ad7-9ab1-4cbc-84dc-b3ef483ce4e1)


## Changes made
This pull request includes several changes to improve the handling of thread states and reduce unnecessary re-renders in the application. The most important changes involve replacing individual state atoms with a combined state atom and updating various components to use this new combined state.

Changes to thread state handling:

* [`web/helpers/atoms/Thread.atom.ts`](diffhunk://#diff-4d7af9a9bba964e4d35729b2cdafe1ac8c4d6a7fd7eae7ed2c680f67bdc3a15cR37-R52): Added `isWaitingForResponseAtom` and `isBlockingSendAtom` to combine thread states and reduce re-renders.
* [`web/containers/Providers/ModelHandler.tsx`](diffhunk://#diff-c52744b512485151ef69f9c9e8b58535cc47dc550c4caf152cb52ec103ea898dL59-R59): Updated `subscribedGeneratingMessage` to use `useAtomValue` instead of `useAtom`.

Updates to components to use combined state:

* [`web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx`](diffhunk://#diff-3f5d1c0b7af75f2f221b9504d3f50f0cb42b683d7eb7b565caf7ced16b2c765fL68-R67): Replaced `isGeneratingResponse` and `threadStates` with `isBlockingSend` in various places to simplify state management. [[1]](diffhunk://#diff-3f5d1c0b7af75f2f221b9504d3f50f0cb42b683d7eb7b565caf7ced16b2c765fL68-R67) [[2]](diffhunk://#diff-3f5d1c0b7af75f2f221b9504d3f50f0cb42b683d7eb7b565caf7ced16b2c765fL98-R104) [[3]](diffhunk://#diff-3f5d1c0b7af75f2f221b9504d3f50f0cb42b683d7eb7b565caf7ced16b2c765fL127-R121) [[4]](diffhunk://#diff-3f5d1c0b7af75f2f221b9504d3f50f0cb42b683d7eb7b565caf7ced16b2c765fL139-R133) [[5]](diffhunk://#diff-3f5d1c0b7af75f2f221b9504d3f50f0cb42b683d7eb7b565caf7ced16b2c765fL157-R151)
* [`web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx`](diffhunk://#diff-6939e74c6339668f085c4edb1a90987fea21a6e5679fa3ff95495629ba249b4aL70-R67): Updated to use `isBlockingSend` instead of individual state atoms for better performance. [[1]](diffhunk://#diff-6939e74c6339668f085c4edb1a90987fea21a6e5679fa3ff95495629ba249b4aL70-R67) [[2]](diffhunk://#diff-6939e74c6339668f085c4edb1a90987fea21a6e5679fa3ff95495629ba249b4aL80-L83) [[3]](diffhunk://#diff-6939e74c6339668f085c4edb1a90987fea21a6e5679fa3ff95495629ba249b4aL305-R297)
* [`web/screens/Thread/ThreadCenterPanel/MessageToolbar/index.tsx`](diffhunk://#diff-07bea7d15d67880f331f5ffb1c2debfce463d3057b4caa1e85575031f0bf78ceR47): Modified to use `isBlockingSend` to control the visibility of certain actions. [[1]](diffhunk://#diff-07bea7d15d67880f331f5ffb1c2debfce463d3057b4caa1e85575031f0bf78ceR47) [[2]](diffhunk://#diff-07bea7d15d67880f331f5ffb1c2debfce463d3057b4caa1e85575031f0bf78ceL94-R97) [[3]](diffhunk://#diff-07bea7d15d67880f331f5ffb1c2debfce463d3057b4caa1e85575031f0bf78ceL113-R117)
