### PR TITLE
fix: Correct index for Windows download button

### DIFF
--- a/docs/src/components/DropdownDownload/index.tsx
+++ b/docs/src/components/DropdownDownload/index.tsx
@@ -65,7 +65,7 @@ const DropdownDownload = ({ lastRelease }: Props) => {
     const userAgent = navigator.userAgent
     if (userAgent.includes('Windows')) {
       // windows user
-      setDefaultSystem(systems[2])
+      setDefaultSystem(systems[1])
     } else if (userAgent.includes('Linux')) {
       // linux user
       setDefaultSystem(systems[3])


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a small change to the `DropdownDownload` component in the `docs/src/components/DropdownDownload/index.tsx` file. The change updates the default system setting for Windows users.

* [`docs/src/components/DropdownDownload/index.tsx`](diffhunk://#diff-31842c3a9c132b23b5a3900edd457747c73325b128e37bc5ab05ab477891d750L68-R68): Changed the default system for Windows users from `systems[2]` to `systems[1]`.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
