### PR TITLE
fix: button state reset on switching models

### DIFF
--- a/web/helpers/atoms/Thread.atom.ts
+++ b/web/helpers/atoms/Thread.atom.ts
@@ -205,6 +205,14 @@ export const resetThreadWaitingForResponseAtom = atom(null, (get, set) => {
 })
 
 /**
+ * Reset all generating states
+ **/
+export const resetGeneratingResponseAtom = atom(null, (get, set) => {
+  set(resetThreadWaitingForResponseAtom)
+  set(isGeneratingResponseAtom, false)
+})
+
+/**
  * Update the thread last message
  */
 export const updateThreadStateLastMessageAtom = atom(

--- a/web/hooks/useActiveModel.ts
+++ b/web/hooks/useActiveModel.ts
@@ -38,10 +38,6 @@ export function useActiveModel() {
   const pendingModelLoad = useRef(false)
   const isVulkanEnabled = useAtomValue(vulkanEnabledAtom)
   const activeAssistant = useAtomValue(activeAssistantAtom)
-  const setGeneratingResponse = useSetAtom(isGeneratingResponseAtom)
-  const resetThreadWaitingForResponseState = useSetAtom(
-    resetThreadWaitingForResponseAtom
-  )
 
   const downloadedModelsRef = useRef<Model[]>([])
 
@@ -147,8 +143,6 @@ export function useActiveModel() {
         return
 
       const engine = EngineManager.instance().get(stoppingModel.engine)
-      setGeneratingResponse(false)
-      resetThreadWaitingForResponseState()
       return engine
         ?.unloadModel(stoppingModel)
         .catch((e) => console.error(e))
@@ -158,14 +152,7 @@ export function useActiveModel() {
           pendingModelLoad.current = false
         })
     },
-    [
-      activeModel,
-      setStateModel,
-      setActiveModel,
-      stateModel,
-      setGeneratingResponse,
-      resetThreadWaitingForResponseState,
-    ]
+    [activeModel, setStateModel, setActiveModel, stateModel]
   )
 
   const stopInference = useCallback(async () => {

--- a/web/screens/Thread/ThreadCenterPanel/AssistantSetting/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/AssistantSetting/index.tsx
@@ -12,6 +12,7 @@ import { activeAssistantAtom } from '@/helpers/atoms/Assistant.atom'
 import {
   activeThreadAtom,
   engineParamsUpdateAtom,
+  resetGeneratingResponseAtom,
 } from '@/helpers/atoms/Thread.atom'
 
 type Props = {
@@ -24,6 +25,7 @@ const AssistantSetting: React.FC<Props> = ({ componentData }) => {
   const { updateThreadMetadata } = useCreateNewThread()
   const { stopModel } = useActiveModel()
   const setEngineParamsUpdate = useSetAtom(engineParamsUpdateAtom)
+  const resetGenerating = useSetAtom(resetGeneratingResponseAtom)
 
   const onValueChanged = useCallback(
     (key: string, value: string | number | boolean | string[]) => {
@@ -32,6 +34,7 @@ const AssistantSetting: React.FC<Props> = ({ componentData }) => {
         componentData.find((x) => x.key === key)?.requireModelReload ?? false
       if (shouldReloadModel) {
         setEngineParamsUpdate(true)
+        resetGenerating()
         stopModel()
       }
 


### PR DESCRIPTION
## Describe Your Changes

This PR resolved the issue where switching to a new button would cause the stop button to disappear.

## Changes made
This pull request includes several changes to improve state management and streamline the codebase in the `web` directory. The changes focus on the use of Jotai atoms for state management, the addition of new utility atoms, and the removal of redundant code.

### State Management Improvements:
* [`web/containers/Providers/ModelHandler.tsx`](diffhunk://#diff-c52744b512485151ef69f9c9e8b58535cc47dc550c4caf152cb52ec103ea898dL59-R59): Replaced the use of `useAtom` with `useAtomValue` for `subscribedGeneratingMessageAtom` to simplify state retrieval.
* [`web/helpers/atoms/Thread.atom.ts`](diffhunk://#diff-4d7af9a9bba964e4d35729b2cdafe1ac8c4d6a7fd7eae7ed2c680f67bdc3a15cR37-R52): Added `isWaitingForResponseAtom` and `isBlockingSendAtom` to manage thread states and reduce unnecessary re-renders.

### Utility Atom Additions:
* [`web/helpers/atoms/Thread.atom.ts`](diffhunk://#diff-4d7af9a9bba964e4d35729b2cdafe1ac8c4d6a7fd7eae7ed2c680f67bdc3a15cR192-R214): Introduced `resetThreadWaitingForResponseAtom` and `resetGeneratingResponseAtom` to reset thread states and generating states.

### Code Simplification:
* [`web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx`](diffhunk://#diff-3f5d1c0b7af75f2f221b9504d3f50f0cb42b683d7eb7b565caf7ced16b2c765fL68-R67): Replaced multiple state checks with `isBlockingSendAtom` to streamline the logic for blocking send operations. [[1]](diffhunk://#diff-3f5d1c0b7af75f2f221b9504d3f50f0cb42b683d7eb7b565caf7ced16b2c765fL68-R67) [[2]](diffhunk://#diff-3f5d1c0b7af75f2f221b9504d3f50f0cb42b683d7eb7b565caf7ced16b2c765fL88-R88) [[3]](diffhunk://#diff-3f5d1c0b7af75f2f221b9504d3f50f0cb42b683d7eb7b565caf7ced16b2c765fL124-R97)
* [`web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx`](diffhunk://#diff-6939e74c6339668f085c4edb1a90987fea21a6e5679fa3ff95495629ba249b4aL70-R67): Removed redundant state checks and replaced them with `isBlockingSendAtom` for cleaner code. [[1]](diffhunk://#diff-6939e74c6339668f085c4edb1a90987fea21a6e5679fa3ff95495629ba249b4aL70-R67) [[2]](diffhunk://#diff-6939e74c6339668f085c4edb1a90987fea21a6e5679fa3ff95495629ba249b4aL80-L83) [[3]](diffhunk://#diff-6939e74c6339668f085c4edb1a90987fea21a6e5679fa3ff95495629ba249b4aL305-R297)

### Test Updates:
* [`web/hooks/useCreateNewThread.test.ts`](diffhunk://#diff-17175a80952b1f1ed2167f9096045db49b190d33c5790168ab5a630b23259110L70): Removed unnecessary assertions for `mockSetAtom` calls to focus on essential test validations. [[1]](diffhunk://#diff-17175a80952b1f1ed2167f9096045db49b190d33c5790168ab5a630b23259110L70) [[2]](diffhunk://#diff-17175a80952b1f1ed2167f9096045db49b190d33c5790168ab5a630b23259110L116) [[3]](diffhunk://#diff-17175a80952b1f1ed2167f9096045db49b190d33c5790168ab5a630b23259110L161)
