### PR TITLE
fix: app shows update button even there is no new release

### DIFF
--- a/web/screens/Settings/Engines/LocalEngineSettings.tsx
+++ b/web/screens/Settings/Engines/LocalEngineSettings.tsx
@@ -60,7 +60,7 @@ const LocalEngineSettings = ({ engine }: { engine: InferenceEngine }) => {
 
   const isEngineUpdated =
     latestReleasedEngine &&
-    latestReleasedEngine.every((item) =>
+    latestReleasedEngine.some((item) =>
       item.name.includes(
         defaultEngineVariant?.version.replace(/^v/, '') as string
       )


### PR DESCRIPTION
This pull request includes a change to the `LocalEngineSettings` component in the `web/screens/Settings/Engines/LocalEngineSettings.tsx` file. The change modifies the logic to check if the engine is updated by using the `some` method instead of `every` on the `latestReleasedEngine` array.

In Linux and Windows, there are cuda artifacts which do not have version inside so that it could not check every item.

* [`web/screens/Settings/Engines/LocalEngineSettings.tsx`](diffhunk://#diff-fb438e50789357b1faa6cc0a4695db4ba333e3f5bb597d9f4dd05d53ea121723L63-R63): Changed the method from `every` to `some` to determine if any items in `latestReleasedEngine` match the condition, instead of requiring all items to match.