### PR TITLE
chore: change cortex.cpp log level to info for easier log observation

### DIFF
--- a/extensions/inference-cortex-extension/src/node/index.ts
+++ b/extensions/inference-cortex-extension/src/node/index.ts
@@ -46,6 +46,8 @@ function run(): Promise<any> {
         `${path.join(dataFolderPath, '.janrc')}`,
         '--data_folder_path',
         dataFolderPath,
+        '--loglevel',
+        'INFO',
       ],
       {
         env: {


### PR DESCRIPTION
This pull request includes a small change to the `extensions/inference-cortex-extension/src/node/index.ts` file. The change adds logging configuration to the `run` function to set the log level to `INFO`.

* [`extensions/inference-cortex-extension/src/node/index.ts`](diffhunk://#diff-f8f14f9faebbb7438e169298472574322d46c7f4e7901479defc6a24efdd0a64R49-R50): Added `--loglevel` and `INFO` parameters to the `run` function to configure logging.