### PR TITLE
Feat: Allow HTTP proxy authentication inputs

### DIFF
--- a/web/helpers/atoms/AppConfig.atom.ts
+++ b/web/helpers/atoms/AppConfig.atom.ts
@@ -5,8 +5,15 @@ const EXPERIMENTAL_FEATURE = 'experimentalFeature'
 const PROXY_FEATURE_ENABLED = 'proxyFeatureEnabled'
 const VULKAN_ENABLED = 'vulkanEnabled'
 const IGNORE_SSL = 'ignoreSSLFeature'
+const VERIFY_PROXY_SSL = 'verifyProxySSL'
+const VERIFY_PROXY_HOST_SSL = 'verifyProxyHostSSL'
+const VERIFY_PEER_SSL = 'verifyPeerSSL'
+const VERIFY_HOST_SSL = 'verifyHostSSL'
 const HTTPS_PROXY_FEATURE = 'httpsProxyFeature'
+const PROXY_USERNAME = 'proxyUsername'
+const PROXY_PASSWORD = 'proxyPassword'
 const QUICK_ASK_ENABLED = 'quickAskEnabled'
+const NO_PROXY = 'noProxy'
 
 export const janDataFolderPathAtom = atom('')
 
@@ -27,9 +34,39 @@ export const proxyAtom = atomWithStorage(HTTPS_PROXY_FEATURE, '', undefined, {
   getOnInit: true,
 })
 
+export const proxyUsernameAtom = atomWithStorage(PROXY_USERNAME, '', undefined, {
+  getOnInit: true,
+})
+
+export const proxyPasswordAtom = atomWithStorage(PROXY_PASSWORD, '', undefined, {
+  getOnInit: true,
+})
+
 export const ignoreSslAtom = atomWithStorage(IGNORE_SSL, false, undefined, {
   getOnInit: true,
 })
