### PR TITLE
fix: filter out fake gpu

### DIFF
--- a/web/services/appService.ts
+++ b/web/services/appService.ts
@@ -34,7 +34,9 @@ export const appService = {
     const hardwareInfo = await hardwareExtension?.getHardware()
 
     const gpuSettingInfo: GpuSetting | undefined = {
-      gpus: hardwareInfo.gpus as GpuSettingInfo[],
+      gpus: hardwareInfo.gpus.filter(
+        (gpu) => gpu.total_vram > 0
+      ) as GpuSettingInfo[],
       vulkan: isMac ? false : selectedVariants.includes('vulkan'),
       cpu: hardwareInfo.cpu,
     }


### PR DESCRIPTION
## Describe Your Changes

This pull request includes an important change to the `appService` in the `web/services/appService.ts` file. The change ensures that only GPUs with a total VRAM greater than 0 are included in the `gpuSettingInfo`.

* [`web/services/appService.ts`](diffhunk://#diff-10ba7524a3bbc6790bdfcd1f9ecae35602c1f124d1483c8d817278325cc9730fL37-R39): Modified the `gpuSettingInfo` to filter out GPUs with zero total VRAM.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
