### PR TITLE
fix: thread title summarization doesn't work well on reasoning models

### DIFF
--- a/web/containers/Providers/ModelHandler.tsx
+++ b/web/containers/Providers/ModelHandler.tsx
@@ -132,7 +132,7 @@ export default function ModelHandler() {
         return
       }
 
-      const messageContent = message.content[0]?.text?.value
+      let messageContent = message.content[0]?.text?.value
       if (!messageContent) {
         console.warn(
           `Failed to update title for thread ${message.thread_id}: Responded content is null!`
@@ -144,26 +144,16 @@ export default function ModelHandler() {
       // And no new line character is present
       // And non-alphanumeric characters should be removed
       if (messageContent.includes('\n')) {
-        console.warn(
-          `Failed to update title for thread ${message.thread_id}: Title can't contain new line character!`
-        )
-        return
+        messageContent = messageContent.replace(/\n/g, ' ')
       }
-
+      const match = messageContent.match(/<\/think>(.*)$/)
+      if (match) {
+        messageContent = match[1]
+      }
       // Remove non-alphanumeric characters
       const cleanedMessageContent = messageContent
         .replace(/[^\p{L}\s]+/gu, '')
         .trim()
-
-      // Split the message into words
-      const words = cleanedMessageContent.split(' ')
-
-      if (words.length >= maxWordForThreadTitle) {
-        console.warn(
-          `Failed to update title for thread ${message.thread_id}: Title can't be greater than ${maxWordForThreadTitle} words!`
-        )
-        return
-      }
 
       // Do not persist empty message
       if (!cleanedMessageContent.trim().length) return
@@ -361,7 +351,7 @@ export default function ModelHandler() {
 
     if (!threadMessages || threadMessages.length === 0) return
 
-    const summarizeFirstPrompt = `Summarize in a ${maxWordForThreadTitle}-word Title. Give the title only. "${threadMessages[0]?.content[0]?.text?.value}"`
+    const summarizeFirstPrompt = `Summarize in a ${maxWordForThreadTitle}-word Title. Give the title only. Here is the message: "${threadMessages[0]?.content[0]?.text?.value}"`
 
     // Prompt: Given this query from user {query}, return to me the summary in 10 words as the title
     const msgId = ulid()


### PR DESCRIPTION
## Describe Your Changes

This PR resolved the issue where thread titles weren't being generated for threads using reasoning models.

1. Summarization title shouldn't break when encountering a line break
2. Exclude `thought` section

![CleanShot 2025-01-22 at 11 18 02@2x](https://github.com/user-attachments/assets/356cd392-e91e-4273-ad2e-2e3ece1d3207)

## Changes
This pull request includes several changes to the `ModelHandler` function in the `web/containers/Providers/ModelHandler.tsx` file. The changes focus on improving the handling and cleaning of message content before updating the thread title.

Improvements to message content handling:

* Changed `messageContent` from `const` to `let` to allow for modifications.
* Replaced newline characters in `messageContent` with spaces and extracted content after `</think>` tag if present.

Simplification of code:

* Removed unnecessary checks and warnings related to the length of the message content.

Clarification in prompt message:

* Updated the `summarizeFirstPrompt` to provide clearer instructions by adding "Here is the message:" before the message content.
