### PR TITLE
chore: deprecate make build-joi

### DIFF
--- a/.github/workflows/jan-electron-linter-and-test.yml
+++ b/.github/workflows/jan-electron-linter-and-test.yml
@@ -51,6 +51,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          make config-yarn
           yarn
           yarn build:joi
           yarn build:core

--- a/.github/workflows/jan-electron-linter-and-test.yml
+++ b/.github/workflows/jan-electron-linter-and-test.yml
@@ -51,9 +51,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          make build-joi
-          yarn build:core
           yarn
+          yarn build:joi
+          yarn build:core
 
       - name: Run test coverage
         run: yarn test:coverage


### PR DESCRIPTION
## Describe Your Changes

This PR remove build-joi step from CI script

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Add
This pull request includes a small change to the `.github/workflows/jan-electron-linter-and-test.yml` file. The change corrects the order of the build commands to ensure proper dependency installation.

* [`.github/workflows/jan-electron-linter-and-test.yml`](diffhunk://#diff-2ddb5adaf1a0673126fe60af7cf39a5d87b4936f65bd223f28ff8cb979c57650L54-R56): Modified the `Install dependencies` step to run `yarn build:joi` before `yarn build:core` to ensure proper build order.
