### PR TITLE
fix: messages re-render on different threads

### DIFF
--- a/web/containers/Providers/ModelHandler.tsx
+++ b/web/containers/Providers/ModelHandler.tsx
@@ -143,8 +143,7 @@ export default function ModelHandler() {
         return
       }
 
-      // The thread title should not be updated if the message is less than 10 words
-      // And no new line character is present
+      // No new line character is presented in the title
       // And non-alphanumeric characters should be removed
       if (messageContent.includes('\n')) {
         messageContent = messageContent.replace(/\n/g, ' ')
@@ -290,13 +289,7 @@ export default function ModelHandler() {
           .catch(() => undefined)
         if (updatedMessage) {
           deleteMessage(message.id)
-          addNewMessage({
-            ...updatedMessage,
-            metadata: {
-              ...updatedMessage.metadata,
-              reserve_id: message.id,
-            },
-          })
+          addNewMessage(updatedMessage)
           setTokenSpeed((prev) =>
             prev ? { ...prev, message: updatedMessage.id } : undefined
           )

--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
@@ -160,12 +160,7 @@ const ChatBody = memo(
             >
               {items.map((virtualRow) => (
                 <div
-                  key={
-                    (messages[virtualRow.index]?.metadata
-                      ?.reserve_id as string) ??
-                    messages[virtualRow.index]?.id ??
-                    virtualRow.index
-                  }
+                  key={messages[virtualRow.index]?.id ?? virtualRow.index}
                   data-index={virtualRow.index}
                   ref={virtualizer.measureElement}
                 >
@@ -175,6 +170,7 @@ const ChatBody = memo(
                     <ChatItem
                       {...messages[virtualRow.index]}
                       loadModelError={loadModelError}
+                      index={virtualRow.index}
                       isCurrentMessage={
                         virtualRow.index === messages?.length - 1
                       }

--- a/web/screens/Thread/ThreadCenterPanel/ChatItem/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatItem/index.tsx
@@ -21,6 +21,7 @@ type Ref = HTMLDivElement
 type Props = {
   loadModelError?: string
   isCurrentMessage?: boolean
+  index: number
 } & ThreadMessage
 
 const ChatItem = forwardRef<Ref, Props>((message, ref) => {
@@ -78,6 +79,7 @@ const ChatItem = forwardRef<Ref, Props>((message, ref) => {
               {...message}
               content={content}
               status={status}
+              index={message.index}
               isCurrentMessage={message.isCurrentMessage ?? false}
             />
           </div>

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/ThinkingBlock.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/ThinkingBlock.tsx
@@ -8,10 +8,10 @@ import { MarkdownTextMessage } from './MarkdownTextMessage'
 interface Props {
   text: string
   status: string
-  id: string
+  id: number
 }
 
-const thinkingBlockStateAtom = atom<{ [id: string]: boolean }>({})
+const thinkingBlockStateAtom = atom<{ [id: number]: boolean }>({})
 
 const ThinkingBlock = ({ id, text, status }: Props) => {
   const [thinkingState, setThinkingState] = useAtom(thinkingBlockStateAtom)

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
@@ -27,7 +27,7 @@ import {
 import { chatWidthAtom } from '@/helpers/atoms/Setting.atom'
 
 const MessageContainer: React.FC<
-  ThreadMessage & { isCurrentMessage: boolean }
+  ThreadMessage & { isCurrentMessage: boolean; index: number }
 > = (props) => {
   const isUser = props.role === ChatCompletionRole.User
   const isSystem = props.role === ChatCompletionRole.System
@@ -162,7 +162,7 @@ const MessageContainer: React.FC<
               >
                 {reasoningSegment && (
                   <ThinkingBlock
-                    id={(props.metadata?.reserve_id as string) ?? props.id}
+                    id={props.index}
                     text={reasoningSegment}
                     status={props.status}
                   />


### PR DESCRIPTION
This pull request includes several changes to the `web/screens/Thread/ThreadCenterPanel` and `web/containers/Providers/ModelHandler.tsx` files to streamline the handling of messages and improve the codebase.

### Streamlining message handling:

* [`web/containers/Providers/ModelHandler.tsx`](diffhunk://#diff-c52744b512485151ef69f9c9e8b58535cc47dc550c4caf152cb52ec103ea898dL293-R292): Simplified the logic for adding new messages by removing the `metadata.reserve_id` property and directly using `updatedMessage`.
* [`web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx`](diffhunk://#diff-3f5d1c0b7af75f2f221b9504d3f50f0cb42b683d7eb7b565caf7ced16b2c765fL163-R163): Updated the key for each message to use `messages[virtualRow.index]?.id ?? virtualRow.index` instead of the `reserve_id` metadata.
* [`web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx`](diffhunk://#diff-3f5d1c0b7af75f2f221b9504d3f50f0cb42b683d7eb7b565caf7ced16b2c765fR173): Added the `index` property to the `ChatItem` component to ensure the correct message is identified.
* [`web/screens/Thread/ThreadCenterPanel/ChatItem/index.tsx`](diffhunk://#diff-a65de6c58564879ec75c0a56f73cb855ae72c9b4c07d2986b10c4584419748a1R24): Updated the `ChatItem` component to include the `index` property in its props and passed it to the `MessageContainer` component. [[1]](diffhunk://#diff-a65de6c58564879ec75c0a56f73cb855ae72c9b4c07d2986b10c4584419748a1R24) [[2]](diffhunk://#diff-a65de6c58564879ec75c0a56f73cb855ae72c9b4c07d2986b10c4584419748a1R82)

### Codebase improvements:

* [`web/screens/Thread/ThreadCenterPanel/TextMessage/ThinkingBlock.tsx`](diffhunk://#diff-ab6a818fc54ea9f5203a346ab74e247517f9e3bdece1c4f52c109fe68c48e14eL11-R14): Changed the type of the `id` property from `string` to `number` and updated the `thinkingBlockStateAtom` accordingly.
* [`web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx`](diffhunk://#diff-efce7749ad34c34cc3f189aea671b9975208995580033b9de787c3c96c878cccL30-R30): Updated the `MessageContainer` component to include the `index` property and used it for the `ThinkingBlock` component's `id`. [[1]](diffhunk://#diff-efce7749ad34c34cc3f189aea671b9975208995580033b9de787c3c96c878cccL30-R30) [[2]](diffhunk://#diff-efce7749ad34c34cc3f189aea671b9975208995580033b9de787c3c96c878cccL165-R165)

These changes aim to simplify the message handling process and improve the overall maintainability of the code.