### PR TITLE
chore:add deepseek r1 distill models to hub

### DIFF
--- a/extensions/inference-cortex-extension/package.json
+++ b/extensions/inference-cortex-extension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@janhq/inference-cortex-extension",
   "productName": "Cortex Inference Engine",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "This extension embeds cortex.cpp, a lightweight inference engine written in C++. See https://jan.ai.\nAdditional dependencies could be installed to run without Cuda Toolkit installation.",
   "main": "dist/index.js",
   "node": "dist/node/index.cjs.js",

--- a/extensions/inference-cortex-extension/resources/models/deepseek-r1-distill-llama-70b/model.json
+++ b/extensions/inference-cortex-extension/resources/models/deepseek-r1-distill-llama-70b/model.json
@@ -1,0 +1,35 @@
+{
+  "sources": [
+    {
+      "filename": "DeepSeek-R1-Distill-Llama-70B-Q4_K_M.gguf",
+      "url": "https://huggingface.co/unsloth/DeepSeek-R1-Distill-Llama-70B-GGUF/resolve/main/DeepSeek-R1-Distill-Llama-70B-Q4_K_M.gguf"
+    }
+  ],
+  "id": "deepseek-r1-distill-llama-70b",
+  "object": "model",
+  "name": "DeepSeek R1 Distill Llama 70B Q4",
+  "version": "1.0",
+  "description": "DeepSeek-R1 is a cheaper and open-source model that excels at agentic reasoning, superior multilingual capabilities, large context windows, and generalization across domains.",
+  "format": "gguf",
+  "settings": {
+    "ctx_len": 131072,
+    "prompt_template": "<｜User｜> {prompt} <｜Assistant｜>",
+    "llama_model_path": "DeepSeek-R1-Distill-Llama-70B-Q4_K_M.gguf",
+    "ngl": 81
+  },
+  "parameters": {
+    "temperature": 0.6,
+    "top_p": 0.95,
+    "stream": true,
+    "max_tokens": 131072,
+    "stop": [],
+    "frequency_penalty": 0,
+    "presence_penalty": 0
+  },
+  "metadata": {
+    "author": "DeepSeek",
+    "tags": ["70B", "Featured"],
+    "size": 42500000000
+  },
+  "engine": "llama-cpp"
+}

--- a/extensions/inference-cortex-extension/resources/models/deepseek-r1-distill-llama-8b/model.json
+++ b/extensions/inference-cortex-extension/resources/models/deepseek-r1-distill-llama-8b/model.json
@@ -1,0 +1,35 @@
+{
+  "sources": [
+    {
+      "filename": "DeepSeek-R1-Distill-Llama-8B-Q5_K_M.gguf",
+      "url": "https://huggingface.co/unsloth/DeepSeek-R1-Distill-Llama-8B-GGUF/resolve/main/DeepSeek-R1-Distill-Llama-8B-Q5_K_M.gguf"
+    }
+  ],
+  "id": "deepseek-r1-distill-llama-8b",
+  "object": "model",
+  "name": "DeepSeek R1 Distill Llama 8B Q5",
+  "version": "1.0",
+  "description": "DeepSeek-R1 is a cheaper and open-source model that excels at agentic reasoning, superior multilingual capabilities, large context windows, and generalization across domains.",
+  "format": "gguf",
+  "settings": {
+    "ctx_len": 131072,
+    "prompt_template": "<｜User｜> {prompt} <｜Assistant｜>",
+    "llama_model_path": "DeepSeek-R1-Distill-Llama-8B-Q5_K_M.gguf",
+    "ngl": 33
+  },
+  "parameters": {
+    "temperature": 0.6,
+    "top_p": 0.95,
+    "stream": true,
+    "max_tokens": 131072,
+    "stop": [],
+    "frequency_penalty": 0,
+    "presence_penalty": 0
+  },
+  "metadata": {
+    "author": "DeepSeek",
+    "tags": ["8B", "Featured"],
+    "size": 5730000000
+  },
+  "engine": "llama-cpp"
+}

--- a/extensions/inference-cortex-extension/resources/models/deepseek-r1-distill-qwen-1.5b/model.json
+++ b/extensions/inference-cortex-extension/resources/models/deepseek-r1-distill-qwen-1.5b/model.json
@@ -1,0 +1,35 @@
+{
+  "sources": [
+    {
+      "filename": "DeepSeek-R1-Distill-Qwen-1.5B-Q5_K_M.gguf",
+      "url": "https://huggingface.co/unsloth/DeepSeek-R1-Distill-Qwen-1.5B-GGUF/resolve/main/DeepSeek-R1-Distill-Qwen-1.5B-Q5_K_M.gguf"
+    }
+  ],
+  "id": "deepseek-r1-distill-qwen-1.5b",
+  "object": "model",
+  "name": "DeepSeek R1 Distill Qwen 1.5B Q5",
+  "version": "1.0",
+  "description": "DeepSeek-R1 is a cheaper and open-source model that excels at agentic reasoning, superior multilingual capabilities, large context windows, and generalization across domains.",
+  "format": "gguf",
+  "settings": {
+    "ctx_len": 131072,
+    "prompt_template": "<｜User｜> {prompt} <｜Assistant｜>",
+    "llama_model_path": "DeepSeek-R1-Distill-Qwen-1.5B-Q5_K_M.gguf",
+    "ngl": 29
+  },
+  "parameters": {
+    "temperature": 0.6,
+    "top_p": 0.95,
+    "stream": true,
+    "max_tokens": 131072,
+    "stop": [],
+    "frequency_penalty": 0,
+    "presence_penalty": 0
+  },
+  "metadata": {
+    "author": "DeepSeek",
+    "tags": ["1.5B", "Featured"],
+    "size": 1290000000
+  },
+  "engine": "llama-cpp"
+}

