### PR TITLE
fix: format compact number utils

### DIFF
--- a/docs/src/utils/format.ts
+++ b/docs/src/utils/format.ts
@@ -1,5 +1,5 @@
 export function formatCompactNumber(count: number) {
-  const formatter = Intl.NumberFormat('en', { notation: 'compact' })
+  const formatter = Intl.NumberFormat('en', { notation: 'compact', maximumFractionDigits: 1 })
   return formatter.format(count)
 }
 


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a small change to the `docs/src/utils/format.ts` file. The change modifies the `formatCompactNumber` function to include a `maximumFractionDigits` option in the number formatter.

* [`docs/src/utils/format.ts`](diffhunk://#diff-29ca9662b787658f96a8616026b10f474b42a37a7fca0f8087d7a9d7c684c7f5L2-R2): Added `maximumFractionDigits: 1` to the `Intl.NumberFormat` options in the `formatCompactNumber` function.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
