### PR TITLE
fix: if the default engine isn't installed, the app should reset it

### DIFF
--- a/extensions/engine-management-extension/rolldown.config.mjs
+++ b/extensions/engine-management-extension/rolldown.config.mjs
@@ -12,7 +12,7 @@ export default defineConfig([
       NODE: JSON.stringify(`${pkgJson.name}/${pkgJson.node}`),
       API_URL: JSON.stringify('http://127.0.0.1:39291'),
       SOCKET_URL: JSON.stringify('ws://127.0.0.1:39291'),
-      CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.42'),
+      CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.43'),
     },
   },
   {
@@ -23,7 +23,7 @@ export default defineConfig([
       file: 'dist/node/index.cjs.js',
     },
     define: {
-      CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.42'),
+      CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.43'),
     },
   },
   {

--- a/extensions/engine-management-extension/src/index.ts
+++ b/extensions/engine-management-extension/src/index.ts
@@ -31,11 +31,16 @@ export default class JSONEngineManagementExtension extends EngineManagementExten
       const variant = await this.getDefaultEngineVariant(
         InferenceEngine.cortex_llamacpp
       )
-      // Check whether should use bundled version or installed version
-      // Only use larger version
-      if (this.compareVersions(CORTEX_ENGINE_VERSION, variant.version) > 0) {
+      const installedEngines = await this.getInstalledEngines(
+        InferenceEngine.cortex_llamacpp
+      )
+      if (
+        !installedEngines.some(
+          (e) => e.name === variant.variant && e.version === variant.version
+        )
+      ) {
         throw new EngineError(
-          'Default engine version is smaller than bundled version'
+          'Default engine is not available, use bundled version.'
         )
       }
     } catch (error) {
@@ -204,16 +209,5 @@ export default class JSONEngineManagementExtension extends EngineManagementExten
         retry: { limit: 20, delay: () => 500, methods: ['get'] },
       })
       .then(() => {})
-  }
-
-  private compareVersions(version1: string, version2: string): number {
-    const parseVersion = (version: string) => version.split('.').map(Number)
-
-    const [major1, minor1, patch1] = parseVersion(version1.replace(/^v/, ''))
-    const [major2, minor2, patch2] = parseVersion(version2.replace(/^v/, ''))
-
-    if (major1 !== major2) return major1 - major2
-    if (minor1 !== minor2) return minor1 - minor2
-    return patch1 - patch2
   }
 }

