### PR TITLE
chore: change app logo for build nightly

### DIFF
--- a/.github/workflows/jan-electron-build-beta.yml
+++ b/.github/workflows/jan-electron-build-beta.yml
@@ -9,24 +9,10 @@ jobs:
   get-update-version:
     uses: ./.github/workflows/template-get-update-version.yml
 
-  rename-icons-beta:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-
-      - name: Replace Icons for Beta Build
-        run: |
-          mv electron/icons/jan-beta-512x512.png electron/icons/512x512.png
-          mv electron/icons/jan-beta.ico electron/icons/icon.ico
-          mv electron/icons/jan-beta.png electron/icons/icon.png
-          mv electron/icons/jan-beta-tray@2x.png electron/icons/icon-tray@2x.png
-          mv electron/icons/jan-beta-tray.png electron/icons/icon-tray.png
-
   build-macos:
     uses: ./.github/workflows/template-build-macos.yml
     secrets: inherit
-    needs: [rename-icons-beta, get-update-version]
+    needs: [get-update-version]
     with:
       ref: ${{ github.ref }}
       public_provider: github
@@ -37,7 +23,7 @@ jobs:
   build-windows-x64:
     uses: ./.github/workflows/template-build-windows-x64.yml
     secrets: inherit
-    needs: [rename-icons-beta, get-update-version]
+    needs: [get-update-version]
     with:
       ref: ${{ github.ref }}
       public_provider: github
@@ -48,7 +34,7 @@ jobs:
   build-linux-x64:
     uses: ./.github/workflows/template-build-linux-x64.yml
     secrets: inherit
-    needs: [rename-icons-beta, get-update-version]
+    needs: [get-update-version]
     with:
       ref: ${{ github.ref }}
       public_provider: github

--- a/.github/workflows/jan-electron-build-nightly.yml
+++ b/.github/workflows/jan-electron-build-nightly.yml
@@ -47,55 +47,36 @@ jobs:
   get-update-version:
     uses: ./.github/workflows/template-get-update-version.yml
 
-  rename-icons:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ needs.set-public-provider.outputs.ref }}
-
-      - name: Rename Icons
-        run: |
-          mv electron/icons/jan-nightly-512x512.png electron/icons/512x512.png
-          mv electron/icons/jan-nightly.ico electron/icons/icon.ico
-          mv electron/icons/jan-nightly.png electron/icons/icon.png
-          mv electron/icons/jan-nightly-tray@2x.png electron/icons/icon-tray@2x.png
-          mv electron/icons/jan-nightly-tray.png electron/icons/icon-tray.png
-
-      - name: Upload Icons
-        uses: actions/upload-artifact@v3
-        with:
-          name: renamed-icons
-          path: electron/icons/
-
   build-macos:
     uses: ./.github/workflows/template-build-macos.yml
-    needs: [get-update-version, set-public-provider, rename-icons]
+    needs: [get-update-version, set-public-provider]
     secrets: inherit
     with:
       ref: ${{ needs.set-public-provider.outputs.ref }}
       public_provider: ${{ needs.set-public-provider.outputs.public_provider }}
       new_version: ${{ needs.get-update-version.outputs.new_version }}
+      nightly: true
       cortex_api_port: "39261"
 
   build-windows-x64:
     uses: ./.github/workflows/template-build-windows-x64.yml
     secrets: inherit
-    needs: [get-update-version, set-public-provider, rename-icons]
+    needs: [get-update-version, set-public-provider]
     with:
       ref: ${{ needs.set-public-provider.outputs.ref }}
       public_provider: ${{ needs.set-public-provider.outputs.public_provider }}
       new_version: ${{ needs.get-update-version.outputs.new_version }}
+      nightly: true
       cortex_api_port: "39261"
   build-linux-x64:
     uses: ./.github/workflows/template-build-linux-x64.yml
     secrets: inherit
-    needs: [get-update-version, set-public-provider, rename-icons]
+    needs: [get-update-version, set-public-provider]
     with:
       ref: ${{ needs.set-public-provider.outputs.ref }}
       public_provider: ${{ needs.set-public-provider.outputs.public_provider }}
       new_version: ${{ needs.get-update-version.outputs.new_version }}
