### PR TITLE
fix: broken range slider ctx length

### DIFF
--- a/web/screens/Thread/ThreadRightPanel/index.tsx
+++ b/web/screens/Thread/ThreadRightPanel/index.tsx
@@ -202,16 +202,6 @@ const ThreadRightPanel = () => {
             },
           })
         }
-        if (
-          key === 'ctx_len' &&
-          Number(value) < activeAssistant.model.parameters.max_tokens
-        ) {
-          updateModelParameter(activeThread, {
-            params: {
-              max_tokens: activeAssistant.model.settings.ctx_len,
-            },
-          })
-        }
       }
     },
     [


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a change to the `ThreadRightPanel` component in the `web/screens/Thread/ThreadRightPanel/index.tsx` file. The change removes a conditional block that was responsible for updating the `max_tokens` parameter in the `activeAssistant` model settings based on the `ctx_len` key.

* [`web/screens/Thread/ThreadRightPanel/index.tsx`](diffhunk://#diff-edaf5f3af4dcdced18bb55d7ef086e99b3025a77ac18f9797d18cbbbc51bf69fL205-L214): Removed the conditional block that updates the `max_tokens` parameter when the `ctx_len` key is present and its value is less than the `max_tokens` parameter in the `activeAssistant` model settings.

## Fixes Issues

https://github.com/user-attachments/assets/8f9be3f0-38ff-4efe-b4fc-61d26ec62382


- Closes #4427 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
