### PR TITLE
chore: rotate model hub banner on app launch until set

### DIFF
--- a/web/helpers/atoms/App.atom.ts
+++ b/web/helpers/atoms/App.atom.ts
@@ -32,13 +32,28 @@ export const copyOverInstructionEnabledAtom = atomWithStorage(
 )
 
 /**
- * App Hub Banner configured image
+ * App Banner Hub Atom - storage last banner setting - default undefined
  */
-export const appBannerHubAtom = atomWithStorage<string>(
+const appBannerHubStorageAtom = atomWithStorage<string | undefined>(
   'appBannerHub',
-  './images/HubBanner/banner-8.jpg',
+  undefined,
   undefined,
   {
     getOnInit: true,
   }
 )
+/**
+ * App Hub Banner configured image - Retrieve from appBannerHubStorageAtom - fallback a random banner
+ */
+export const getAppBannerHubAtom = atom<string>(
+  (get) =>
+    get(appBannerHubStorageAtom) ??
+    `./images/HubBanner/banner-${Math.floor(Math.random() * 30) + 1}.jpg`
+)
+
+/**
+ * Set App Hub Banner - store in appBannerHubStorageAtom
+ */
+export const setAppBannerHubAtom = atom(null, (get, set, banner: string) => {
+  set(appBannerHubStorageAtom, banner)
+})

--- a/web/screens/Hub/index.tsx
+++ b/web/screens/Hub/index.tsx
@@ -10,7 +10,7 @@ import { ModelSource } from '@janhq/core'
 import { ScrollArea, Button, Select, Tabs, useClickOutside } from '@janhq/joi'
 import { motion as m } from 'framer-motion'
 
-import { useAtom, useSetAtom } from 'jotai'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { ImagePlusIcon, UploadCloudIcon, UploadIcon } from 'lucide-react'
 
 import { twMerge } from 'tailwind-merge'
@@ -33,7 +33,10 @@ import { fuzzySearch } from '@/utils/search'
 
 import ModelPage from './ModelPage'
 
-import { appBannerHubAtom } from '@/helpers/atoms/App.atom'
+import {
+  getAppBannerHubAtom,
+  setAppBannerHubAtom,
+} from '@/helpers/atoms/App.atom'
 import { modelDetailAtom } from '@/helpers/atoms/Model.atom'
 
 const sortMenus = [
@@ -70,7 +73,8 @@ const HubScreen = () => {
   const [filterOption, setFilterOption] = useState('all')
   const [hubBannerOption, setHubBannerOption] = useState('gallery')
   const [showHubBannerSetting, setShowHubBannerSetting] = useState(false)
-  const [appBannerHub, setAppBannerHub] = useAtom(appBannerHubAtom)
+  const appBannerHub = useAtomValue(getAppBannerHubAtom)
+  const setAppBannerHub = useSetAtom(setAppBannerHubAtom)
   const [selectedModel, setSelectedModel] = useState<ModelSource | undefined>(
     undefined
   )


### PR DESCRIPTION
## Describe Your Changes

As designed, users will see a different Model Hub banner every time they reopen the app if they haven't set any banner. This PR is for that.

1. Users have not changed the banner hub -> Set a random hub image from the default list when the app is opened using Atom Storage and a bridge ReadOnly Atom.
2. As soon as users set a banner hub image, WriteOnly Atom writes this setting into Atom Storage. From then on, it returns the latest banner hub image.

## Fixes Issues

- Closes #4170

## Self Checklist
This pull request introduces changes to the `web/helpers/atoms/App.atom.ts` and `web/screens/Hub/index.tsx` files to enhance the management of the app banner hub settings. The most important changes include renaming and refactoring atoms for better clarity, adding new atoms for retrieving and setting the banner, and updating the `Hub` screen to use these new atoms.

Refactoring and renaming atoms:

* [`web/helpers/atoms/App.atom.ts`](diffhunk://#diff-1d0026312115a8f15cb85d46967de396a06b678f662e44b76710baba90682c99L35-R59): Renamed `appBannerHubAtom` to `appBannerHubStorageAtom` and changed its type to `string | undefined`. Added new atoms `getAppBannerHubAtom` for retrieving the banner and `setAppBannerHubAtom` for setting the banner.

Updating imports and usage in `Hub` screen:

* [`web/screens/Hub/index.tsx`](diffhunk://#diff-4acda36130f9ceb893281d73ffa88c92378b2a79c7b9a6c1b0704300cb2dd5d1L36-R39): Updated imports to use the new atoms `getAppBannerHubAtom` and `setAppBannerHubAtom` instead of `appBannerHubAtom`.
* [`web/screens/Hub/index.tsx`](diffhunk://#diff-4acda36130f9ceb893281d73ffa88c92378b2a79c7b9a6c1b0704300cb2dd5d1L73-R77): Modified the `HubScreen` component to use `useAtomValue` for `getAppBannerHubAtom` and `useSetAtom` for `setAppBannerHubAtom`.

Additional import adjustments:

* [`web/screens/Hub/index.tsx`](diffhunk://#diff-4acda36130f9ceb893281d73ffa88c92378b2a79c7b9a6c1b0704300cb2dd5d1L13-R13): Added `useAtomValue` to the list of imports from `jotai`.
