### PR TITLE
fix: error handling - pull remote models list raise an error on fail

### DIFF
--- a/extensions/engine-management-extension/src/index.ts
+++ b/extensions/engine-management-extension/src/index.ts
@@ -250,10 +250,7 @@ export default class JanEngineManagementExtension extends EngineManagementExtens
     return this.queue.add(() =>
       ky
         .post(`${API_URL}/v1/engines/${name}/update`, { json: engineConfig })
-        .then((e) => {
-          this.populateRemoteModels(engineConfig)
-          return e
-        })
+        .then((e) => e)
     ) as Promise<{ messages: string }>
   }
 

--- a/extensions/engine-management-extension/src/index.ts
+++ b/extensions/engine-management-extension/src/index.ts
@@ -359,17 +359,18 @@ export default class JanEngineManagementExtension extends EngineManagementExtens
   private populateRemoteModels = async (engineConfig: EngineConfig) => {
     return this.getRemoteModels(engineConfig.engine)
       .then((models: ModelList) => {
-        Promise.all(
-          models?.data?.map((model) =>
-            this.addRemoteModel({
-              ...model,
-              engine: engineConfig.engine as InferenceEngine,
-              model: model.model ?? model.id,
-            }).catch(console.info)
-          )
-        ).then(() => {
-          events.emit(ModelEvent.OnModelsUpdate, { fetch: true })
-        })
+        if (models?.data)
+          Promise.all(
+            models.data.map((model) =>
+              this.addRemoteModel({
+                ...model,
+                engine: engineConfig.engine as InferenceEngine,
+                model: model.model ?? model.id,
+              }).catch(console.info)
+            )
+          ).then(() => {
+            events.emit(ModelEvent.OnModelsUpdate, { fetch: true })
+          })
       })
       .catch(console.info)
   }

--- a/extensions/engine-management-extension/src/index.ts
+++ b/extensions/engine-management-extension/src/index.ts
@@ -25,10 +25,10 @@ interface ModelList {
   data: Model[]
 }
 /**
- * JSONEngineManagementExtension is a EngineManagementExtension implementation that provides
+ * JanEngineManagementExtension is a EngineManagementExtension implementation that provides
  * functionality for managing engines.
  */
-export default class JSONEngineManagementExtension extends EngineManagementExtension {
+export default class JanEngineManagementExtension extends EngineManagementExtension {
   queue = new PQueue({ concurrency: 1 })
 
   /**

--- a/extensions/engine-management-extension/src/index.ts
+++ b/extensions/engine-management-extension/src/index.ts
@@ -250,7 +250,10 @@ export default class JSONEngineManagementExtension extends EngineManagementExten
     return this.queue.add(() =>
       ky
         .post(`${API_URL}/v1/engines/${name}/update`, { json: engineConfig })
-        .then((e) => e)
+        .then((e) => {
+          this.populateRemoteModels(engineConfig)
+          return e
+        })
     ) as Promise<{ messages: string }>
   }
 
@@ -357,7 +360,7 @@ export default class JSONEngineManagementExtension extends EngineManagementExten
     return this.getRemoteModels(engineConfig.engine)
       .then((models: ModelList) => {
         Promise.all(
-          models.data?.map((model) =>
+          models?.data?.map((model) =>
             this.addRemoteModel({
               ...model,
               engine: engineConfig.engine as InferenceEngine,


### PR DESCRIPTION
This pull request includes changes to the `extensions/engine-management-extension/src/index.ts` file to rename a class and improve the handling of remote models.

In the latest beta version, users will need to delete the engine and then add it back to have the /models pulled. Instead, with this update, users will only need to update the /models endpoint to trigger the models pull.

![Uploading CleanShot 2025-02-09 at 19.13.34@2x.jpg…]()


Class renaming:

* [`extensions/engine-management-extension/src/index.ts`](diffhunk://#diff-d8c74089c1ad29e79d22182a9a2d8721dd5c77e8bd937363487496ba8cd8c991L28-R31): Renamed `JSONEngineManagementExtension` to `JanEngineManagementExtension` to better reflect its functionality.

Handling of remote models:

* [`extensions/engine-management-extension/src/index.ts`](diffhunk://#diff-d8c74089c1ad29e79d22182a9a2d8721dd5c77e8bd937363487496ba8cd8c991L253-R256): Updated the `updateEngine` method to call `populateRemoteModels` after posting the engine configuration to ensure remote models are populated.
* [`extensions/engine-management-extension/src/index.ts`](diffhunk://#diff-d8c74089c1ad29e79d22182a9a2d8721dd5c77e8bd937363487496ba8cd8c991L360-R363): Modified the `getRemoteModels` method to use safe navigation (`?.`) when mapping models to handle cases where `data` might be undefined.