### PR TITLE
chore: open URL from model detail page should open in an external browser

### DIFF
--- a/web/screens/Hub/ModelList/ModelHeader/index.tsx
+++ b/web/screens/Hub/ModelList/ModelHeader/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 
 import { ModelSource } from '@janhq/core'
 
@@ -19,6 +19,8 @@ import { useSettings } from '@/hooks/useSettings'
 import { toGigabytes } from '@/utils/converter'
 
 import { extractModelName } from '@/utils/modelSource'
+
+import { fuzzySearch } from '@/utils/search'
 
 import { mainViewStateAtom } from '@/helpers/atoms/App.atom'
 import { assistantsAtom } from '@/helpers/atoms/Assistant.atom'
@@ -66,6 +68,11 @@ const ModelItemHeader = ({ model, onSelectedModel }: Props) => {
   const isDownloaded = downloadedModels.some((md) =>
     model.models.some((m) => m.id === md.id)
   )
+  const defaultModel = useMemo(() => {
+    return model.models?.find(
+      (e) => e.id.includes('q4-km') || fuzzySearch('q4km', e.id)
+    )
+  }, [model])
 
   let downloadButton = (
     <div className="group flex h-8 cursor-pointer items-center justify-center rounded-md bg-[hsla(var(--primary-bg))]">
@@ -76,19 +83,21 @@ const ModelItemHeader = ({ model, onSelectedModel }: Props) => {
         <span className="mx-4 font-medium text-white">Download</span>
       </div>
       <Dropdown
-        className="z-50 max-h-[240px] min-w-[240px] max-w-[320px] overflow-y-auto border border-[hsla(var(--app-border))] bg-[hsla(var(--app-bg))] shadow"
+        className="z-50 min-w-[240px]"
         options={model.models?.map((e) => ({
           name: (
             <div className="flex space-x-2">
               <span className="line-clamp-1 max-w-[340px] font-normal">
                 {e.id}
               </span>
-              <Badge
-                theme="secondary"
-                className="inline-flex w-[60px] items-center font-medium"
-              >
-                <span>Default</span>
-              </Badge>
+              {e.id === defaultModel?.id && (
+                <Badge
+                  theme="secondary"
+                  className="inline-flex w-[60px] items-center font-medium"
+                >
+                  <span>Default</span>
+                </Badge>
+              )}
             </div>
           ),
           value: e.id,

--- a/web/screens/Hub/ModelList/ModelItem/index.tsx
+++ b/web/screens/Hub/ModelList/ModelItem/index.tsx
@@ -10,6 +10,8 @@ import ModelLabel from '@/containers/ModelLabel'
 
 import ModelItemHeader from '@/screens/Hub/ModelList/ModelHeader'
 
+import { markdownComponents } from '@/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownUtils'
+
 import { toGigabytes } from '@/utils/converter'
 import { extractDescription } from '@/utils/modelSource'
 import '@/styles/components/model.scss'
@@ -31,7 +33,10 @@ const ModelItem: React.FC<Props> = ({ model, onSelectedModel }) => {
             <ModelLabel size={model.models?.[0]?.size} />
           </div>
           <div className="flex flex-col">
-            <Markdown className="md-short-desc line-clamp-3 max-w-full overflow-hidden font-light text-[hsla(var(--text-secondary))]">
+            <Markdown
+              className="md-short-desc line-clamp-3 max-w-full overflow-hidden font-light text-[hsla(var(--text-secondary))]"
+              components={markdownComponents}
+            >
               {extractDescription(model.metadata?.description) || '-'}
             </Markdown>
           </div>

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx
@@ -20,6 +20,8 @@ import { useClipboard } from '@/hooks/useClipboard'
 
 import { getLanguageFromExtension } from '@/utils/codeLanguageExtension'
 
+import { markdownComponents } from './MarkdownUtils'
+
 interface Props {
   text: string
   isUser?: boolean
@@ -222,6 +224,7 @@ export const MarkdownTextMessage = memo(
               wrapCodeBlocksWithoutVisit,
             ].filter((e) => !!e) as PluggableList
           }
+          components={markdownComponents}
         >
           {preprocessMarkdown(text)}
         </Markdown>

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownUtils.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownUtils.tsx
@@ -1,7 +1,7 @@
 import { Components } from 'react-markdown'
 
 export const markdownComponents: Partial<Components> = {
-  a: ({ node, href, children, ...props }) => (
+  a: ({ href, children, ...props }) => (
     <a
       target="_blank"
       href={href}

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownUtils.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownUtils.tsx
@@ -1,0 +1,14 @@
+import { Components } from 'react-markdown'
+
+export const markdownComponents: Partial<Components> = {
+  a: ({ node, href, children, ...props }) => (
+    <a
+      target="_blank"
+      href={href}
+      className="text-[hsla(var(--app-link))]"
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+}


### PR DESCRIPTION
This pull request includes several changes aimed at enhancing the functionality and user interface of the Model List and Markdown components in the Hub and Thread screens. The most important changes include the addition of a default model indicator, the integration of custom markdown components, and the simplification of dropdown options.

![CleanShot 2025-02-08 at 23 03 06@2x](https://github.com/user-attachments/assets/242d08a6-56c8-4945-b58d-b90c3a0600f3)

![CleanShot 2025-02-09 at 10 50 51](https://github.com/user-attachments/assets/67488cf1-11ab-4a70-be56-4d5718535955)


### Related issues
- Closes #4563

### Enhancements to Model List:

* [`web/screens/Hub/ModelList/ModelHeader/index.tsx`](diffhunk://#diff-c12507244d72ba8a5e975aa7ed41cdc8d996e3030a5248237aa84dd5f9da02a4L1-R1): Added `useMemo` to compute the default model and included a `Badge` to indicate the default model in the dropdown options. [[1]](diffhunk://#diff-c12507244d72ba8a5e975aa7ed41cdc8d996e3030a5248237aa84dd5f9da02a4L1-R1) [[2]](diffhunk://#diff-c12507244d72ba8a5e975aa7ed41cdc8d996e3030a5248237aa84dd5f9da02a4R71-R75) [[3]](diffhunk://#diff-c12507244d72ba8a5e975aa7ed41cdc8d996e3030a5248237aa84dd5f9da02a4L79-R100)
* [`web/screens/Hub/ModelList/ModelItem/index.tsx`](diffhunk://#diff-cb3e07a310eb449312da3731e3667aa9d92c0df386d0796454f4f2675b98e232R13-R14): Integrated `markdownComponents` into the `Markdown` component to enhance the rendering of model descriptions. [[1]](diffhunk://#diff-cb3e07a310eb449312da3731e3667aa9d92c0df386d0796454f4f2675b98e232R13-R14) [[2]](diffhunk://#diff-cb3e07a310eb449312da3731e3667aa9d92c0df386d0796454f4f2675b98e232L34-R39)

### Enhancements to Markdown components:

* [`web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx`](diffhunk://#diff-248577b16f0456ecc74b4c2feb89430842934aea33e2a7d3fcbec9cced25bf1bR23-R24): Added `markdownComponents` to the `Markdown` component to support custom link rendering. [[1]](diffhunk://#diff-248577b16f0456ecc74b4c2feb89430842934aea33e2a7d3fcbec9cced25bf1bR23-R24) [[2]](diffhunk://#diff-248577b16f0456ecc74b4c2feb89430842934aea33e2a7d3fcbec9cced25bf1bR227)
* [`web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownUtils.tsx`](diffhunk://#diff-5aeffa1f37d6a07d7c13880bbf949af39e58962c8b394045ec540998a9b56274R1-R14): Defined `markdownComponents` to customize the rendering of markdown links, opening them in a new tab and applying a specific text color.