### PR TITLE
chore: update remote provider response transform template

### DIFF
--- a/extensions/engine-management-extension/models/openrouter.json
+++ b/extensions/engine-management-extension/models/openrouter.json
@@ -58,5 +58,35 @@
       "stream": true
     },
     "engine": "openrouter"
+  },
+  {
+    "model": "qwen/qwen-vl-plus:free",
+    "object": "model",
+    "name": "Qwen: Qwen VL Plus",
+    "version": "1.0",
+    "description": "OpenRouter scouts for the lowest prices and best latencies/throughputs across dozens of providers, and lets you choose how to prioritize them.",
+    "inference_params": {
+      "temperature": 0.7,
+      "top_p": 0.95,
+      "frequency_penalty": 0,
+      "presence_penalty": 0,
+      "stream": true
+    },
+    "engine": "openrouter"
+  },
+  {
+    "model": "qwen/qwen2.5-vl-72b-instruct:free",
+    "object": "model",
+    "name": "Qwen: Qwen2.5 VL 72B Instruct",
+    "version": "1.0",
+    "description": "OpenRouter scouts for the lowest prices and best latencies/throughputs across dozens of providers, and lets you choose how to prioritize them.",
+    "inference_params": {
+      "temperature": 0.7,
+      "top_p": 0.95,
+      "frequency_penalty": 0,
+      "presence_penalty": 0,
+      "stream": true
+    },
+    "engine": "openrouter"
   }
 ]

--- a/extensions/engine-management-extension/resources/deepseek.json
+++ b/extensions/engine-management-extension/resources/deepseek.json
@@ -15,7 +15,7 @@
     },
     "transform_resp": {
       "chat_completions": {
-        "template": "{ {% set first = true %} {% for key, value in input_request %} {% if key == \"choices\" or key == \"created\" or key == \"model\" or key == \"service_tier\" or key == \"system_fingerprint\" or key == \"stream\" or key == \"object\" or key == \"usage\" %} {% if not first %},{% endif %} \"{{ key }}\": {{ tojson(value) }} {% set first = false %} {% endif %} {% endfor %} }"
+        "template": "{{tojson(input_request)}}"
       }
     },
     "explore_models_url": "https://api-docs.deepseek.com/quick_start/pricing"

--- a/extensions/engine-management-extension/resources/google_gemini.json
+++ b/extensions/engine-management-extension/resources/google_gemini.json
@@ -15,7 +15,7 @@
     },
     "transform_resp": {
       "chat_completions": {
-        "template": "{ {% set first = true %} {% for key, value in input_request %} {% if key == \"choices\" or key == \"created\" or key == \"model\" or key == \"service_tier\" or key == \"system_fingerprint\" or key == \"stream\" or key == \"object\" or key == \"usage\" %} {% if not first %},{% endif %} \"{{ key }}\": {{ tojson(value) }} {% set first = false %} {% endif %} {% endfor %} }"
+        "template": "{{tojson(input_request)}}"
       }
     },
     "explore_models_url": "https://ai.google.dev/gemini-api/docs/models/gemini"

--- a/extensions/engine-management-extension/resources/groq.json
+++ b/extensions/engine-management-extension/resources/groq.json
@@ -15,7 +15,7 @@
     },
     "transform_resp": {
       "chat_completions": {
-        "template": "{ {% set first = true %} {% for key, value in input_request %} {% if key == \"choices\" or key == \"created\" or key == \"model\" or key == \"service_tier\" or key == \"system_fingerprint\" or key == \"stream\" or key == \"object\" or key == \"usage\" %} {% if not first %},{% endif %} \"{{ key }}\": {{ tojson(value) }} {% set first = false %} {% endif %} {% endfor %} }"
+        "template": "{{tojson(input_request)}}"
       }
     },
     "explore_models_url": "https://console.groq.com/docs/models"

--- a/extensions/engine-management-extension/resources/martian.json
+++ b/extensions/engine-management-extension/resources/martian.json
@@ -15,7 +15,7 @@
     },
     "transform_resp": {
       "chat_completions": {
-        "template": "{ {% set first = true %} {% for key, value in input_request %} {% if key == \"choices\" or key == \"created\" or key == \"model\" or key == \"service_tier\" or key == \"system_fingerprint\" or key == \"stream\" or key == \"object\" or key == \"usage\" %} {% if not first %},{% endif %} \"{{ key }}\": {{ tojson(value) }} {% set first = false %} {% endif %} {% endfor %} }"
+        "template": "{{tojson(input_request)}}"
       }
     },
     "explore_models_url": "https://withmartian.github.io/llm-adapters/"

--- a/extensions/engine-management-extension/resources/nvidia.json
+++ b/extensions/engine-management-extension/resources/nvidia.json
@@ -15,7 +15,7 @@
     },
     "transform_resp": {
       "chat_completions": {
-        "template": "{ {% set first = true %} {% for key, value in input_request %} {% if key == \"choices\" or key == \"created\" or key == \"model\" or key == \"service_tier\" or key == \"system_fingerprint\" or key == \"stream\" or key == \"object\" or key == \"usage\" %} {% if not first %},{% endif %} \"{{ key }}\": {{ tojson(value) }} {% set first = false %} {% endif %} {% endfor %} }"
+        "template": "{{tojson(input_request)}}"
       }
     },
     "explore_models_url": "https://build.nvidia.com/models"

