### PR TITLE
fix: beta noti discord

### DIFF
--- a/.github/workflows/jan-electron-build-beta.yml
+++ b/.github/workflows/jan-electron-build-beta.yml
@@ -63,7 +63,9 @@ jobs:
     steps:
       - name: Set version to environment variable
         run: |
-          echo "VERSION=${{ needs.get-update-version.outputs.new_version }}" >> $GITHUB_ENV
+          VERSION=${{ needs.get-update-version.outputs.new_version }}
+          VERSION="${VERSION#v}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Notify Discord
         uses: Ilshidur/action-discord@master


### PR DESCRIPTION
This pull request includes a small but important change to the `.github/workflows/jan-electron-build-beta.yml` file. The change modifies the way the version is set to an environment variable by stripping the leading 'v' character from the version string.

* [`.github/workflows/jan-electron-build-beta.yml`](diffhunk://#diff-3eda9251187aa95e51016c05c5813e16d13e53225833d5bf4ae19b196e9ad8e0L66-R68): Updated the script to strip the leading 'v' from the version string before setting it as an environment variable.