--- a/extensions/inference-cortex-extension/resources/models/deepseek-r1-distill-qwen-14b/model.json
+++ b/extensions/inference-cortex-extension/resources/models/deepseek-r1-distill-qwen-14b/model.json
@@ -1,0 +1,35 @@
+{
+  "sources": [
+    {
+      "filename": "DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf",
+      "url": "https://huggingface.co/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/main/DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf"
+    }
+  ],
+  "id": "deepseek-r1-distill-qwen-14b",
+  "object": "model",
+  "name": "DeepSeek R1 Distill Qwen 14B Q4",
+  "version": "1.0",
+  "description": "DeepSeek-R1 is a cheaper and open-source model that excels at agentic reasoning, superior multilingual capabilities, large context windows, and generalization across domains.",
+  "format": "gguf",
+  "settings": {
+    "ctx_len": 131072,
+    "prompt_template": "<｜User｜> {prompt} <｜Assistant｜>",
+    "llama_model_path": "DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf",
+    "ngl": 49
+  },
+  "parameters": {
+    "temperature": 0.6,
+    "top_p": 0.95,
+    "stream": true,
+    "max_tokens": 131072,
+    "stop": [],
+    "frequency_penalty": 0,
+    "presence_penalty": 0
+  },
+  "metadata": {
+    "author": "DeepSeek",
+    "tags": ["14B", "Featured"],
+    "size": 8990000000
+  },
+  "engine": "llama-cpp"
+}

--- a/extensions/inference-cortex-extension/resources/models/deepseek-r1-distill-qwen-32b/model.json
+++ b/extensions/inference-cortex-extension/resources/models/deepseek-r1-distill-qwen-32b/model.json
@@ -1,0 +1,35 @@
+{
+  "sources": [
+    {
+      "filename": "DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf",
+      "url": "https://huggingface.co/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/main/DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf"
+    }
+  ],
+  "id": "deepseek-r1-distill-qwen-32b",
+  "object": "model",
+  "name": "DeepSeek R1 Distill Qwen 32B Q4",
+  "version": "1.0",
+  "description": "DeepSeek-R1 is a cheaper and open-source model that excels at agentic reasoning, superior multilingual capabilities, large context windows, and generalization across domains.",
+  "format": "gguf",
+  "settings": {
+    "ctx_len": 131072,
+    "prompt_template": "<｜User｜> {prompt} <｜Assistant｜>",
+    "llama_model_path": "DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf",
+    "ngl": 65
+  },
+  "parameters": {
+    "temperature": 0.6,
+    "top_p": 0.95,
+    "stream": true,
+    "max_tokens": 131072,
+    "stop": [],
+    "frequency_penalty": 0,
+    "presence_penalty": 0
+  },
+  "metadata": {
+    "author": "DeepSeek",
+    "tags": ["32B", "Featured"],
+    "size": 19900000000
+  },
+  "engine": "llama-cpp"
+}

--- a/extensions/inference-cortex-extension/resources/models/deepseek-r1-distill-qwen-7b/model.json
+++ b/extensions/inference-cortex-extension/resources/models/deepseek-r1-distill-qwen-7b/model.json
@@ -1,0 +1,35 @@
+{
+  "sources": [
+    {
+      "filename": "DeepSeek-R1-Distill-Qwen-7B-Q5_K_M.gguf",
+      "url": "https://huggingface.co/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/main/DeepSeek-R1-Distill-Qwen-7B-Q5_K_M.gguf"
+    }
+  ],
+  "id": "deepseek-r1-distill-qwen-7b",
+  "object": "model",
+  "name": "DeepSeek R1 Distill Qwen 7B Q5",
+  "version": "1.0",
+  "description": "DeepSeek-R1 is a cheaper and open-source model that excels at agentic reasoning, superior multilingual capabilities, large context windows, and generalization across domains.",
+  "format": "gguf",
+  "settings": {
+    "ctx_len": 131072,
+    "prompt_template": "<｜User｜> {prompt} <｜Assistant｜>",
+    "llama_model_path": "DeepSeek-R1-Distill-Qwen-7B-Q5_K_M.gguf",
+    "ngl": 29
+  },
+  "parameters": {
+    "temperature": 0.6,
+    "top_p": 0.95,
+    "stream": true,
+    "max_tokens": 131072,
+    "stop": [],
+    "frequency_penalty": 0,
+    "presence_penalty": 0
+  },
+  "metadata": {
+    "author": "DeepSeek",
+    "tags": ["7B", "Featured"],
+    "size": 5440000000
+  },
+  "engine": "llama-cpp"
+}

