### PR TITLE
Fix typo for Red Hat company name

### DIFF
--- a/docs/src/pages/about/index.mdx
+++ b/docs/src/pages/about/index.mdx
@@ -93,7 +93,7 @@ We are inspired by and actively try to emulate the paths of companies we admire 
 - [Obsidian](https://obsidian.md/)
 - [Discourse](https://www.discourse.org/about)
 - [Gitlab](https://handbook.gitlab.com/handbook/company/history/#2017-gitlab-storytime)
-- [Redhat](https://www.redhat.com/en/about/development-model)
+- [Red Hat](https://www.redhat.com/en/about/development-model)
 - [Ghost](https://ghost.org/docs/contributing/)
 - [Lago](https://www.getlago.com/blog/open-source-licensing-and-why-lago-chose-agplv3)
 - [Twenty](https://twenty.com/story)


### PR DESCRIPTION

Changed "Redhat" to "Red Hat" (which is the correct company name).



