### PR TITLE
fix: mismatch NGL number between UI and model settings

### DIFF
--- a/web/utils/componentSettings.ts
+++ b/web/utils/componentSettings.ts
@@ -33,6 +33,11 @@ export const getConfigurationsData = (
                 componentSetting.controllerProps.max ||
                 2048
               break
+            case 'ngl':
+              componentSetting.controllerProps.max =
+                selectedModel?.settings.ngl ||
+                componentSetting.controllerProps.max ||
+                100
           }
         }
       }


### PR DESCRIPTION
## Describe Your Changes

This pull request addressed an issue where Jan application displayed an incorrect maximum number of NGL settings. It always displayed 100 instead of using the value specified in the model configuration.

![CleanShot 2025-01-15 at 20 00 44@2x](https://github.com/user-attachments/assets/9aa22cf2-888b-4b85-a908-cdc1dc243d5d)
![CleanShot 2025-01-15 at 20 00 26@2x](https://github.com/user-attachments/assets/624e8284-9f16-4a3f-922e-c568d42b2732)


## Fixes Issues

- Closes #4035

## Changes
This pull request includes a change to the `web/utils/componentSettings.ts` file to add a new case for handling 'ngl' settings in the `getConfigurationsData` function.

The most important change is:

* [`web/utils/componentSettings.ts`](diffhunk://#diff-ab2c4bdf5e5c7d108c34453a926aac4e09d984458c183ba82fd091b5d86190acR36-R40): Added a new case 'ngl' to set `componentSetting.controllerProps.max` based on `selectedModel?.settings.ngl` or a default value of 100.
