### PR TITLE
chore: bump engine version to 0.1.43

### DIFF
--- a/extensions/inference-cortex-extension/rolldown.config.mjs
+++ b/extensions/inference-cortex-extension/rolldown.config.mjs
@@ -111,7 +111,7 @@ export default defineConfig([
       SETTINGS: JSON.stringify(defaultSettingJson),
       CORTEX_API_URL: JSON.stringify('http://127.0.0.1:39291'),
       CORTEX_SOCKET_URL: JSON.stringify('ws://127.0.0.1:39291'),
-      CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.42'),
+      CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.43'),
     },
   },
   {


### PR DESCRIPTION
## Describe Your Changes

This PR is solely intended to synchronize the engine version to 0.1.43.

## Self Checklist
This pull request includes a small but important update to the `extensions/inference-cortex-extension/rolldown.config.mjs` file. The change updates the version of the Cortex engine used in the project.

* [`extensions/inference-cortex-extension/rolldown.config.mjs`](diffhunk://#diff-9b93590cc9312a835d0c11d009d45deeb5ff72bca39e246b2e3f8fde7e3d5e8eL114-R114): Updated `CORTEX_ENGINE_VERSION` from 'v0.1.42' to 'v0.1.43'.