### PR TITLE
fix: remote engine model auto select

### DIFF
--- a/extensions/yarn.lock
+++ b/extensions/yarn.lock
@@ -509,61 +509,61 @@ __metadata:
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fassistant-extension%40workspace%3Aassistant-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=3d036d&locator=%40janhq%2Fassistant-extension%40workspace%3Aassistant-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=a48b38&locator=%40janhq%2Fassistant-extension%40workspace%3Aassistant-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/17705794156b91070790dc0bc9adf1ff65405c06b057c9103f325c350f22e25e530fccd9c634b2633d842f8e95eccc30d66370353734f4620ce99657ad4307bd
+  checksum: 10c0/c8c1596e7031923552572136a2aab8c12567a2ab9a5a1cd0b72d7a4d56e41a10135f272331c90762b859b29065aa6313f3f8764d2704130b6a4151cb02924fbc
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fconversational-extension%40workspace%3Aconversational-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=3d036d&locator=%40janhq%2Fconversational-extension%40workspace%3Aconversational-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=a48b38&locator=%40janhq%2Fconversational-extension%40workspace%3Aconversational-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/17705794156b91070790dc0bc9adf1ff65405c06b057c9103f325c350f22e25e530fccd9c634b2633d842f8e95eccc30d66370353734f4620ce99657ad4307bd
+  checksum: 10c0/c8c1596e7031923552572136a2aab8c12567a2ab9a5a1cd0b72d7a4d56e41a10135f272331c90762b859b29065aa6313f3f8764d2704130b6a4151cb02924fbc
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fengine-management-extension%40workspace%3Aengine-management-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=3d036d&locator=%40janhq%2Fengine-management-extension%40workspace%3Aengine-management-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=a48b38&locator=%40janhq%2Fengine-management-extension%40workspace%3Aengine-management-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/17705794156b91070790dc0bc9adf1ff65405c06b057c9103f325c350f22e25e530fccd9c634b2633d842f8e95eccc30d66370353734f4620ce99657ad4307bd
+  checksum: 10c0/c8c1596e7031923552572136a2aab8c12567a2ab9a5a1cd0b72d7a4d56e41a10135f272331c90762b859b29065aa6313f3f8764d2704130b6a4151cb02924fbc
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fhardware-management-extension%40workspace%3Ahardware-management-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=3d036d&locator=%40janhq%2Fhardware-management-extension%40workspace%3Ahardware-management-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=a48b38&locator=%40janhq%2Fhardware-management-extension%40workspace%3Ahardware-management-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/17705794156b91070790dc0bc9adf1ff65405c06b057c9103f325c350f22e25e530fccd9c634b2633d842f8e95eccc30d66370353734f4620ce99657ad4307bd
+  checksum: 10c0/c8c1596e7031923552572136a2aab8c12567a2ab9a5a1cd0b72d7a4d56e41a10135f272331c90762b859b29065aa6313f3f8764d2704130b6a4151cb02924fbc
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Finference-cortex-extension%40workspace%3Ainference-cortex-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=3d036d&locator=%40janhq%2Finference-cortex-extension%40workspace%3Ainference-cortex-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=a48b38&locator=%40janhq%2Finference-cortex-extension%40workspace%3Ainference-cortex-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/17705794156b91070790dc0bc9adf1ff65405c06b057c9103f325c350f22e25e530fccd9c634b2633d842f8e95eccc30d66370353734f4620ce99657ad4307bd
+  checksum: 10c0/c8c1596e7031923552572136a2aab8c12567a2ab9a5a1cd0b72d7a4d56e41a10135f272331c90762b859b29065aa6313f3f8764d2704130b6a4151cb02924fbc
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fmodel-extension%40workspace%3Amodel-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=3d036d&locator=%40janhq%2Fmodel-extension%40workspace%3Amodel-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=a48b38&locator=%40janhq%2Fmodel-extension%40workspace%3Amodel-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/17705794156b91070790dc0bc9adf1ff65405c06b057c9103f325c350f22e25e530fccd9c634b2633d842f8e95eccc30d66370353734f4620ce99657ad4307bd
+  checksum: 10c0/c8c1596e7031923552572136a2aab8c12567a2ab9a5a1cd0b72d7a4d56e41a10135f272331c90762b859b29065aa6313f3f8764d2704130b6a4151cb02924fbc
   languageName: node
   linkType: hard
 

