### PR TITLE
chore: sync cortex engine version

### DIFF
--- a/extensions/engine-management-extension/rolldown.config.mjs
+++ b/extensions/engine-management-extension/rolldown.config.mjs
@@ -13,7 +13,7 @@ export default defineConfig([
       NODE: JSON.stringify(`${pkgJson.name}/${pkgJson.node}`),
       API_URL: JSON.stringify('http://127.0.0.1:39291'),
       SOCKET_URL: JSON.stringify('ws://127.0.0.1:39291'),
-      CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.46'),
+      CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.49'),
       DEFAULT_REMOTE_ENGINES: JSON.stringify(engines),
       DEFAULT_REMOTE_MODELS: JSON.stringify(models),
     },
@@ -26,7 +26,7 @@ export default defineConfig([
       file: 'dist/node/index.cjs.js',
     },
     define: {
-      CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.46'),
+      CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.49'),
     },
   },
   {

--- a/extensions/inference-cortex-extension/rolldown.config.mjs
+++ b/extensions/inference-cortex-extension/rolldown.config.mjs
@@ -111,7 +111,7 @@ export default defineConfig([
       SETTINGS: JSON.stringify(defaultSettingJson),
       CORTEX_API_URL: JSON.stringify('http://127.0.0.1:39291'),
       CORTEX_SOCKET_URL: JSON.stringify('ws://127.0.0.1:39291'),
-      CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.46'),
+      CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.49'),
     },
   },
   {


### PR DESCRIPTION
## Describe Your Changes

This PR aims to synchronize the Cortex engine with the latest version.


## Self Checklist
This pull request includes updates to the Cortex engine version in the configuration files for both the engine management and inference cortex extensions.

Updates to Cortex engine version:

* [`extensions/engine-management-extension/rolldown.config.mjs`](diffhunk://#diff-30942dcc326a20cefe8cde68225a2aebaf2dab82021400521c5f63724210f558L16-R16): Updated `CORTEX_ENGINE_VERSION` from `v0.1.46` to `v0.1.49` in both occurrences. [[1]](diffhunk://#diff-30942dcc326a20cefe8cde68225a2aebaf2dab82021400521c5f63724210f558L16-R16) [[2]](diffhunk://#diff-30942dcc326a20cefe8cde68225a2aebaf2dab82021400521c5f63724210f558L29-R29)
* [`extensions/inference-cortex-extension/rolldown.config.mjs`](diffhunk://#diff-9b93590cc9312a835d0c11d009d45deeb5ff72bca39e246b2e3f8fde7e3d5e8eL114-R114): Updated `CORTEX_ENGINE_VERSION` from `v0.1.46` to `v0.1.49`.