### PR TITLE
fix: should not disable Vulkan support option

### DIFF
--- a/web/screens/Settings/Advanced/index.tsx
+++ b/web/screens/Settings/Advanced/index.tsx
@@ -417,7 +417,7 @@ const Advanced = () => {
         )}
 
         {/* Vulkan for AMD GPU/ APU and Intel Arc GPU */}
-        {!isMac && gpuList.length > 0 && experimentalEnabled && (
+        {!isMac && experimentalEnabled && (
           <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">
             <div className="space-y-1">
               <div className="flex gap-x-2">


### PR DESCRIPTION
## Describe Your Changes
Users should not be restricted from enabling Vulkan mode solely based on GPU detection.

Context: 

- Some GPUs aren't detected by the app.
- We will allow users to select the Vulkan variant anyway soon.

## Fixes Issues

- #4378

## Self Checklist
This pull request includes a change to the `Advanced` component in the `Settings` screen. The change simplifies the condition for displaying the Vulkan settings for AMD GPU/APU and Intel Arc GPU by removing the dependency on `gpuList.length`.

* [`web/screens/Settings/Advanced/index.tsx`](diffhunk://#diff-8d119b4ddbfcbb13597702a44730e486bc4c02dc630069686effa3333ab90411L420-R420): Simplified the condition for displaying Vulkan settings by removing the check for `gpuList.length > 0`.