--- a/web/screens/Settings/Engines/RemoteEngineSettings.tsx
+++ b/web/screens/Settings/Engines/RemoteEngineSettings.tsx
@@ -17,7 +17,7 @@ interface EngineConfig extends OriginalEngineConfig {
 
 import { ScrollArea, Input, TextArea } from '@janhq/joi'
 
-import { useAtomValue } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 
 import { set } from 'lodash'
 import { ChevronDown, ChevronRight, Eye, EyeOff } from 'lucide-react'
@@ -32,7 +32,11 @@ import { getLogoEngine } from '@/utils/modelEngine'
 import ModalAddModel from './ModalAddModel'
 import ModalDeleteModel from './ModalDeleteModel'
 
-import { downloadedModelsAtom } from '@/helpers/atoms/Model.atom'
+import {
+  downloadedModelsAtom,
+  selectedModelAtom,
+} from '@/helpers/atoms/Model.atom'
+import { threadsAtom } from '@/helpers/atoms/Thread.atom'
 
 const RemoteEngineSettings = ({
   engine: name,
@@ -44,8 +48,9 @@ const RemoteEngineSettings = ({
   const [showApiKey, setShowApiKey] = useState(false)
   const remoteModels = downloadedModels.filter((e) => e.engine === name)
   const [isActiveAdvanceSetting, setisActiveAdvanceSetting] = useState(false)
-
+  const setSelectedModel = useSetAtom(selectedModelAtom)
   const customEngineLogo = getLogoEngine(name)
+  const threads = useAtomValue(threadsAtom)
 
   const engine =
     engines &&
@@ -100,6 +105,9 @@ const RemoteEngineSettings = ({
   })
 
   useEffect(() => {
+    if (threads.length === 0) {
+      setSelectedModel(remoteModels[0])
+    }
     if (engine) {
       setData({
         api_key: engine.api_key || '',


### PR DESCRIPTION
## Describe Your Changes

<img width="563" alt="Screenshot 2025-02-07 at 23 41 55" src="https://github.com/user-attachments/assets/00f46021-ffb4-41b9-956d-3239cda90c22" />

This pull request includes updates to the `RemoteEngineSettings.tsx` file to enhance functionality and improve state management by adding new atom values and setters from the `jotai` library. The most important changes include importing additional atoms, setting the selected model atom based on conditions, and using the `threadsAtom` to manage thread-related data.

Enhancements to state management:

* [`web/screens/Settings/Engines/RemoteEngineSettings.tsx`](diffhunk://#diff-d8d84f4f488f0d35b2751fee2cad04a83f6661a0f11b2b6a2355ac0e70aec575L20-R20): Added `useSetAtom` from `jotai` to manage state updates.
* [`web/screens/Settings/Engines/RemoteEngineSettings.tsx`](diffhunk://#diff-d8d84f4f488f0d35b2751fee2cad04a83f6661a0f11b2b6a2355ac0e70aec575L35-R39): Imported `selectedModelAtom` and `threadsAtom` from `Model.atom` and `Thread.atom` respectively to handle selected model and thread-related states.

Functional improvements:

* [`web/screens/Settings/Engines/RemoteEngineSettings.tsx`](diffhunk://#diff-d8d84f4f488f0d35b2751fee2cad04a83f6661a0f11b2b6a2355ac0e70aec575L47-R53): Introduced `setSelectedModel` to set the selected model atom.
* [`web/screens/Settings/Engines/RemoteEngineSettings.tsx`](diffhunk://#diff-d8d84f4f488f0d35b2751fee2cad04a83f6661a0f11b2b6a2355ac0e70aec575R108-R110): Updated `useEffect` to set the selected model to the first remote model if no threads are present.

## Fixes Issues

https://github.com/user-attachments/assets/b458c9c8-2f20-4a0d-95d1-24b7a063fd4b

https://github.com/user-attachments/assets/b2fd1b84-2ae9-4ff9-ae55-6eb42955ac64

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
