### PR TITLE
refactor: different Jan builds should have different Cortex server port

### DIFF
--- a/.github/workflows/jan-electron-build-beta.yml
+++ b/.github/workflows/jan-electron-build-beta.yml
@@ -9,10 +9,17 @@ jobs:
   get-update-version:
     uses: ./.github/workflows/template-get-update-version.yml
 
+  # Different Jan instances should have different Cortex server port configurations
+  set-cortex-api-port:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set CORTEX_API_PORT environment variable
+        run: echo "CORTEX_API_PORT=39271" >> $GITHUB_ENV
+
   build-macos:
     uses: ./.github/workflows/template-build-macos.yml
     secrets: inherit
-    needs: [get-update-version]
+    needs: [get-update-version, set-cortex-api-port]
     with:
       ref: ${{ github.ref }}
       public_provider: github
@@ -22,7 +29,7 @@ jobs:
   build-windows-x64:
     uses: ./.github/workflows/template-build-windows-x64.yml
     secrets: inherit
-    needs: [get-update-version]
+    needs: [get-update-version, set-cortex-api-port]
     with:
       ref: ${{ github.ref }}
       public_provider: github
@@ -32,7 +39,7 @@ jobs:
   build-linux-x64:
     uses: ./.github/workflows/template-build-linux-x64.yml
     secrets: inherit
-    needs: [get-update-version]
+    needs: [get-update-version, set-cortex-api-port]
     with:
       ref: ${{ github.ref }}
       public_provider: github

--- a/.github/workflows/jan-electron-build-nightly.yml
+++ b/.github/workflows/jan-electron-build-nightly.yml
@@ -47,9 +47,16 @@ jobs:
   get-update-version:
     uses: ./.github/workflows/template-get-update-version.yml
 
+  # Different Jan instances should have different Cortex server port configurations
+  set-cortex-api-port:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set CORTEX_API_PORT environment variable
+        run: echo "CORTEX_API_PORT=39261" >> $GITHUB_ENV
+
   build-macos:
     uses: ./.github/workflows/template-build-macos.yml
-    needs: [get-update-version, set-public-provider]
+    needs: [get-update-version, set-public-provider, set-cortex-api-port]
     secrets: inherit
     with:
       ref: ${{ needs.set-public-provider.outputs.ref }}
@@ -59,7 +66,7 @@ jobs:
   build-windows-x64:
     uses: ./.github/workflows/template-build-windows-x64.yml
     secrets: inherit
-    needs: [get-update-version, set-public-provider]
+    needs: [get-update-version, set-public-provider, set-cortex-api-port]
     with:
       ref: ${{ needs.set-public-provider.outputs.ref }}
       public_provider: ${{ needs.set-public-provider.outputs.public_provider }}
@@ -69,7 +76,7 @@ jobs:
   build-linux-x64:
     uses: ./.github/workflows/template-build-linux-x64.yml
     secrets: inherit
-    needs: [get-update-version, set-public-provider]
+    needs: [get-update-version, set-public-provider, set-cortex-api-port]
     with:
       ref: ${{ needs.set-public-provider.outputs.ref }}
       public_provider: ${{ needs.set-public-provider.outputs.public_provider }}

--- a/extensions/assistant-extension/rolldown.config.mjs
+++ b/extensions/assistant-extension/rolldown.config.mjs
@@ -26,6 +26,9 @@ export default defineConfig([
     resolve: {
       extensions: ['.js', '.ts'],
     },
+    define: {
+      CORTEX_API_URL: JSON.stringify(`http://127.0.0.1:${process.env.CORTEX_API_PORT ?? "39291"}`),
+    },
     platform: 'node',
   },
 ])

--- a/extensions/assistant-extension/src/@types/global.d.ts
+++ b/extensions/assistant-extension/src/@types/global.d.ts
@@ -1,2 +1,3 @@
 declare const NODE: string
 declare const VERSION: string
+declare const CORTEX_API_URL: string