--- a/extensions/yarn.lock
+++ b/extensions/yarn.lock
@@ -509,161 +509,161 @@ __metadata:
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fassistant-extension%40workspace%3Aassistant-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=663527&locator=%40janhq%2Fassistant-extension%40workspace%3Aassistant-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=91cd98&locator=%40janhq%2Fassistant-extension%40workspace%3Aassistant-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/1297917d8be757142645a76657af16193ea3ac58de53a2cc60142ef7c2a5900b461e84c237da0f13be58f6ce70155d53d1d1745702d8d9fdf8b177a5c67b09b5
+  checksum: 10c0/af79c509b1ff8a2893f5fd6545cfa8b3bb6a2e2bc13acdd5963766a1caac635b8b69ab627bfb356e052f16542f2b7187b607bdaed6acec24cd7c9a6087e4abc2
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fconversational-extension%40workspace%3Aconversational-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=663527&locator=%40janhq%2Fconversational-extension%40workspace%3Aconversational-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=91cd98&locator=%40janhq%2Fconversational-extension%40workspace%3Aconversational-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/1297917d8be757142645a76657af16193ea3ac58de53a2cc60142ef7c2a5900b461e84c237da0f13be58f6ce70155d53d1d1745702d8d9fdf8b177a5c67b09b5
+  checksum: 10c0/af79c509b1ff8a2893f5fd6545cfa8b3bb6a2e2bc13acdd5963766a1caac635b8b69ab627bfb356e052f16542f2b7187b607bdaed6acec24cd7c9a6087e4abc2
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fengine-management-extension%40workspace%3Aengine-management-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=663527&locator=%40janhq%2Fengine-management-extension%40workspace%3Aengine-management-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=91cd98&locator=%40janhq%2Fengine-management-extension%40workspace%3Aengine-management-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/1297917d8be757142645a76657af16193ea3ac58de53a2cc60142ef7c2a5900b461e84c237da0f13be58f6ce70155d53d1d1745702d8d9fdf8b177a5c67b09b5
+  checksum: 10c0/af79c509b1ff8a2893f5fd6545cfa8b3bb6a2e2bc13acdd5963766a1caac635b8b69ab627bfb356e052f16542f2b7187b607bdaed6acec24cd7c9a6087e4abc2
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Finference-anthropic-extension%40workspace%3Ainference-anthropic-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=663527&locator=%40janhq%2Finference-anthropic-extension%40workspace%3Ainference-anthropic-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=91cd98&locator=%40janhq%2Finference-anthropic-extension%40workspace%3Ainference-anthropic-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/1297917d8be757142645a76657af16193ea3ac58de53a2cc60142ef7c2a5900b461e84c237da0f13be58f6ce70155d53d1d1745702d8d9fdf8b177a5c67b09b5
+  checksum: 10c0/af79c509b1ff8a2893f5fd6545cfa8b3bb6a2e2bc13acdd5963766a1caac635b8b69ab627bfb356e052f16542f2b7187b607bdaed6acec24cd7c9a6087e4abc2
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Finference-cohere-extension%40workspace%3Ainference-cohere-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=663527&locator=%40janhq%2Finference-cohere-extension%40workspace%3Ainference-cohere-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=91cd98&locator=%40janhq%2Finference-cohere-extension%40workspace%3Ainference-cohere-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/1297917d8be757142645a76657af16193ea3ac58de53a2cc60142ef7c2a5900b461e84c237da0f13be58f6ce70155d53d1d1745702d8d9fdf8b177a5c67b09b5
+  checksum: 10c0/af79c509b1ff8a2893f5fd6545cfa8b3bb6a2e2bc13acdd5963766a1caac635b8b69ab627bfb356e052f16542f2b7187b607bdaed6acec24cd7c9a6087e4abc2
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Finference-cortex-extension%40workspace%3Ainference-cortex-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=663527&locator=%40janhq%2Finference-cortex-extension%40workspace%3Ainference-cortex-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=91cd98&locator=%40janhq%2Finference-cortex-extension%40workspace%3Ainference-cortex-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/1297917d8be757142645a76657af16193ea3ac58de53a2cc60142ef7c2a5900b461e84c237da0f13be58f6ce70155d53d1d1745702d8d9fdf8b177a5c67b09b5
+  checksum: 10c0/af79c509b1ff8a2893f5fd6545cfa8b3bb6a2e2bc13acdd5963766a1caac635b8b69ab627bfb356e052f16542f2b7187b607bdaed6acec24cd7c9a6087e4abc2
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Finference-groq-extension%40workspace%3Ainference-groq-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=663527&locator=%40janhq%2Finference-groq-extension%40workspace%3Ainference-groq-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=91cd98&locator=%40janhq%2Finference-groq-extension%40workspace%3Ainference-groq-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/1297917d8be757142645a76657af16193ea3ac58de53a2cc60142ef7c2a5900b461e84c237da0f13be58f6ce70155d53d1d1745702d8d9fdf8b177a5c67b09b5
+  checksum: 10c0/af79c509b1ff8a2893f5fd6545cfa8b3bb6a2e2bc13acdd5963766a1caac635b8b69ab627bfb356e052f16542f2b7187b607bdaed6acec24cd7c9a6087e4abc2
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Finference-martian-extension%40workspace%3Ainference-martian-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=663527&locator=%40janhq%2Finference-martian-extension%40workspace%3Ainference-martian-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=91cd98&locator=%40janhq%2Finference-martian-extension%40workspace%3Ainference-martian-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/1297917d8be757142645a76657af16193ea3ac58de53a2cc60142ef7c2a5900b461e84c237da0f13be58f6ce70155d53d1d1745702d8d9fdf8b177a5c67b09b5
+  checksum: 10c0/af79c509b1ff8a2893f5fd6545cfa8b3bb6a2e2bc13acdd5963766a1caac635b8b69ab627bfb356e052f16542f2b7187b607bdaed6acec24cd7c9a6087e4abc2
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Finference-mistral-extension%40workspace%3Ainference-mistral-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=663527&locator=%40janhq%2Finference-mistral-extension%40workspace%3Ainference-mistral-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=91cd98&locator=%40janhq%2Finference-mistral-extension%40workspace%3Ainference-mistral-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/1297917d8be757142645a76657af16193ea3ac58de53a2cc60142ef7c2a5900b461e84c237da0f13be58f6ce70155d53d1d1745702d8d9fdf8b177a5c67b09b5
+  checksum: 10c0/af79c509b1ff8a2893f5fd6545cfa8b3bb6a2e2bc13acdd5963766a1caac635b8b69ab627bfb356e052f16542f2b7187b607bdaed6acec24cd7c9a6087e4abc2
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Finference-nvidia-extension%40workspace%3Ainference-nvidia-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=663527&locator=%40janhq%2Finference-nvidia-extension%40workspace%3Ainference-nvidia-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=91cd98&locator=%40janhq%2Finference-nvidia-extension%40workspace%3Ainference-nvidia-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/1297917d8be757142645a76657af16193ea3ac58de53a2cc60142ef7c2a5900b461e84c237da0f13be58f6ce70155d53d1d1745702d8d9fdf8b177a5c67b09b5
+  checksum: 10c0/af79c509b1ff8a2893f5fd6545cfa8b3bb6a2e2bc13acdd5963766a1caac635b8b69ab627bfb356e052f16542f2b7187b607bdaed6acec24cd7c9a6087e4abc2
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Finference-openai-extension%40workspace%3Ainference-openai-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=663527&locator=%40janhq%2Finference-openai-extension%40workspace%3Ainference-openai-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=91cd98&locator=%40janhq%2Finference-openai-extension%40workspace%3Ainference-openai-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/1297917d8be757142645a76657af16193ea3ac58de53a2cc60142ef7c2a5900b461e84c237da0f13be58f6ce70155d53d1d1745702d8d9fdf8b177a5c67b09b5
+  checksum: 10c0/af79c509b1ff8a2893f5fd6545cfa8b3bb6a2e2bc13acdd5963766a1caac635b8b69ab627bfb356e052f16542f2b7187b607bdaed6acec24cd7c9a6087e4abc2
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Finference-openrouter-extension%40workspace%3Ainference-openrouter-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=663527&locator=%40janhq%2Finference-openrouter-extension%40workspace%3Ainference-openrouter-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=91cd98&locator=%40janhq%2Finference-openrouter-extension%40workspace%3Ainference-openrouter-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/1297917d8be757142645a76657af16193ea3ac58de53a2cc60142ef7c2a5900b461e84c237da0f13be58f6ce70155d53d1d1745702d8d9fdf8b177a5c67b09b5
+  checksum: 10c0/af79c509b1ff8a2893f5fd6545cfa8b3bb6a2e2bc13acdd5963766a1caac635b8b69ab627bfb356e052f16542f2b7187b607bdaed6acec24cd7c9a6087e4abc2
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Finference-triton-trt-llm-extension%40workspace%3Ainference-triton-trtllm-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=663527&locator=%40janhq%2Finference-triton-trt-llm-extension%40workspace%3Ainference-triton-trtllm-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=91cd98&locator=%40janhq%2Finference-triton-trt-llm-extension%40workspace%3Ainference-triton-trtllm-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/1297917d8be757142645a76657af16193ea3ac58de53a2cc60142ef7c2a5900b461e84c237da0f13be58f6ce70155d53d1d1745702d8d9fdf8b177a5c67b09b5
+  checksum: 10c0/af79c509b1ff8a2893f5fd6545cfa8b3bb6a2e2bc13acdd5963766a1caac635b8b69ab627bfb356e052f16542f2b7187b607bdaed6acec24cd7c9a6087e4abc2
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fmodel-extension%40workspace%3Amodel-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=663527&locator=%40janhq%2Fmodel-extension%40workspace%3Amodel-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=91cd98&locator=%40janhq%2Fmodel-extension%40workspace%3Amodel-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/1297917d8be757142645a76657af16193ea3ac58de53a2cc60142ef7c2a5900b461e84c237da0f13be58f6ce70155d53d1d1745702d8d9fdf8b177a5c67b09b5
+  checksum: 10c0/af79c509b1ff8a2893f5fd6545cfa8b3bb6a2e2bc13acdd5963766a1caac635b8b69ab627bfb356e052f16542f2b7187b607bdaed6acec24cd7c9a6087e4abc2
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fmonitoring-extension%40workspace%3Amonitoring-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=663527&locator=%40janhq%2Fmonitoring-extension%40workspace%3Amonitoring-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=91cd98&locator=%40janhq%2Fmonitoring-extension%40workspace%3Amonitoring-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/1297917d8be757142645a76657af16193ea3ac58de53a2cc60142ef7c2a5900b461e84c237da0f13be58f6ce70155d53d1d1745702d8d9fdf8b177a5c67b09b5
+  checksum: 10c0/af79c509b1ff8a2893f5fd6545cfa8b3bb6a2e2bc13acdd5963766a1caac635b8b69ab627bfb356e052f16542f2b7187b607bdaed6acec24cd7c9a6087e4abc2
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Ftensorrt-llm-extension%40workspace%3Atensorrt-llm-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=663527&locator=%40janhq%2Ftensorrt-llm-extension%40workspace%3Atensorrt-llm-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=91cd98&locator=%40janhq%2Ftensorrt-llm-extension%40workspace%3Atensorrt-llm-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/1297917d8be757142645a76657af16193ea3ac58de53a2cc60142ef7c2a5900b461e84c237da0f13be58f6ce70155d53d1d1745702d8d9fdf8b177a5c67b09b5
+  checksum: 10c0/af79c509b1ff8a2893f5fd6545cfa8b3bb6a2e2bc13acdd5963766a1caac635b8b69ab627bfb356e052f16542f2b7187b607bdaed6acec24cd7c9a6087e4abc2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe Your Changes

