### PR TITLE
fix: rename google gemini into gemini

### DIFF
--- a/web/utils/modelEngine.ts
+++ b/web/utils/modelEngine.ts
@@ -65,7 +65,7 @@ export const getTitleByEngine = (engine: InferenceEngine | string) => {
     case InferenceEngine.openrouter:
       return 'OpenRouter'
     case 'google_gemini':
-      return 'Google Gemini'
+      return 'Gemini'
     default:
       return engine.charAt(0).toUpperCase() + engine.slice(1)
   }


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a small change to the `web/utils/modelEngine.ts` file. The change updates the title returned for the `google_gemini` engine to 'Gemini' instead of 'Google Gemini'. 

* [`web/utils/modelEngine.ts`](diffhunk://#diff-309cd47b5075dcd8ead194871d0804128567943093ba99c5138ce1c173cf1918L68-R68): Modified the return value for the `google_gemini` engine to 'Gemini'.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
