### PR TITLE
chore: streaming should be turned on by default

### DIFF
--- a/extensions/engine-management-extension/models/cohere.json
+++ b/extensions/engine-management-extension/models/cohere.json
@@ -9,7 +9,7 @@
       "max_tokens": 4096,
       "temperature": 0.7,
       "max_temperature": 1.0,
-      "stream": false
+      "stream": true
     },
     "engine": "cohere"
   },
@@ -23,7 +23,7 @@
       "max_tokens": 4096,
       "temperature": 0.7,
       "max_temperature": 1.0,
-      "stream": false
+      "stream": true
     },
     "engine": "cohere"
   }


### PR DESCRIPTION
This pull request includes changes to the `extensions/engine-management-extension/models/cohere.json` file to update the streaming configuration.

Configuration updates:

* [`extensions/engine-management-extension/models/cohere.json`](diffhunk://#diff-0f356207d41156712777d654492953c89a59617bac89b8266507652492e395efL12-R12): Changed the `stream` parameter from `false` to `true` to enable streaming. [[1]](diffhunk://#diff-0f356207d41156712777d654492953c89a59617bac89b8266507652492e395efL12-R12) [[2]](diffhunk://#diff-0f356207d41156712777d654492953c89a59617bac89b8266507652492e395efL26-R26)

- Closes #4682