### PR TITLE
chore: fix engine description hyperlink display

### DIFF
--- a/web/screens/Settings/Engines/LocalEngineSettings.tsx
+++ b/web/screens/Settings/Engines/LocalEngineSettings.tsx
@@ -217,8 +217,14 @@ const LocalEngineSettings = ({ engine }: { engine: InferenceEngine }) => {
                   <div className="mt-2 w-full font-medium leading-relaxed text-[hsla(var(--text-secondary))]">
                     <p>
                       Choose the default variant that best suited for your
-                      hardware. See [our
-                      guides](https://jan.ai/docs/local-engines/llama-cpp).
+                      hardware. See&nbsp;
+                      <a
+                        href="https://jan.ai/docs/local-engines/llama-cpp"
+                        className="cursor-pointer text-blue-600 dark:text-blue-400"
+                        target="_blank"
+                      >
+                        our guides.
+                      </a>
                     </p>
                   </div>
                 </div>


### PR DESCRIPTION
## Describe Your Changes

- Fixed a minor display issue where hyperlinks were displayed as plain text.

![CleanShot 2025-01-16 at 10 25 40@2x](https://github.com/user-attachments/assets/cba389aa-00b5-41bc-950d-6defe9f3a7e9)


## Changes
This pull request includes a small but important change to the `LocalEngineSettings` component in the `web/screens/Settings/Engines/LocalEngineSettings.tsx` file. The change improves the user interface by converting a plain text link into a clickable HTML anchor tag with styling.

* [`web/screens/Settings/Engines/LocalEngineSettings.tsx`](diffhunk://#diff-fb438e50789357b1faa6cc0a4695db4ba333e3f5bb597d9f4dd05d53ea121723L220-R227): Changed the plain text link to an HTML anchor tag with classes for cursor pointer and text color, and added `target="_blank"` to open the link in a new tab.
