### PR TITLE
chore: sticky model hub filter panel

### DIFF
--- a/web/screens/Hub/index.tsx
+++ b/web/screens/Hub/index.tsx
@@ -445,7 +445,7 @@ const HubScreen = () => {
               {/* Filters and Model List */}
               <div className="ml-4 mt-8 flex h-full w-full flex-row">
                 {/* Filters */}
-                <div className="hidden h-full w-[200px] shrink-0 flex-col mr-6 md:flex sticky top-10">
+                <div className="sticky top-10 mr-6 hidden h-full w-[200px] shrink-0 flex-col md:flex">
                   <div className="flex w-full flex-row justify-between">
                     Filters
                     <button
@@ -477,7 +477,7 @@ const HubScreen = () => {
                 </div>
 
                 {/* Model List */}
-                <div className="w-full p-4 py-0 sm:px-16 md:border-l border-[hsla(var(--app-border))] border-0">
+                <div className="w-full border-0 border-[hsla(var(--app-border))] p-4 py-0 sm:px-16 md:border-l">
                   <>
                     <div className="flex flex-row">
                       <div className="flex w-full flex-col items-start justify-between gap-4 py-4 first:pt-0 sm:flex-row">

--- a/web/screens/Hub/index.tsx
+++ b/web/screens/Hub/index.tsx
@@ -445,7 +445,7 @@ const HubScreen = () => {
               {/* Filters and Model List */}
               <div className="ml-4 mt-8 flex h-full w-full flex-row">
                 {/* Filters */}
-                <div className="hidden h-full w-[224px] shrink-0 flex-col border-r border-[hsla(var(--app-border))] pr-6 md:flex">
+                <div className="hidden h-full w-[200px] shrink-0 flex-col mr-6 md:flex sticky top-10">
                   <div className="flex w-full flex-row justify-between">
                     Filters
                     <button
@@ -477,7 +477,7 @@ const HubScreen = () => {
                 </div>
 
                 {/* Model List */}
-                <div className="w-full p-4 py-0 sm:px-16">
+                <div className="w-full p-4 py-0 sm:px-16 md:border-l border-[hsla(var(--app-border))] border-0">
                   <>
                     <div className="flex flex-row">
                       <div className="flex w-full flex-col items-start justify-between gap-4 py-4 first:pt-0 sm:flex-row">

--- a/web/screens/LocalServer/LocalServerCenterPanel/index.tsx
+++ b/web/screens/LocalServer/LocalServerCenterPanel/index.tsx
@@ -27,7 +27,7 @@ const LocalServerCenterPanel = () => {
   return (
     <CenterPanelContainer>
       <div className="flex h-full w-full flex-col">
-        <div className="sticky top-0 z-10  flex items-center justify-between border-b border-[hsla(var(--app-border))] bg-[hsla(var(--app-bg))] px-4 py-2">
+        <div className="sticky top-0 z-10 flex items-center justify-between border-b border-[hsla(var(--app-border))] bg-[hsla(var(--app-bg))] px-4 py-2">
           <h2 className="font-bold">Server Logs</h2>
           <div className="space-x-2">
             <Button


### PR DESCRIPTION
This pull request includes changes to the layout and styling of the `HubScreen` component in the `web/screens/Hub/index.tsx` file. The most important changes involve adjustments to the filters section and the model list section.

![CleanShot 2025-02-21 at 17 29 56](https://github.com/user-attachments/assets/f7e694f6-529d-4a8b-a5e3-721dd0163184)


Layout and styling adjustments:

* Modified the filters section to have a width of `200px`, added a right margin of `6px`, and made it sticky with a top offset of `10px`.
* Added a left border to the model list section with `md:border-l` and adjusted the border color using `border-[hsla(var(--app-border))]`.