### PR TITLE
fix: input scrolls to the bottom when set the caret to the top

### DIFF
--- a/extensions/inference-cortex-extension/download.bat
+++ b/extensions/inference-cortex-extension/download.bat
@@ -2,7 +2,7 @@
 set BIN_PATH=./bin
 set SHARED_PATH=./../../electron/shared
 set /p CORTEX_VERSION=<./bin/version.txt
-set ENGINE_VERSION=0.1.42
+set ENGINE_VERSION=0.1.43
 
 @REM Download cortex.llamacpp binaries
 set DOWNLOAD_URL=https://github.com/janhq/cortex.llamacpp/releases/download/v%ENGINE_VERSION%/cortex.llamacpp-%ENGINE_VERSION%-windows-amd64

--- a/extensions/inference-cortex-extension/download.sh
+++ b/extensions/inference-cortex-extension/download.sh
@@ -2,7 +2,7 @@
 
 # Read CORTEX_VERSION
 CORTEX_VERSION=$(cat ./bin/version.txt)
-ENGINE_VERSION=0.1.42
+ENGINE_VERSION=0.1.43
 CORTEX_RELEASE_URL="https://github.com/janhq/cortex.cpp/releases/download"
 ENGINE_DOWNLOAD_URL="https://github.com/janhq/cortex.llamacpp/releases/download/v${ENGINE_VERSION}/cortex.llamacpp-${ENGINE_VERSION}"
 CUDA_DOWNLOAD_URL="https://github.com/janhq/cortex.llamacpp/releases/download/v${ENGINE_VERSION}"