--- a/extensions/inference-cortex-extension/resources/models/llama3.1-8b-instruct/model.json
+++ b/extensions/inference-cortex-extension/resources/models/llama3.1-8b-instruct/model.json
@@ -22,19 +22,13 @@
     "top_p": 0.95,
     "stream": true,
     "max_tokens": 8192,
-    "stop": [
-      "<|end_of_text|>",
-      "<|eot_id|>",
-      "<|eom_id|>"
-    ],
+    "stop": ["<|end_of_text|>", "<|eot_id|>", "<|eom_id|>"],
     "frequency_penalty": 0,
     "presence_penalty": 0
   },
   "metadata": {
     "author": "MetaAI",
-    "tags": [
-      "8B", "Featured"
-    ],
+    "tags": ["8B", "Featured"],
     "size": 4920000000
   },
   "engine": "llama-cpp"

--- a/extensions/inference-cortex-extension/rolldown.config.mjs
+++ b/extensions/inference-cortex-extension/rolldown.config.mjs
@@ -49,6 +49,13 @@ import qwen2514bJson from './resources/models/qwen2.5-14b-instruct/model.json' w
 import qwen2532bJson from './resources/models/qwen2.5-32b-instruct/model.json' with { type: 'json' }
 import qwen2572bJson from './resources/models/qwen2.5-72b-instruct/model.json' with { type: 'json' }
 
+import deepseekR1DistillQwen_1_5b from './resources/models/deepseek-r1-distill-qwen-1.5b/model.json' with { type: 'json' }
+import deepseekR1DistillQwen_7b from './resources/models/deepseek-r1-distill-qwen-7b/model.json' with { type: 'json' }
+import deepseekR1DistillQwen_14b from './resources/models/deepseek-r1-distill-qwen-14b/model.json' with { type: 'json' }
+import deepseekR1DistillQwen_32b from './resources/models/deepseek-r1-distill-qwen-32b/model.json' with { type: 'json' }
+import deepseekR1DistillLlama_8b from './resources/models/deepseek-r1-distill-llama-8b/model.json' with { type: 'json' }
+import deepseekR1DistillLlama_70b from './resources/models/deepseek-r1-distill-llama-70b/model.json' with { type: 'json' }
+
 export default defineConfig([
   {
     input: 'src/index.ts',
@@ -106,6 +113,12 @@ export default defineConfig([
         qwen2514bJson,
         qwen2532bJson,
         qwen2572bJson,
+        deepseekR1DistillQwen_1_5b,
+        deepseekR1DistillQwen_7b,
+        deepseekR1DistillQwen_14b,
+        deepseekR1DistillQwen_32b,
+        deepseekR1DistillLlama_8b,
+        deepseekR1DistillLlama_70b,
       ]),
       NODE: JSON.stringify(`${packageJson.name}/${packageJson.node}`),
       SETTINGS: JSON.stringify(defaultSettingJson),


### PR DESCRIPTION
This pull request includes several updates to the `inference-cortex-extension` package, focusing on adding new model configurations and updating the package version. The most significant changes involve the addition of multiple new models and necessary configuration adjustments.

### Model Additions:
* Added new model configuration for `DeepSeek R1 Distill Llama 70B Q4` in `resources/models/deepseek-r1-distill-llama-70b/model.json`.
* Added new model configuration for `DeepSeek R1 Distill Llama 8B Q5` in `resources/models/deepseek-r1-distill-llama-8b/model.json`.
* Added new model configuration for `DeepSeek R1 Distill Qwen 1.5B Q5` in `resources/models/deepseek-r1-distill-qwen-1.5b/model.json`.
* Added new model configuration for `DeepSeek R1 Distill Qwen 14B Q4` in `resources/models/deepseek-r1-distill-qwen-14b/model.json`.
* Added new model configuration for `DeepSeek R1 Distill Qwen 32B Q4` in `resources/models/deepseek-r1-distill-qwen-32b/model.json`.
* Added new model configuration for `DeepSeek R1 Distill Qwen 7B Q5` in `resources/models/deepseek-r1-distill-qwen-7b/model.json`.

### Configuration Updates:
* Updated `package.json` version from `1.0.24` to `1.0.25` in `extensions/inference-cortex-extension/package.json`.
* Modified `rolldown.config.mjs` to import the new DeepSeek model configurations. [[1]](diffhunk://#diff-9b93590cc9312a835d0c11d009d45deeb5ff72bca39e246b2e3f8fde7e3d5e8eR52-R58) [[2]](diffhunk://#diff-9b93590cc9312a835d0c11d009d45deeb5ff72bca39e246b2e3f8fde7e3d5e8eR116-R121)

### Minor Adjustments:
* Formatted the `stop` and `tags` arrays in `resources/models/llama3.1-8b-instruct/model.json` to be single-line.