### PR TITLE
chore: ignore external contributors

### DIFF
--- a/.github/workflows/auto-assign-author.yml
+++ b/.github/workflows/auto-assign-author.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   assign-author:
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a small change to the `.github/workflows/auto-assign-author.yml` file. The change adds a conditional statement to ensure that the job only runs if the pull request's head repository matches the current repository.

* [`.github/workflows/auto-assign-author.yml`](diffhunk://#diff-241936f6a26af3f159725951c5a3302bfa839fdde96b98ed891b555e8faaab9aR9): Added a conditional statement to the `assign-author` job to check if the pull request's head repository matches the current repository.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
