### PR TITLE
fix: typo on apple

### DIFF
--- a/docs/src/pages/docs/desktop/mac.mdx
+++ b/docs/src/pages/docs/desktop/mac.mdx
@@ -41,7 +41,7 @@ Ensure that your system meets the following requirements to use Jan effectively:
 
 ### Mac Performance Guide
 <Callout type="info">
-**Apple Silicon Macs** leverage Metal for GPU acceleration, providing faster performance than **Appple Intel Macs**, which rely solely on CPU processing.
+**Apple Silicon Macs** leverage Metal for GPU acceleration, providing faster performance than **Apple Intel Macs**, which rely solely on CPU processing.
 </Callout>
 **Apple Silicon (M1, M2, M3)**
 - Metal acceleration enabled by default, no configuration required


### PR DESCRIPTION
## Describe Your Changes

- Fix a typo where "Apple Intel Macs" are written as "Appple Intel Macs" at https://jan.ai/docs/desktop/mac

## Fixes Issues

N/A

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [x] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
