### PR TITLE
fix: enable default opt in analytic

### DIFF
--- a/web/helpers/atoms/Setting.atom.ts
+++ b/web/helpers/atoms/Setting.atom.ts
@@ -47,7 +47,7 @@ export const spellCheckAtom = atomWithStorage<boolean>(
 )
 export const productAnalyticAtom = atomWithStorage<boolean>(
   PRODUCT_ANALYTIC,
-  false,
+  true,
   undefined,
   { getOnInit: true }
 )


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a small change to the `web/helpers/atoms/Setting.atom.ts` file. The change modifies the default value of `productAnalyticAtom` from `false` to `true`.

* [`web/helpers/atoms/Setting.atom.ts`](diffhunk://#diff-fe970dc673b247de554e793d3e1a453f1456278107ae53a390229595621c4384L50-R50): Changed the default value of `productAnalyticAtom` from `false` to `true` to enable product analytics by default.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
