### PR TITLE
feat: move cortex extension settings to local engine page

### DIFF
--- a/web/screens/Settings/Engines/LocalEngineSettings.tsx
+++ b/web/screens/Settings/Engines/LocalEngineSettings.tsx
@@ -23,6 +23,8 @@ import {
 
 import { formatDownloadPercentage } from '@/utils/converter'
 
+import ExtensionSetting from '../ExtensionSetting'
+
 import DeleteEngineVariant from './DeleteEngineVariant'
 const os = () => {
   switch (PLATFORM) {
@@ -338,6 +340,11 @@ const LocalEngineSettings = ({ engine }: { engine: InferenceEngine }) => {
               </div>
             </div>
           </div>
+        </div>
+        <div className="border-b border-[hsla(var(--app-border))]" />
+        <div className="flex w-full border-b border-[hsla(var(--app-border))]">
+          {/* TODO: Pull settings from engine when it's supported */}
+          <ExtensionSetting extensionName="@janhq/inference-cortex-extension" />
         </div>
       </div>
     </ScrollArea>

--- a/web/screens/Settings/Engines/index.tsx
+++ b/web/screens/Settings/Engines/index.tsx
@@ -2,8 +2,7 @@ import React from 'react'
 
 import { InferenceEngine } from '@janhq/core'
 import { ScrollArea } from '@janhq/joi'
-
-import { useGetEngines } from '@/hooks/useEngineManagement'
+import { useAtomValue } from 'jotai'
 
 import { isLocalEngine } from '@/utils/modelEngine'
 
@@ -11,8 +10,10 @@ import LocalEngineItems from './LocalEngineItem'
 import ModalAddRemoteEngine from './ModalAddRemoteEngine'
 import RemoteEngineItems from './RemoteEngineItem'
 
+import { installedEnginesAtom } from '@/helpers/atoms/Engines.atom'
+
 const Engines = () => {
-  const { engines } = useGetEngines()
+  const engines = useAtomValue(installedEnginesAtom)
 
   return (
     <ScrollArea className="h-full w-full">

--- a/web/screens/Settings/ExtensionSetting/index.tsx
+++ b/web/screens/Settings/ExtensionSetting/index.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useState } from 'react'
+import React, { Fragment, useEffect, useMemo, useState } from 'react'
 
 import {
   BaseExtension,
@@ -14,7 +14,7 @@ import SettingDetailItem from '../SettingDetail/SettingDetailItem'
 import { extensionManager } from '@/extension'
 import { selectedSettingAtom } from '@/helpers/atoms/Setting.atom'
 
-const ExtensionSetting = () => {
+const ExtensionSetting = ({ extensionName }: { extensionName?: string }) => {
   const selectedExtensionName = useAtomValue(selectedSettingAtom)
   const [settings, setSettings] = useState<SettingComponentProps[]>([])
   const [installationState, setInstallationState] =
@@ -23,11 +23,16 @@ const ExtensionSetting = () => {
     undefined
   )
 
+  const currentExtensionName = useMemo(
+    () => extensionName ?? selectedExtensionName,
+    [selectedExtensionName, extensionName]
+  )
+
   useEffect(() => {
     const getExtensionSettings = async () => {
-      if (!selectedExtensionName) return
+      if (!currentExtensionName) return
       const allSettings: SettingComponentProps[] = []
-      const baseExtension = extensionManager.getByName(selectedExtensionName)
+      const baseExtension = extensionManager.getByName(currentExtensionName)
       if (!baseExtension) return
 
       setBaseExtension(baseExtension)
@@ -40,7 +45,7 @@ const ExtensionSetting = () => {
       setInstallationState(await baseExtension.installationState())
     }
     getExtensionSettings()
-  }, [selectedExtensionName])
+  }, [currentExtensionName])
 
   const onValueChanged = async (
     key: string,

--- a/web/screens/Settings/SettingDetail/SettingDetailItem/SettingDetailTextInputItem/index.tsx
+++ b/web/screens/Settings/SettingDetail/SettingDetailItem/SettingDetailTextInputItem/index.tsx
@@ -87,7 +87,7 @@ const SettingDetailTextInputItem = ({
       <div
         className={twMerge(
           'w-full flex-shrink-0 pr-1 sm:w-1/2',
-          type === 'number' && 'sm:w-22 w-24'
+          type === 'number' && 'sm:w-22 w-50'
         )}
       >
         <Input

--- a/web/screens/Settings/SettingDetail/SettingDetailItem/index.tsx
+++ b/web/screens/Settings/SettingDetail/SettingDetailItem/index.tsx
@@ -56,7 +56,7 @@ const SettingDetailItem = ({ componentProps, onValueUpdated }: Props) => {
     <div className="flex h-full w-full flex-col overflow-y-auto">
       {components.map((component, index) => (
         <div
-          className={`mx-4 ${index === components.length - 1 ? '' : 'border-b border-[hsla(var(--app-border))]'}`}
+          className={`${index === components.length - 1 ? '' : 'border-b border-[hsla(var(--app-border))]'}`}
           key={index}
         >
           {component}

--- a/web/screens/Settings/SettingDetail/index.tsx
+++ b/web/screens/Settings/SettingDetail/index.tsx
@@ -59,7 +59,11 @@ const SettingDetail = () => {
           <RemoteEngineSettings engine={selectedSetting as InferenceEngine} />
         )
       }
-      return <ExtensionSetting />
+      return (
+        <div className="mx-4">
+          <ExtensionSetting />
+        </div>
+      )
   }
 }
 

--- a/web/screens/Settings/SettingLeftPanel/index.tsx
+++ b/web/screens/Settings/SettingLeftPanel/index.tsx
@@ -144,6 +144,7 @@ const SettingLeftPanel = () => {
 
         {extensionHasSettings
           .sort((a, b) => String(a.name).localeCompare(String(b.name)))
+          .filter((e) => !e.name?.includes('Cortex'))
           .map((item) => (
             <SettingItem
               key={item.name}


### PR DESCRIPTION
## Describe Your Changes

This PR is to update app local engine settings which extended from it's parent extension settings. From now on, there is no Cortex extensions page, but all settings moved to llama.cpp engine page.

![CleanShot 2025-01-15 at 19 47 07](https://github.com/user-attachments/assets/7abd8d46-cb61-406a-8a03-d21f054b3778)


## Fixes Issues

- Closes #4441

## Changes
This pull request includes several changes to the `Settings` screen in the web application, primarily focusing on the `ExtensionSetting` component and related files. The changes introduce new functionality, improve existing code, and fix minor issues.

### Changes to `ExtensionSetting` component:

* Updated `ExtensionSetting` to accept an optional `extensionName` prop and use `useMemo` to determine the current extension name. This allows for more flexible usage of the component. [[1]](diffhunk://#diff-758ec3f45cd922288cdf5c18ff0d9481d997b843eeb918588aa783bf4d4cc3afL17-R17) [[2]](diffhunk://#diff-758ec3f45cd922288cdf5c18ff0d9481d997b843eeb918588aa783bf4d4cc3afR26-R35) [[3]](diffhunk://#diff-758ec3f45cd922288cdf5c18ff0d9481d997b843eeb918588aa783bf4d4cc3afL43-R48)
* Added import of `ExtensionSetting` in `LocalEngineSettings.tsx` and included it in the component's JSX structure. This integrates the `ExtensionSetting` component into the `LocalEngineSettings` screen. [[1]](diffhunk://#diff-fb438e50789357b1faa6cc0a4695db4ba333e3f5bb597d9f4dd05d53ea121723R26-R27) [[2]](diffhunk://#diff-fb438e50789357b1faa6cc0a4695db4ba333e3f5bb597d9f4dd05d53ea121723R344-R349)

### Other improvements and fixes:

* Adjusted the width of the text input for number types in `SettingDetailTextInputItem` to improve the layout.
* Simplified the conditional class assignment in `SettingDetailItem` to remove unnecessary `mx-4` class.
* Wrapped `ExtensionSetting` in a `div` with `mx-4` class in `SettingDetail` to ensure consistent padding.
* Filtered out extensions with names containing 'Cortex' in `SettingLeftPanel` to exclude them from the settings list.
