### PR TITLE
feat: preserve token speed in the thread

### DIFF
--- a/web/containers/Providers/ModelHandler.tsx
+++ b/web/containers/Providers/ModelHandler.tsx
@@ -75,7 +75,7 @@ export default function ModelHandler() {
   const activeThreadRef = useRef(activeThread)
   const activeModelParams = useAtomValue(getActiveThreadModelParamsAtom)
   const activeModelParamsRef = useRef(activeModelParams)
-  
+
   const [tokenSpeed, setTokenSpeed] = useAtom(tokenSpeedAtom)
   const { engines } = useGetEngines()
   const tokenSpeedRef = useRef(tokenSpeed)

--- a/web/containers/Providers/ModelHandler.tsx
+++ b/web/containers/Providers/ModelHandler.tsx
@@ -18,7 +18,7 @@ import {
   extractInferenceParams,
   ModelExtension,
 } from '@janhq/core'
-import { useAtomValue, useSetAtom } from 'jotai'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { ulid } from 'ulidx'
 
 import { activeModelAtom, stateModelAtom } from '@/hooks/useActiveModel'
@@ -75,8 +75,10 @@ export default function ModelHandler() {
   const activeThreadRef = useRef(activeThread)
   const activeModelParams = useAtomValue(getActiveThreadModelParamsAtom)
   const activeModelParamsRef = useRef(activeModelParams)
-  const setTokenSpeed = useSetAtom(tokenSpeedAtom)
+  
+  const [tokenSpeed, setTokenSpeed] = useAtom(tokenSpeedAtom)
   const { engines } = useGetEngines()
+  const tokenSpeedRef = useRef(tokenSpeed)
 
   useEffect(() => {
     activeThreadRef.current = activeThread
@@ -105,6 +107,10 @@ export default function ModelHandler() {
   useEffect(() => {
     messageGenerationSubscriber.current = subscribedGeneratingMessage
   }, [subscribedGeneratingMessage])
+
+  useEffect(() => {
+    tokenSpeedRef.current = tokenSpeed
+  }, [tokenSpeed])
 
   const onNewMessageResponse = useCallback(
     async (message: ThreadMessage) => {
@@ -274,6 +280,12 @@ export default function ModelHandler() {
           ...thread,
           metadata,
         })
+
+      // Update message's metadata with token usage
+      message.metadata = {
+        ...message.metadata,
+        token_speed: tokenSpeedRef.current?.tokenSpeed,
+      }
 
       if (message.status === MessageStatus.Error) {
         message.metadata = {

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
@@ -122,13 +122,16 @@ const MessageContainer: React.FC<
           )}
         >
           <div>
-            {tokenSpeed &&
+            {((!!tokenSpeed &&
               tokenSpeed.message === props.id &&
-              tokenSpeed.tokenSpeed > 0 && (
-                <p className="text-xs font-medium text-[hsla(var(--text-secondary))]">
-                  Token Speed: {Number(tokenSpeed.tokenSpeed).toFixed(2)}t/s
-                </p>
-              )}
+              tokenSpeed.tokenSpeed > 0) ||
+              (props.metadata &&
+                'token_speed' in props.metadata &&
+                !!props.metadata?.token_speed)) && (
+              <p className="text-xs font-medium text-[hsla(var(--text-secondary))]">
+                Token Speed: {Number(props.metadata?.token_speed ?? tokenSpeed?.tokenSpeed).toFixed(2)}t/s
+              </p>
+            )}
           </div>
 
           <MessageToolbar message={props} />

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
@@ -129,7 +129,11 @@ const MessageContainer: React.FC<
                 'token_speed' in props.metadata &&
                 !!props.metadata?.token_speed)) && (
               <p className="text-xs font-medium text-[hsla(var(--text-secondary))]">
-                Token Speed: {Number(props.metadata?.token_speed ?? tokenSpeed?.tokenSpeed).toFixed(2)}t/s
+                Token Speed:{' '}
+                {Number(
+                  props.metadata?.token_speed ?? tokenSpeed?.tokenSpeed
+                ).toFixed(2)}
+                t/s
               </p>
             )}
           </div>


### PR DESCRIPTION
This pull request includes several updates to the `ModelHandler` component and related files to improve the handling and display of token speed. The most important changes include adding the `useAtom` hook, updating references to token speed, and ensuring token speed is correctly displayed in the UI.

Token usages will be stored in the metadata of messages from now on. There'll be another update to persist token usage from cortex.cpp chat/completion.

![CleanShot 2025-02-20 at 23 48 00@2x](https://github.com/user-attachments/assets/394e542f-9c6c-42bf-9303-1d36e1884c18)

![CleanShot 2025-02-20 at 23 48 08@2x](https://github.com/user-attachments/assets/24ad48a4-4656-4c85-ae3b-3c9eed200e84)

- Closes #2750
Improvements to token speed handling:

* [`web/containers/Providers/ModelHandler.tsx`](diffhunk://#diff-c52744b512485151ef69f9c9e8b58535cc47dc550c4caf152cb52ec103ea898dL21-R21): Added `useAtom` from `jotai` to manage the token speed state and updated references to use this hook. [[1]](diffhunk://#diff-c52744b512485151ef69f9c9e8b58535cc47dc550c4caf152cb52ec103ea898dL21-R21) [[2]](diffhunk://#diff-c52744b512485151ef69f9c9e8b58535cc47dc550c4caf152cb52ec103ea898dL78-R81)
* [`web/containers/Providers/ModelHandler.tsx`](diffhunk://#diff-c52744b512485151ef69f9c9e8b58535cc47dc550c4caf152cb52ec103ea898dR111-R114): Added an effect to update the `tokenSpeedRef` when token speed changes.
* [`web/containers/Providers/ModelHandler.tsx`](diffhunk://#diff-c52744b512485151ef69f9c9e8b58535cc47dc550c4caf152cb52ec103ea898dR284-R289): Updated message metadata with token usage information.

UI updates for token speed display:

* [`web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx`](diffhunk://#diff-efce7749ad34c34cc3f189aea671b9975208995580033b9de787c3c96c878cccL125-R132): Modified the token speed display logic to check both the current token speed and the metadata.