### PR TITLE
chore: fix model hub sorting

### DIFF
--- a/web/screens/Hub/index.tsx
+++ b/web/screens/Hub/index.tsx
@@ -121,22 +121,8 @@ const HubScreen = () => {
     [sources, searchValue]
   )
 
-  const sortedModels = useMemo(() => {
-    if (!sources) return []
-    return sources.sort((a, b) => {
-      if (sortSelected === 'most-downloaded') {
-        return b.metadata.downloads - a.metadata.downloads
-      } else {
-        return (
-          new Date(b.metadata.createdAt).getTime() -
-          new Date(a.metadata.createdAt).getTime()
-        )
-      }
-    })
-  }, [sortSelected, sources])
-
   const filteredModels = useMemo(() => {
-    return sortedModels.filter((model) => {
+    return (sources ?? []).filter((model) => {
       const isCompatible =
         !compatible ||
         model.models?.some((e) => e.size * 1.5 < totalRam * (1 << 20))
@@ -153,13 +139,27 @@ const HubScreen = () => {
       return isCompatible && matchesCtxLen && matchesMinSize && matchesMaxSize
     })
   }, [
-    sortedModels,
+    sources,
     compatible,
     ctxLenFilter,
     minModelSizeFilter,
     maxModelSizeFilter,
     totalRam,
   ])
+
+  const sortedModels = useMemo(() => {
+    return filteredModels.sort((a, b) => {
+      if (sortSelected === 'most-downloaded') {
+        return b.metadata.downloads - a.metadata.downloads
+      } else {
+        return (
+          new Date(b.metadata.createdAt).getTime() -
+          new Date(a.metadata.createdAt).getTime()
+        )
+      }
+    })
+  }, [sortSelected, filteredModels])
+
 
   useEffect(() => {
     if (modelDetail) {
@@ -516,7 +516,7 @@ const HubScreen = () => {
                     {(filterOption === 'on-device' ||
                       filterOption === 'all') && (
                       <ModelList
-                        models={filteredModels}
+                        models={sortedModels}
                         onSelectedModel={(model) => setSelectedModel(model)}
                       />
                     )}

--- a/web/screens/Hub/index.tsx
+++ b/web/screens/Hub/index.tsx
@@ -160,7 +160,6 @@ const HubScreen = () => {
     })
   }, [sortSelected, filteredModels])
 
-
   useEffect(() => {
     if (modelDetail) {
       setSelectedModel(sources?.find((e) => e.id === modelDetail))


### PR DESCRIPTION
This pull request includes changes to the `HubScreen` component in the `web/screens/Hub/index.tsx` file to optimize the sorting and filtering logic for models. The key changes involve reordering the sorting and filtering operations to improve performance and code clarity.

Key updates:
- Fixed the issue where sorting before filtering had no effect.

![CleanShot 2025-02-24 at 14 14 56@2x](https://github.com/user-attachments/assets/005d7a73-15f7-4d2a-9691-f14253a0eaf2)


Optimizations to sorting and filtering logic:

* Moved the sorting logic to occur after the filtering logic by relocating the `sortedModels` `useMemo` hook to follow the `filteredModels` `useMemo` hook. This ensures that only the filtered models are sorted, reducing the number of items that need to be sorted.
* Updated the `filteredModels` `useMemo` hook to directly filter the `sources` array, and adjusted its dependencies to reflect this change.
* Updated the `ModelList` component to use `sortedModels` instead of `filteredModels` to ensure that the displayed models are both filtered and sorted.