### PR TITLE
fix: inconsistent models list on first launch

### DIFF
--- a/extensions/engine-management-extension/src/index.ts
+++ b/extensions/engine-management-extension/src/index.ts
@@ -341,9 +341,11 @@ export default class JanEngineManagementExtension extends EngineManagementExtens
         })
       )
       events.emit(EngineEvent.OnEngineUpdate, {})
-      DEFAULT_REMOTE_MODELS.forEach(async (data: Model) => {
-        await this.addRemoteModel(data).catch(() => {})
-      })
+      await Promise.all(
+        DEFAULT_REMOTE_MODELS.map((data: Model) =>
+          this.addRemoteModel(data).catch(() => {})
+        )
+      )
       events.emit(ModelEvent.OnModelsUpdate, { fetch: true })
     }
   }


### PR DESCRIPTION
This pull request includes a change to the `JanEngineManagementExtension` class in the `extensions/engine-management-extension/src/index.ts` file to improve the handling of remote models during the engine update process.

Improvements to handling remote models:

* [`extensions/engine-management-extension/src/index.ts`](diffhunk://#diff-d8c74089c1ad29e79d22182a9a2d8721dd5c77e8bd937363487496ba8cd8c991L344-R348): Modified the code to use `Promise.all` for adding remote models concurrently instead of sequentially. This change ensures that all remote models are added before emitting the `ModelEvent.OnModelsUpdate` event.