+      nightly: true
       cortex_api_port: "39261"
 
   sync-temp-to-latest:
@@ -164,4 +145,3 @@ jobs:
           RUN_ID=${{ github.run_id }}
           COMMENT="This is the build for this pull request. You can download it from the Artifacts section here: [Build URL](https://github.com/${{ github.repository }}/actions/runs/${RUN_ID})."
           gh pr comment $PR_URL --body "$COMMENT"
-    

--- a/.github/workflows/jan-electron-build-nightly.yml
+++ b/.github/workflows/jan-electron-build-nightly.yml
@@ -16,20 +16,6 @@ on:
     types: [submitted]
 
 jobs:
-  rename-icons-nightly:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-
-      - name: Replace Icons for Nightly Build
-        run: |
-          mv electron/icons/jan-nightly-512x512.png electron/icons/512x512.png
-          mv electron/icons/jan-nightly.ico electron/icons/icon.ico
-          mv electron/icons/jan-nightly.png electron/icons/icon.png
-          mv electron/icons/jan-nightly-tray@2x.png electron/icons/icon-tray@2x.png
-          mv electron/icons/jan-nightly-tray.png electron/icons/icon-tray.png
-  
   set-public-provider:
     runs-on: ubuntu-latest
     outputs:
@@ -61,9 +47,31 @@ jobs:
   get-update-version:
     uses: ./.github/workflows/template-get-update-version.yml
 
+  rename-icons:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.set-public-provider.outputs.ref }}
+
+      - name: Rename Icons
+        run: |
+          mv electron/icons/jan-nightly-512x512.png electron/icons/512x512.png
+          mv electron/icons/jan-nightly.ico electron/icons/icon.ico
+          mv electron/icons/jan-nightly.png electron/icons/icon.png
+          mv electron/icons/jan-nightly-tray@2x.png electron/icons/icon-tray@2x.png
+          mv electron/icons/jan-nightly-tray.png electron/icons/icon-tray.png
+
+      - name: Upload Icons
+        uses: actions/upload-artifact@v3
+        with:
+          name: renamed-icons
+          path: electron/icons/
+
   build-macos:
     uses: ./.github/workflows/template-build-macos.yml
-    needs: [rename-icons-nightly, get-update-version, set-public-provider]
+    needs: [get-update-version, set-public-provider, rename-icons]
     secrets: inherit
     with:
       ref: ${{ needs.set-public-provider.outputs.ref }}
@@ -74,18 +82,16 @@ jobs:
   build-windows-x64:
     uses: ./.github/workflows/template-build-windows-x64.yml
     secrets: inherit
-    needs: [rename-icons-nightly, get-update-version, set-public-provider]
+    needs: [get-update-version, set-public-provider, rename-icons]
     with:
       ref: ${{ needs.set-public-provider.outputs.ref }}
       public_provider: ${{ needs.set-public-provider.outputs.public_provider }}
       new_version: ${{ needs.get-update-version.outputs.new_version }}
       cortex_api_port: "39261"
-
-          
   build-linux-x64:
     uses: ./.github/workflows/template-build-linux-x64.yml
     secrets: inherit
-    needs: [rename-icons-nightly, get-update-version, set-public-provider]
+    needs: [get-update-version, set-public-provider, rename-icons]
     with:
       ref: ${{ needs.set-public-provider.outputs.ref }}
       public_provider: ${{ needs.set-public-provider.outputs.public_provider }}

--- a/.github/workflows/template-build-linux-x64.yml
+++ b/.github/workflows/template-build-linux-x64.yml
@@ -23,6 +23,10 @@ on:
         required: false
         type: boolean
         default: false
+      nightly:
+        required: false
+        type: boolean
+        default: false
       cortex_api_port:
         required: false
         type: string