--- a/web/screens/Thread/ThreadCenterPanel/ChatInput/RichTextEditor.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatInput/RichTextEditor.tsx
@@ -315,7 +315,10 @@ const RichTextEditor = ({
     </Slate>
   )
 
-  function scrollSelectionIntoView(editor: any, domRange: any) {
+  function scrollSelectionIntoView(
+    editor: ReactEditor,
+    domRange: globalThis.Range
+  ) {
     // This was affecting the selection of multiple blocks and dragging behavior,
     // so enabled only if the selection has been collapsed.
     if (editor.selection && Range.isExpanded(editor.selection)) return
@@ -324,6 +327,9 @@ const RichTextEditor = ({
 
     const leafEl = domRange.startContainer.parentElement
     const scrollParent = getScrollParent(leafEl)
+
+    // Check if browser supports getBoundingClientRect
+    if (typeof domRange.getBoundingClientRect !== 'function') return
 
     const { top: elementTop, height: elementHeight } =
       domRange.getBoundingClientRect()

--- a/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
@@ -59,7 +59,7 @@ const ChatInput = () => {
 
   const activeThreadId = useAtomValue(getActiveThreadIdAtom)
   const [fileUpload, setFileUpload] = useAtom(fileUploadAtom)
-  const [showAttacmentMenus, setShowAttacmentMenus] = useState(false)
+  const [showAttachmentMenus, setShowAttachmentMenus] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const imageInputRef = useRef<HTMLInputElement>(null)
@@ -73,7 +73,9 @@ const ChatInput = () => {
     activeTabThreadRightPanelAtom
   )
 
-  const refAttachmentMenus = useClickOutside(() => setShowAttacmentMenus(false))
+  const refAttachmentMenus = useClickOutside(() =>
+    setShowAttachmentMenus(false)
+  )
   const [showRightPanel, setShowRightPanel] = useAtom(showRightPanelAtom)
 
   useEffect(() => {
@@ -169,7 +171,7 @@ const ChatInput = () => {
                   ) {
                     e.stopPropagation()
                   } else {
-                    setShowAttacmentMenus(!showAttacmentMenus)
+                    setShowAttachmentMenus(!showAttachmentMenus)
                   }
                 }}
               >
@@ -214,7 +216,7 @@ const ChatInput = () => {
           />
         )}
 
-        {showAttacmentMenus && (
+        {showAttachmentMenus && (
           <div
             ref={refAttachmentMenus}
             className={twMerge(
@@ -234,7 +236,7 @@ const ChatInput = () => {
                 onClick={() => {
                   if (activeAssistant?.model.settings?.vision_model) {
                     imageInputRef.current?.click()
-                    setShowAttacmentMenus(false)
+                    setShowAttachmentMenus(false)
                   }
                 }}
               >
@@ -254,7 +256,7 @@ const ChatInput = () => {
                     onClick={() => {
                       if (isModelSupportRagAndTools) {
                         fileInputRef.current?.click()
-                        setShowAttacmentMenus(false)
+                        setShowAttachmentMenus(false)
                       }
                     }}
                   >

--- a/web/screens/Thread/index.test.tsx
+++ b/web/screens/Thread/index.test.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import ThreadScreen from './index'
 import { useStarterScreen } from '../../hooks/useStarterScreen'
 import '@testing-library/jest-dom'
 
 global.ResizeObserver = class {
-  observe() { }
-  unobserve() { }
-  disconnect() { }
+  observe() {}
+  unobserve() {}
+  disconnect() {}
 }
 // Mock the useStarterScreen hook
 jest.mock('@/hooks/useStarterScreen')
@@ -17,7 +17,7 @@ global.API_BASE_URL = 'http://localhost:3000'
 
 describe('ThreadScreen', () => {
   it('renders OnDeviceStarterScreen when isShowStarterScreen is true', () => {
-    ; (useStarterScreen as jest.Mock).mockReturnValue({
+    ;(useStarterScreen as jest.Mock).mockReturnValue({
       isShowStarterScreen: true,
       extensionHasSettings: false,
     })
@@ -27,7 +27,7 @@ describe('ThreadScreen', () => {
   })
 
   it('renders Thread panels when isShowStarterScreen is false', () => {
-    ; (useStarterScreen as jest.Mock).mockReturnValue({
+    ;(useStarterScreen as jest.Mock).mockReturnValue({
       isShowStarterScreen: false,
       extensionHasSettings: false,
     })


### PR DESCRIPTION
## Describe Your Changes

This PR fixed the issue where app force-scroll to bottom every time user set the caret to top of the long input.

![CleanShot 2025-01-03 at 22 25 28](https://github.com/user-attachments/assets/cf1dfee7-cf2d-414a-859a-ce2daa2d8e9f)

This PR also added a minor engine version bump to be the same as the engine management extension.

## Fixes Issues

- Closes #4377

## Changes made
This pull request includes several changes across multiple files to update the engine version, fix a typo, and enhance the functionality of the `RichTextEditor` component. The most important changes include updating the engine version, correcting a typo in the `ChatInput` component, and adding new functionality to the `RichTextEditor`.

Updates and fixes:

* [`extensions/inference-cortex-extension/download.bat`](diffhunk://#diff-8a7d1c23da498167c2b1a94a2d4ce076f6f2549607a116a66528fe8e44c678a6L5-R5): Updated `ENGINE_VERSION` from `0.1.42` to `0.1.43`.
* [`extensions/inference-cortex-extension/download.sh`](diffhunk://#diff-f67e38c5644b8fd2bea4d9a5ef8ac582f57884716ff91932b02809aa3fe36bedL5-R5): Updated `ENGINE_VERSION` from `0.1.42` to `0.1.43`.
* [`web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx`](diffhunk://#diff-6939e74c6339668f085c4edb1a90987fea21a6e5679fa3ff95495629ba249b4aL62-R62): Corrected the typo `showAttacmentMenus` to `showAttachmentMenus` in multiple instances. [[1]](diffhunk://#diff-6939e74c6339668f085c4edb1a90987fea21a6e5679fa3ff95495629ba249b4aL62-R62) [[2]](diffhunk://#diff-6939e74c6339668f085c4edb1a90987fea21a6e5679fa3ff95495629ba249b4aL76-R78) [[3]](diffhunk://#diff-6939e74c6339668f085c4edb1a90987fea21a6e5679fa3ff95495629ba249b4aL172-R174) [[4]](diffhunk://#diff-6939e74c6339668f085c4edb1a90987fea21a6e5679fa3ff95495629ba249b4aL217-R219) [[5]](diffhunk://#diff-6939e74c6339668f085c4edb1a90987fea21a6e5679fa3ff95495629ba249b4aL237-R239) [[6]](diffhunk://#diff-6939e74c6339668f085c4edb1a90987fea21a6e5679fa3ff95495629ba249b4aL257-R259)

Enhancements to `RichTextEditor`:

* [`web/screens/Thread/ThreadCenterPanel/ChatInput/RichTextEditor.tsx`](diffhunk://#diff-3a47c34cdde40a71d284d97ee2e3d6235eced5ed23322b02be7569348c070d58L7-R7): Added import for `Range` from `slate`.
* [`web/screens/Thread/ThreadCenterPanel/ChatInput/RichTextEditor.tsx`](diffhunk://#diff-3a47c34cdde40a71d284d97ee2e3d6235eced5ed23322b02be7569348c070d58L189-L192): Removed unnecessary `scrollTo` call on `textareaRef`.
* [`web/screens/Thread/ThreadCenterPanel/ChatInput/RichTextEditor.tsx`](diffhunk://#diff-3a47c34cdde40a71d284d97ee2e3d6235eced5ed23322b02be7569348c070d58R317-R387): Added `scrollSelectionIntoView` and `getScrollParent` functions to improve scrolling behavior when selecting text.


