### PR TITLE
chore: ensure app Id is maintained

### DIFF
--- a/core/src/types/config/appConfigEntity.ts
+++ b/core/src/types/config/appConfigEntity.ts
@@ -1,4 +1,5 @@
 export type AppConfiguration = {
   data_folder: string
   quick_ask: boolean
+  distinct_id?: string
 }

--- a/web/containers/Layout/index.tsx
+++ b/web/containers/Layout/index.tsx
@@ -26,6 +26,8 @@ import ImportModelOptionModal from '@/screens/Settings/ImportModelOptionModal'
 import ImportingModelModal from '@/screens/Settings/ImportingModelModal'
 import SelectingModelModal from '@/screens/Settings/SelectingModelModal'
 
+import { getAppDistinctId, updateDistinctId } from '@/utils/settings'
+
 import LoadingModal from '../LoadingModal'
 
 import MainViewContainer from '../MainViewContainer'
@@ -93,8 +95,16 @@ const BaseLayout = () => {
           return properties
         },
       })
-      posthog.opt_in_capturing()
-      posthog.register({ app_version: VERSION })
+      // Attempt to restore distinct Id from app global settings
+      getAppDistinctId()
+        .then((id) => {
+          if (id) posthog.identify(id)
+        })
+        .finally(() => {
+          posthog.opt_in_capturing()
+          posthog.register({ app_version: VERSION })
+          updateDistinctId(posthog.get_distinct_id())
+        })
     } else {
       posthog.opt_out_capturing()
     }

--- a/web/hooks/useFactoryReset.ts
+++ b/web/hooks/useFactoryReset.ts
@@ -58,6 +58,7 @@ export default function useFactoryReset() {
         const configuration: AppConfiguration = {
           data_folder: defaultJanDataFolder,
           quick_ask: appConfiguration?.quick_ask ?? false,
+          distinct_id: appConfiguration?.distinct_id,
         }
         await window.core?.api?.updateAppConfiguration(configuration)
       }

--- a/web/utils/settings.ts
+++ b/web/utils/settings.ts
@@ -1,0 +1,22 @@
+import { AppConfiguration } from '@janhq/core'
+
+/**
+ * Update app distinct Id
+ * @param id
+ */
+export const updateDistinctId = async (id: string) => {
+  const appConfiguration: AppConfiguration =
+    await window.core?.api?.getAppConfigurations()
+  appConfiguration.distinct_id = id
+  await window.core?.api?.updateAppConfiguration(appConfiguration)
+}
+
+/**
+ * Retrieve app distinct Id
+ * @param id
+ */
+export const getAppDistinctId = async (): Promise<string | undefined> => {
+  const appConfiguration: AppConfiguration =
+    await window.core?.api?.getAppConfigurations()
+  return appConfiguration.distinct_id
+}


### PR DESCRIPTION
## Describe Your Changes

This PR ensures that the app ID remains unchanged, just like other global app settings.

## Changes
This pull request introduces changes to support the management of a distinct ID within the app configuration. The most important changes include adding a new optional `distinct_id` field to the `AppConfiguration` type, updating the layout to handle this distinct ID, and adding utility functions for updating and retrieving the distinct ID.

Changes to support distinct ID management:

* [`core/src/types/config/appConfigEntity.ts`](diffhunk://#diff-81d34794166bc265d38342b18eabd32a24bcb444a9d56afdc11995469b32e517R4): Added an optional `distinct_id` field to the `AppConfiguration` type.
* [`web/containers/Layout/index.tsx`](diffhunk://#diff-14ae8afe09456109846de9e991341105e0d570a68d771860be34c3626c438f59R29-R30): Imported `getAppDistinctId` and `updateDistinctId` functions and updated the `BaseLayout` component to manage the distinct ID. [[1]](diffhunk://#diff-14ae8afe09456109846de9e991341105e0d570a68d771860be34c3626c438f59R29-R30) [[2]](diffhunk://#diff-14ae8afe09456109846de9e991341105e0d570a68d771860be34c3626c438f59R98-R107)
* [`web/hooks/useFactoryReset.ts`](diffhunk://#diff-f7217a9f24cc75d11abb236c50cb12934d0d178621b120b39f9bce19c3113c05R61): Updated the `useFactoryReset` hook to include the `distinct_id` in the app configuration.
* [`web/utils/settings.ts`](diffhunk://#diff-4b77965340a1b0bcc8a3182659556b26ce28661ce687575da707364fdde16145R1-R22): Added `updateDistinctId` and `getAppDistinctId` functions to handle the distinct ID in the app configuration.
