### PR TITLE
feat: pull models list when setting up a new remote engine

### DIFF
--- a/core/src/types/model/modelEntity.ts
+++ b/core/src/types/model/modelEntity.ts
@@ -71,7 +71,7 @@ export type Model = {
   /**
    * The model identifier, modern version of id.
    */
-  mode?: string
+  model?: string
 
   /**
    * Human-readable name that is used for UI.

--- a/extensions/engine-management-extension/rolldown.config.mjs
+++ b/extensions/engine-management-extension/rolldown.config.mjs
@@ -16,6 +16,13 @@ export default defineConfig([
       CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.49'),
       DEFAULT_REMOTE_ENGINES: JSON.stringify(engines),
       DEFAULT_REMOTE_MODELS: JSON.stringify(models),
+      DEFAULT_REQUEST_PAYLOAD_TRANSFORM: JSON.stringify('{{ tojson(value) }}'),
+      DEFAULT_RESPONSE_BODY_TRANSFORM: JSON.stringify(
+        '{ {% set first = true %} {% for key, value in input_request %} {% if key == "choices" or key == "created" or key == "model" or key == "service_tier" or key == "stream" or key == "object" or key == "usage" %} {% if not first %},{% endif %} "{{ key }}": {{ tojson(value) }} {% set first = false %} {% endif %} {% endfor %} }'
+      ),
+      DEFAULT_REQUEST_HEADERS_TRANSFORM: JSON.stringify(
+        'Authorization: Bearer {{api_key}}'
+      ),
     },
   },
   {

--- a/extensions/engine-management-extension/src/@types/global.d.ts
+++ b/extensions/engine-management-extension/src/@types/global.d.ts
@@ -2,6 +2,9 @@ declare const API_URL: string
 declare const CORTEX_ENGINE_VERSION: string
 declare const SOCKET_URL: string
 declare const NODE: string
+declare const DEFAULT_REQUEST_PAYLOAD_TRANSFORM: string
+declare const DEFAULT_RESPONSE_BODY_TRANSFORM: string
+declare const DEFAULT_REQUEST_HEADERS_TRANSFORM: string
 
 declare const DEFAULT_REMOTE_ENGINES: ({
   id: string


### PR DESCRIPTION
## Describe Your Changes

Previously, when setting up a new remote provider, users had to manually set up models. With this update, as soon as users set up a new provider, it will automatically attempt to pull models from the specified /models endpoint.

![CleanShot 2025-01-30 at 15 15 11](https://github.com/user-attachments/assets/dceb45ec-0f35-469f-8a89-7f60bdfe566c)


## Fixes Issues

- Closes #4515

## Self Checklist
This pull request includes several changes to the `JSONEngineManagementExtension` class and related configuration files to enhance the handling of remote models and engines. The most important changes include modifying the `Model` type, updating the configuration, and improving the methods for adding and populating remote models.

Changes to `Model` type:

* [`core/src/types/model/modelEntity.ts`](diffhunk://#diff-710b560c58b045d2eae48d8fc5305758af6f9a48886230395b028d94bdf635f5L74-R74): Renamed the `mode` property to `model` in the `Model` type.

Configuration updates:

* [`extensions/engine-management-extension/rolldown.config.mjs`](diffhunk://#diff-30942dcc326a20cefe8cde68225a2aebaf2dab82021400521c5f63724210f558R19-R25): Added default payload, response body, and request headers transformations to the configuration.

Enhancements to `JSONEngineManagementExtension` class:

* [`extensions/engine-management-extension/src/index.ts`](diffhunk://#diff-d8c74089c1ad29e79d22182a9a2d8721dd5c77e8bd937363487496ba8cd8c991R23-R25): Introduced a new `ModelList` interface for handling remote models.
* [`extensions/engine-management-extension/src/index.ts`](diffhunk://#diff-d8c74089c1ad29e79d22182a9a2d8721dd5c77e8bd937363487496ba8cd8c991L66-R74): Modified the `getRemoteModels` method to return a `ModelList` instead of an array of `Model` objects.
* [`extensions/engine-management-extension/src/index.ts`](diffhunk://#diff-d8c74089c1ad29e79d22182a9a2d8721dd5c77e8bd937363487496ba8cd8c991L141-R172): Enhanced the `addRemoteEngine` method to include default settings and optionally persist models.
* [`extensions/engine-management-extension/src/index.ts`](diffhunk://#diff-d8c74089c1ad29e79d22182a9a2d8721dd5c77e8bd937363487496ba8cd8c991R337-R359): Added a private `populateRemoteModels` method to pull and persist models from the remote provider.
