### PR TITLE
feat: allow users to add remote models

### DIFF
--- a/core/src/browser/extensions/enginesManagement.ts
+++ b/core/src/browser/extensions/enginesManagement.ts
@@ -5,6 +5,7 @@ import {
   EngineReleased,
   EngineConfig,
   DefaultEngineVariant,
+  Model,
 } from '../../types'
 import { BaseExtension, ExtensionTypeEnum } from '../extension'
 
@@ -102,6 +103,11 @@ export abstract class EngineManagementExtension extends BaseExtension {
     name: InferenceEngine,
     engineConfig?: EngineConfig
   ): Promise<{ messages: string }>
+
+  /**
+   * Add a new remote model for a specific engine
+   */
+  abstract addRemoteModel(model: Model): Promise<void>
 
   /**
    * @returns A Promise that resolves to an object of remote models list .

--- a/core/src/types/model/modelEntity.ts
+++ b/core/src/types/model/modelEntity.ts
@@ -1,5 +1,3 @@
-import { FileMetadata } from '../file'
-
 /**
  * Represents the information about a model.
  * @stored
@@ -69,6 +67,11 @@ export type Model = {
    * The model identifier, which can be referenced in the API endpoints.
    */
   id: string
+
+  /**
+   * The model identifier, modern version of id.
+   */
+  mode?: string
 
   /**
    * Human-readable name that is used for UI.

--- a/web/hooks/useEngineManagement.ts
+++ b/web/hooks/useEngineManagement.ts
@@ -8,6 +8,10 @@ import {
   EngineConfig,
   events,
   EngineEvent,
+  ModelSource,
+  ModelSibling,
+  Model,
+  ModelEvent,
 } from '@janhq/core'
 import { useAtom } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
@@ -383,5 +387,69 @@ export const uninstallEngine = async (
   } catch (error) {
     console.error('Failed to install engine variant:', error)
     throw error
+  }
+}
+
+/**
+ * Add a new remote engine model
+ * @param name
+ * @param engine
+ * @returns
+ */
+export const addRemoteEngineModel = async (name: string, engine: string) => {
+  const extension = getExtension()
+
+  if (!extension) {
+    throw new Error('Extension is not available')
+  }
+
+  try {
+    // Call the extension's method
+    const response = await extension.addRemoteModel({
+      id: name,
+      model: name,
+      engine: engine as InferenceEngine,
+    } as unknown as Model)
+    events.emit(ModelEvent.OnModelsUpdate, { fetch: true })
+    return response
+  } catch (error) {
+    console.error('Failed to install engine variant:', error)
+    throw error
+  }
+}
+
+/**
+ * Remote model sources
+ * @returns A Promise that resolves to an object of model sources.
+ */
+export const useGetEngineModelSources = () => {
+  const { engines } = useGetEngines()
+  const downloadedModels = useAtomValue(downloadedModelsAtom)
+
+  return {
+    sources: Object.entries(engines ?? {})
+      ?.filter((e) => e?.[1]?.[0]?.type === 'remote')
+      .map(
+        ([key, values]) =>
+          ({
+            id: key,
+            models: (
+              downloadedModels.filter((e) => e.engine === values[0]?.engine) ??
+              []
+            ).map(
+              (e) =>
+                ({
+                  id: e.id,
+                  size: e.metadata?.size,
+                }) as unknown as ModelSibling
+            ),
+            metadata: {
+              id: getTitleByEngine(key as InferenceEngine),
+              description: getDescriptionByEngine(key as InferenceEngine),
+              apiKey: values[0]?.api_key,
+            },
+            type: 'cloud',
+          }) as unknown as ModelSource
+      ),
   }
 }

--- a/web/hooks/useEngineManagement.ts
+++ b/web/hooks/useEngineManagement.ts
@@ -8,8 +8,6 @@ import {
   EngineConfig,
   events,
   EngineEvent,
-  ModelSource,
-  ModelSibling,
   Model,
   ModelEvent,
 } from '@janhq/core'
@@ -415,41 +413,5 @@ export const addRemoteEngineModel = async (name: string, engine: string) => {
   } catch (error) {
     console.error('Failed to install engine variant:', error)
     throw error
-  }
-}
-
-/**
- * Remote model sources
- * @returns A Promise that resolves to an object of model sources.
- */
-export const useGetEngineModelSources = () => {
-  const { engines } = useGetEngines()
-  const downloadedModels = useAtomValue(downloadedModelsAtom)
-
-  return {
-    sources: Object.entries(engines ?? {})
-      ?.filter((e) => e?.[1]?.[0]?.type === 'remote')
-      .map(
-        ([key, values]) =>
-          ({
-            id: key,
-            models: (
-              downloadedModels.filter((e) => e.engine === values[0]?.engine) ??
-              []
-            ).map(
-              (e) =>
-                ({
-                  id: e.id,
-                  size: e.metadata?.size,
-                }) as unknown as ModelSibling
-            ),
-            metadata: {
-              id: getTitleByEngine(key as InferenceEngine),
-              description: getDescriptionByEngine(key as InferenceEngine),
-              apiKey: values[0]?.api_key,
-            },
-            type: 'cloud',
-          }) as unknown as ModelSource
-      ),
   }
 }

