### PR TITLE
fix: max_tokens revert back to 8192 automatically when creating a new thread

### DIFF
--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -98,7 +98,7 @@ export const useCreateNewThread = () => {
     // Use ctx length by default
     const overriddenParameters = {
       max_tokens: !isLocalEngine(defaultModel?.engine)
-        ? (defaultModel?.parameters.token_limit ?? 8192)
+        ? (defaultModel?.parameters.max_tokens ?? 8192)
         : defaultContextLength,
     }
 


### PR DESCRIPTION
## Describe Your Changes

This PR addresses an issue where the app resets the max_tokens to 8192 whenever users create a new thread. This occurs because the parameter retrieve when creating a new thread is incorrect. It should instead use the max_tokens from the model settings instead of token_limit.

![CleanShot 2025-01-03 at 12 57 28](https://github.com/user-attachments/assets/59be3894-b367-44c8-a56e-37c7196d4ac1)


## Fixes Issues

- Closes #4372 

## Changes made

This pull request includes a small but important change to the `useCreateNewThread` function in `web/hooks/useCreateNewThread.ts`. The change corrects the parameter name from `token_limit` to `max_tokens` to ensure the correct value is used.

* Corrected the parameter name from `token_limit` to `max_tokens` in `useCreateNewThread` function to ensure the correct value is used.