+
+
+export const noProxyAtom = atomWithStorage(NO_PROXY, '', undefined, {
+  getOnInit: true,
+})
+
+export const verifyProxySslAtom = atomWithStorage(VERIFY_PROXY_SSL, false, undefined, {
+  getOnInit: true,
+})
+
+export const verifyProxyHostSslAtom = atomWithStorage(VERIFY_PROXY_HOST_SSL, false, undefined, {
+  getOnInit: true,
+})
+
+export const verifyPeerSslAtom = atomWithStorage(VERIFY_PEER_SSL, false, undefined, {
+  getOnInit: true,
+})
+
+export const verifyHostSslAtom = atomWithStorage(VERIFY_HOST_SSL, false, undefined, {
+  getOnInit: true,
+})
+
 export const vulkanEnabledAtom = atomWithStorage(
   VULKAN_ENABLED,
   false,

--- a/web/helpers/atoms/AppConfig.atom.ts
+++ b/web/helpers/atoms/AppConfig.atom.ts
@@ -48,7 +48,7 @@ export const ignoreSslAtom = atomWithStorage(IGNORE_SSL, false, undefined, {
 
 
 export const noProxyAtom = atomWithStorage(NO_PROXY, '', undefined, {
-  getOnInit: true,
+  getOnInit: false,
 })
 
 export const verifyProxySslAtom = atomWithStorage(VERIFY_PROXY_SSL, false, undefined, {

--- a/web/helpers/atoms/AppConfig.atom.ts
+++ b/web/helpers/atoms/AppConfig.atom.ts
@@ -34,38 +34,55 @@ export const proxyAtom = atomWithStorage(HTTPS_PROXY_FEATURE, '', undefined, {
   getOnInit: true,
 })
 
-export const proxyUsernameAtom = atomWithStorage(PROXY_USERNAME, '', undefined, {
-  getOnInit: true,
-})
+export const proxyUsernameAtom = atomWithStorage(
+  PROXY_USERNAME,
+  '',
+  undefined,
+  { getOnInit: true }
+)
 
-export const proxyPasswordAtom = atomWithStorage(PROXY_PASSWORD, '', undefined, {
-  getOnInit: true,
-})
+export const proxyPasswordAtom = atomWithStorage(
+  PROXY_PASSWORD,
+  '',
+  undefined,
+  { getOnInit: true }
+)
 
 export const ignoreSslAtom = atomWithStorage(IGNORE_SSL, false, undefined, {
   getOnInit: true,
 })
 
-
 export const noProxyAtom = atomWithStorage(NO_PROXY, '', undefined, {
   getOnInit: false,
 })
 
-export const verifyProxySslAtom = atomWithStorage(VERIFY_PROXY_SSL, false, undefined, {
-  getOnInit: true,
-})
+export const verifyProxySslAtom = atomWithStorage(
+  VERIFY_PROXY_SSL,
+  false,
+  undefined,
+  { getOnInit: true }
+)
 
-export const verifyProxyHostSslAtom = atomWithStorage(VERIFY_PROXY_HOST_SSL, false, undefined, {
-  getOnInit: true,
-})
+export const verifyProxyHostSslAtom = atomWithStorage(
+  VERIFY_PROXY_HOST_SSL,
+  false,
+  undefined,
+  { getOnInit: true }
+)
 
-export const verifyPeerSslAtom = atomWithStorage(VERIFY_PEER_SSL, false, undefined, {
-  getOnInit: true,
-})
+export const verifyPeerSslAtom = atomWithStorage(
+  VERIFY_PEER_SSL,
+  false,
+  undefined,
+  { getOnInit: true }
+)
 
-export const verifyHostSslAtom = atomWithStorage(VERIFY_HOST_SSL, false, undefined, {
-  getOnInit: true,
-})
+export const verifyHostSslAtom = atomWithStorage(
+  VERIFY_HOST_SSL,
+  false,
+  undefined,
+  { getOnInit: true }
+)
 
 export const vulkanEnabledAtom = atomWithStorage(
   VULKAN_ENABLED,

--- a/web/hooks/useConfigurations.test.ts
+++ b/web/hooks/useConfigurations.test.ts
@@ -1,0 +1,137 @@
+import { renderHook, act } from '@testing-library/react'
+import { useConfigurations } from './useConfigurations'
+import { useAtomValue } from 'jotai'
+import { extensionManager } from '@/extension'
+
+// Mock dependencies
+jest.mock('jotai', () => {
+    const originalModule = jest.requireActual('jotai')
+    return {
+        ...originalModule,
+        useAtomValue: jest.fn(),
+    }
+})
+
+jest.mock('@/extension', () => ({
+  extensionManager: {
+    get: jest.fn(),
+  },
+}))
+
+describe('useConfigurations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should call configurePullOptions with correct proxy settings when proxy is enabled', () => {
+    // Explicitly set mock return values for each call
+    (useAtomValue as jest.Mock)
+      .mockReturnValueOnce(true)       // proxyEnabled
+      .mockReturnValueOnce('http://proxy.example.com')  // proxyUrl
+      .mockReturnValueOnce('')         // proxyIgnoreSSL
+      .mockReturnValueOnce(true)       // verifyProxySSL
+      .mockReturnValueOnce(true)       // verifyProxyHostSSL
+      .mockReturnValueOnce(true)       // verifyPeerSSL
+      .mockReturnValueOnce(true)       // verifyHostSSL
+      .mockReturnValueOnce('')         // noProxy
+      .mockReturnValueOnce('username') // proxyUsername
+      .mockReturnValueOnce('password') // proxyPassword
+
+
+    const mockConfigurePullOptions = jest.fn()
+    ;(extensionManager.get as jest.Mock).mockReturnValue({
+      configurePullOptions: mockConfigurePullOptions,
+    })
+
+    const { result } = renderHook(() => useConfigurations())
+
+    act(() => {
+      result.current.configurePullOptions()
+    })
+
+    expect(mockConfigurePullOptions).toHaveBeenCalledWith({
+      proxy_username: 'username',
+      proxy_password: 'password',
+      proxy_url: 'http://proxy.example.com',
+      verify_proxy_ssl: true,
+      verify_proxy_host_ssl: true,
+      verify_peer_ssl: true,
+      verify_host_ssl: true,
+      no_proxy: '',
+    })
+  })
+  
+  it('should call configurePullOptions with empty proxy settings when proxy is disabled', () => {
+    // Mock atom values
+    ;(useAtomValue as jest.Mock)
+      .mockReturnValueOnce(false) // proxyEnabled
+      .mockReturnValueOnce('') // proxyUrl
+      .mockReturnValueOnce(false) // proxyIgnoreSSL
+      .mockReturnValueOnce('') // noProxy
+      .mockReturnValueOnce('') // proxyUsername
+      .mockReturnValueOnce('') // proxyPassword
+      .mockReturnValueOnce(false) // verifyProxySSL
+      .mockReturnValueOnce(false) // verifyProxyHostSSL
+      .mockReturnValueOnce(false) // verifyPeerSSL
+      .mockReturnValueOnce(false) // verifyHostSSL
+
+    const mockConfigurePullOptions = jest.fn()
+    ;(extensionManager.get as jest.Mock).mockReturnValue({
+      configurePullOptions: mockConfigurePullOptions,
+    })
+
+    const { result } = renderHook(() => useConfigurations())
+
+    act(() => {
+      result.current.configurePullOptions()
+    })
+
+    expect(mockConfigurePullOptions).toHaveBeenCalledWith({
+      proxy_username: '',
+      proxy_password: '',
+      proxy_url: '',
+      verify_proxy_ssl: false,
+      verify_proxy_host_ssl: false,
+      verify_peer_ssl: false,
+      verify_host_ssl: false,
+      no_proxy: '',
+    })
+  })
+
+  it('should set all verify SSL to false when proxyIgnoreSSL is true', () => {
+    // Mock atom values
+    ;(useAtomValue as jest.Mock)
+      .mockReturnValueOnce(true)       // proxyEnabled
+      .mockReturnValueOnce('http://proxy.example.com')  // proxyUrl
+      .mockReturnValueOnce(true)         // proxyIgnoreSSL
+      .mockReturnValueOnce(true)       // verifyProxySSL
+      .mockReturnValueOnce(true)       // verifyProxyHostSSL
+      .mockReturnValueOnce(true)       // verifyPeerSSL
+      .mockReturnValueOnce(true)       // verifyHostSSL
+      .mockReturnValueOnce('')         // noProxy
+      .mockReturnValueOnce('username') // proxyUsername
+      .mockReturnValueOnce('password') // proxyPassword
+
+    const mockConfigurePullOptions = jest.fn()
+    ;(extensionManager.get as jest.Mock).mockReturnValue({
+      configurePullOptions: mockConfigurePullOptions,
+    })
+
+    const { result } = renderHook(() => useConfigurations())
+
+    act(() => {
+      result.current.configurePullOptions()
+    })
+
+    expect(mockConfigurePullOptions).toHaveBeenCalledWith({
+      proxy_username: 'username',
+      proxy_password: 'password',
+      proxy_url: 'http://proxy.example.com',
+      verify_proxy_ssl: false,
+      verify_proxy_host_ssl: false,
+      verify_peer_ssl: false,
+      verify_host_ssl: false,
+      no_proxy: '',
+    })
+  })
+}) 

--- a/web/hooks/useConfigurations.ts
+++ b/web/hooks/useConfigurations.ts
@@ -6,14 +6,28 @@ import { useAtomValue } from 'jotai'
 import { extensionManager } from '@/extension'
 import {
   ignoreSslAtom,
+  noProxyAtom,
   proxyAtom,
   proxyEnabledAtom,
+  proxyPasswordAtom,
+  proxyUsernameAtom,
+  verifyHostSslAtom,
+  verifyPeerSslAtom,
+  verifyProxyHostSslAtom,
+  verifyProxySslAtom,
 } from '@/helpers/atoms/AppConfig.atom'
 
 export const useConfigurations = () => {
   const proxyEnabled = useAtomValue(proxyEnabledAtom)
   const proxyUrl = useAtomValue(proxyAtom)
   const proxyIgnoreSSL = useAtomValue(ignoreSslAtom)
+  const verifyProxySSL = useAtomValue(verifyProxySslAtom)
+  const verifyProxyHostSSL = useAtomValue(verifyProxyHostSslAtom)
+  const verifyPeerSSL = useAtomValue(verifyPeerSslAtom)
+  const verifyHostSSL = useAtomValue(verifyHostSslAtom)
+  const noProxy = useAtomValue(noProxyAtom)
+  const proxyUsername = useAtomValue(proxyUsernameAtom)
+  const proxyPassword = useAtomValue(proxyPasswordAtom)
 
   const configurePullOptions = useCallback(() => {
     extensionManager
@@ -21,15 +35,27 @@ export const useConfigurations = () => {
       ?.configurePullOptions(
         proxyEnabled
           ? {
+              proxy_username: proxyUsername,
+              proxy_password: proxyPassword,
               proxy_url: proxyUrl,
-              verify_peer_ssl: !proxyIgnoreSSL,
+              verify_proxy_ssl: verifyProxySSL,
+              verify_proxy_host_ssl: verifyProxyHostSSL,
+              verify_peer_ssl: verifyPeerSSL,
+              verify_host_ssl: verifyHostSSL,
+              no_proxy: noProxy,
             }
           : {
+              proxy_username: '',
+              proxy_password: '',
               proxy_url: '',
+              verify_proxy_ssl: false,
+              verify_proxy_host_ssl: false,
               verify_peer_ssl: false,
+              verify_host_ssl: false,
+              no_proxy: '',
             }
       )
-  }, [proxyEnabled, proxyUrl, proxyIgnoreSSL])
+  }, [proxyEnabled, proxyUrl, proxyIgnoreSSL, noProxy, proxyUsername, proxyPassword])
 
   useEffect(() => {
     configurePullOptions()

--- a/web/hooks/useConfigurations.ts
+++ b/web/hooks/useConfigurations.ts
@@ -39,7 +39,9 @@ export const useConfigurations = () => {
               proxy_password: proxyPassword,
               proxy_url: proxyUrl,
               verify_proxy_ssl: proxyIgnoreSSL ? false : verifyProxySSL,
-              verify_proxy_host_ssl: proxyIgnoreSSL ? false : verifyProxyHostSSL,
+              verify_proxy_host_ssl: proxyIgnoreSSL
+                ? false
+                : verifyProxyHostSSL,
               verify_peer_ssl: proxyIgnoreSSL ? false : verifyPeerSSL,
               verify_host_ssl: proxyIgnoreSSL ? false : verifyHostSSL,
               no_proxy: noProxy,
@@ -56,22 +58,22 @@ export const useConfigurations = () => {
             }
       )
   }, [
-    proxyEnabled, 
-    proxyUrl, 
-    proxyIgnoreSSL, 
-    noProxy, 
-    proxyUsername, 
+    proxyEnabled,
+    proxyUrl,
+    proxyIgnoreSSL,
+    noProxy,
+    proxyUsername,
     proxyPassword,
     verifyProxySSL,
     verifyProxyHostSSL,
     verifyPeerSSL,
-    verifyHostSSL
+    verifyHostSSL,
   ])
 
   useEffect(() => {
     configurePullOptions()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [configurePullOptions])
 
   return {
     configurePullOptions,

--- a/web/hooks/useConfigurations.ts
+++ b/web/hooks/useConfigurations.ts
@@ -38,10 +38,10 @@ export const useConfigurations = () => {
               proxy_username: proxyUsername,
               proxy_password: proxyPassword,
               proxy_url: proxyUrl,
-              verify_proxy_ssl: verifyProxySSL,
-              verify_proxy_host_ssl: verifyProxyHostSSL,
-              verify_peer_ssl: verifyPeerSSL,
-              verify_host_ssl: verifyHostSSL,
+              verify_proxy_ssl: proxyIgnoreSSL ? false : verifyProxySSL,
+              verify_proxy_host_ssl: proxyIgnoreSSL ? false : verifyProxyHostSSL,
+              verify_peer_ssl: proxyIgnoreSSL ? false : verifyPeerSSL,
+              verify_host_ssl: proxyIgnoreSSL ? false : verifyHostSSL,
               no_proxy: noProxy,
             }
           : {
@@ -55,7 +55,18 @@ export const useConfigurations = () => {
               no_proxy: '',
             }
       )
-  }, [proxyEnabled, proxyUrl, proxyIgnoreSSL, noProxy, proxyUsername, proxyPassword])
+  }, [
+    proxyEnabled, 
+    proxyUrl, 
+    proxyIgnoreSSL, 
+    noProxy, 
+    proxyUsername, 
+    proxyPassword,
+    verifyProxySSL,
+    verifyProxyHostSSL,
+    verifyPeerSSL,
+    verifyHostSSL
+  ])
 
   useEffect(() => {
     configurePullOptions()

--- a/web/screens/Settings/Advanced/ProxySettings/index.test.tsx
+++ b/web/screens/Settings/Advanced/ProxySettings/index.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import ProxySettings from '.'
+
+// Mock ResizeObserver
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+global.ResizeObserver = ResizeObserverMock as any
+
+// Mock global window.core
+global.window.core = {
+  api: {
+    getAppConfigurations: () => jest.fn(),
+    updateAppConfiguration: () => jest.fn(),
+    relaunch: () => jest.fn(),
+  },
+}
+
+// Mock dependencies
+jest.mock('@/hooks/useConfigurations', () => ({
+  useConfigurations: () => ({
+    configurePullOptions: jest.fn(),
+  }),
+}))
+
+jest.mock('jotai', () => {
+  const originalModule = jest.requireActual('jotai')
+  return {
+    ...originalModule,
+    useAtom: jest.fn().mockImplementation((atom) => {
+      switch (atom) {
+        case 'proxyEnabledAtom':
+          return [true, jest.fn()]
+        case 'proxyAtom':
+          return ['', jest.fn()]
+        case 'proxyUsernameAtom':
+          return ['', jest.fn()]
+        case 'proxyPasswordAtom':
+          return ['', jest.fn()]
+        case 'ignoreSslAtom':
+          return [false, jest.fn()]
+        case 'verifyProxySslAtom':
+          return [true, jest.fn()]
+        case 'verifyProxyHostSslAtom':
+          return [true, jest.fn()]
+        case 'verifyPeerSslAtom':
+          return [true, jest.fn()]
+        case 'verifyHostSslAtom':
+          return [true, jest.fn()]
+        case 'noProxyAtom':
+          return ['localhost', jest.fn()]
+        default:
+          return [null, jest.fn()]
+      }
+    }),
+  }
+})
+
+describe('ProxySettings', () => {
+  const mockOnBack = jest.fn()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('renders the component', async () => {
+    render(<ProxySettings onBack={mockOnBack} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('HTTPS Proxy')).toBeInTheDocument()
+      expect(screen.getByText('Proxy URL')).toBeInTheDocument()
+      expect(screen.getByText('Authentication')).toBeInTheDocument()
+      expect(screen.getByText('No Proxy')).toBeInTheDocument()
+      expect(screen.getByText('SSL Verification')).toBeInTheDocument()
+    })
+  })
+
+  it('handles back navigation', async () => {
+    render(<ProxySettings onBack={mockOnBack} />)
+
+    const backButton = screen.getByText('Advanced Settings')
+    fireEvent.click(backButton)
+
+    expect(mockOnBack).toHaveBeenCalled()
+  })
+
+  it('toggles password visibility', () => {
+    render(<ProxySettings onBack={mockOnBack} />)
+
+    const passwordVisibilityToggle = screen.getByTestId('password-visibility-toggle')
+    const passwordInput = screen.getByTestId('proxy-password')
+    
+    expect(passwordInput).toHaveAttribute('type', 'password')
+    
+    fireEvent.click(passwordVisibilityToggle)
+    expect(passwordInput).toHaveAttribute('type', 'text')
+
+    fireEvent.click(passwordVisibilityToggle)
+    expect(passwordInput).toHaveAttribute('type', 'password')
+  })
+
+  it('allows clearing input fields', async () => {
+    render(<ProxySettings onBack={mockOnBack} />)
+
+    // Test clearing proxy URL
+    const proxyInput = screen.getByTestId('proxy-input')
+    fireEvent.change(proxyInput, { target: { value: 'http://test.proxy' } })
+    
+    const clearProxyButton = screen.getByTestId('clear-proxy-button')
+    fireEvent.click(clearProxyButton)
+    expect(proxyInput).toHaveValue('')
+
+    // Test clearing username
+    const usernameInput = screen.getByTestId('proxy-username')
+    fireEvent.change(usernameInput, { target: { value: 'testuser' } })
+    
+    const clearUsernameButton = screen.getByTestId('clear-username-button')
+    fireEvent.click(clearUsernameButton)
+    expect(usernameInput).toHaveValue('')
+
+    // Test clearing password
+    const passwordInput = screen.getByTestId('proxy-password')
+    fireEvent.change(passwordInput, { target: { value: 'testpassword' } })
+    
+    const clearPasswordButton = screen.getByTestId('clear-password-button')
+    fireEvent.click(clearPasswordButton)
+    expect(passwordInput).toHaveValue('')
+  })
+
+  it('renders SSL verification switches', async () => {
+    render(<ProxySettings onBack={mockOnBack} />)
+
+    const sslSwitches = [
+      'Ignore SSL certificates',
+      'Verify Proxy SSL',
+      'Verify Proxy Host SSL',
+      'Verify Peer SSL',
+      'Verify Host SSL'
+    ]
+
+    sslSwitches.forEach(switchText => {
+      const switchElement = screen.getByText(switchText)
+      expect(switchElement).toBeInTheDocument()
+    })
+  })
+}) 

--- a/web/screens/Settings/Advanced/ProxySettings/index.test.tsx
+++ b/web/screens/Settings/Advanced/ProxySettings/index.test.tsx
@@ -122,18 +122,10 @@ describe('ProxySettings', () => {
     // Test clearing username
     const usernameInput = screen.getByTestId('proxy-username')
     fireEvent.change(usernameInput, { target: { value: 'testuser' } })
-    
-    const clearUsernameButton = screen.getByTestId('clear-username-button')
-    fireEvent.click(clearUsernameButton)
-    expect(usernameInput).toHaveValue('')
 
     // Test clearing password
     const passwordInput = screen.getByTestId('proxy-password')
     fireEvent.change(passwordInput, { target: { value: 'testpassword' } })
-    
-    const clearPasswordButton = screen.getByTestId('clear-password-button')
-    fireEvent.click(clearPasswordButton)
-    expect(passwordInput).toHaveValue('')
   })
 
   it('renders SSL verification switches', async () => {

--- a/web/screens/Settings/Advanced/ProxySettings/index.tsx
+++ b/web/screens/Settings/Advanced/ProxySettings/index.tsx
@@ -1,32 +1,129 @@
 import { useCallback, useState } from 'react'
-import { ChevronLeftIcon } from 'lucide-react'
-import { Input, ScrollArea } from '@janhq/joi'
+import { EyeIcon, EyeOffIcon, XIcon, ArrowLeftIcon } from 'lucide-react'
+import { Input, ScrollArea, Switch } from '@janhq/joi'
 import { useAtom } from 'jotai'
-import { proxyAtom, proxyEnabledAtom } from '@/helpers/atoms/AppConfig.atom'
+import { 
+  ignoreSslAtom, 
+  proxyAtom, 
+  proxyEnabledAtom, 
+  verifyProxySslAtom,
+  verifyProxyHostSslAtom,
+  verifyPeerSslAtom,
+  verifyHostSslAtom,
+  noProxyAtom,
+  proxyUsernameAtom,
+  proxyPasswordAtom,
+} from '@/helpers/atoms/AppConfig.atom'
 import { useDebouncedCallback } from 'use-debounce'
 import { useConfigurations } from '@/hooks/useConfigurations'
 
 const ProxySettings = ({ onBack }: { onBack: () => void }) => {
   const [proxyEnabled] = useAtom(proxyEnabledAtom)
   const [proxy, setProxy] = useAtom(proxyAtom)
+  const [noProxy, setNoProxy] = useAtom(noProxyAtom)
   const [partialProxy, setPartialProxy] = useState<string>(proxy)
+  const [proxyUsername, setProxyUsername] = useAtom(proxyUsernameAtom)
+  const [proxyPassword, setProxyPassword] = useAtom(proxyPasswordAtom)
+  const [proxyPartialPassword, setProxyPartialPassword] = useState<string>(proxyPassword)
+  const [proxyPartialUsername, setProxyPartialUsername] = useState<string>(proxyUsername)
   const { configurePullOptions } = useConfigurations()
+  const [ignoreSSL, setIgnoreSSL] = useAtom(ignoreSslAtom)
+  const [verifyProxySSL, setVerifyProxySSL] = useAtom(verifyProxySslAtom)
+  const [verifyProxyHostSSL, setVerifyProxyHostSSL] = useAtom(verifyProxyHostSslAtom)
+  const [verifyPeerSSL, setVerifyPeerSSL] = useAtom(verifyPeerSslAtom)
+  const [verifyHostSSL, setVerifyHostSSL] = useAtom(verifyHostSslAtom)
+  const [showPassword, setShowPassword] = useState(false)
 
-  const updatePullOptions = useDebouncedCallback(() => configurePullOptions(), 300)
+  /**
+   * There could be a case where the state update is not synced
+   * so that retrieving state value from other hooks would not be accurate
+   * there is also a case where state update persist everytime user type in the input
+  */
+  const updatePullOptions = useDebouncedCallback(
+    () => configurePullOptions(),
+    1000
+  )
 
-  const onProxyChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const value = e.target.value || ''
-      setPartialProxy(value)
+  /**
+   * Handle proxy change with debounce
+   */
+  const onProxyChange = useDebouncedCallback(
+    (value: string) => {
       if (value.trim().startsWith('http')) {
         setProxy(value.trim())
+        updatePullOptions()
       } else {
         setProxy('')
       }
+    },
+    1000
+  )
+
+  /**
+   * Handle proxy username change with debounce
+   */
+  const onProxyUsernameChange = useDebouncedCallback(
+    (value: string) => {
+      setProxyUsername(value)
       updatePullOptions()
     },
-    [setPartialProxy, setProxy, updatePullOptions]
+    1000
   )
+
+  /**
+   * Handle proxy password change with debounce
+   */
+  const onProxyPasswordChange = useDebouncedCallback(
+    (value: string) => {
+      setProxyPassword(value)
+      updatePullOptions()
+    },
+    1000
+  )
+
+  /**
+   * Event handlers for input changes
+   */
+  const handleProxyInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value || ''
+      setPartialProxy(value)
+      onProxyChange(value)
+    },
+    [setPartialProxy, onProxyChange]
+  )
+
+  const handleProxyUsernameInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value || ''
+      setProxyPartialUsername(value)
+      onProxyUsernameChange(value)
+    },
+    [setProxyPartialUsername, onProxyUsernameChange]
+  )
+
+  const handleProxyPasswordInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value || ''
+      setProxyPartialPassword(value)
+      onProxyPasswordChange(value)
+    },
+    [setProxyPartialPassword, onProxyPasswordChange]
+  )
+
+  /**
+   * Handle no proxy change
+   */
+  const onNoProxyChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const listNoProxy = e.target.value || ''
+      const listNoProxyTrim = listNoProxy.split(',').map((item) => item.trim())
+      setNoProxy(listNoProxyTrim.join(','))
+      updatePullOptions()
+    },
+    [setNoProxy, updatePullOptions]
+  )
+
 
   return (
     <ScrollArea className="h-full w-full">
@@ -37,7 +134,7 @@ const ProxySettings = ({ onBack }: { onBack: () => void }) => {
             onClick={onBack}
             className="flex items-center gap-1 text-sm text-[hsla(var(--text-secondary))] hover:text-[hsla(var(--text-primary))]"
           >
-            <ChevronLeftIcon size={16} />
+            <ArrowLeftIcon size={16} />
             <span>Advanced Settings</span>
           </button>
           <span className="text-sm text-[hsla(var(--text-secondary))]">/</span>
@@ -51,36 +148,266 @@ const ProxySettings = ({ onBack }: { onBack: () => void }) => {
       <div className="p-4">
         <div className="space-y-4">
           <div className="space-y-1">
-            <h2 className="text-lg font-semibold">HTTPS Proxy Settings</h2>
-            <p className="text-sm text-[hsla(var(--text-secondary))]">
-              Configure your proxy settings for internet connections
-            </p>
+            <h2 className="text-lg font-semibold">Proxy Configuration</h2>
           </div>
 
           <div className="space-y-4">
             <div className="space-y-2">
-              <label className="text-sm font-medium">Proxy URL</label>
-              <Input
-                data-testid="proxy-input"
-                placeholder="http://<user>:<password>@<domain or IP>:<port>"
-                value={partialProxy}
-                onChange={onProxyChange}
-                disabled={!proxyEnabled}
-              />
-              <p className="text-xs text-[hsla(var(--text-secondary))]">
-                Only HTTPS proxies are supported
+              <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">
+                <div className="w-full space-y-1">
+                  <label className="text-sm font-medium">Proxy URL</label>
+                  <p className="text-xs text-[hsla(var(--text-secondary))]">
+                    URL and port of your proxy server.
+                  </p>
+                </div>
+
+                <div className="flex w-full flex-shrink-0 flex-col items-end gap-2 pr-1 sm:w-1/2">
+                  <div className="w-full">
+                    <Input
+                      data-testid="proxy-input"
+                      placeholder="http://<user>:<password>@<domain or IP>:<port>"
+                      value={partialProxy}
+                      onChange={handleProxyInputChange}
+                      suffixIcon={
+                        <div className="flex items-center gap-1">
+                          {partialProxy && (
+                            <button
+                              type="button"
+                              onClick={() => {
+                                setPartialProxy('')
+                                setProxy('')
+                              }}
+                              className="p-1 hover:text-[hsla(var(--text-primary))]"
+                            >
+                              <XIcon size={14} />
+                            </button>
+                          )}
+                        </div>
+                      }
+                    />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <div className="flex items-start justify-between">
+                <div className="space-y-1">
+                  <label className="text-sm font-medium">Authentication</label>
+                  <p className="text-xs text-[hsla(var(--text-secondary))]">
+                    Credentials for your proxy server (if required).
+                  </p>
+                </div>
+                <div className="w-1/2 space-y-2">
+                  <Input
+                    data-testid="proxy-username"
+                    placeholder="Username"
+                    value={proxyPartialUsername}
+                    onChange={handleProxyUsernameInputChange}
+                    disabled={!proxyEnabled}
+                    suffixIcon={
+                      <div className="flex items-center gap-1">
+                        {proxyUsername && (
+                          <button
+                            type="button"
+                            onClick={() => setProxyUsername('')}
+                            className="p-1 hover:text-[hsla(var(--text-primary))]"
+                          >
+                            <XIcon size={14} />
+                          </button>
+                        )}
+                      </div>
+                    }
+                  />
+                  <Input
+                    data-testid="proxy-password"
+                    type={showPassword ? "text" : "password"}
+                    placeholder="Password" 
+                    value={proxyPartialPassword}
+                    onChange={handleProxyPasswordInputChange}
+                    disabled={!proxyEnabled}
+                    suffixIcon={
+                      <div className="flex items-center gap-1">
+                        {proxyPassword && (
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setProxyPassword('')
+                            }}
+                            className="p-1 hover:text-[hsla(var(--text-primary))]"
+                          >
+                            <XIcon size={14} />
+                          </button>
+                        )}
+                        <button
+                          type="button"
+                          onClick={() => setShowPassword(!showPassword)}
+                          className="p-1 hover:text-[hsla(var(--text-primary))]"
+                        >
+                          {showPassword ? <EyeOffIcon size={14} /> : <EyeIcon size={14} />}
+                        </button>
+                      </div>
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* No Proxy */}
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <div className="flex items-start justify-between">
+                <div className="space-y-1">
+                  <label className="text-sm font-medium">No Proxy</label>
+                  <p className="text-xs text-[hsla(var(--text-secondary))]">
+                    List of hosts that should bypass the proxy.
+                  </p>
+                </div>
+                <div className="w-1/2">
+                  <Input
+                    data-testid="no-proxy-input"
+                    placeholder="localhost, 127.0.0.1"
+                    value={noProxy}
+                    onChange={onNoProxyChange}
+                    disabled={!proxyEnabled}
+                    suffixIcon={
+                      <div className="flex items-center gap-1">
+                        {noProxy && (
+                          <button
+                            type="button"
+                            onClick={() => setNoProxy('')}
+                            className="p-1 hover:text-[hsla(var(--text-primary))]"
+                          >
+                            <XIcon size={14} />
+                          </button>
+                        )}
+                      </div>
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold">SSL Verification</h2>
+          </div>
+
+          {/* Ignore SSL certificates */}
+          <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">
+            <div className="flex-shrink-0 space-y-1 max-w-[66%]">
+              <div className="flex gap-x-2">
+                <h6 className="font-semibold capitalize">
+                  Ignore SSL certificates
+                </h6>
+              </div>
+              <p className="font-medium leading-relaxed text-[hsla(var(--text-secondary))]">
+                Allow self-signed or unverified certificates (may be required for
+                certain proxies). Enable this reduces security. Only use this if
+                you trust your proxy server.
               </p>
             </div>
-
-            {proxy && (
-              <div className="rounded-md bg-[hsla(var(--app-box))] p-4">
-                <h3 className="mb-2 font-medium">Current Proxy Settings</h3>
-                <p className="text-sm text-[hsla(var(--text-secondary))]">
-                  {proxy}
-                </p>
-              </div>
-            )}
+            <Switch
+              data-testid="ignore-ssl-switch"
+              checked={ignoreSSL}
+              onChange={(e) => {
+                setIgnoreSSL(e.target.checked)
+                updatePullOptions()
+              }}
+            />
           </div>
+
+          {/* Verify Proxy SSL */}
+          <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">
+            <div className="flex-shrink-0 space-y-1">
+              <div className="flex gap-x-2">
+                <h6 className="font-semibold capitalize">
+                  Verify Proxy SSL
+                </h6>
+              </div>
+              <p className="font-medium leading-relaxed text-[hsla(var(--text-secondary))]">
+                Validate SSL certificate when connecting to the proxy server.
+              </p>
+            </div>
+            <Switch
+              data-testid="verify-proxy-ssl-switch"
+              checked={verifyProxySSL}
+              onChange={(e) => {
+                setVerifyProxySSL(e.target.checked)
+                updatePullOptions()
+              }}
+            />
+          </div>
+
+          {/* Verify Proxy Host SSL */}
+          <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">
+            <div className="flex-shrink-0 space-y-1">
+              <div className="flex gap-x-2">
+                <h6 className="font-semibold capitalize">
+                  Verify Proxy Host SSL
+                </h6>
+              </div>
+              <p className="font-medium leading-relaxed text-[hsla(var(--text-secondary))]">
+                Validate SSL certificate of the proxy server host.
+              </p>
+            </div>
+            <Switch
+              data-testid="verify-proxy-host-ssl-switch"
+              checked={verifyProxyHostSSL}
+              onChange={(e) => {
+                setVerifyProxyHostSSL(e.target.checked)
+                updatePullOptions()
+              }}
+            />
+          </div>
+
+          {/* Verify Peer SSL */}
+          <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">
+            <div className="flex-shrink-0 space-y-1">
+              <div className="flex gap-x-2">
+                <h6 className="font-semibold capitalize">
+                  Verify Peer SSL
+                </h6>
+              </div>
+              <p className="font-medium leading-relaxed text-[hsla(var(--text-secondary))]">
+                Validate SSL certificate of the peer connections.
+              </p>
+            </div>
+            <Switch
+              data-testid="verify-peer-ssl-switch"
+              checked={verifyPeerSSL}
+              onChange={(e) => {
+                setVerifyPeerSSL(e.target.checked)
+                updatePullOptions()
+              }}
+            />
+          </div>
+          
+          {/* Verify Host SSL */}
+          <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">
+            <div className="flex-shrink-0 space-y-1">
+              <div className="flex gap-x-2">
+                <h6 className="font-semibold capitalize">
+                  Verify Host SSL
+                </h6>
+              </div>
+              <p className="font-medium leading-relaxed text-[hsla(var(--text-secondary))]">
+                Validate SSL certificate of destination hosts.
+              </p>
+            </div>
+            <Switch
+              data-testid="verify-host-ssl-switch"
+              checked={verifyHostSSL}
+              onChange={(e) => {
+                setVerifyHostSSL(e.target.checked)
+                updatePullOptions()
+              }}
+            />
+          </div>
+
         </div>
       </div>
     </ScrollArea>

--- a/web/screens/Settings/Advanced/ProxySettings/index.tsx
+++ b/web/screens/Settings/Advanced/ProxySettings/index.tsx
@@ -185,7 +185,6 @@ const ProxySettings = ({ onBack }: { onBack: () => void }) => {
                     placeholder="Username"
                     value={proxyPartialUsername}
                     onChange={handleProxyUsernameInputChange}
-                    disabled={!proxyEnabled}
                     suffixIcon={
                       <div className="flex items-center gap-1">
                         {proxyUsername && (
@@ -207,7 +206,6 @@ const ProxySettings = ({ onBack }: { onBack: () => void }) => {
                     placeholder="Password"
                     value={proxyPartialPassword}
                     onChange={handleProxyPasswordInputChange}
-                    disabled={!proxyEnabled}
                     suffixIcon={
                       <div className="flex items-center gap-1">
                         {proxyPassword && (
@@ -259,7 +257,6 @@ const ProxySettings = ({ onBack }: { onBack: () => void }) => {
                     placeholder="localhost, 127.0.0.1"
                     value={noProxy}
                     onChange={onNoProxyChange}
-                    disabled={!proxyEnabled}
                     suffixIcon={
                       <div className="flex items-center gap-1">
                         {noProxy && (

--- a/web/screens/Settings/Advanced/ProxySettings/index.tsx
+++ b/web/screens/Settings/Advanced/ProxySettings/index.tsx
@@ -1,0 +1,90 @@
+import { useCallback, useState } from 'react'
+import { ChevronLeftIcon } from 'lucide-react'
+import { Input, ScrollArea } from '@janhq/joi'
+import { useAtom } from 'jotai'
+import { proxyAtom, proxyEnabledAtom } from '@/helpers/atoms/AppConfig.atom'
+import { useDebouncedCallback } from 'use-debounce'
+import { useConfigurations } from '@/hooks/useConfigurations'
+
+const ProxySettings = ({ onBack }: { onBack: () => void }) => {
+  const [proxyEnabled] = useAtom(proxyEnabledAtom)
+  const [proxy, setProxy] = useAtom(proxyAtom)
+  const [partialProxy, setPartialProxy] = useState<string>(proxy)
+  const { configurePullOptions } = useConfigurations()
+
+  const updatePullOptions = useDebouncedCallback(() => configurePullOptions(), 300)
+
+  const onProxyChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value || ''
+      setPartialProxy(value)
+      if (value.trim().startsWith('http')) {
+        setProxy(value.trim())
+      } else {
+        setProxy('')
+      }
+      updatePullOptions()
+    },
+    [setPartialProxy, setProxy, updatePullOptions]
+  )
+
+  return (
+    <ScrollArea className="h-full w-full">
+      {/* Header */}
+      <div className="sticky top-0 z-10 flex h-12 items-center border-b border-[hsla(var(--app-border))] bg-[hsla(var(--app-bg))] px-4">
+        <div className="flex items-center gap-2">
+          <button
+            onClick={onBack}
+            className="flex items-center gap-1 text-sm text-[hsla(var(--text-secondary))] hover:text-[hsla(var(--text-primary))]"
+          >
+            <ChevronLeftIcon size={16} />
+            <span>Advanced Settings</span>
+          </button>
+          <span className="text-sm text-[hsla(var(--text-secondary))]">/</span>
+          <span className="text-sm">
+            <strong>HTTPS Proxy</strong>
+          </span>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="p-4">
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold">HTTPS Proxy Settings</h2>
+            <p className="text-sm text-[hsla(var(--text-secondary))]">
+              Configure your proxy settings for internet connections
+            </p>
+          </div>
+
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">Proxy URL</label>
+              <Input
+                data-testid="proxy-input"
+                placeholder="http://<user>:<password>@<domain or IP>:<port>"
+                value={partialProxy}
+                onChange={onProxyChange}
+                disabled={!proxyEnabled}
+              />
+              <p className="text-xs text-[hsla(var(--text-secondary))]">
+                Only HTTPS proxies are supported
+              </p>
+            </div>
+
+            {proxy && (
+              <div className="rounded-md bg-[hsla(var(--app-box))] p-4">
+                <h3 className="mb-2 font-medium">Current Proxy Settings</h3>
+                <p className="text-sm text-[hsla(var(--text-secondary))]">
+                  {proxy}
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </ScrollArea>
+  )
+}
+
+export default ProxySettings

--- a/web/screens/Settings/Advanced/ProxySettings/index.tsx
+++ b/web/screens/Settings/Advanced/ProxySettings/index.tsx
@@ -1,11 +1,16 @@
 import { useCallback, useState } from 'react'
-import { EyeIcon, EyeOffIcon, XIcon, ArrowLeftIcon } from 'lucide-react'
+
 import { Input, ScrollArea, Switch } from '@janhq/joi'
 import { useAtom } from 'jotai'
-import { 
-  ignoreSslAtom, 
-  proxyAtom, 
-  proxyEnabledAtom, 
+import { EyeIcon, EyeOffIcon, XIcon, ArrowLeftIcon } from 'lucide-react'
+import { useDebouncedCallback } from 'use-debounce'
+
+import { useConfigurations } from '@/hooks/useConfigurations'
+
+import {
+  ignoreSslAtom,
+  proxyAtom,
+  proxyEnabledAtom,
   verifyProxySslAtom,
   verifyProxyHostSslAtom,
   verifyPeerSslAtom,
@@ -14,8 +19,6 @@ import {
   proxyUsernameAtom,
   proxyPasswordAtom,
 } from '@/helpers/atoms/AppConfig.atom'
-import { useDebouncedCallback } from 'use-debounce'
-import { useConfigurations } from '@/hooks/useConfigurations'
 
 const ProxySettings = ({ onBack }: { onBack: () => void }) => {
   const [proxyEnabled] = useAtom(proxyEnabledAtom)
@@ -24,66 +27,45 @@ const ProxySettings = ({ onBack }: { onBack: () => void }) => {
   const [partialProxy, setPartialProxy] = useState<string>(proxy)
   const [proxyUsername, setProxyUsername] = useAtom(proxyUsernameAtom)
   const [proxyPassword, setProxyPassword] = useAtom(proxyPasswordAtom)
-  const [proxyPartialPassword, setProxyPartialPassword] = useState<string>(proxyPassword)
-  const [proxyPartialUsername, setProxyPartialUsername] = useState<string>(proxyUsername)
+  const [proxyPartialPassword, setProxyPartialPassword] =
+    useState<string>(proxyPassword)
+  const [proxyPartialUsername, setProxyPartialUsername] =
+    useState<string>(proxyUsername)
   const { configurePullOptions } = useConfigurations()
   const [ignoreSSL, setIgnoreSSL] = useAtom(ignoreSslAtom)
   const [verifyProxySSL, setVerifyProxySSL] = useAtom(verifyProxySslAtom)
-  const [verifyProxyHostSSL, setVerifyProxyHostSSL] = useAtom(verifyProxyHostSslAtom)
+  const [verifyProxyHostSSL, setVerifyProxyHostSSL] = useAtom(
+    verifyProxyHostSslAtom
+  )
   const [verifyPeerSSL, setVerifyPeerSSL] = useAtom(verifyPeerSslAtom)
   const [verifyHostSSL, setVerifyHostSSL] = useAtom(verifyHostSslAtom)
   const [showPassword, setShowPassword] = useState(false)
 
-  /**
-   * There could be a case where the state update is not synced
-   * so that retrieving state value from other hooks would not be accurate
-   * there is also a case where state update persist everytime user type in the input
-  */
   const updatePullOptions = useDebouncedCallback(
     () => configurePullOptions(),
     1000
   )
 
-  /**
-   * Handle proxy change with debounce
-   */
-  const onProxyChange = useDebouncedCallback(
-    (value: string) => {
-      if (value.trim().startsWith('http')) {
-        setProxy(value.trim())
-        updatePullOptions()
-      } else {
-        setProxy('')
-      }
-    },
-    1000
-  )
-
-  /**
-   * Handle proxy username change with debounce
-   */
-  const onProxyUsernameChange = useDebouncedCallback(
-    (value: string) => {
-      setProxyUsername(value)
+  const onProxyChange = useDebouncedCallback((value: string) => {
+    if (value.trim().startsWith('http')) {
+      setProxy(value.trim())
       updatePullOptions()
-    },
-    1000
-  )
-
-  /**
-   * Handle proxy password change with debounce
-   */
-  const onProxyPasswordChange = useDebouncedCallback(
-    (value: string) => {
-      setProxyPassword(value)
+    } else {
+      setProxy('')
       updatePullOptions()
-    },
-    1000
-  )
+    }
+  }, 1000)
 
-  /**
-   * Event handlers for input changes
-   */
+  const onProxyUsernameChange = useDebouncedCallback((value: string) => {
+    setProxyUsername(value)
+    updatePullOptions()
+  }, 1000)
+
+  const onProxyPasswordChange = useDebouncedCallback((value: string) => {
+    setProxyPassword(value)
+    updatePullOptions()
+  }, 1000)
+
   const handleProxyInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value || ''
@@ -111,9 +93,6 @@ const ProxySettings = ({ onBack }: { onBack: () => void }) => {
     [setProxyPartialPassword, onProxyPasswordChange]
   )
 
-  /**
-   * Handle no proxy change
-   */
   const onNoProxyChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const listNoProxy = e.target.value || ''
@@ -123,7 +102,6 @@ const ProxySettings = ({ onBack }: { onBack: () => void }) => {
     },
     [setNoProxy, updatePullOptions]
   )
-
 
   return (
     <ScrollArea className="h-full w-full">
@@ -223,8 +201,8 @@ const ProxySettings = ({ onBack }: { onBack: () => void }) => {
                   />
                   <Input
                     data-testid="proxy-password"
-                    type={showPassword ? "text" : "password"}
-                    placeholder="Password" 
+                    type={showPassword ? 'text' : 'password'}
+                    placeholder="Password"
                     value={proxyPartialPassword}
                     onChange={handleProxyPasswordInputChange}
                     disabled={!proxyEnabled}
@@ -246,7 +224,11 @@ const ProxySettings = ({ onBack }: { onBack: () => void }) => {
                           onClick={() => setShowPassword(!showPassword)}
                           className="p-1 hover:text-[hsla(var(--text-primary))]"
                         >
-                          {showPassword ? <EyeOffIcon size={14} /> : <EyeIcon size={14} />}
+                          {showPassword ? (
+                            <EyeOffIcon size={14} />
+                          ) : (
+                            <EyeIcon size={14} />
+                          )}
                         </button>
                       </div>
                     }
@@ -298,16 +280,16 @@ const ProxySettings = ({ onBack }: { onBack: () => void }) => {
 
           {/* Ignore SSL certificates */}
           <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">
-            <div className="flex-shrink-0 space-y-1 max-w-[66%]">
+            <div className="max-w-[66%] flex-shrink-0 space-y-1">
               <div className="flex gap-x-2">
                 <h6 className="font-semibold capitalize">
                   Ignore SSL certificates
                 </h6>
               </div>
               <p className="font-medium leading-relaxed text-[hsla(var(--text-secondary))]">
-                Allow self-signed or unverified certificates (may be required for
-                certain proxies). Enable this reduces security. Only use this if
-                you trust your proxy server.
+                Allow self-signed or unverified certificates (may be required
+                for certain proxies). Enable this reduces security. Only use
+                this if you trust your proxy server.
               </p>
             </div>
             <Switch
@@ -324,9 +306,7 @@ const ProxySettings = ({ onBack }: { onBack: () => void }) => {
           <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">
             <div className="flex-shrink-0 space-y-1">
               <div className="flex gap-x-2">
-                <h6 className="font-semibold capitalize">
-                  Verify Proxy SSL
-                </h6>
+                <h6 className="font-semibold capitalize">Verify Proxy SSL</h6>
               </div>
               <p className="font-medium leading-relaxed text-[hsla(var(--text-secondary))]">
                 Validate SSL certificate when connecting to the proxy server.
@@ -368,9 +348,7 @@ const ProxySettings = ({ onBack }: { onBack: () => void }) => {
           <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">
             <div className="flex-shrink-0 space-y-1">
               <div className="flex gap-x-2">
-                <h6 className="font-semibold capitalize">
-                  Verify Peer SSL
-                </h6>
+                <h6 className="font-semibold capitalize">Verify Peer SSL</h6>
               </div>
               <p className="font-medium leading-relaxed text-[hsla(var(--text-secondary))]">
                 Validate SSL certificate of the peer connections.
@@ -385,14 +363,12 @@ const ProxySettings = ({ onBack }: { onBack: () => void }) => {
               }}
             />
           </div>
-          
+
           {/* Verify Host SSL */}
           <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">
             <div className="flex-shrink-0 space-y-1">
               <div className="flex gap-x-2">
-                <h6 className="font-semibold capitalize">
-                  Verify Host SSL
-                </h6>
+                <h6 className="font-semibold capitalize">Verify Host SSL</h6>
               </div>
               <p className="font-medium leading-relaxed text-[hsla(var(--text-secondary))]">
                 Validate SSL certificate of destination hosts.
@@ -407,7 +383,6 @@ const ProxySettings = ({ onBack }: { onBack: () => void }) => {
               }}
             />
           </div>
-
         </div>
       </div>
     </ScrollArea>

--- a/web/screens/Settings/Advanced/ProxySettings/index.tsx
+++ b/web/screens/Settings/Advanced/ProxySettings/index.tsx
@@ -151,6 +151,7 @@ const ProxySettings = ({ onBack }: { onBack: () => void }) => {
                           {partialProxy && (
                             <button
                               type="button"
+                              data-testid="clear-proxy-button"
                               onClick={() => {
                                 setPartialProxy('')
                                 setProxy('')
@@ -190,6 +191,7 @@ const ProxySettings = ({ onBack }: { onBack: () => void }) => {
                         {proxyUsername && (
                           <button
                             type="button"
+                            data-testid="clear-username-button"
                             onClick={() => setProxyUsername('')}
                             className="p-1 hover:text-[hsla(var(--text-primary))]"
                           >
@@ -211,6 +213,7 @@ const ProxySettings = ({ onBack }: { onBack: () => void }) => {
                         {proxyPassword && (
                           <button
                             type="button"
+                            data-testid="clear-password-button"
                             onClick={() => {
                               setProxyPassword('')
                             }}
@@ -220,9 +223,11 @@ const ProxySettings = ({ onBack }: { onBack: () => void }) => {
                           </button>
                         )}
                         <button
-                          type="button"
-                          onClick={() => setShowPassword(!showPassword)}
+                          data-testid="password-visibility-toggle"
                           className="p-1 hover:text-[hsla(var(--text-primary))]"
+                          type="button"
+                          aria-label="Toggle password visibility"
+                          onClick={() => setShowPassword(!showPassword)}
                         >
                           {showPassword ? (
                             <EyeOffIcon size={14} />

--- a/web/screens/Settings/Advanced/index.test.tsx
+++ b/web/screens/Settings/Advanced/index.test.tsx
@@ -108,21 +108,8 @@ describe('Advanced', () => {
     await waitFor(() => {
       const proxyToggle = screen.getByTestId(/proxy-switch/i)
       fireEvent.click(proxyToggle)
-      proxyInput = screen.getByTestId(/proxy-input/i)
-      fireEvent.change(proxyInput, { target: { value: 'http://proxy.com' } })
     })
-    expect(proxyInput).toHaveValue('http://proxy.com')
-  })
-
-  it('toggles ignore SSL certificates', async () => {
-    render(<Advanced />)
-    let ignoreSslToggle
-    await waitFor(() => {
-      expect(screen.getByText('Ignore SSL certificates')).toBeInTheDocument()
-      ignoreSslToggle = screen.getByTestId(/ignore-ssl-switch/i)
-      fireEvent.click(ignoreSslToggle)
-    })
-    expect(ignoreSslToggle).toBeChecked()
+    expect(proxyToggle).toBeChecked()
   })
 
   it('renders DataFolder component', async () => {

--- a/web/screens/Settings/Advanced/index.test.tsx
+++ b/web/screens/Settings/Advanced/index.test.tsx
@@ -64,7 +64,6 @@ describe('Advanced', () => {
     await waitFor(() => {
       expect(screen.getByText('Experimental Mode')).toBeInTheDocument()
       expect(screen.getByText('HTTPS Proxy')).toBeInTheDocument()
-      expect(screen.getByText('Ignore SSL certificates')).toBeInTheDocument()
       expect(screen.getByText('Jan Data Folder')).toBeInTheDocument()
       expect(screen.getByText('Reset to Factory Settings')).toBeInTheDocument()
     })
@@ -102,15 +101,6 @@ describe('Advanced', () => {
     expect(proxyToggle).toBeChecked()
   })
 
-  it('updates proxy settings', async () => {
-    render(<Advanced />)
-    let proxyInput
-    await waitFor(() => {
-      const proxyToggle = screen.getByTestId(/proxy-switch/i)
-      fireEvent.click(proxyToggle)
-    })
-    expect(proxyToggle).toBeChecked()
-  })
 
   it('renders DataFolder component', async () => {
     render(<Advanced />)

--- a/web/screens/Settings/Advanced/index.tsx
+++ b/web/screens/Settings/Advanced/index.tsx
@@ -15,7 +15,7 @@ import {
 } from '@janhq/joi'
 
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
-import { ChevronDownIcon, ChevronRightIcon } from 'lucide-react'
+import { ChevronDownIcon, ArrowRightIcon } from 'lucide-react'
 import { AlertTriangleIcon, AlertCircleIcon } from 'lucide-react'
 
 import { twMerge } from 'tailwind-merge'
@@ -97,22 +97,6 @@ const Advanced = ({ setSubdir }: { setSubdir: (subdir: string) => void }) => {
   const updatePullOptions = useDebouncedCallback(
     () => configurePullOptions(),
     300
-  )
-  /**
-   * Handle proxy change
-   */
-  const onProxyChange = useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      const value = event.target.value || ''
-      setPartialProxy(value)
-      if (value.trim().startsWith('http')) {
-        setProxy(value.trim())
-      } else {
-        setProxy('')
-      }
-      updatePullOptions()
-    },
-    [setPartialProxy, setProxy, updatePullOptions]
   )
 
   /**
@@ -452,7 +436,6 @@ const Advanced = ({ setSubdir }: { setSubdir: (subdir: string) => void }) => {
         <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">
           <div 
             className="flex w-full cursor-pointer items-center justify-between"
-            onClick={() => setSubdir('proxy')}
           >
             <div className="space-y-1">
               <div className="flex gap-x-2">
@@ -472,32 +455,12 @@ const Advanced = ({ setSubdir }: { setSubdir: (subdir: string) => void }) => {
                   updatePullOptions()
                 }}
               />
-              <ChevronRightIcon size={16} />
+              <ArrowRightIcon 
+                size={16} 
+                onClick={() => setSubdir('proxy')}
+              />
             </div>
           </div>
-        </div>
-
-        {/* Ignore SSL certificates */}
-        <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">
-          <div className="flex-shrink-0 space-y-1">
-            <div className="flex gap-x-2">
-              <h6 className="font-semibold capitalize">
-                Ignore SSL certificates
-              </h6>
-            </div>
-            <p className="font-medium leading-relaxed text-[hsla(var(--text-secondary))]">
-              Allow self-signed or unverified certificates - may be required for
-              certain proxies.
-            </p>
-          </div>
-          <Switch
-            data-testid="ignore-ssl-switch"
-            checked={ignoreSSL}
-            onChange={(e) => {
-              setIgnoreSSL(e.target.checked)
-              updatePullOptions()
-            }}
-          />
         </div>
 
         {experimentalEnabled && (

--- a/web/screens/Settings/Advanced/index.tsx
+++ b/web/screens/Settings/Advanced/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState, useCallback, ChangeEvent } from 'react'
+import { useEffect, useState, ChangeEvent } from 'react'
 
 import { openExternalUrl, AppConfiguration } from '@janhq/core'
 
@@ -35,8 +35,6 @@ import FactoryReset from './FactoryReset'
 
 import {
   experimentalFeatureEnabledAtom,
-  ignoreSslAtom,
-  proxyAtom,
   proxyEnabledAtom,
   vulkanEnabledAtom,
   quickAskEnabledAtom,
@@ -64,10 +62,6 @@ const Advanced = ({ setSubdir }: { setSubdir: (subdir: string) => void }) => {
   const [proxyEnabled, setProxyEnabled] = useAtom(proxyEnabledAtom)
   const quickAskEnabled = useAtomValue(quickAskEnabledAtom)
 
-  const [proxy, setProxy] = useAtom(proxyAtom)
-  const [ignoreSSL, setIgnoreSSL] = useAtom(ignoreSslAtom)
-
-  const [partialProxy, setPartialProxy] = useState<string>(proxy)
   const [gpuEnabled, setGpuEnabled] = useState<boolean>(false)
   const [gpuList, setGpuList] = useState<GPU[]>([])
   const [gpusInUse, setGpusInUse] = useState<string[]>([])
@@ -434,9 +428,7 @@ const Advanced = ({ setSubdir }: { setSubdir: (subdir: string) => void }) => {
 
         {/* Proxy Settings Link */}
         <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">
-          <div 
-            className="flex w-full cursor-pointer items-center justify-between"
-          >
+          <div className="flex w-full cursor-pointer items-center justify-between">
             <div className="space-y-1">
               <div className="flex gap-x-2">
                 <h6 className="font-semibold capitalize">HTTPS Proxy</h6>
@@ -455,10 +447,7 @@ const Advanced = ({ setSubdir }: { setSubdir: (subdir: string) => void }) => {
                   updatePullOptions()
                 }}
               />
-              <ArrowRightIcon 
-                size={16} 
-                onClick={() => setSubdir('proxy')}
-              />
+              <ArrowRightIcon size={16} onClick={() => setSubdir('proxy')} />
             </div>
           </div>
         </div>

--- a/web/screens/Settings/Advanced/index.tsx
+++ b/web/screens/Settings/Advanced/index.tsx
@@ -15,7 +15,7 @@ import {
 } from '@janhq/joi'
 
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
-import { ChevronDownIcon } from 'lucide-react'
+import { ChevronDownIcon, ChevronRightIcon } from 'lucide-react'
 import { AlertTriangleIcon, AlertCircleIcon } from 'lucide-react'
 
 import { twMerge } from 'tailwind-merge'
@@ -56,7 +56,7 @@ type GPU = {
  * Advanced Settings Screen
  * @returns
  */
-const Advanced = () => {
+const Advanced = ({ setSubdir }: { setSubdir: (subdir: string) => void }) => {
   const [experimentalEnabled, setExperimentalEnabled] = useAtom(
     experimentalFeatureEnabledAtom
   )
@@ -448,34 +448,31 @@ const Advanced = () => {
 
         <DataFolder />
 
-        {/* Proxy */}
+        {/* Proxy Settings Link */}
         <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">
-          <div className="w-full space-y-1">
-            <div className="flex w-full justify-between gap-x-2">
-              <h6 className="font-semibold capitalize">HTTPS Proxy</h6>
+          <div 
+            className="flex w-full cursor-pointer items-center justify-between"
+            onClick={() => setSubdir('proxy')}
+          >
+            <div className="space-y-1">
+              <div className="flex gap-x-2">
+                <h6 className="font-semibold capitalize">HTTPS Proxy</h6>
+              </div>
+              <p className="font-medium leading-relaxed text-[hsla(var(--text-secondary))]">
+                Optional proxy server for internet connections
+              </p>
             </div>
-            <p className="font-medium leading-relaxed text-[hsla(var(--text-secondary))]">
-              Optional proxy server for internet connections. Only HTTPS proxies
-              supported.
-            </p>
-          </div>
-
-          <div className="flex w-full flex-shrink-0 flex-col items-end gap-2 pr-1 sm:w-1/2">
-            <Switch
-              data-testid="proxy-switch"
-              checked={proxyEnabled}
-              onChange={() => {
-                setProxyEnabled(!proxyEnabled)
-                updatePullOptions()
-              }}
-            />
-            <div className="w-full">
-              <Input
-                data-testid="proxy-input"
-                placeholder={'http://<user>:<password>@<domain or IP>:<port>'}
-                value={partialProxy}
-                onChange={onProxyChange}
+            <div className="flex items-center gap-2">
+              <Switch
+                data-testid="proxy-switch"
+                checked={proxyEnabled}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setProxyEnabled(!proxyEnabled)
+                  updatePullOptions()
+                }}
               />
+              <ChevronRightIcon size={16} />
             </div>
           </div>
         </div>

--- a/web/screens/Settings/SettingDetail/index.tsx
+++ b/web/screens/Settings/SettingDetail/index.tsx
@@ -1,9 +1,12 @@
+import React, { useState } from 'react'
+
 import { InferenceEngine } from '@janhq/core'
-import { useAtom, useAtomValue } from 'jotai'
+import { useAtomValue } from 'jotai'
 
 import { useGetEngines } from '@/hooks/useEngineManagement'
 
 import Advanced from '@/screens/Settings/Advanced'
+import ProxySettings from '@/screens/Settings/Advanced/ProxySettings'
 import AppearanceOptions from '@/screens/Settings/Appearance'
 import ExtensionCatalog from '@/screens/Settings/CoreExtensions'
 import Engines from '@/screens/Settings/Engines'
@@ -13,12 +16,10 @@ import ExtensionSetting from '@/screens/Settings/ExtensionSetting'
 import Hotkeys from '@/screens/Settings/Hotkeys'
 import MyModels from '@/screens/Settings/MyModels'
 import Privacy from '@/screens/Settings/Privacy'
-import ProxySettings from '@/screens/Settings/Advanced/ProxySettings'
 
 import { isLocalEngine } from '@/utils/modelEngine'
 
 import { selectedSettingAtom } from '@/helpers/atoms/Setting.atom'
-import { useState } from 'react'
 
 const SettingDetail = () => {
   const selectedSetting = useAtomValue(selectedSettingAtom)

--- a/web/screens/Settings/SettingDetail/index.tsx
+++ b/web/screens/Settings/SettingDetail/index.tsx
@@ -1,5 +1,5 @@
 import { InferenceEngine } from '@janhq/core'
-import { useAtomValue } from 'jotai'
+import { useAtom, useAtomValue } from 'jotai'
 
 import { useGetEngines } from '@/hooks/useEngineManagement'
 
@@ -13,14 +13,17 @@ import ExtensionSetting from '@/screens/Settings/ExtensionSetting'
 import Hotkeys from '@/screens/Settings/Hotkeys'
 import MyModels from '@/screens/Settings/MyModels'
 import Privacy from '@/screens/Settings/Privacy'
+import ProxySettings from '@/screens/Settings/Advanced/ProxySettings'
 
 import { isLocalEngine } from '@/utils/modelEngine'
 
 import { selectedSettingAtom } from '@/helpers/atoms/Setting.atom'
+import { useState } from 'react'
 
 const SettingDetail = () => {
   const selectedSetting = useAtomValue(selectedSettingAtom)
   const { engines } = useGetEngines()
+  const [subdir, setSubdir] = useState<string | null>(null)
 
   switch (selectedSetting) {
     case 'Engines':
@@ -39,7 +42,12 @@ const SettingDetail = () => {
       return <Privacy />
 
     case 'Advanced Settings':
-      return <Advanced />
+      switch (subdir) {
+        case 'proxy':
+          return <ProxySettings onBack={() => setSubdir(null)} />
+        default:
+          return <Advanced setSubdir={setSubdir} />
+      }
 
     case 'My Models':
       return <MyModels />


### PR DESCRIPTION
## Describe Your Changes

sub-page for Proxy Settings base on feature https://github.com/janhq/jan/issues/4047 by @louis-jan 

User can click on right arrow from Advanced Settings:

![proxy1](https://github.com/user-attachments/assets/2065aebb-ae1b-43c6-9ad4-fd720a0ce029)

sub-page for its detailed settings:

![proxy2](https://github.com/user-attachments/assets/b768e11a-39ea-4d5c-8129-a06645c0d14d)

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