--- a/web/screens/Settings/Engines/ModalAddModel.tsx
+++ b/web/screens/Settings/Engines/ModalAddModel.tsx
@@ -1,0 +1,154 @@
+import { memo, ReactNode, useState } from 'react'
+
+import { useForm } from 'react-hook-form'
+
+import Image from 'next/image'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+
+import { InferenceEngine, Model } from '@janhq/core'
+
+import { Button, Input, Modal } from '@janhq/joi'
+import { PlusIcon } from 'lucide-react'
+
+import { z } from 'zod'
+
+import {
+  addRemoteEngineModel,
+  useGetEngines,
+  useGetRemoteModels,
+} from '@/hooks/useEngineManagement'
+
+import { getLogoEngine, getTitleByEngine } from '@/utils/modelEngine'
+import { useAtomValue } from 'jotai'
+import { downloadedModelsAtom } from '@/helpers/atoms/Model.atom'
+
+const modelSchema = z.object({
+  modelName: z.string().min(1, 'Model name is required'),
+})
+
+const ModelAddModel = ({ engine }: { engine: string }) => {
+  const [open, setOpen] = useState(false)
+  const { mutate: mutateListEngines } = useGetRemoteModels(engine)
+  const { engines } = useGetEngines()
+  const models = useAtomValue(downloadedModelsAtom)
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    setError,
+  } = useForm({
+    resolver: zodResolver(modelSchema),
+    defaultValues: {
+      modelName: '',
+    },
+  })
+
+  const onSubmit = async (data: z.infer<typeof modelSchema>) => {
+    if (models.some((e: Model) => e.id === data.modelName)) {
+      setError('modelName', {
+        type: 'manual',
+        message: 'Model already exists',
+      })
+      return
+    }
+    await addRemoteEngineModel(data.modelName, engine)
+    mutateListEngines()
+
+    setOpen(false)
+  }
+
+  // Helper to render labels with asterisks for required fields
+  const renderLabel = (
+    prefix: ReactNode,
+    label: string,
+    isRequired: boolean,
+    desc?: string
+  ) => (
+    <>
+      <span className="flex flex-row items-center gap-1">
+        {prefix}
+        {label}
+      </span>
+      <p className="mt-1 font-normal text-[hsla(var(--text-secondary))]">
+        {desc}
+        {isRequired && <span className="text-red-500">*</span>}
+      </p>
+    </>
+  )
+
+  return (
+    <Modal
+      title={
+        <div>
+          <p>Add Model</p>
+        </div>
+      }
+      fullPage
+      open={open}
+      onOpenChange={() => setOpen(!open)}
+      trigger={
+        <Button>
+          <PlusIcon className="mr-2" size={14} />
+          Add Model
+        </Button>
+      }
+      className="w-[500px]"
+      content={
+        <div>
+          <form className="mt-8 space-y-6" onSubmit={handleSubmit(onSubmit)}>
+            <div className="space-y-2">
+              <label htmlFor="modelName" className="font-semibold">
+                {renderLabel(
+                  getLogoEngine(engine as InferenceEngine) ? (
+                    <Image
+                      src={getLogoEngine(engine as InferenceEngine) ?? ''}
+                      width={40}
+                      height={40}
+                      alt="Engine logo"
+                      className="h-5 w-5 flex-shrink-0"
+                    />
+                  ) : (
+                    <></>
+                  ),
+                  getTitleByEngine(engine as InferenceEngine) ?? engine,
+                  false,
+                  'Model ID'
+                )}
+              </label>
+              <Input placeholder="Enter model ID" {...register('modelName')} />
+              {errors.modelName && (
+                <p className="text-sm text-red-500">
+                  {errors.modelName.message}
+                </p>
+              )}
+              <div className="pt-4">
+                <a
+                  target="_blank"
+                  href={engines?.[engine as InferenceEngine]?.[0]?.url}
+                  className="text-[hsla(var(--app-link))]"
+                >
+                  See model list from{' '}
+                  {getTitleByEngine(engine as InferenceEngine)}
+                </a>
+              </div>
+            </div>
+
+            <div className="mt-8 flex justify-end gap-x-2">
+              <Button
+                theme="ghost"
+                variant="outline"
+                onClick={() => setOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button type="submit">Add</Button>
+            </div>
+          </form>
+        </div>
+      }
+    />
+  )
+}
+
+export default memo(ModelAddModel)

