### PR TITLE
fix: app crashes on select cloud model first time onboarding

### DIFF
--- a/web/screens/Settings/Engines/RemoteEngineSettings.tsx
+++ b/web/screens/Settings/Engines/RemoteEngineSettings.tsx
@@ -115,6 +115,8 @@ const RemoteEngineSettings = ({
     }
   }, [engine])
 
+  if (!engine) return null
+
   return (
     <ScrollArea className="h-full w-full">
       <div className="block w-full px-4">

--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/OnDeviceStarterScreen/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/OnDeviceStarterScreen/index.tsx
@@ -298,40 +298,46 @@ const OnDeviceStarterScreen = ({ isShowStarterScreen }: Props) => {
                         key={rowIndex}
                         className="my-2 flex items-center gap-4 md:gap-10"
                       >
-                        {row.map((remoteEngine) => {
-                          const engineLogo = getLogoEngine(
-                            remoteEngine as InferenceEngine
+                        {row
+                          .filter(
+                            (e) =>
+                              engines?.[e as InferenceEngine]?.[0]?.type ===
+                              'remote'
                           )
+                          .map((remoteEngine) => {
+                            const engineLogo = getLogoEngine(
+                              remoteEngine as InferenceEngine
+                            )
 
-                          return (
-                            <div
-                              className="flex cursor-pointer flex-col items-center justify-center gap-4"
-                              key={remoteEngine}
-                              onClick={() => {
-                                setMainViewState(MainViewState.Settings)
-                                setSelectedSetting(
-                                  remoteEngine as InferenceEngine
-                                )
-                              }}
-                            >
-                              {engineLogo && (
-                                <Image
-                                  width={48}
-                                  height={48}
-                                  src={engineLogo}
-                                  alt="Engine logo"
-                                  className="h-10 w-10 flex-shrink-0"
-                                />
-                              )}
-
-                              <p className="font-medium">
-                                {getTitleByEngine(
-                                  remoteEngine as InferenceEngine
+                            return (
+                              <div
+                                className="flex cursor-pointer flex-col items-center justify-center gap-4"
+                                key={remoteEngine}
+                                onClick={() => {
+                                  setMainViewState(MainViewState.Settings)
+                                  setSelectedSetting(
+                                    remoteEngine as InferenceEngine
+                                  )
+                                }}
+                              >
+                                {engineLogo && (
+                                  <Image
+                                    width={48}
+                                    height={48}
+                                    src={engineLogo}
+                                    alt="Engine logo"
+                                    className="h-10 w-10 flex-shrink-0"
+                                  />
                                 )}
-                              </p>
-                            </div>
-                          )
-                        })}
+
+                                <p className="font-medium">
+                                  {getTitleByEngine(
+                                    remoteEngine as InferenceEngine
+                                  )}
+                                </p>
+                              </div>
+                            )
+                          })}
                       </div>
                     )
                   })}


### PR DESCRIPTION
## Describe Your Changes

Fixed an issue where the app would crash if the user clicked on the cloud model during the first time of onboarding.
![CleanShot 2025-01-16 at 19 56 58](https://github.com/user-attachments/assets/06bca308-085c-410e-ad57-701420b43e17)

## Changes

This pull request includes changes to improve the handling of engine settings and filtering logic in the `RemoteEngineSettings` and `OnDeviceStarterScreen` components. The most important changes include adding a null check for the `engine` variable and filtering engines by type before mapping them.

Improvements to engine settings handling:

* [`web/screens/Settings/Engines/RemoteEngineSettings.tsx`](diffhunk://#diff-d8d84f4f488f0d35b2751fee2cad04a83f6661a0f11b2b6a2355ac0e70aec575R118-R119): Added a null check for the `engine` variable to return null if the engine is not defined.

Enhancements to filtering logic:

* [`web/screens/Thread/ThreadCenterPanel/ChatBody/OnDeviceStarterScreen/index.tsx`](diffhunk://#diff-1bf3e697514b9f8f76f36f1ad419bab293a66024fe07002df969814ab9f9d726L301-R307): Added a filter to only include engines of type 'remote' before mapping them in the `OnDeviceStarterScreen` component.
