### PR TITLE
fix: add per_page params on github releases endpoint

### DIFF
--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -20,7 +20,7 @@ import Home from "@/components/Home"
 
 export const getStaticProps = async() => {
   const resReleaseLatest = await fetch('https://api.github.com/repos/janhq/jan/releases/latest')  
-  const resRelease = await fetch('https://api.github.com/repos/janhq/jan/releases')  
+  const resRelease = await fetch('https://api.github.com/repos/janhq/jan/releases?per_page=500')  
   const resRepo = await fetch('https://api.github.com/repos/janhq/jan')
   const repo = await resRepo.json()
   const latestRelease = await resReleaseLatest.json()


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a change to the `docs/src/pages/index.mdx` file to improve the fetching of release data from the GitHub API.

* Modified the `resRelease` fetch call to include a query parameter that increases the number of releases fetched to 500.

## Fixes Issues
<img width="422" alt="Screenshot 2025-01-09 at 14 32 29" src="https://github.com/user-attachments/assets/c069a6ef-034f-40bf-a47f-06f82ed9e10f" />

- Closes #https://discord.com/channels/1107178041848909847/1251527460021993593/1326764176194011190
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