--- a/extensions/engine-management-extension/resources/openai.json
+++ b/extensions/engine-management-extension/resources/openai.json
@@ -15,7 +15,7 @@
     },
     "transform_resp": {
       "chat_completions": {
-        "template": "{ {% set first = true %} {% for key, value in input_request %} {% if key == \"choices\" or key == \"created\" or key == \"model\" or key == \"service_tier\" or key == \"stream\" or key == \"object\" or key == \"usage\" %} {% if not first %},{% endif %} \"{{ key }}\": {{ tojson(value) }} {% set first = false %} {% endif %} {% endfor %} }"
+        "template": "{{tojson(input_request)}}"
       }
     },
     "explore_models_url": "https://platform.openai.com/docs/models"

--- a/extensions/engine-management-extension/resources/openrouter.json
+++ b/extensions/engine-management-extension/resources/openrouter.json
@@ -15,7 +15,7 @@
     },
     "transform_resp": {
       "chat_completions": {
-        "template": "{ {% set first = true %} {% for key, value in input_request %} {% if key == \"choices\" or key == \"created\" or key == \"model\" or key == \"service_tier\" or key == \"system_fingerprint\" or key == \"stream\" or key == \"object\" or key == \"usage\" %} {% if not first %},{% endif %} \"{{ key }}\": {{ tojson(value) }} {% set first = false %} {% endif %} {% endfor %} }"
+        "template": "{{tojson(input_request)}}"
       }
     },
     "explore_models_url": "https://openrouter.ai/models"

--- a/extensions/engine-management-extension/rolldown.config.mjs
+++ b/extensions/engine-management-extension/rolldown.config.mjs
@@ -17,9 +17,11 @@ export default defineConfig([
       CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.49'),
       DEFAULT_REMOTE_ENGINES: JSON.stringify(engines),
       DEFAULT_REMOTE_MODELS: JSON.stringify(models),
-      DEFAULT_REQUEST_PAYLOAD_TRANSFORM: JSON.stringify(`{ {% set first = true %} {% for key, value in input_request %} {% if key == "messages" or key == "model" or key == "temperature" or key == "store" or key == "max_tokens" or key == "stream" or key == "presence_penalty" or key == "metadata" or key == "frequency_penalty" or key == "tools" or key == "tool_choice" or key == "logprobs" or key == "top_logprobs" or key == "logit_bias" or key == "n" or key == "modalities" or key == "prediction" or key == "response_format" or key == "service_tier" or key == "seed" or key == "stop" or key == "stream_options" or key == "top_p" or key == "parallel_tool_calls" or key == "user" %} {% if not first %},{% endif %} "{{ key }}": {{ tojson(value) }} {% set first = false %} {% endif %} {% endfor %} }`),
+      DEFAULT_REQUEST_PAYLOAD_TRANSFORM: JSON.stringify(
+        `{ {% set first = true %} {% for key, value in input_request %} {% if key == "messages" or key == "model" or key == "temperature" or key == "store" or key == "max_tokens" or key == "stream" or key == "presence_penalty" or key == "metadata" or key == "frequency_penalty" or key == "tools" or key == "tool_choice" or key == "logprobs" or key == "top_logprobs" or key == "logit_bias" or key == "n" or key == "modalities" or key == "prediction" or key == "response_format" or key == "service_tier" or key == "seed" or key == "stop" or key == "stream_options" or key == "top_p" or key == "parallel_tool_calls" or key == "user" %} {% if not first %},{% endif %} "{{ key }}": {{ tojson(value) }} {% set first = false %} {% endif %} {% endfor %} }`
+      ),
       DEFAULT_RESPONSE_BODY_TRANSFORM: JSON.stringify(
-        '{ {% set first = true %} {% for key, value in input_request %} {% if key == "choices" or key == "created" or key == "model" or key == "service_tier" or key == "stream" or key == "object" or key == "usage" %} {% if not first %},{% endif %} "{{ key }}": {{ tojson(value) }} {% set first = false %} {% endif %} {% endfor %} }'
+        '{{tojson(input_request)}}'
       ),
       DEFAULT_REQUEST_HEADERS_TRANSFORM: JSON.stringify(
         'Authorization: Bearer {{api_key}}'


### PR DESCRIPTION
This pull request includes several changes to the `extensions/engine-management-extension` module, primarily focusing on adding new models to `openrouter.json` and simplifying the response transformation templates across various resource files.

### Additions to Models:
* Added new models `qwen/qwen-vl-plus:free` and `qwen/qwen2.5-vl-72b-instruct:free` to the `openrouter.json` file.

### Simplification of Response Templates:
* Simplified the response transformation template in `deepseek.json` to use `{{tojson(input_request)}}`.
* Simplified the response transformation template in `google_gemini.json` to use `{{tojson(input_request)}}`.
* Simplified the response transformation template in `groq.json` to use `{{tojson(input_request)}}`.
* Simplified the response transformation template in `martian.json` to use `{{tojson(input_request)}}`.
* Simplified the response transformation template in `nvidia.json` to use `{{tojson(input_request)}}`.
* Simplified the response transformation template in `openai.json` to use `{{tojson(input_request)}}`.
* Simplified the response transformation template in `openrouter.json` to use `{{tojson(input_request)}}`.

### Configuration Update:
* Updated `DEFAULT_REQUEST_PAYLOAD_TRANSFORM` and `DEFAULT_RESPONSE_BODY_TRANSFORM` in `rolldown.config.mjs` to use the simplified template format.
