### PR TITLE
chore: fix engine variant for mac targets

### DIFF
--- a/extensions/engine-management-extension/src/utils.ts
+++ b/extensions/engine-management-extension/src/utils.ts
@@ -60,8 +60,13 @@ const cudaVersion = (settings?: GpuSetting): '12-0' | '11-7' | undefined => {
 export const engineVariant = async (
   gpuSetting?: GpuSetting
 ): Promise<string> => {
+  const platform = os(gpuSetting)
+
+  // There is no need to append the variant extension for mac
+  if (platform.startsWith('mac')) return platform
+
   let engineVariant = [
-    os(gpuSetting),
+    platform,
     gpuSetting?.vulkan
       ? 'vulkan'
       : (gpuRunMode(gpuSetting) === 'cuda' && // GPU mode - packaged CUDA variants of avx2 and noavx


### PR DESCRIPTION
This pull request includes modifications to the `extensions/engine-management-extension/src/utils.ts` file to enhance the `engineVariant` function by introducing a new constant `platform` and optimizing the logic for determining the engine variant.

This will fix the issue where running Jan on Mac, by default it appends `no-avx` extension to the engine variant, hence no model can run.

When I first time open Jan it should show configured engine instead of a blank setting.
![CleanShot 2025-02-11 at 14 27 24@2x](https://github.com/user-attachments/assets/985d272e-abc0-482b-ada7-27e031dc274a)


Improvements to the `engineVariant` function:

* Introduced a new constant `platform` to store the result of the `os(gpuSetting)` function call, which simplifies the subsequent code.
* Added a conditional check to return the `platform` directly if it starts with 'mac', avoiding unnecessary processing for macOS platforms.
* Replaced the repeated call to `os(gpuSetting)` with the `platform` constant to improve code readability and efficiency.