### PR TITLE
fix: revert back product analytic with default opt-out

### DIFF
--- a/web/containers/Layout/index.tsx
+++ b/web/containers/Layout/index.tsx
@@ -123,7 +123,6 @@ const BaseLayout = () => {
     if (isAllowed) {
       posthog.opt_in_capturing()
     } else {
-      posthog.capture('user_opt_out', { timestamp: new Date() })
       posthog.opt_out_capturing()
     }
   }

--- a/web/helpers/atoms/Setting.atom.ts
+++ b/web/helpers/atoms/Setting.atom.ts
@@ -47,7 +47,7 @@ export const spellCheckAtom = atomWithStorage<boolean>(
 )
 export const productAnalyticAtom = atomWithStorage<boolean>(
   PRODUCT_ANALYTIC,
-  true,
+  false,
   undefined,
   { getOnInit: true }
 )


### PR DESCRIPTION
## Describe Your Changes

This pull request includes two changes to the `web` directory, focusing on user analytics and settings.

Changes to user analytics:

* [`web/containers/Layout/index.tsx`](diffhunk://#diff-14ae8afe09456109846de9e991341105e0d570a68d771860be34c3626c438f59L126): Removed the `posthog.capture('user_opt_out', { timestamp: new Date() })` call when a user opts out of capturing.

Changes to settings:

* [`web/helpers/atoms/Setting.atom.ts`](diffhunk://#diff-fe970dc673b247de554e793d3e1a453f1456278107ae53a390229595621c4384L50-R50): Changed the default value of `productAnalyticAtom` from `true` to `false`.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
