### PR TITLE
fix: link open new window inside chat message

### DIFF
--- a/extensions/yarn.lock
+++ b/extensions/yarn.lock
@@ -509,61 +509,61 @@ __metadata:
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fassistant-extension%40workspace%3Aassistant-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=2e50a2&locator=%40janhq%2Fassistant-extension%40workspace%3Aassistant-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=4cc123&locator=%40janhq%2Fassistant-extension%40workspace%3Aassistant-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/92904b534f4f82c31effd9eade0f8685b87165e28f0c3ba3a0c18a6a0a21bf21ee769a98c562c4ba7488ceb1238e2dacce2bb2f729c1bdd84ad44054fb985da0
+  checksum: 10c0/9298cf2f21ffdb4cc599596cf2cd00cd99be718be4f0087469b533e509549ba26ec410e869b5f4137285217962f4d296849905f654965aa47275114ec21a4f65
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fconversational-extension%40workspace%3Aconversational-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=2e50a2&locator=%40janhq%2Fconversational-extension%40workspace%3Aconversational-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=4cc123&locator=%40janhq%2Fconversational-extension%40workspace%3Aconversational-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/92904b534f4f82c31effd9eade0f8685b87165e28f0c3ba3a0c18a6a0a21bf21ee769a98c562c4ba7488ceb1238e2dacce2bb2f729c1bdd84ad44054fb985da0
+  checksum: 10c0/9298cf2f21ffdb4cc599596cf2cd00cd99be718be4f0087469b533e509549ba26ec410e869b5f4137285217962f4d296849905f654965aa47275114ec21a4f65
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fengine-management-extension%40workspace%3Aengine-management-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=2e50a2&locator=%40janhq%2Fengine-management-extension%40workspace%3Aengine-management-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=4cc123&locator=%40janhq%2Fengine-management-extension%40workspace%3Aengine-management-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/92904b534f4f82c31effd9eade0f8685b87165e28f0c3ba3a0c18a6a0a21bf21ee769a98c562c4ba7488ceb1238e2dacce2bb2f729c1bdd84ad44054fb985da0
+  checksum: 10c0/9298cf2f21ffdb4cc599596cf2cd00cd99be718be4f0087469b533e509549ba26ec410e869b5f4137285217962f4d296849905f654965aa47275114ec21a4f65
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fhardware-management-extension%40workspace%3Ahardware-management-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=2e50a2&locator=%40janhq%2Fhardware-management-extension%40workspace%3Ahardware-management-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=4cc123&locator=%40janhq%2Fhardware-management-extension%40workspace%3Ahardware-management-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/92904b534f4f82c31effd9eade0f8685b87165e28f0c3ba3a0c18a6a0a21bf21ee769a98c562c4ba7488ceb1238e2dacce2bb2f729c1bdd84ad44054fb985da0
+  checksum: 10c0/9298cf2f21ffdb4cc599596cf2cd00cd99be718be4f0087469b533e509549ba26ec410e869b5f4137285217962f4d296849905f654965aa47275114ec21a4f65
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Finference-cortex-extension%40workspace%3Ainference-cortex-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=2e50a2&locator=%40janhq%2Finference-cortex-extension%40workspace%3Ainference-cortex-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=4cc123&locator=%40janhq%2Finference-cortex-extension%40workspace%3Ainference-cortex-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/92904b534f4f82c31effd9eade0f8685b87165e28f0c3ba3a0c18a6a0a21bf21ee769a98c562c4ba7488ceb1238e2dacce2bb2f729c1bdd84ad44054fb985da0
+  checksum: 10c0/9298cf2f21ffdb4cc599596cf2cd00cd99be718be4f0087469b533e509549ba26ec410e869b5f4137285217962f4d296849905f654965aa47275114ec21a4f65
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fmodel-extension%40workspace%3Amodel-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=2e50a2&locator=%40janhq%2Fmodel-extension%40workspace%3Amodel-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=4cc123&locator=%40janhq%2Fmodel-extension%40workspace%3Amodel-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/92904b534f4f82c31effd9eade0f8685b87165e28f0c3ba3a0c18a6a0a21bf21ee769a98c562c4ba7488ceb1238e2dacce2bb2f729c1bdd84ad44054fb985da0
+  checksum: 10c0/9298cf2f21ffdb4cc599596cf2cd00cd99be718be4f0087469b533e509549ba26ec410e869b5f4137285217962f4d296849905f654965aa47275114ec21a4f65
   languageName: node
   linkType: hard
 

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx
@@ -17,6 +17,7 @@ import 'highlight.js/styles/atom-one-dark.css'
 import { useClipboard } from '@/hooks/useClipboard'
 
 import { getLanguageFromExtension } from '@/utils/codeLanguageExtension'
+import { markdownComponents } from './MarkdownUtils'
 
 export const MarkdownTextMessage = memo(
   ({ text, isUser }: { id?: string; text: string; isUser?: boolean }) => {
@@ -209,6 +210,7 @@ export const MarkdownTextMessage = memo(
             [rehypeHighlightCodeLines, { showLineNumbers: true }],
             wrapCodeBlocksWithoutVisit,
           ]}
+          components={markdownComponents}
         >
           {preprocessMarkdown(text)}
         </Markdown>

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownUtils.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownUtils.tsx
@@ -1,0 +1,14 @@
+import { Components } from 'react-markdown'
+
+export const markdownComponents: Partial<Components> = {
+  a: ({ href, children, ...props }) => (
+    <a
+      target="_blank"
+      href={href}
+      className="text-[hsla(var(--app-link))]"
+      {...props}
+    >
+      {children}
+    </a>
+  ),
+}


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces changes to enhance the handling of markdown components within the `MarkdownTextMessage` component. The most important changes include importing a new utility and adding custom components for markdown rendering.

Enhancements to markdown handling:

* [`web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx`](diffhunk://#diff-248577b16f0456ecc74b4c2feb89430842934aea33e2a7d3fcbec9cced25bf1bR20): Imported `markdownComponents` from `MarkdownUtils` to customize the rendering of markdown elements.
* [`web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx`](diffhunk://#diff-248577b16f0456ecc74b4c2feb89430842934aea33e2a7d3fcbec9cced25bf1bR213): Added `components={markdownComponents}` to the `Markdown` component to apply the custom markdown components.
* [`web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownUtils.tsx`](diffhunk://#diff-5aeffa1f37d6a07d7c13880bbf949af39e58962c8b394045ec540998a9b56274R1-R14): Created a new `markdownComponents` object to define custom rendering for markdown links, ensuring they open in a new tab and have a specific text color.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