--- a/web/screens/Settings/Engines/ModalAddModel.tsx
+++ b/web/screens/Settings/Engines/ModalAddModel.tsx
@@ -9,6 +9,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { InferenceEngine, Model } from '@janhq/core'
 
 import { Button, Input, Modal } from '@janhq/joi'
+import { useAtomValue } from 'jotai'
 import { PlusIcon } from 'lucide-react'
 
 import { z } from 'zod'
@@ -20,7 +21,7 @@ import {
 } from '@/hooks/useEngineManagement'
 
 import { getLogoEngine, getTitleByEngine } from '@/utils/modelEngine'
-import { useAtomValue } from 'jotai'
+
 import { downloadedModelsAtom } from '@/helpers/atoms/Model.atom'
 
 const modelSchema = z.object({

--- a/web/screens/Settings/Engines/RemoteEngineSettings.tsx
+++ b/web/screens/Settings/Engines/RemoteEngineSettings.tsx
@@ -27,6 +27,8 @@ import { updateEngine, useGetEngines } from '@/hooks/useEngineManagement'
 
 import { getTitleByEngine } from '@/utils/modelEngine'
 
+import ModalAddModel from './ModalAddModel'
+
 import { downloadedModelsAtom } from '@/helpers/atoms/Model.atom'
 
 const RemoteEngineSettings = ({
@@ -194,10 +196,11 @@ const RemoteEngineSettings = ({
         <div className="mb-3 mt-4 pb-4">
           <div className="flex w-full flex-col items-start justify-between sm:flex-row">
             <div className="w-full flex-shrink-0 ">
-              <div className="flex items-center justify-between gap-x-2">
+              <div className="mb-4 flex items-center justify-between gap-x-2">
                 <div>
                   <h6 className="mb-2 line-clamp-1 font-semibold">Model</h6>
                 </div>
+                <ModalAddModel engine={name} />
               </div>
 
               <div>


### PR DESCRIPTION
## Describe Your Changes

Allow users to manually add models when model list URL is unavailable/inaccessible (e.g. OpenRouter).

AC:
- User can manually add models for any remote 
- Added models appear in the model list in respective remote engine settings
- Models can be configured and used normally
- Proper error handling if:
  - model ID already exists

### User can add new remote model
![CleanShot 2025-01-28 at 16 56 01](https://github.com/user-attachments/assets/046c2bc9-51ed-46b0-8ac0-86429f4467f7)

### Error handling - model already exists
![CleanShot 2025-01-28 at 16 56 56](https://github.com/user-attachments/assets/21205643-dd34-4602-9a56-3c832d1a59a1)

Out of scope:
- model ID doesn't exists (/models settings don't work for all endpoints - KIV)

## Fixes Issues

- Closes #4515

## Changes
This pull request includes several changes to improve the management and addition of remote engine models. The key changes involve adding new functionalities for handling remote engine models, updating the UI components, and importing necessary modules.

### Improvements to remote engine model management:

* [`core/src/types/model/modelEntity.ts`](diffhunk://#diff-710b560c58b045d2eae48d8fc5305758af6f9a48886230395b028d94bdf635f5R71-R75): Added a new optional `mode` field to the `Model` type to represent a modern version of the model identifier.
* [`web/hooks/useEngineManagement.ts`](diffhunk://#diff-2be7333c9d57e11689071fc1bf5aa7eaf12b907ebc5236ed5abbdb53b031201aR392-R455): Added `addRemoteEngineModel` and `useGetEngineModelSources` functions to handle adding remote engine models and fetching remote model sources.

### UI updates and new components:

* [`web/screens/Settings/Engines/ModalAddModel.tsx`](diffhunk://#diff-d278ea856b9cd1315ee88da94c77e0dc7b5c723647a6532e9a50d1895be219fdR1-R154): Introduced a new `ModalAddModel` component to provide a user interface for adding new remote engine models.
* [`web/screens/Settings/Engines/RemoteEngineSettings.tsx`](diffhunk://#diff-d8d84f4f488f0d35b2751fee2cad04a83f6661a0f11b2b6a2355ac0e70aec575L197-R203): Integrated the `ModalAddModel` component into the `RemoteEngineSettings` screen to allow users to add models directly from the settings.

### Module imports:

* [`web/hooks/useEngineManagement.ts`](diffhunk://#diff-2be7333c9d57e11689071fc1bf5aa7eaf12b907ebc5236ed5abbdb53b031201aR11-R14): Imported additional necessary modules (`ModelSource`, `ModelSibling`, `Model`, `ModelEvent`) to support the new functionalities.
* [`web/screens/Settings/Engines/RemoteEngineSettings.tsx`](diffhunk://#diff-d8d84f4f488f0d35b2751fee2cad04a83f6661a0f11b2b6a2355ac0e70aec575R30-R31): Imported the `ModalAddModel` component to be used in the settings screen.