### PR TITLE
fix: model dropdown icon miss align

### DIFF
--- a/web/containers/ModelDropdown/index.tsx
+++ b/web/containers/ModelDropdown/index.tsx
@@ -475,7 +475,7 @@ const ModelDropdown = ({
                                 >
                                   <div className="flex items-center gap-2">
                                     <p
-                                      className="line-clamp-1 text-[hsla(var(--text-secondary))]"
+                                      className="max-w-[200px] overflow-hidden truncate whitespace-nowrap text-[hsla(var(--text-secondary))]"
                                       title={model.name}
                                     >
                                       {model.name}
@@ -573,7 +573,7 @@ const ModelDropdown = ({
                                     <div className="flex gap-x-2">
                                       <p
                                         className={twMerge(
-                                          'line-clamp-1',
+                                          'max-w-[200px] overflow-hidden truncate whitespace-nowrap',
                                           !isDownloaded &&
                                             'text-[hsla(var(--text-secondary))]'
                                         )}


### PR DESCRIPTION
## Describe Your Changes

This pull request includes changes to the `ModelDropdown` component in the `web/containers/ModelDropdown/index.tsx` file to improve the display of model names by truncating long text.

Improvements to model name display:

* Modified the `className` of the `p` element to truncate long model names, ensuring they do not overflow and are displayed within a maximum width of 200px. [[1]](diffhunk://#diff-897fe0e9366de0fa6ec9428b1423439aaab3dee774cea4b7efd6401a42fb00fbL478-R478) [[2]](diffhunk://#diff-897fe0e9366de0fa6ec9428b1423439aaab3dee774cea4b7efd6401a42fb00fbL576-R576)

## Fixes Issues
![CleanShot 2025-02-13 at 15 59 26](https://github.com/user-attachments/assets/60e159ce-6a3d-4ea8-aeab-4aedcbdd19e5)

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
