### PR TITLE
chore:  don't stop inference and hide the stop button when creating a new thread

### DIFF
--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -21,8 +21,6 @@ import { toaster } from '@/containers/Toast'
 
 import { isLocalEngine } from '@/utils/modelEngine'
 
-import { useActiveModel } from './useActiveModel'
-
 import useRecommendedModel from './useRecommendedModel'
 import useSetActiveThread from './useSetActiveThread'
 
@@ -52,10 +50,8 @@ export const useCreateNewThread = () => {
   const [activeAssistant, setActiveAssistant] = useAtom(activeAssistantAtom)
 
   const experimentalEnabled = useAtomValue(experimentalFeatureEnabledAtom)
-  const setIsGeneratingResponse = useSetAtom(isGeneratingResponseAtom)
 
   const threads = useAtomValue(threadsAtom)
-  const { stopInference } = useActiveModel()
 
   const { recommendedModel } = useRecommendedModel()
 
@@ -63,10 +59,6 @@ export const useCreateNewThread = () => {
     assistant: (ThreadAssistantInfo & { id: string; name: string }) | Assistant,
     model?: Model | undefined
   ) => {
-    // Stop generating if any
-    setIsGeneratingResponse(false)
-    stopInference()
-
     const defaultModel = model || recommendedModel
 
     if (!model) {


### PR DESCRIPTION

## Describe Your Changes

This is to fix the issue where stop button is disabled when creating a new thread


## Changes made
This pull request includes changes to the `web/hooks/useCreateNewThread.ts` file, focusing on code cleanup and removal of unused imports and variables. The most important changes include the removal of the `useActiveModel` import and associated variables and functions.

Code cleanup and simplification:

* Removed unused import `useActiveModel` from `web/hooks/useCreateNewThread.ts`.
* Removed the `setIsGeneratingResponse` variable and the `stopInference` function from the `useCreateNewThread` function in `web/hooks/useCreateNewThread.ts`.
