### PR TITLE
fix: download progress import from hgf

### DIFF
--- a/extensions/yarn.lock
+++ b/extensions/yarn.lock
@@ -509,61 +509,61 @@ __metadata:
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fassistant-extension%40workspace%3Aassistant-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=8a4445&locator=%40janhq%2Fassistant-extension%40workspace%3Aassistant-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=28a570&locator=%40janhq%2Fassistant-extension%40workspace%3Aassistant-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/74cb4d1126dd504b81b31a3a1da89b1f332e327e980a99d645a9088cba0ccd5fafdb94e1c31d40991cbfc7e18615cf6644f4882ff8df29293ea6adc6a2977d65
+  checksum: 10c0/db6db06721a2eff01d4400d87645529f5447b31274132931cb0848a9bb397b32bc3805105be2f31ca1843be926f4102dbf9fb529502f5f48afb73ae726891232
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fconversational-extension%40workspace%3Aconversational-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=8a4445&locator=%40janhq%2Fconversational-extension%40workspace%3Aconversational-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=28a570&locator=%40janhq%2Fconversational-extension%40workspace%3Aconversational-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/74cb4d1126dd504b81b31a3a1da89b1f332e327e980a99d645a9088cba0ccd5fafdb94e1c31d40991cbfc7e18615cf6644f4882ff8df29293ea6adc6a2977d65
+  checksum: 10c0/db6db06721a2eff01d4400d87645529f5447b31274132931cb0848a9bb397b32bc3805105be2f31ca1843be926f4102dbf9fb529502f5f48afb73ae726891232
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fengine-management-extension%40workspace%3Aengine-management-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=8a4445&locator=%40janhq%2Fengine-management-extension%40workspace%3Aengine-management-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=28a570&locator=%40janhq%2Fengine-management-extension%40workspace%3Aengine-management-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/74cb4d1126dd504b81b31a3a1da89b1f332e327e980a99d645a9088cba0ccd5fafdb94e1c31d40991cbfc7e18615cf6644f4882ff8df29293ea6adc6a2977d65
+  checksum: 10c0/db6db06721a2eff01d4400d87645529f5447b31274132931cb0848a9bb397b32bc3805105be2f31ca1843be926f4102dbf9fb529502f5f48afb73ae726891232
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fhardware-management-extension%40workspace%3Ahardware-management-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=8a4445&locator=%40janhq%2Fhardware-management-extension%40workspace%3Ahardware-management-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=28a570&locator=%40janhq%2Fhardware-management-extension%40workspace%3Ahardware-management-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/74cb4d1126dd504b81b31a3a1da89b1f332e327e980a99d645a9088cba0ccd5fafdb94e1c31d40991cbfc7e18615cf6644f4882ff8df29293ea6adc6a2977d65
+  checksum: 10c0/db6db06721a2eff01d4400d87645529f5447b31274132931cb0848a9bb397b32bc3805105be2f31ca1843be926f4102dbf9fb529502f5f48afb73ae726891232
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Finference-cortex-extension%40workspace%3Ainference-cortex-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=8a4445&locator=%40janhq%2Finference-cortex-extension%40workspace%3Ainference-cortex-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=28a570&locator=%40janhq%2Finference-cortex-extension%40workspace%3Ainference-cortex-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/74cb4d1126dd504b81b31a3a1da89b1f332e327e980a99d645a9088cba0ccd5fafdb94e1c31d40991cbfc7e18615cf6644f4882ff8df29293ea6adc6a2977d65
+  checksum: 10c0/db6db06721a2eff01d4400d87645529f5447b31274132931cb0848a9bb397b32bc3805105be2f31ca1843be926f4102dbf9fb529502f5f48afb73ae726891232
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fmodel-extension%40workspace%3Amodel-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=8a4445&locator=%40janhq%2Fmodel-extension%40workspace%3Amodel-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=28a570&locator=%40janhq%2Fmodel-extension%40workspace%3Amodel-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/74cb4d1126dd504b81b31a3a1da89b1f332e327e980a99d645a9088cba0ccd5fafdb94e1c31d40991cbfc7e18615cf6644f4882ff8df29293ea6adc6a2977d65
+  checksum: 10c0/db6db06721a2eff01d4400d87645529f5447b31274132931cb0848a9bb397b32bc3805105be2f31ca1843be926f4102dbf9fb529502f5f48afb73ae726891232
   languageName: node
   linkType: hard
 

--- a/web/screens/Settings/HuggingFaceRepoDetailModal/ModelDownloadRow/index.tsx
+++ b/web/screens/Settings/HuggingFaceRepoDetailModal/ModelDownloadRow/index.tsx
@@ -51,7 +51,9 @@ const ModelDownloadRow: React.FC<Props> = ({
   const setMainViewState = useSetAtom(mainViewStateAtom)
   const assistants = useAtomValue(assistantsAtom)
   const downloadedModel = downloadedModels.find((md) => md.id === fileName)
-  const isDownloading = downloadingModels.some((md) => md === fileName)
+  const isDownloading = downloadingModels.some(
+    (md) => md === fileName || fileName.includes(md)
+  )
 
   const setHfImportingStage = useSetAtom(importHuggingFaceModelStageAtom)
 


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a change to the `ModelDownloadRow` component in the `HuggingFaceRepoDetailModal` screen. The change modifies the logic for determining if a model is currently downloading.

* [`web/screens/Settings/HuggingFaceRepoDetailModal/ModelDownloadRow/index.tsx`](diffhunk://#diff-b5c4343baba94d9357d77fd6e643b315b466f367e4b3ee7c87d96f5576a6e51fL54-R56): Updated the `isDownloading` variable to check if the `fileName` includes any of the `downloadingModels` elements, in addition to checking for equality.

## Fixes Issues

![CleanShot 2025-02-04 at 15 37 53](https://github.com/user-attachments/assets/2010c08e-b9ed-4e35-a97e-5205d7c6cee0)


- Closes # https://discord.com/channels/1107178041848909847/1324287882722021407/1336221159712358430
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
