### PR TITLE
enhancement: create new thread with last chosen model

### DIFF
--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -51,11 +51,13 @@ export const useCreateNewThread = () => {
 
   const { recommendedModel } = useRecommendedModel()
 
+  const selectedModel = useAtomValue(selectedModelAtom)
+
   const requestCreateNewThread = async (
     assistant: (ThreadAssistantInfo & { id: string; name: string }) | Assistant,
     model?: Model | undefined
   ) => {
-    const defaultModel = model || recommendedModel
+    const defaultModel = model || selectedModel || recommendedModel
 
     if (!model) {
       // if we have model, which means user wants to create new thread from Model hub. Allow them.

--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -84,12 +84,12 @@ export const useCreateNewThread = () => {
     // Default context length is 8192
     const defaultContextLength = Math.min(
       8192,
-      defaultModel?.settings.ctx_len ?? 8192
+      defaultModel?.settings?.ctx_len ?? 8192
     )
 
     const overriddenSettings = {
-      ctx_len: defaultModel?.settings.ctx_len
-        ? Math.min(8192, defaultModel.settings.ctx_len)
+      ctx_len: defaultModel?.settings?.ctx_len
+        ? Math.min(8192, defaultModel?.settings?.ctx_len)
         : undefined,
     }
 
@@ -97,10 +97,10 @@ export const useCreateNewThread = () => {
     const overriddenParameters = {
       max_tokens: defaultContextLength
         ? Math.min(
-            defaultModel?.parameters.max_tokens ?? 8192,
+            defaultModel?.parameters?.max_tokens ?? 8192,
             defaultContextLength
           )
-        : defaultModel?.parameters.max_tokens,
+        : defaultModel?.parameters?.max_tokens,
     }
 
     const createdAt = Date.now()


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a small but significant change to the `useCreateNewThread` hook in the `web/hooks/useCreateNewThread.ts` file. The change introduces the use of a `selectedModel` state value to prioritize the model selection process when creating a new thread.

Key change:

* [`web/hooks/useCreateNewThread.ts`](diffhunk://#diff-11adf34745ca476ecb45f143cb48d7ceb507793be060729acb9b0708ee3fd6ceR54-R60): Added `selectedModel` from the `selectedModelAtom` and updated the `defaultModel` assignment to prioritize `selectedModel` over `recommendedModel` when no specific model is provided.

## Fixes Issues

https://github.com/user-attachments/assets/8354b0c9-e55c-47c1-a67e-b88002a9370c


- Closes #4398 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
