### PR TITLE
fix: sass legacy warn

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -131,7 +131,6 @@
     "electron-playwright-helpers": "^1.6.0",
     "eslint": "8.57.0",
     "eslint-plugin-react": "^7.34.0",
-    "jq": "^1.7.2",
     "rimraf": "^5.0.5",
     "run-script-os": "^1.1.6",
     "typescript": "^5.3.3",

--- a/joi/package.json
+++ b/joi/package.json
@@ -40,7 +40,6 @@
     "@types/jest": "^29.5.12",
     "autoprefixer": "10.4.16",
     "jest": "^29.7.0",
-    "rollup-plugin-sass": "^1.14.0",
     "tailwind-merge": "^2.2.0",
     "tailwindcss": "^3.4.1",
     "ts-jest": "^29.2.5"
@@ -71,6 +70,7 @@
     "rollup-plugin-peer-deps-external": "2.2.4",
     "rollup-plugin-postcss": "4.0.2",
     "rollup-plugin-typescript2": "0.36.0",
+    "sass": "^1.83.1",
     "typescript": "^5.7.2"
   },
   "packageManager": "yarn@4.5.3"

--- a/joi/rollup.config.mjs
+++ b/joi/rollup.config.mjs
@@ -11,7 +11,6 @@ import tailwindcss from 'tailwindcss'
 import typescriptEngine from 'typescript'
 import resolve from '@rollup/plugin-node-resolve'
 import copy from 'rollup-plugin-copy'
-import sass from 'rollup-plugin-sass'
 
 const packageJson = JSON.parse(readFileSync('./package.json'))
 
@@ -36,6 +35,7 @@ export default [
         use: {
           sass: {
             silenceDeprecations: ['legacy-js-api'],
+            api: 'modern',
           },
         },
         minimize: true,
@@ -58,7 +58,6 @@ export default [
         ],
       }),
       terser(),
