### PR TITLE
chore: support request headers template

### DIFF
--- a/core/src/types/engine/index.ts
+++ b/core/src/types/engine/index.ts
@@ -6,7 +6,7 @@ export type Engines = {
 
 export type EngineMetadata = {
   get_models_url?: string
-  api_key_template?: string
+  header_template?: string
   transform_req?: {
     chat_completions?: {
       url?: string

--- a/web/containers/ModelDropdown/index.tsx
+++ b/web/containers/ModelDropdown/index.tsx
@@ -142,7 +142,7 @@ const ModelDropdown = ({
         .filter((e) => {
           if (searchFilter === 'local') {
             return (
-              engineList.find((t) => t.engine.engine === e.engine)?.type ===
+              engineList.find((t) => t.engine?.engine === e.engine)?.type ===
               'local'
             )
           }

--- a/web/screens/Settings/Engines/ModalAddRemoteEngine.tsx
+++ b/web/screens/Settings/Engines/ModalAddRemoteEngine.tsx
@@ -13,7 +13,7 @@ const engineSchema = z.object({
   engineName: z.string().min(1, 'Engine name is required'),
   apiUrl: z.string().url('Enter a valid API URL'),
   modelListUrl: z.string().url('Enter a valid Model List URL'),
-  apiKeyTemplate: z.string().optional(),
+  headerTemplate: z.string().optional(),
   apiKey: z.string().optional(),
   requestFormat: z.string().optional(),
   responseFormat: z.string().optional(),
@@ -32,7 +32,7 @@ const ModalAddRemoteEngine = () => {
       engineName: '',
       apiUrl: '',
       modelListUrl: '',
-      apiKeyTemplate: '',
+      headerTemplate: '',
       apiKey: '',
       requestFormat: '',
       responseFormat: '',
@@ -46,7 +46,7 @@ const ModalAddRemoteEngine = () => {
       engine: data.engineName,
       api_key: data.apiKey,
       metadata: {
-        api_key_template: data.apiKeyTemplate,
+        header_template: data.headerTemplate,
         get_models_url: data.modelListUrl,
         transform_req: {
           chat_completions: {
@@ -148,25 +148,6 @@ const ModalAddRemoteEngine = () => {
             </div>
 
             <div className="space-y-2">
-              <label htmlFor="apiKeyTemplate" className="font-semibold">
-                {renderLabel(
-                  'API Key Template',
-                  false,
-                  `Template for authorization header format.`
-                )}
-              </label>
-              <Input
-                placeholder="Enter API key template"
-                {...register('apiKeyTemplate')}
-              />
-              {errors.apiKeyTemplate && (
-                <p className="text-sm text-red-500">
-                  {errors.apiKeyTemplate.message}
-                </p>
-              )}
-            </div>
-
-            <div className="space-y-2">
               <label htmlFor="apiKey" className="font-semibold">
                 {renderLabel(
                   'API Key',
@@ -179,6 +160,25 @@ const ModalAddRemoteEngine = () => {
                 type="password"
                 {...register('apiKey')}
               />
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="headerTemplate" className="font-semibold">
+                {renderLabel(
+                  'Request Headers Template',
+                  false,
+                  `Template for request headers format.`
+                )}
+              </label>
+              <TextArea
+                placeholder="Enter conversion function"
+                {...register('headerTemplate')}
+              />
+              {errors.headerTemplate && (
+                <p className="text-sm text-red-500">
+                  {errors.headerTemplate.message}
+                </p>
+              )}
             </div>
 
             <div className="space-y-2">

--- a/web/screens/Settings/Engines/RemoteEngineSettings.tsx
+++ b/web/screens/Settings/Engines/RemoteEngineSettings.tsx
@@ -213,19 +213,19 @@ const RemoteEngineSettings = ({
                   <div className="flex items-start justify-between gap-x-2">
                     <div className="w-full sm:w-3/4">
                       <h6 className="line-clamp-1 font-semibold">
-                        API Key Template
+                        Request Headers Template
                       </h6>
                       <p className="mt-1 text-[hsla(var(--text-secondary))]">
-                        Template for authorization header format.
+                        Template for request headers format.
                       </p>
                     </div>
                     <div className="w-full">
-                      <Input
-                        placeholder="Enter API key template"
-                        value={engine?.metadata?.api_key_template}
+                      <TextArea
+                        placeholder="Enter headers template"
+                        value={engine?.metadata?.header_template}
                         onChange={(e) =>
                           handleChange(
-                            'metadata.api_key_template',
+                            'metadata.header_template',
                             e.target.value
                           )
                         }


### PR DESCRIPTION
## Describe Your Changes

This PR added support for custom request headers, such as anthropic requires version header to work. Deprecated API Key template since it's a part of request headers template already.

![CleanShot 2025-01-08 at 07 27 01@2x](https://github.com/user-attachments/assets/08522585-4417-4269-846a-57b9475b3607)

## Self Checklist
This pull request includes changes to update the handling of API key templates to header templates, and to improve the filtering logic in the `ModelDropdown` component. The most important changes include renaming `api_key_template` to `header_template` across various files and modifying the `ModelDropdown` component to handle potential undefined values.

### Updates to API key templates:

* [`core/src/types/engine/index.ts`](diffhunk://#diff-409789d5b5f115c05e88675475c28af9ba0aab7206e250dd5ad0b90930bf0d3dL9-R9): Renamed `api_key_template` to `header_template` in the `EngineMetadata` type.
* [`web/screens/Settings/Engines/ModalAddRemoteEngine.tsx`](diffhunk://#diff-5e7396c224a11e90fca9f92866aa0071fd66aabfde9457e254de451c77912e60L16-R16): Updated all references from `apiKeyTemplate` to `headerTemplate` and adjusted the corresponding form fields and error handling. [[1]](diffhunk://#diff-5e7396c224a11e90fca9f92866aa0071fd66aabfde9457e254de451c77912e60L16-R16) [[2]](diffhunk://#diff-5e7396c224a11e90fca9f92866aa0071fd66aabfde9457e254de451c77912e60L35-R35) [[3]](diffhunk://#diff-5e7396c224a11e90fca9f92866aa0071fd66aabfde9457e254de451c77912e60L49-R49) [[4]](diffhunk://#diff-5e7396c224a11e90fca9f92866aa0071fd66aabfde9457e254de451c77912e60L151-R181)
* [`web/screens/Settings/Engines/RemoteEngineSettings.tsx`](diffhunk://#diff-d8d84f4f488f0d35b2751fee2cad04a83f6661a0f11b2b6a2355ac0e70aec575L216-R228): Changed the label and input for `API Key Template` to `Request Headers Template` and updated the input type from `Input` to `TextArea`.

### Improvements to filtering logic:

* [`web/containers/ModelDropdown/index.tsx`](diffhunk://#diff-897fe0e9366de0fa6ec9428b1423439aaab3dee774cea4b7efd6401a42fb00fbL145-R145): Modified the filtering logic to handle potential undefined values in the `engineList` by using optional chaining.
