### PR TITLE
chore: bump llama.cpp to the latest version

### DIFF
--- a/extensions/inference-cortex-extension/download.bat
+++ b/extensions/inference-cortex-extension/download.bat
@@ -2,7 +2,7 @@
 set BIN_PATH=./bin
 set SHARED_PATH=./../../electron/shared
 set /p CORTEX_VERSION=<./bin/version.txt
-set ENGINE_VERSION=0.1.42-hotfix
+set ENGINE_VERSION=0.1.49
 
 @REM Download cortex.llamacpp binaries
 set DOWNLOAD_URL=https://github.com/janhq/cortex.llamacpp/releases/download/v%ENGINE_VERSION%/cortex.llamacpp-%ENGINE_VERSION%-windows-amd64

--- a/extensions/inference-cortex-extension/download.sh
+++ b/extensions/inference-cortex-extension/download.sh
@@ -2,7 +2,7 @@
 
 # Read CORTEX_VERSION
 CORTEX_VERSION=$(cat ./bin/version.txt)
-ENGINE_VERSION=0.1.42-hotfix
+ENGINE_VERSION=0.1.49
 CORTEX_RELEASE_URL="https://github.com/janhq/cortex.cpp/releases/download"
 ENGINE_DOWNLOAD_URL="https://github.com/janhq/cortex.llamacpp/releases/download/v${ENGINE_VERSION}/cortex.llamacpp-${ENGINE_VERSION}"
 CUDA_DOWNLOAD_URL="https://github.com/janhq/cortex.llamacpp/releases/download/v${ENGINE_VERSION}"

--- a/extensions/inference-cortex-extension/rollup.config.ts
+++ b/extensions/inference-cortex-extension/rollup.config.ts
@@ -120,7 +120,7 @@ export default [
         SETTINGS: JSON.stringify(defaultSettingJson),
         CORTEX_API_URL: JSON.stringify('http://127.0.0.1:39291'),
         CORTEX_SOCKET_URL: JSON.stringify('ws://127.0.0.1:39291'),
-        CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.42-hotfix'),
+        CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.49'),
       }),
       // Allow json resolution
       json(),


### PR DESCRIPTION
## Describe Your Changes

This PR aims to bump llama.cpp engine to the latest version. The scope of this version bump is to support new DeepSeek R1 models, incorporating the latest fix from llama.cpp upstream.

## Changes

This pull request updates the `ENGINE_VERSION` for the Cortex extension across multiple files to ensure consistency and compatibility with the latest release. The most important changes include updating the version in batch and shell scripts, as well as in the rollup configuration file.

Version update:

* [`extensions/inference-cortex-extension/download.bat`](diffhunk://#diff-8a7d1c23da498167c2b1a94a2d4ce076f6f2549607a116a66528fe8e44c678a6L5-R5): Updated `ENGINE_VERSION` from `0.1.42-hotfix` to `0.1.49` to download the latest binaries.
* [`extensions/inference-cortex-extension/download.sh`](diffhunk://#diff-f67e38c5644b8fd2bea4d9a5ef8ac582f57884716ff91932b02809aa3fe36bedL5-R5): Updated `ENGINE_VERSION` from `0.1.42-hotfix` to `0.1.49` to download the latest binaries.
* [`extensions/inference-cortex-extension/rollup.config.ts`](diffhunk://#diff-452a68fc0027fb5aad2a82d61d63dc567d275ce734855ff86b19ad70bfcb125fL123-R123): Updated `CORTEX_ENGINE_VERSION` from `v0.1.42-hotfix` to `v0.1.49` to reflect the new version in the configuration.