-      sass(),
     ],
     watch: {
       clearScreen: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,6 +43,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@asamuzakjp/css-color@npm:^2.8.2":
+  version: 2.8.2
+  resolution: "@asamuzakjp/css-color@npm:2.8.2"
+  dependencies:
+    "@csstools/css-calc": "npm:^2.1.1"
+    "@csstools/css-color-parser": "npm:^3.0.7"
+    "@csstools/css-parser-algorithms": "npm:^3.0.4"
+    "@csstools/css-tokenizer": "npm:^3.0.3"
+    lru-cache: "npm:^11.0.2"
+  checksum: 10c0/352b91ca7741876e459cd3cb350a969e842da1e532577157d38365a6da89b7d6e6944249489366ee61b8a225ede1b521e7ab305b70ad4c688b01404061eecca8
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.10.4, @babel/code-frame@npm:^7.12.13, @babel/code-frame@npm:^7.22.13, @babel/code-frame@npm:^7.25.9, @babel/code-frame@npm:^7.26.0, @babel/code-frame@npm:^7.26.2":
   version: 7.26.2
   resolution: "@babel/code-frame@npm:7.26.2"
@@ -418,6 +431,52 @@ __metadata:
   version: 0.2.3
   resolution: "@bcoe/v8-coverage@npm:0.2.3"
   checksum: 10c0/6b80ae4cb3db53f486da2dc63b6e190a74c8c3cca16bb2733f234a0b6a9382b09b146488ae08e2b22cf00f6c83e20f3e040a2f7894f05c045c946d6a090b1d52
+  languageName: node
+  linkType: hard
+
+"@csstools/color-helpers@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "@csstools/color-helpers@npm:5.0.1"
+  checksum: 10c0/77fa3b7236eaa3f36dea24708ac0d5e53168903624ac5aed54615752a0730cd20773fda50e742ce868012eca8c000cc39688e05869e79f34714230ab6968d1e6
+  languageName: node
+  linkType: hard
+
+"@csstools/css-calc@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@csstools/css-calc@npm:2.1.1"
+  peerDependencies:
+    "@csstools/css-parser-algorithms": ^3.0.4
+    "@csstools/css-tokenizer": ^3.0.3
+  checksum: 10c0/857c8dac40eb6ba8810408dad141bbcad060b28bce69dfd3bcf095a060fcaa23d5c4dbf52be88fcb57e12ce32c666e855dc68de1d8020851f6b432e3f9b29950
+  languageName: node
+  linkType: hard
+
+"@csstools/css-color-parser@npm:^3.0.7":
+  version: 3.0.7
+  resolution: "@csstools/css-color-parser@npm:3.0.7"
+  dependencies:
+    "@csstools/color-helpers": "npm:^5.0.1"
+    "@csstools/css-calc": "npm:^2.1.1"
+  peerDependencies:
+    "@csstools/css-parser-algorithms": ^3.0.4
+    "@csstools/css-tokenizer": ^3.0.3
+  checksum: 10c0/b81780e6c50f0b0605776bd39bbd6203780231a561601853a9835cc70788560e7a281d0fbfe47ebe8affcb07dd64b0b1dcd4b67552520cfbe0e5088df158f12c
+  languageName: node
+  linkType: hard
+
+"@csstools/css-parser-algorithms@npm:^3.0.4":
+  version: 3.0.4
+  resolution: "@csstools/css-parser-algorithms@npm:3.0.4"
+  peerDependencies:
+    "@csstools/css-tokenizer": ^3.0.3
+  checksum: 10c0/d411f07765e14eede17bccc6bd4f90ff303694df09aabfede3fd104b2dfacfd4fe3697cd25ddad14684c850328f3f9420ebfa9f78380892492974db24ae47dbd
+  languageName: node
+  linkType: hard
+
+"@csstools/css-tokenizer@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "@csstools/css-tokenizer@npm:3.0.3"
+  checksum: 10c0/c31bf410e1244b942e71798e37c54639d040cb59e0121b21712b40015fced2b0fb1ffe588434c5f8923c9cd0017cfc1c1c8f3921abc94c96edf471aac2eba5e5
   languageName: node
   linkType: hard
 
@@ -997,8 +1056,8 @@ __metadata:
     rollup-plugin-dts: "npm:6.1.0"
     rollup-plugin-peer-deps-external: "npm:2.2.4"
     rollup-plugin-postcss: "npm:4.0.2"
-    rollup-plugin-sass: "npm:^1.14.0"
     rollup-plugin-typescript2: "npm:0.36.0"
+    sass: "npm:^1.83.1"
     tailwind-merge: "npm:^2.2.0"
     tailwindcss: "npm:^3.4.1"
     ts-jest: "npm:^29.2.5"
@@ -3353,7 +3412,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/pluginutils@npm:^3 || ^4 || ^5, @rollup/pluginutils@npm:^5.0.1":
+"@rollup/pluginutils@npm:^4.1.2":
+  version: 4.2.1
+  resolution: "@rollup/pluginutils@npm:4.2.1"
+  dependencies:
+    estree-walker: "npm:^2.0.1"
+    picomatch: "npm:^2.2.2"
+  checksum: 10c0/3ee56b2c8f1ed8dfd0a92631da1af3a2dfdd0321948f089b3752b4de1b54dc5076701eadd0e5fc18bd191b77af594ac1db6279e83951238ba16bf8a414c64c48
+  languageName: node
+  linkType: hard
+
+"@rollup/pluginutils@npm:^5.0.1":
   version: 5.1.4
   resolution: "@rollup/pluginutils@npm:5.1.4"
   dependencies:
@@ -3366,16 +3435,6 @@ __metadata:
     rollup:
       optional: true
   checksum: 10c0/6d58fbc6f1024eb4b087bc9bf59a1d655a8056a60c0b4021d3beaeec3f0743503f52467fd89d2cf0e7eccf2831feb40a05ad541a17637ea21ba10b21c2004deb
-  languageName: node
-  linkType: hard
-
-"@rollup/pluginutils@npm:^4.1.2":
-  version: 4.2.1
-  resolution: "@rollup/pluginutils@npm:4.2.1"
-  dependencies:
-    estree-walker: "npm:^2.0.1"
-    picomatch: "npm:^2.2.2"
-  checksum: 10c0/3ee56b2c8f1ed8dfd0a92631da1af3a2dfdd0321948f089b3752b4de1b54dc5076701eadd0e5fc18bd191b77af594ac1db6279e83951238ba16bf8a414c64c48
   languageName: node
   linkType: hard
 
@@ -5603,7 +5662,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bindings@npm:1.5.0, bindings@npm:^1.5.0":
+"bindings@npm:1.5.0, bindings@npm:^1.2.1, bindings@npm:^1.5.0":
   version: 1.5.0
   resolution: "bindings@npm:1.5.0"
   dependencies:
@@ -6506,6 +6565,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"contextify@npm:0.1.x":
+  version: 0.1.15
+  resolution: "contextify@npm:0.1.15"
+  dependencies:
+    bindings: "npm:^1.2.1"
+    nan: "npm:^2.1.0"
+    node-gyp: "npm:latest"
+  checksum: 10c0/818ce9ff0867050e50ba18fea112d12932f30ee1c0350000a9a28fb2df3efc97c7922ea891b03c83244d8132c462e472f18b8d824d95dafde43520c2395bb781
+  languageName: node
+  linkType: hard
+
 "convert-source-map@npm:^2.0.0":
   version: 2.0.0
   resolution: "convert-source-map@npm:2.0.0"
@@ -6781,6 +6851,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cssom@npm:0.2.x":
+  version: 0.2.5
+  resolution: "cssom@npm:0.2.5"
+  checksum: 10c0/d8fae52a1b2cc37fdcc7ab81ff2294ba239959a690bec764446a4f6219de443b5bf82b5fa2249f7b3ead74e5b521cc7a4808790e5c518eaa2b199bc895443fd3
+  languageName: node
+  linkType: hard
+
 "cssom@npm:^0.5.0":
   version: 0.5.0
   resolution: "cssom@npm:0.5.0"
@@ -6792,6 +6869,16 @@ __metadata:
   version: 0.3.8
   resolution: "cssom@npm:0.3.8"
   checksum: 10c0/d74017b209440822f9e24d8782d6d2e808a8fdd58fa626a783337222fe1c87a518ba944d4c88499031b4786e68772c99dfae616638d71906fe9f203aeaf14411
+  languageName: node
+  linkType: hard
+
+"cssstyle@npm:>=0.2.3":
+  version: 4.2.1
+  resolution: "cssstyle@npm:4.2.1"
+  dependencies:
+    "@asamuzakjp/css-color": "npm:^2.8.2"
+    rrweb-cssom: "npm:^0.8.0"
+  checksum: 10c0/02ba8c47c0caaab57acadacb3eb6c0f5f009000f55d61f6563670e07d389b26edefeed497e6c1847fcd2e6bbe0b6974c2d4291f97fa0c6ec6add13a7fa926d84
   languageName: node
   linkType: hard
 
@@ -9759,6 +9846,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"htmlparser@npm:1.x":
+  version: 1.7.7
+  resolution: "htmlparser@npm:1.7.7"
+  checksum: 10c0/b4ef1d2031f1370f274f646f824da10c8d946e671001d92878a4db77332abe84541667728063bb374a2742659b9549fd7d2e7ecdf71605ff016ef18b328becf5
+  languageName: node
+  linkType: hard
+
 "http-cache-semantics@npm:^4.0.0, http-cache-semantics@npm:^4.1.1":
   version: 4.1.1
   resolution: "http-cache-semantics@npm:4.1.1"
@@ -10916,7 +11010,6 @@ __metadata:
     jest: "npm:^29.7.0"
     jest-environment-jsdom: "npm:^29.7.0"
     rimraf: "npm:^3.0.2"
-    run-script-os: "npm:^1.1.6"
     wait-on: "npm:^7.0.1"
   languageName: unknown
   linkType: soft
@@ -10948,6 +11041,7 @@ __metadata:
     eslint: "npm:8.57.0"
     eslint-plugin-react: "npm:^7.34.0"
     fs-extra: "npm:^11.2.0"
+    jq: "npm:^1.7.2"
     node-fetch: "npm:2"
     pacote: "npm:^21.0.0"
     request: "npm:^2.88.2"
@@ -11503,6 +11597,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jq@npm:^1.7.2":
+  version: 1.7.2
+  resolution: "jq@npm:1.7.2"
+  dependencies:
+    jsdom: "npm:0.2.x"
+    xmlhttprequest: "npm:1.3.x"
+  bin:
+    jq: ./bin/jq
+  checksum: 10c0/ac23f36e3455435f7da90fe3dc4134cbbd5c04b52bdb04591efedb236aff7e0384c08f27849d44e3123357f6e8f1afca60b63c3af1663cbdc04b4a0ae0c11e3b
+  languageName: node
+  linkType: hard
+
 "js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -11544,6 +11650,22 @@ __metadata:
   version: 0.1.1
   resolution: "jsbn@npm:0.1.1"
   checksum: 10c0/e046e05c59ff880ee4ef68902dbdcb6d2f3c5d60c357d4d68647dc23add556c31c0e5f41bdb7e69e793dd63468bd9e085da3636341048ef577b18f5b713877c0
+  languageName: node
+  linkType: hard
+
+"jsdom@npm:0.2.x":
+  version: 0.2.19
+  resolution: "jsdom@npm:0.2.19"
+  dependencies:
+    contextify: "npm:0.1.x"
+    cssom: "npm:0.2.x"
+    cssstyle: "npm:>=0.2.3"
+    htmlparser: "npm:1.x"
+    request: "npm:2.x"
+  dependenciesMeta:
+    contextify:
+      optional: true
+  checksum: 10c0/7a0aaff6b4d4ae96e1e3489667926782117cfcbee0f7aaefafcc7b04a4e00a1588b2f03db50978612cbb47441fe31bedf28179cdd4c5e144a8cc5a7218a2f0e6
   languageName: node
   linkType: hard
 
@@ -12121,7 +12243,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lru-cache@npm:^11.0.0":
+"lru-cache@npm:^11.0.0, lru-cache@npm:^11.0.2":
   version: 11.0.2
   resolution: "lru-cache@npm:11.0.2"
   checksum: 10c0/c993b8e06ead0b24b969c1dbb5b301716aed66e320e9014a80012f5febe280b438f28ff50046b2c55ff404e889351ccb332ff91f8dd175a21f5eae80e3fb155f
@@ -13148,7 +13270,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nan@npm:^2.12.1":
+"nan@npm:^2.1.0, nan@npm:^2.12.1":
   version: 2.22.0
   resolution: "nan@npm:2.22.0"
   dependencies:
@@ -15826,7 +15948,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"request@npm:^2.88.2":
+"request@npm:2.x, request@npm:^2.88.2":
   version: 2.88.2
   resolution: "request@npm:2.88.2"
   dependencies:
@@ -15926,7 +16048,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@npm:^1.1.7, resolve@npm:^1.11.0, resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.2, resolve@npm:^1.22.4, resolve@npm:^1.22.8, resolve@npm:^1.5.0":
+"resolve@npm:^1.1.7, resolve@npm:^1.11.0, resolve@npm:^1.19.0, resolve@npm:^1.20.0, resolve@npm:^1.22.1, resolve@npm:^1.22.2, resolve@npm:^1.22.4, resolve@npm:^1.22.8":
   version: 1.22.10
   resolution: "resolve@npm:1.22.10"
   dependencies:
@@ -15952,7 +16074,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.11.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.5.0#optional!builtin<compat/resolve>":
+"resolve@patch:resolve@npm%3A^1.1.7#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.11.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.19.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.20.0#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.1#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.2#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.4#optional!builtin<compat/resolve>, resolve@patch:resolve@npm%3A^1.22.8#optional!builtin<compat/resolve>":
   version: 1.22.10
   resolution: "resolve@patch:resolve@npm%3A1.22.10#optional!builtin<compat/resolve>::version=1.22.10&hash=c3c19d"
   dependencies:
@@ -16216,17 +16338,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup-plugin-sass@npm:^1.14.0":
-  version: 1.14.0
-  resolution: "rollup-plugin-sass@npm:1.14.0"
-  dependencies:
-    "@rollup/pluginutils": "npm:^3 || ^4 || ^5"
-    resolve: "npm:^1.5.0"
-    sass: "npm:^1.7.2"
-  checksum: 10c0/231d08e0a5c453e291b73e322cf176382855f597e41dbbaa1bc65bb480ae9a9fe8b45f611e62103eaada07a72e9ed5a5c9f4653507a9542735a0c6cb68f880b9
-  languageName: node
-  linkType: hard
-
 "rollup-plugin-typescript2@npm:0.36.0":
   version: 0.36.0
   resolution: "rollup-plugin-typescript2@npm:0.36.0"
@@ -16303,6 +16414,13 @@ __metadata:
   bin:
     rollup: dist/bin/rollup
   checksum: 10c0/1650168231ae8e2bd6fb4d82cc232e53b5c0fe67895188fa683370c9bd3f1febaa28e45c6b100cea333e54f8f5fae6f4d0eea7d86256ec2cc3e38212c55796d6
+  languageName: node
+  linkType: hard
+
+"rrweb-cssom@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "rrweb-cssom@npm:0.8.0"
+  checksum: 10c0/56f2bfd56733adb92c0b56e274c43f864b8dd48784d6fe946ef5ff8d438234015e59ad837fc2ad54714b6421384141c1add4eb569e72054e350d1f8a50b8ac7b
   languageName: node
   linkType: hard
 
@@ -16420,7 +16538,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sass@npm:^1.69.4, sass@npm:^1.7.2":
+"sass@npm:^1.69.4":
   version: 1.83.0
   resolution: "sass@npm:1.83.0"
   dependencies:
@@ -16434,6 +16552,23 @@ __metadata:
   bin:
     sass: sass.js
   checksum: 10c0/4415361229879a9041d77c953da85482e89032aa4321ba13250a9987d39c80fac6c88af3777f2a2d76a4e8b0c8afbd21c1970fdbe84e0b3ec25fb26741f92beb
+  languageName: node
+  linkType: hard
+
+"sass@npm:^1.83.1":
+  version: 1.83.1
+  resolution: "sass@npm:1.83.1"
+  dependencies:
+    "@parcel/watcher": "npm:^2.4.1"
+    chokidar: "npm:^4.0.0"
+    immutable: "npm:^5.0.2"
+    source-map-js: "npm:>=0.6.2 <2.0.0"
+  dependenciesMeta:
+    "@parcel/watcher":
+      optional: true
+  bin:
+    sass: sass.js
+  checksum: 10c0/9772506cd8290df7b5e800055098e91a8a65100840fd9e90c660deb74b248b3ddbbd1a274b8f7f09777d472d2c873575357bd87939a40fb5a80bdf654985486f
   languageName: node
   linkType: hard
 
@@ -18989,6 +19124,13 @@ __metadata:
   version: 2.2.0
   resolution: "xmlchars@npm:2.2.0"
   checksum: 10c0/b64b535861a6f310c5d9bfa10834cf49127c71922c297da9d4d1b45eeaae40bf9b4363275876088fbe2667e5db028d2cd4f8ee72eed9bede840a67d57dab7593
+  languageName: node
+  linkType: hard
+
+"xmlhttprequest@npm:1.3.x":
+  version: 1.3.0
+  resolution: "xmlhttprequest@npm:1.3.0"
+  checksum: 10c0/42d59ee0b20099bd3b618c12d99e1fb6efb9e2945d8dee779f015665a74ee0907a0e936b1f66dc4b89653c3d49bd02246195e4cc74601338babc17d9a43e8673
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe Your Changes

![Screenshot 2025-01-13 at 16 08 27](https://github.com/user-attachments/assets/74544e03-02bd-4cae-bb9a-23434a130ca7)

This pull request includes changes to the `joi` package to update dependencies and improve the build configuration. The most important changes include replacing the `rollup-plugin-sass` with the `sass` package and updating the Rollup configuration to use the modern Sass API.

Dependency updates:

* [`joi/package.json`](diffhunk://#diff-c528dc1b5dd8e454997100b4ad27d03c9499e8946dfe7c6bdab5bfca6f3e73a9L43): Removed `rollup-plugin-sass` and added `sass` as a dependency. [[1]](diffhunk://#diff-c528dc1b5dd8e454997100b4ad27d03c9499e8946dfe7c6bdab5bfca6f3e73a9L43) [[2]](diffhunk://#diff-c528dc1b5dd8e454997100b4ad27d03c9499e8946dfe7c6bdab5bfca6f3e73a9R73)

Build configuration improvements:

* [`joi/rollup.config.mjs`](diffhunk://#diff-c39d7d25ca91c984c98b2a928df5f2c32dd4a554dc7e7733c1554961d84b624eL14): Removed the import and usage of `rollup-plugin-sass` and updated the configuration to use the modern Sass API. [[1]](diffhunk://#diff-c39d7d25ca91c984c98b2a928df5f2c32dd4a554dc7e7733c1554961d84b624eL14) [[2]](diffhunk://#diff-c39d7d25ca91c984c98b2a928df5f2c32dd4a554dc7e7733c1554961d84b624eR38) [[3]](diffhunk://#diff-c39d7d25ca91c984c98b2a928df5f2c32dd4a554dc7e7733c1554961d84b624eL61)

## Fixes Issues

![Screenshot 2025-01-13 at 16 10 44](https://github.com/user-attachments/assets/cea29849-8f68-4262-a953-4c3fcac86aa0)

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