@@ -46,6 +50,26 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
+
+      - name: Replace Icons for Beta Build
+        if: inputs.beta == true
+        shell: bash
+        run: |
+          mv electron/icons/jan-beta-512x512.png electron/icons/512x512.png
+          mv electron/icons/jan-beta.ico electron/icons/icon.ico
+          mv electron/icons/jan-beta.png electron/icons/icon.png
+          mv electron/icons/jan-beta-tray@2x.png electron/icons/icon-tray@2x.png
+          mv electron/icons/jan-beta-tray.png electron/icons/icon-tray.png
+
+      - name: Replace Icons for Nightly Build
+        if: inputs.nightly == true
+        shell: bash
+        run: |
+          mv electron/icons/jan-nightly-512x512.png electron/icons/512x512.png
+          mv electron/icons/jan-nightly.ico electron/icons/icon.ico
+          mv electron/icons/jan-nightly.png electron/icons/icon.png
+          mv electron/icons/jan-nightly-tray@2x.png electron/icons/icon-tray@2x.png
+          mv electron/icons/jan-nightly-tray.png electron/icons/icon-tray.png
 
       - name: Installing node
         uses: actions/setup-node@v1

--- a/.github/workflows/template-build-macos.yml
+++ b/.github/workflows/template-build-macos.yml
@@ -23,6 +23,10 @@ on:
         required: false
         type: boolean
         default: false
+      nightly:
+        required: false
+        type: boolean
+        default: false
       cortex_api_port:
         required: false
         type: string

--- a/.github/workflows/template-build-macos.yml
+++ b/.github/workflows/template-build-macos.yml
@@ -60,6 +60,26 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
+      
+      - name: Replace Icons for Beta Build
+        if: inputs.beta == true
+        shell: bash
+        run: |
+          mv electron/icons/jan-beta-512x512.png electron/icons/512x512.png
+          mv electron/icons/jan-beta.ico electron/icons/icon.ico
+          mv electron/icons/jan-beta.png electron/icons/icon.png
+          mv electron/icons/jan-beta-tray@2x.png electron/icons/icon-tray@2x.png
+          mv electron/icons/jan-beta-tray.png electron/icons/icon-tray.png
+
+      - name: Replace Icons for Nightly Build
+        if: inputs.nightly == true
+        shell: bash
+        run: |
+          mv electron/icons/jan-nightly-512x512.png electron/icons/512x512.png
+          mv electron/icons/jan-nightly.ico electron/icons/icon.ico
+          mv electron/icons/jan-nightly.png electron/icons/icon.png
+          mv electron/icons/jan-nightly-tray@2x.png electron/icons/icon-tray@2x.png
+          mv electron/icons/jan-nightly-tray.png electron/icons/icon-tray.png
 
       - name: Installing node
         uses: actions/setup-node@v1

--- a/.github/workflows/template-build-windows-x64.yml
+++ b/.github/workflows/template-build-windows-x64.yml
@@ -60,6 +60,26 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      - name: Replace Icons for Beta Build
+        if: inputs.beta == true
+        shell: bash
+        run: |
+          mv electron/icons/jan-beta-512x512.png electron/icons/512x512.png
+          mv electron/icons/jan-beta.ico electron/icons/icon.ico
+          mv electron/icons/jan-beta.png electron/icons/icon.png
+          mv electron/icons/jan-beta-tray@2x.png electron/icons/icon-tray@2x.png
+          mv electron/icons/jan-beta-tray.png electron/icons/icon-tray.png
+
+      - name: Replace Icons for Nightly Build
+        if: inputs.nightly == true
+        shell: bash
+        run: |
+          mv electron/icons/jan-nightly-512x512.png electron/icons/512x512.png
+          mv electron/icons/jan-nightly.ico electron/icons/icon.ico
+          mv electron/icons/jan-nightly.png electron/icons/icon.png
+          mv electron/icons/jan-nightly-tray@2x.png electron/icons/icon-tray@2x.png
+          mv electron/icons/jan-nightly-tray.png electron/icons/icon-tray.png
+
       - name: Installing node
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/template-build-windows-x64.yml
+++ b/.github/workflows/template-build-windows-x64.yml
@@ -23,6 +23,10 @@ on:
         required: false
         type: boolean
         default: false
