### PR TITLE
fix: should disable start model button when there is a model is loading

### DIFF
--- a/web/screens/Settings/MyModels/MyModelList/index.tsx
+++ b/web/screens/Settings/MyModels/MyModelList/index.tsx
@@ -135,9 +135,11 @@ const MyModelList = ({ model }: Props) => {
                         <div
                           className={twMerge(
                             'flex items-center space-x-2 px-4 py-2 hover:bg-[hsla(var(--dropdown-menu-hover-bg))]',
-                            serverEnabled && 'cursor-not-allowed opacity-40'
+                            (serverEnabled || stateModel.loading) &&
+                              'cursor-not-allowed opacity-40'
                           )}
                           onClick={() => {
+                            if (serverEnabled || stateModel.loading) return
                             onModelActionClick(model.id)
                             setMore(false)
                           }}
@@ -159,7 +161,7 @@ const MyModelList = ({ model }: Props) => {
                           </span>
                         </div>
                       }
-                      disabled={!serverEnabled}
+                      disabled={!serverEnabled || stateModel.loading}
                       content={
                         <span>
                           {activeModel && activeModel.id === model.id


### PR DESCRIPTION
This pull request includes changes to the `MyModelList` component in the `web/screens/Settings/MyModels/MyModelList/index.tsx` file to enhance the user interface behavior by considering the loading state of the model.

There are two issues with the current app regarding this action:
1. Race condition when starting model if users interact with the button too fast
2. Starting button is not gated properly, it's disabled but still clickable

![CleanShot 2025-02-21 at 00 45 31](https://github.com/user-attachments/assets/9217829a-6933-4f3c-81e2-4da3e9c23930)

- Closes #4673 

Improvements to user interface behavior:

* Updated the conditional class assignment to disable the cursor and reduce opacity when either `serverEnabled` or `stateModel.loading` is true.
* Modified the `onClick` handler to prevent action when either `serverEnabled` or `stateModel.loading` is true.
* Adjusted the `disabled` attribute to disable the component when either `serverEnabled` or `stateModel.loading` is true.