### PR TITLE
chore: Hub UI and markdown CSS

### DIFF
--- a/web/screens/Hub/ModelList/ModelHeader/index.tsx
+++ b/web/screens/Hub/ModelList/ModelHeader/index.tsx
@@ -83,7 +83,7 @@ const ModelItemHeader = ({ model, onSelectedModel }: Props) => {
         <span className="mx-4 font-medium text-white">Download</span>
       </div>
       <Dropdown
-        className="z-50 min-w-[240px]"
+        className="z-50  max-h-[240px] min-w-[240px] max-w-[320px] overflow-y-auto border border-[hsla(var(--app-border))] bg-[hsla(var(--app-bg))] shadow"
         options={model.models?.map((e) => ({
           name: (
             <div className="flex space-x-2">

--- a/web/screens/Hub/ModelPage/index.tsx
+++ b/web/screens/Hub/ModelPage/index.tsx
@@ -9,7 +9,6 @@ import {
   FileJson,
   SettingsIcon,
 } from 'lucide-react'
-import '@/styles/components/marked.scss'
 
 import ModelDownloadButton from '@/containers/ModelDownloadButton'
 
@@ -193,7 +192,7 @@ const ModelPage = ({ model, onGoBack }: Props) => {
             <div className="mt-8 flex w-full flex-col items-start justify-between sm:flex-row">
               <MarkdownTextMessage
                 text={model.metadata?.description ?? ''}
-                className="markdown-content h-full w-full text-[hsla(var(--text-secondary))]"
+                className="h-full w-full text-[hsla(var(--text-secondary))]"
               />
             </div>
           </div>

--- a/web/screens/Hub/ModelPage/index.tsx
+++ b/web/screens/Hub/ModelPage/index.tsx
@@ -49,7 +49,9 @@ const ModelPage = ({ model, onGoBack }: Props) => {
             {/* Header */}
             <div className="flex items-center justify-between py-2">
               <span className="line-clamp-1 text-base font-medium capitalize group-hover:text-blue-500 group-hover:underline">
-                {model.type !== 'cloud' ? extractModelName(model.metadata.id) : model.metadata.id}
+                {model.type !== 'cloud'
+                  ? extractModelName(model.metadata.id)
+                  : model.metadata.id}
               </span>
               <div className="inline-flex items-center space-x-2">
                 {model.type !== 'cloud' ? (
@@ -150,7 +152,9 @@ const ModelPage = ({ model, onGoBack }: Props) => {
                         >
                           <td className="flex items-center space-x-4 px-6 py-4">
                             <span className="line-clamp-1">
-                              {model.type === 'cloud' ? item.id :  item.id?.split(':')?.pop()}
+                              {model.type === 'cloud'
+                                ? item.id
+                                : item.id?.split(':')?.pop()}
                             </span>
                             {i === 0 && model.type !== 'cloud' && (
                               <Badge

--- a/web/screens/Hub/ModelPage/index.tsx
+++ b/web/screens/Hub/ModelPage/index.tsx
@@ -50,7 +50,7 @@ const ModelPage = ({ model, onGoBack }: Props) => {
             {/* Header */}
             <div className="flex items-center justify-between py-2">
               <span className="line-clamp-1 text-base font-medium capitalize group-hover:text-blue-500 group-hover:underline">
-                {extractModelName(model.metadata.id)}
+                {model.type !== 'cloud' ? extractModelName(model.metadata.id) : model.metadata.id}
               </span>
               <div className="inline-flex items-center space-x-2">
                 {model.type !== 'cloud' ? (
@@ -151,7 +151,7 @@ const ModelPage = ({ model, onGoBack }: Props) => {
                         >
                           <td className="flex items-center space-x-4 px-6 py-4">
                             <span className="line-clamp-1">
-                              {item.id?.split(':')?.pop()}
+                              {model.type === 'cloud' ? item.id :  item.id?.split(':')?.pop()}
                             </span>
                             {i === 0 && model.type !== 'cloud' && (
                               <Badge

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx
@@ -18,12 +18,13 @@ import 'katex/dist/katex.min.css'
 import 'highlight.js/styles/atom-one-dark.css'
 import '@/styles/components/marked.scss'
 
+import { twMerge } from 'tailwind-merge'
+
 import { useClipboard } from '@/hooks/useClipboard'
 
 import { getLanguageFromExtension } from '@/utils/codeLanguageExtension'
 
 import { markdownComponents } from './MarkdownUtils'
-import { twMerge } from 'tailwind-merge'
 
 interface Props {
   text: string

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx
@@ -16,11 +16,14 @@ import remarkMath from 'remark-math'
 
 import 'katex/dist/katex.min.css'
 import 'highlight.js/styles/atom-one-dark.css'
+import '@/styles/components/marked.scss'
+
 import { useClipboard } from '@/hooks/useClipboard'
 
 import { getLanguageFromExtension } from '@/utils/codeLanguageExtension'
 
 import { markdownComponents } from './MarkdownUtils'
+import { twMerge } from 'tailwind-merge'
 
 interface Props {
   text: string
@@ -214,7 +217,7 @@ export const MarkdownTextMessage = memo(
     return (
       <>
         <Markdown
-          className={className}
+          className={twMerge('markdown-content', className)}
           remarkPlugins={[remarkMath, remarkGfm]}
           rehypePlugins={
             [


### PR DESCRIPTION
This pull request includes several changes to the `web/screens/Hub/ModelPage/index.tsx`, `web/screens/Hub/ModelList/ModelHeader/index.tsx`, and `web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx` files. The changes mainly focus on UI enhancements, conditional rendering based on model types, and CSS class adjustments.

![CleanShot 2025-02-19 at 14 53 47@2x](https://github.com/user-attachments/assets/d2a367de-169b-4ab7-aecd-03f2c7c31dd8)
![CleanShot 2025-02-19 at 14 53 57@2x](https://github.com/user-attachments/assets/367f8fba-2d53-4b43-b860-d3a0ad171c9c)


UI Enhancements:

* [`web/screens/Hub/ModelList/ModelHeader/index.tsx`](diffhunk://#diff-c12507244d72ba8a5e975aa7ed41cdc8d996e3030a5248237aa84dd5f9da02a4L86-R86): Updated the `Dropdown` component to include additional styles for better appearance and usability, such as `max-h`, `max-w`, `overflow-y`, and border properties.

Conditional Rendering:

* [`web/screens/Hub/ModelPage/index.tsx`](diffhunk://#diff-02e81029a62de211929358113c60a101efd0bd0f7ce9b2237fa4cfabecba0a21L53-R52): Modified the display logic for model names and item IDs to handle 'cloud' type models differently. Specifically, updated the model name extraction and item ID display based on the model type. [[1]](diffhunk://#diff-02e81029a62de211929358113c60a101efd0bd0f7ce9b2237fa4cfabecba0a21L53-R52) [[2]](diffhunk://#diff-02e81029a62de211929358113c60a101efd0bd0f7ce9b2237fa4cfabecba0a21L154-R153)

CSS Class Adjustments:

* [`web/screens/Hub/ModelPage/index.tsx`](diffhunk://#diff-02e81029a62de211929358113c60a101efd0bd0f7ce9b2237fa4cfabecba0a21L196-R195): Removed the `markdown-content` class from the `MarkdownTextMessage` component to simplify the class usage.
* [`web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx`](diffhunk://#diff-248577b16f0456ecc74b4c2feb89430842934aea33e2a7d3fcbec9cced25bf1bR19-R26): Added the `marked.scss` import and used `twMerge` to combine Tailwind CSS classes dynamically. [[1]](diffhunk://#diff-248577b16f0456ecc74b4c2feb89430842934aea33e2a7d3fcbec9cced25bf1bR19-R26) [[2]](diffhunk://#diff-248577b16f0456ecc74b4c2feb89430842934aea33e2a7d3fcbec9cced25bf1bL217-R220)

Other Minor Changes:

* [`web/screens/Hub/ModelPage/index.tsx`](diffhunk://#diff-02e81029a62de211929358113c60a101efd0bd0f7ce9b2237fa4cfabecba0a21L12): Removed an unused import for `marked.scss`.

- Closes #4588 