### PR TITLE
fix: bump llama.cpp engine hotfix version to address model load issue on some MacOS Intel machines

### DIFF
--- a/extensions/inference-cortex-extension/download.bat
+++ b/extensions/inference-cortex-extension/download.bat
@@ -2,7 +2,7 @@
 set BIN_PATH=./bin
 set SHARED_PATH=./../../electron/shared
 set /p CORTEX_VERSION=<./bin/version.txt
-set ENGINE_VERSION=0.1.42
+set ENGINE_VERSION=0.1.42-hotfix
 
 @REM Download cortex.llamacpp binaries
 set DOWNLOAD_URL=https://github.com/janhq/cortex.llamacpp/releases/download/v%ENGINE_VERSION%/cortex.llamacpp-%ENGINE_VERSION%-windows-amd64

--- a/extensions/inference-cortex-extension/download.sh
+++ b/extensions/inference-cortex-extension/download.sh
@@ -2,7 +2,7 @@
 
 # Read CORTEX_VERSION
 CORTEX_VERSION=$(cat ./bin/version.txt)
-ENGINE_VERSION=0.1.42
+ENGINE_VERSION=0.1.42-hotfix
 CORTEX_RELEASE_URL="https://github.com/janhq/cortex.cpp/releases/download"
 ENGINE_DOWNLOAD_URL="https://github.com/janhq/cortex.llamacpp/releases/download/v${ENGINE_VERSION}/cortex.llamacpp-${ENGINE_VERSION}"
 CUDA_DOWNLOAD_URL="https://github.com/janhq/cortex.llamacpp/releases/download/v${ENGINE_VERSION}"

--- a/extensions/inference-cortex-extension/rollup.config.ts
+++ b/extensions/inference-cortex-extension/rollup.config.ts
@@ -120,7 +120,7 @@ export default [
         SETTINGS: JSON.stringify(defaultSettingJson),
         CORTEX_API_URL: JSON.stringify('http://127.0.0.1:39291'),
         CORTEX_SOCKET_URL: JSON.stringify('ws://127.0.0.1:39291'),
-        CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.42'),
+        CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.42-hotfix'),
       }),
       // Allow json resolution
       json(),


### PR DESCRIPTION
## Describe Your Changes

This PR addressed an issue where the app couldn't load the model on certain MacOS Intel devices because of missing instruction set support from cortex llama.cpp engine. This issue occurs on Jan 0.5.12, as this version was building on a self-hosted CI machine to support MacOS 12.x versions. However, GitHub's runner had already deprecated support for this version.

## Fixes Issues

- #4366 

## Self Checklist

This pull request includes several updates to the `inference-cortex-extension` to address a hotfix for the engine version. The most important changes involve updating the engine version across different scripts and configuration files.

Updates to engine version:

* [`extensions/inference-cortex-extension/download.bat`](diffhunk://#diff-8a7d1c23da498167c2b1a94a2d4ce076f6f2549607a116a66528fe8e44c678a6L5-R5): Changed `ENGINE_VERSION` from `0.1.42` to `0.1.42-hotfix`.
* [`extensions/inference-cortex-extension/download.sh`](diffhunk://#diff-f67e38c5644b8fd2bea4d9a5ef8ac582f57884716ff91932b02809aa3fe36bedL5-R5): Updated `ENGINE_VERSION` from `0.1.42` to `0.1.42-hotfix`.
* [`extensions/inference-cortex-extension/rollup.config.ts`](diffhunk://#diff-452a68fc0027fb5aad2a82d61d63dc567d275ce734855ff86b19ad70bfcb125fL123-R123): Modified `CORTEX_ENGINE_VERSION` from `v0.1.42` to `v0.1.42-hotfix`.
