### PR TITLE
fix: send event opt out

### DIFF
--- a/extensions/inference-cortex-extension/resources/default_settings.json
+++ b/extensions/inference-cortex-extension/resources/default_settings.json
@@ -25,7 +25,7 @@
     "controllerType": "input",
     "controllerProps": {
       "value": "",
-      "placeholder": "4"
+      "placeholder": "Number of CPU threads"
     }
   },
   {

--- a/extensions/inference-cortex-extension/resources/default_settings.json
+++ b/extensions/inference-cortex-extension/resources/default_settings.json
@@ -21,7 +21,7 @@
   {
     "key": "cpu_threads",
     "title": "CPU Threads",
-    "description": "The number of threads to use for inferencing (CPU MODE ONLY)",
+    "description": "The number of CPU threads to use (when in CPU mode)",
     "controllerType": "input",
     "controllerProps": {
       "value": "",

--- a/web/containers/Layout/index.tsx
+++ b/web/containers/Layout/index.tsx
@@ -123,6 +123,7 @@ const BaseLayout = () => {
     if (isAllowed) {
       posthog.opt_in_capturing()
     } else {
+      posthog.capture('user_opt_out', { timestamp: new Date() })
       posthog.opt_out_capturing()
     }
   }


### PR DESCRIPTION
## Describe Your Changes
This pull request includes a small but important change to the `web/containers/Layout/index.tsx` file. The change adds a new event capture for when a user opts out.

* [`web/containers/Layout/index.tsx`](diffhunk://#diff-14ae8afe09456109846de9e991341105e0d570a68d771860be34c3626c438f59R126): Added a `posthog.capture` call to log the 'user_opt_out' event with a timestamp when a user opts out.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
