### PR TITLE
feat: Standardize inline error messages

### DIFF
--- a/web/containers/ErrorMessage/index.test.tsx
+++ b/web/containers/ErrorMessage/index.test.tsx
@@ -69,7 +69,7 @@ describe('ErrorMessage Component', () => {
 
     render(<ErrorMessage message={message} />)
 
-    expect(screen.getByText('troubleshooting assistance')).toBeInTheDocument()
+    expect(screen.getByText('Troubleshooting')).toBeInTheDocument()
   })
 
   it('opens troubleshooting modal when link is clicked', () => {
@@ -84,7 +84,7 @@ describe('ErrorMessage Component', () => {
 
     render(<ErrorMessage message={message} />)
 
-    fireEvent.click(screen.getByText('troubleshooting assistance'))
+    fireEvent.click(screen.getByText('Troubleshooting'))
     expect(mockSetModalTroubleShooting).toHaveBeenCalledWith(true)
   })
 })


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces several changes to the `ErrorMessage` component and its associated tests in order to enhance functionality and improve the user interface. The most important changes include the addition of new icons, a copy-to-clipboard feature, and updates to the test cases to reflect these changes.

Enhancements to the `ErrorMessage` component:

* [`web/containers/ErrorMessage/index.tsx`](diffhunk://#diff-711ca7c6c49338a63c87e2e9eee4cae1cc0ec950daf8269051e23ca64ca0f244R1-R2): Added new imports for `useRef`, `useState`, and icons from `lucide-react`. Introduced a copy-to-clipboard feature using `useRef` and `useState` hooks, and updated the error message display to include new styling and icons for troubleshooting and copying error messages. [[1]](diffhunk://#diff-711ca7c6c49338a63c87e2e9eee4cae1cc0ec950daf8269051e23ca64ca0f244R1-R2) [[2]](diffhunk://#diff-711ca7c6c49338a63c87e2e9eee4cae1cc0ec950daf8269051e23ca64ca0f244R12-R13) [[3]](diffhunk://#diff-711ca7c6c49338a63c87e2e9eee4cae1cc0ec950daf8269051e23ca64ca0f244L27-R49) [[4]](diffhunk://#diff-711ca7c6c49338a63c87e2e9eee4cae1cc0ec950daf8269051e23ca64ca0f244L72-R73) [[5]](diffhunk://#diff-711ca7c6c49338a63c87e2e9eee4cae1cc0ec950daf8269051e23ca64ca0f244L93) [[6]](diffhunk://#diff-711ca7c6c49338a63c87e2e9eee4cae1cc0ec950daf8269051e23ca64ca0f244L102-R148)

Updates to test cases:

* [`web/containers/ErrorMessage/index.test.tsx`](diffhunk://#diff-fb5710e5bc7954cbc6bd4f2c46e29d20a7e8975e0d67008a62c8d2f8d2034ebfL72-R72): Updated test cases to reflect changes in the error message text and interactions. Specifically, changed references from 'troubleshooting assistance' to 'Troubleshooting' to match the updated UI. [[1]](diffhunk://#diff-fb5710e5bc7954cbc6bd4f2c46e29d20a7e8975e0d67008a62c8d2f8d2034ebfL72-R72) [[2]](diffhunk://#diff-fb5710e5bc7954cbc6bd4f2c46e29d20a7e8975e0d67008a62c8d2f8d2034ebfL87-R87)

## Fixes Issues
![CleanShot 2025-01-28 at 13 48 08](https://github.com/user-attachments/assets/55071669-a01e-4dbf-b73f-4fa1772da3bc)
![CleanShot 2025-01-28 at 14 04 44](https://github.com/user-attachments/assets/038ae7fc-674c-400c-a9b1-fb6bf2fb0bf8)
![CleanShot 2025-01-28 at 13 46 45](https://github.com/user-attachments/assets/6b3aa9a1-ef8e-4349-b585-57fbcf7d5544)

Tested long content with scroll behavior
![CleanShot 2025-01-28 at 14 06 09](https://github.com/user-attachments/assets/a9adeddb-4ce0-41b3-b49e-5a8b951fe967)


- Closes #4069 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