--- a/extensions/assistant-extension/src/node/retrieval.ts
+++ b/extensions/assistant-extension/src/node/retrieval.ts
@@ -28,7 +28,7 @@ export class Retrieval {
     this.timeWeightedVectorStore = new MemoryVectorStore(
       new OpenAIEmbeddings(
         { openAIApiKey: 'cortex-embedding' },
-        { basePath: 'http://127.0.0.1:39291/v1' }
+        { basePath: `${CORTEX_API_URL}/v1` }
       )
     )
     this.timeWeightedretriever = new TimeWeightedVectorStoreRetriever({
@@ -51,7 +51,7 @@ export class Retrieval {
     this.embeddingModel = new OpenAIEmbeddings(
       { openAIApiKey: 'cortex-embedding', model },
       // TODO: Raw settings
-      { basePath: 'http://127.0.0.1:39291/v1' }
+      { basePath: `${CORTEX_API_URL}/v1` }
     )
 
     // update time-weighted embedding model

--- a/extensions/conversational-extension/rolldown.config.mjs
+++ b/extensions/conversational-extension/rolldown.config.mjs
@@ -8,7 +8,6 @@ export default defineConfig({
   },
   platform: 'browser',
   define: {
-    API_URL: JSON.stringify('http://127.0.0.1:39291'),
-    SOCKET_URL: JSON.stringify('ws://127.0.0.1:39291'),
+    API_URL: JSON.stringify(`http://127.0.0.1:${process.env.CORTEX_API_PORT ?? "39291"}`),
   },
 })

--- a/extensions/conversational-extension/src/@types/global.d.ts
+++ b/extensions/conversational-extension/src/@types/global.d.ts
@@ -1,5 +1,4 @@
 declare const API_URL: string
-declare const SOCKET_URL: string
 
 interface Core {
   api: APIFunctions

--- a/extensions/engine-management-extension/rolldown.config.mjs
+++ b/extensions/engine-management-extension/rolldown.config.mjs
@@ -11,8 +11,7 @@ export default defineConfig([
     },
     define: {
       NODE: JSON.stringify(`${pkgJson.name}/${pkgJson.node}`),
-      API_URL: JSON.stringify('http://127.0.0.1:39291'),
-      SOCKET_URL: JSON.stringify('ws://127.0.0.1:39291'),
+      API_URL: JSON.stringify(`http://127.0.0.1:${process.env.CORTEX_API_PORT ?? "39291"}`),
       PLATFORM: JSON.stringify(process.platform),
       CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.49'),
       DEFAULT_REMOTE_ENGINES: JSON.stringify(engines),

--- a/extensions/engine-management-extension/src/@types/global.d.ts
+++ b/extensions/engine-management-extension/src/@types/global.d.ts
@@ -1,7 +1,6 @@
 declare const API_URL: string
 declare const CORTEX_ENGINE_VERSION: string
 declare const PLATFORM: string
-declare const SOCKET_URL: string
 declare const NODE: string
 declare const DEFAULT_REQUEST_PAYLOAD_TRANSFORM: string
 declare const DEFAULT_RESPONSE_BODY_TRANSFORM: string

--- a/extensions/hardware-management-extension/rolldown.config.mjs
+++ b/extensions/hardware-management-extension/rolldown.config.mjs
@@ -10,8 +10,7 @@ export default defineConfig([
     },
     define: {
       NODE: JSON.stringify(`${pkgJson.name}/${pkgJson.node}`),
-      API_URL: JSON.stringify('http://127.0.0.1:39291'),
-      SOCKET_URL: JSON.stringify('ws://127.0.0.1:39291'),
+      API_URL: JSON.stringify(`http://127.0.0.1:${process.env.CORTEX_API_PORT ?? "39291"}`),
     },
   },
 ])

--- a/extensions/hardware-management-extension/src/@types/global.d.ts
+++ b/extensions/hardware-management-extension/src/@types/global.d.ts
@@ -1,5 +1,4 @@
 declare const API_URL: string
-declare const SOCKET_URL: string
 declare const NODE: string
 
 interface Core {

--- a/extensions/inference-cortex-extension/rolldown.config.mjs
+++ b/extensions/inference-cortex-extension/rolldown.config.mjs
@@ -122,8 +122,8 @@ export default defineConfig([
       ]),
       NODE: JSON.stringify(`${packageJson.name}/${packageJson.node}`),
       SETTINGS: JSON.stringify(defaultSettingJson),
-      CORTEX_API_URL: JSON.stringify('http://127.0.0.1:39291'),
-      CORTEX_SOCKET_URL: JSON.stringify('ws://127.0.0.1:39291'),
+      CORTEX_API_URL: JSON.stringify(`http://127.0.0.1:${process.env.CORTEX_API_PORT ?? "39291"}`),
+      CORTEX_SOCKET_URL: JSON.stringify(`ws://127.0.0.1:${process.env.CORTEX_API_PORT ?? "39291"}`),
       CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.49'),
     },
   },
@@ -138,6 +138,9 @@ export default defineConfig([
     },
     resolve: {
       extensions: ['.js', '.ts', '.json'],
+    },
+    define: {
+      CORTEX_API_URL: JSON.stringify(`http://127.0.0.1:${process.env.CORTEX_API_PORT ?? "39291"}`),
     },
     platform: 'node',
   },

--- a/extensions/inference-cortex-extension/src/node/index.ts
+++ b/extensions/inference-cortex-extension/src/node/index.ts
@@ -3,13 +3,11 @@ import {
   appResourcePath,
   getJanDataFolderPath,
   log,
-  SystemInformation,
 } from '@janhq/core/node'
 import { ProcessWatchdog } from './watchdog'
-import { readdir, symlink } from 'fs/promises'
 
 // The HOST address to use for the Nitro subprocess
-const LOCAL_PORT = '39291'
+const LOCAL_PORT = CORTEX_API_URL.split(":").pop() ?? "39291"
 let watchdog: ProcessWatchdog | undefined = undefined
 
 /**

--- a/extensions/model-extension/rolldown.config.mjs
+++ b/extensions/model-extension/rolldown.config.mjs
@@ -11,8 +11,7 @@ export default defineConfig({
   platform: 'browser',
   define: {
     SETTINGS: JSON.stringify(settingJson),
-    API_URL: JSON.stringify('http://127.0.0.1:39291'),
-    SOCKET_URL: JSON.stringify('ws://127.0.0.1:39291'),
+    API_URL: JSON.stringify(`http://127.0.0.1:${process.env.CORTEX_API_PORT ?? "39291"}`),
     DEFAULT_MODEL_SOURCES: JSON.stringify(modelSources),
   },
 })

--- a/extensions/model-extension/src/@types/global.d.ts
+++ b/extensions/model-extension/src/@types/global.d.ts
@@ -1,6 +1,5 @@
 declare const NODE: string
 declare const API_URL: string
-declare const SOCKET_URL: string
 declare const SETTINGS: SettingComponentProps[]
 declare const DEFAULT_MODEL_SOURCES: any
 

--- a/server/global.d.ts
+++ b/server/global.d.ts
@@ -1,0 +1,1 @@
+declare const CORTEX_API_URL: string

--- a/server/index.ts
+++ b/server/index.ts
@@ -98,7 +98,7 @@ export const startServer = async (configs?: ServerConfig): Promise<boolean> => {
     })
 
     server.register(require('@fastify/http-proxy'), {
-      upstream: 'http://127.0.0.1:39291/v1',
+      upstream: `${CORTEX_API_URL}/v1`,
       prefix: configs?.prefix ?? '/v1',
       http2: false,
     })

--- a/server/rolldown.config.mjs
+++ b/server/rolldown.config.mjs
@@ -14,5 +14,8 @@ export default defineConfig([
     },
     external: ['@fastify/swagger-ui'],
     platform: 'node',
+    define: {
+      CORTEX_API_URL: JSON.stringify(`http://127.0.0.1:${process.env.CORTEX_API_PORT ?? "39291"}`),
+    }
   },
 ])

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -35,7 +35,8 @@ const nextConfig = {
         POSTHOG_HOST: JSON.stringify(process.env.POSTHOG_HOST),
         ANALYTICS_HOST: JSON.stringify(process.env.ANALYTICS_HOST),
         API_BASE_URL: JSON.stringify(
-          process.env.API_BASE_URL ?? 'http://127.0.0.1:39291'
+          process.env.API_BASE_URL ??
+            `http://127.0.0.1:${process.env.CORTEX_API_PORT ?? '39291'}`
         ),
         isMac: process.platform === 'darwin',
         isWindows: process.platform === 'win32',

--- a/web/screens/Hub/index.tsx
+++ b/web/screens/Hub/index.tsx
@@ -290,7 +290,7 @@ const HubScreen = () => {
                         )}
                         {hubBannerOption === 'upload' && (
                           <div
-                            className={`m-2 flex h-[172px] w-full cursor-pointer items-center justify-center rounded-md border`}
+                            className={`mx-2 mb-2 flex h-[172px] cursor-pointer items-center justify-center rounded-md border`}
                             onClick={() => {
                               imageInputRef.current?.click()
                             }}


### PR DESCRIPTION
This pull request introduces changes to configure different Cortex server port settings for various Jan instances and updates the codebase to use these configurations. The most important changes include updates to GitHub workflows, configuration files, and source code to dynamically set and use the `CORTEX_API_PORT` environment variable.

### GitHub Workflows:
* [`.github/workflows/jan-electron-build-beta.yml`](diffhunk://#diff-3eda9251187aa95e51016c05c5813e16d13e53225833d5bf4ae19b196e9ad8e0R12-R22): Added a new job `set-cortex-api-port` to set the `CORTEX_API_PORT` environment variable and updated dependencies for `build-macos`, `build-windows-x64`, and `build-linux-x64` jobs to include this new job. [[1]](diffhunk://#diff-3eda9251187aa95e51016c05c5813e16d13e53225833d5bf4ae19b196e9ad8e0R12-R22) [[2]](diffhunk://#diff-3eda9251187aa95e51016c05c5813e16d13e53225833d5bf4ae19b196e9ad8e0L25-R32) [[3]](diffhunk://#diff-3eda9251187aa95e51016c05c5813e16d13e53225833d5bf4ae19b196e9ad8e0L35-R42)
* [`.github/workflows/jan-electron-build-nightly.yml`](diffhunk://#diff-18207af9bc84a8331a3aa76995343d1505567e3a2ee86deeacc488720559237dR50-R59): Added a new job `set-cortex-api-port` to set the `CORTEX_API_PORT` environment variable and updated dependencies for `build-macos`, `build-windows-x64`, and `build-linux-x64` jobs to include this new job. [[1]](diffhunk://#diff-18207af9bc84a8331a3aa76995343d1505567e3a2ee86deeacc488720559237dR50-R59) [[2]](diffhunk://#diff-18207af9bc84a8331a3aa76995343d1505567e3a2ee86deeacc488720559237dL62-R69) [[3]](diffhunk://#diff-18207af9bc84a8331a3aa76995343d1505567e3a2ee86deeacc488720559237dL72-R79)

### Configuration Files:
* [`extensions/assistant-extension/rolldown.config.mjs`](diffhunk://#diff-2bccb2b7d81586d692a6f93d043a01abef0b1c50bacb417fcfa6f982a9ac17edR29-R31): Added a `define` block to set `CORTEX_API_URL` using the `CORTEX_API_PORT` environment variable.
* [`extensions/conversational-extension/rolldown.config.mjs`](diffhunk://#diff-99beaac18c91d3aaf733d1cb893fec472734c64d076878d73ea94692e0aad595L11-R11): Updated `API_URL` to use the `CORTEX_API_PORT` environment variable.
* [`extensions/engine-management-extension/rolldown.config.mjs`](diffhunk://#diff-30942dcc326a20cefe8cde68225a2aebaf2dab82021400521c5f63724210f558L14-R14): Updated `API_URL` to use the `CORTEX_API_PORT` environment variable.
* [`extensions/hardware-management-extension/rolldown.config.mjs`](diffhunk://#diff-6eaf588f0a78ae9ba9370f9cdc1deb66cbaaf56640d6beb7ddecc8d9d3af120dL13-R13): Updated `API_URL` to use the `CORTEX_API_PORT` environment variable.
* [`extensions/inference-cortex-extension/rolldown.config.mjs`](diffhunk://#diff-9b93590cc9312a835d0c11d009d45deeb5ff72bca39e246b2e3f8fde7e3d5e8eL125-R126): Updated `CORTEX_API_URL` and `CORTEX_SOCKET_URL` to use the `CORTEX_API_PORT` environment variable. [[1]](diffhunk://#diff-9b93590cc9312a835d0c11d009d45deeb5ff72bca39e246b2e3f8fde7e3d5e8eL125-R126) [[2]](diffhunk://#diff-9b93590cc9312a835d0c11d009d45deeb5ff72bca39e246b2e3f8fde7e3d5e8eR142-R144)

### Source Code:
* [`extensions/assistant-extension/src/node/retrieval.ts`](diffhunk://#diff-eabbaaf08a29a39e9a210733c6cc54a83c267081f5f5c7a464ab7e3b3a206ca7L31-R31): Updated `basePath` for `OpenAIEmbeddings` to use `CORTEX_API_URL`. [[1]](diffhunk://#diff-eabbaaf08a29a39e9a210733c6cc54a83c267081f5f5c7a464ab7e3b3a206ca7L31-R31) [[2]](diffhunk://#diff-eabbaaf08a29a39e9a210733c6cc54a83c267081f5f5c7a464ab7e3b3a206ca7L54-R54)
* [`extensions/inference-cortex-extension/src/node/index.ts`](diffhunk://#diff-f8f14f9faebbb7438e169298472574322d46c7f4e7901479defc6a24efdd0a64L6-R10): Updated `LOCAL_PORT` to use the port from `CORTEX_API_URL`.
* [`server/index.ts`](diffhunk://#diff-786114c6ebf98e577ec30dac884800bb7c9ce800b5323710ed03b916e1d33b68L101-R101): Updated `upstream` URL for the proxy to use `CORTEX_API_URL`.
* [`server/rolldown.config.mjs`](diffhunk://#diff-76addce7e6ef55090c04bb31d05c5f53cf43bf191c729f1eba91eb382d194063R17-R19): Added a `define` block to set `CORTEX_API_URL` using the `CORTEX_API_PORT` environment variable.
* [`web/next.config.js`](diffhunk://#diff-58fe4aacb1ce842c53b34b070ad87585e3ec9a57c0f66c426d5758f82efa2ecbL38-R39): Updated `API_BASE_URL` to use the `CORTEX_API_PORT` environment variable.

### UI Improvements:
* [`web/screens/Hub/index.tsx`](diffhunk://#diff-4acda36130f9ceb893281d73ffa88c92378b2a79c7b9a6c1b0704300cb2dd5d1L293-R293): Adjusted CSS classes for better layout and alignment.

- Closes #4565 