There would be an issue where the app wouldn't reset the default engine if the user manually modifies it or updates from a hotfix version. This would break the default settings, and users would have to manually update the engine in the settings. This isn't a good UX, they should have it configured properly on launch.

On launch: 
Check default variant -> Get installed variants -> If installed variants are not including default variant it would not work -> Reset default variant to bundled version.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

This pull request includes updates to the `extensions/engine-management-extension` to improve version handling and remove unnecessary code. The most important changes include updating the Cortex engine version, modifying the logic for checking installed engines, and removing the `compareVersions` method.

Version update:

* [`extensions/engine-management-extension/rolldown.config.mjs`](diffhunk://#diff-30942dcc326a20cefe8cde68225a2aebaf2dab82021400521c5f63724210f558L15-R15): Updated `CORTEX_ENGINE_VERSION` from 'v0.1.42' to 'v0.1.43'. [[1]](diffhunk://#diff-30942dcc326a20cefe8cde68225a2aebaf2dab82021400521c5f63724210f558L15-R15) [[2]](diffhunk://#diff-30942dcc326a20cefe8cde68225a2aebaf2dab82021400521c5f63724210f558L26-R26)

Logic improvement:

* [`extensions/engine-management-extension/src/index.ts`](diffhunk://#diff-d8c74089c1ad29e79d22182a9a2d8721dd5c77e8bd937363487496ba8cd8c991L34-R43): Modified the logic to check if the default engine is installed instead of comparing versions.

Code simplification:

* [`extensions/engine-management-extension/src/index.ts`](diffhunk://#diff-d8c74089c1ad29e79d22182a9a2d8721dd5c77e8bd937363487496ba8cd8c991L208-L218): Removed the `compareVersions` method as it is no longer needed.
