### PR TITLE
chore: add default inference parameters for custom remote models

### DIFF
--- a/extensions/engine-management-extension/src/index.ts
+++ b/extensions/engine-management-extension/src/index.ts
@@ -195,7 +195,21 @@ export default class JSONEngineManagementExtension extends EngineManagementExten
   async addRemoteModel(model: Model) {
     return this.queue
       .add(() =>
-        ky.post(`${API_URL}/v1/models/add`, { json: model }).then((e) => e)
+        ky
+          .post(`${API_URL}/v1/models/add`, {
+            json: {
+              inference_params: {
+                max_tokens: 8192,
+                temperature: 0.7,
+                top_p: 0.95,
+                stream: true,
+                frequency_penalty: 0,
+                presence_penalty: 0,
+              },
+              ...model,
+            },
+          })
+          .then((e) => e)
       )
       .then(() => {})
   }


### PR DESCRIPTION
This pull request includes an enhancement to the `addRemoteModel` method in the `JSONEngineManagementExtension` class to include additional inference parameters when adding a model.

![CleanShot 2025-02-05 at 16 44 36@2x](https://github.com/user-attachments/assets/4cdd8431-309c-4d0e-ba95-4845b4cfa59e)



Enhancements to `addRemoteModel` method:

* [`extensions/engine-management-extension/src/index.ts`](diffhunk://#diff-d8c74089c1ad29e79d22182a9a2d8721dd5c77e8bd937363487496ba8cd8c991L198-R212): Modified the `addRemoteModel` method to include additional inference parameters (`max_tokens`, `temperature`, `top_p`, `stream`, `frequency_penalty`, `presence_penalty`) in the JSON payload when posting to the API.