+      nightly:
+        required: false
+        type: boolean
+        default: false
       cortex_api_port:
         required: false
         type: string


### PR DESCRIPTION
## Describe Your Changes
This pull request includes significant changes to the GitHub Actions workflows for building the Electron app. The main focus of the changes is to streamline the build process by consolidating the icon replacement steps and adding support for nightly builds.

Changes to streamline the build process:

* [`.github/workflows/jan-electron-build-beta.yml`](diffhunk://#diff-3eda9251187aa95e51016c05c5813e16d13e53225833d5bf4ae19b196e9ad8e0L12-R15): Removed the `rename-icons-beta` job and adjusted dependencies for `build-macos`, `build-windows-x64`, and `build-linux-x64` jobs to no longer depend on `rename-icons-beta`. [[1]](diffhunk://#diff-3eda9251187aa95e51016c05c5813e16d13e53225833d5bf4ae19b196e9ad8e0L12-R15) [[2]](diffhunk://#diff-3eda9251187aa95e51016c05c5813e16d13e53225833d5bf4ae19b196e9ad8e0L40-R26) [[3]](diffhunk://#diff-3eda9251187aa95e51016c05c5813e16d13e53225833d5bf4ae19b196e9ad8e0L51-R37)
* [`.github/workflows/jan-electron-build-nightly.yml`](diffhunk://#diff-18207af9bc84a8331a3aa76995343d1505567e3a2ee86deeacc488720559237dL19-L32): Removed the `rename-icons-nightly` job and adjusted dependencies for `build-macos`, `build-windows-x64`, and `build-linux-x64` jobs to no longer depend on `rename-icons-nightly`. [[1]](diffhunk://#diff-18207af9bc84a8331a3aa76995343d1505567e3a2ee86deeacc488720559237dL19-L32) [[2]](diffhunk://#diff-18207af9bc84a8331a3aa76995343d1505567e3a2ee86deeacc488720559237dL66-R79) [[3]](diffhunk://#diff-18207af9bc84a8331a3aa76995343d1505567e3a2ee86deeacc488720559237dL161)

Consolidation of icon replacement steps:

* [`.github/workflows/template-build-linux-x64.yml`](diffhunk://#diff-f436c88d8d2ac4a3c00ca7098196c08a1dce207bf6ded8b73e379f5a994191c0R26-R29): Added steps to replace icons for beta and nightly builds based on input parameters. [[1]](diffhunk://#diff-f436c88d8d2ac4a3c00ca7098196c08a1dce207bf6ded8b73e379f5a994191c0R26-R29) [[2]](diffhunk://#diff-f436c88d8d2ac4a3c00ca7098196c08a1dce207bf6ded8b73e379f5a994191c0R54-R73)
* [`.github/workflows/template-build-macos.yml`](diffhunk://#diff-ae4bf938d705de465ba9586ab592f836b41d72d596ce1dc491715de7c5f6ac3fR26-R29): Added steps to replace icons for beta and nightly builds based on input parameters. [[1]](diffhunk://#diff-ae4bf938d705de465ba9586ab592f836b41d72d596ce1dc491715de7c5f6ac3fR26-R29) [[2]](diffhunk://#diff-ae4bf938d705de465ba9586ab592f836b41d72d596ce1dc491715de7c5f6ac3fR64-R83)
* [`.github/workflows/template-build-windows-x64.yml`](diffhunk://#diff-924a4926e3256a71a3f3e7cbf729e934c147d96af31aa9ccc4490d471d9e43b0R26-R29): Added steps to replace icons for beta and nightly builds based on input parameters. [[1]](diffhunk://#diff-924a4926e3256a71a3f3e7cbf729e934c147d96af31aa9ccc4490d471d9e43b0R26-R29) [[2]](diffhunk://#diff-924a4926e3256a71a3f3e7cbf729e934c147d96af31aa9ccc4490d471d9e43b0R63-R82)

## Fixes Issues

- https://github.com/janhq/jan/issues/4478#issue-2795005571

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
