### PR TITLE
fix: think content render as markdown

### DIFF
--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx
@@ -19,7 +19,7 @@ import { useClipboard } from '@/hooks/useClipboard'
 import { getLanguageFromExtension } from '@/utils/codeLanguageExtension'
 
 export const MarkdownTextMessage = memo(
-  ({ text, isUser }: { id: string; text: string; isUser: boolean }) => {
+  ({ text, isUser }: { id?: string; text: string; isUser?: boolean }) => {
     const clipboard = useClipboard({ timeout: 1000 })
 
     // Escapes headings

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/ThinkingBlock.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/ThinkingBlock.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { atom, useAtom } from 'jotai'
 import { ChevronDown, ChevronUp, Loader } from 'lucide-react'
+import { MarkdownTextMessage } from './MarkdownTextMessage'
 
 interface Props {
   text: string
@@ -48,7 +49,9 @@ const ThinkingBlock = ({ id, text, status }: Props) => {
 
         {isExpanded && (
           <div className="mt-2 pl-6 text-[hsla(var(--text-secondary))]">
-            {text.replace(/<\/?think>/g, '').trim()}
+            <MarkdownTextMessage
+              text={text.replace(/<\/?think>/g, '').trim()}
+            />
           </div>
         )}
       </div>

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/ThinkingBlock.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/ThinkingBlock.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 import { atom, useAtom } from 'jotai'
 import { ChevronDown, ChevronUp, Loader } from 'lucide-react'
+
 import { MarkdownTextMessage } from './MarkdownTextMessage'
 
 interface Props {


### PR DESCRIPTION
## Describe Your Changes

This pull request includes changes to the `web/screens/Thread/ThreadCenterPanel/TextMessage` components to enhance the handling of markdown text messages. The most important changes include updating the `MarkdownTextMessage` component to make some props optional and integrating this component into the `ThinkingBlock` component.

Enhancements to markdown text message handling:

* [`web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx`](diffhunk://#diff-248577b16f0456ecc74b4c2feb89430842934aea33e2a7d3fcbec9cced25bf1bL22-R22): Updated the `MarkdownTextMessage` component to make the `id` and `isUser` props optional.

Integration of markdown text message component:

* [`web/screens/Thread/ThreadCenterPanel/TextMessage/ThinkingBlock.tsx`](diffhunk://#diff-ab6a818fc54ea9f5203a346ab74e247517f9e3bdece1c4f52c109fe68c48e14eR5): Imported the `MarkdownTextMessage` component and replaced the plain text rendering with the `MarkdownTextMessage` component for better markdown handling. [[1]](diffhunk://#diff-ab6a818fc54ea9f5203a346ab74e247517f9e3bdece1c4f52c109fe68c48e14eR5) [[2]](diffhunk://#diff-ab6a818fc54ea9f5203a346ab74e247517f9e3bdece1c4f52c109fe68c48e14eL51-R54)

## Fixes Issues

![CleanShot 2025-02-03 at 23 20 51](https://github.com/user-attachments/assets/bf262bdd-5a4a-4f71-a76b-fedd73ba12c6)


- Closes # https://discord.com/channels/1107178041848909847/1239846009258119178/1335936400503078923
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
