### PR TITLE
enhancement: scrollbar setting options

### DIFF
--- a/extensions/yarn.lock
+++ b/extensions/yarn.lock
@@ -684,61 +684,61 @@ __metadata:
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fassistant-extension%40workspace%3Aassistant-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=ff5479&locator=%40janhq%2Fassistant-extension%40workspace%3Aassistant-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=b51c7a&locator=%40janhq%2Fassistant-extension%40workspace%3Aassistant-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/a9f5cc6b3e90eecef539a2036385dcdcb5988304a4c78d1bff4fe9e7e9910b319aa1efd92c395a0dabee98821a9bc274f45958a345441204f3dafbeec76ba658
+  checksum: 10c0/14c61c6f50f09da8202fec64a46e3b5b81927872ee25695da209a2cc1cf7638049c9cd981a0be0cd51034479dfd3d921b851b0fa2809a4823095977b41954e6e
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fconversational-extension%40workspace%3Aconversational-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=ff5479&locator=%40janhq%2Fconversational-extension%40workspace%3Aconversational-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=b51c7a&locator=%40janhq%2Fconversational-extension%40workspace%3Aconversational-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/a9f5cc6b3e90eecef539a2036385dcdcb5988304a4c78d1bff4fe9e7e9910b319aa1efd92c395a0dabee98821a9bc274f45958a345441204f3dafbeec76ba658
+  checksum: 10c0/14c61c6f50f09da8202fec64a46e3b5b81927872ee25695da209a2cc1cf7638049c9cd981a0be0cd51034479dfd3d921b851b0fa2809a4823095977b41954e6e
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fengine-management-extension%40workspace%3Aengine-management-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=ff5479&locator=%40janhq%2Fengine-management-extension%40workspace%3Aengine-management-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=b51c7a&locator=%40janhq%2Fengine-management-extension%40workspace%3Aengine-management-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/a9f5cc6b3e90eecef539a2036385dcdcb5988304a4c78d1bff4fe9e7e9910b319aa1efd92c395a0dabee98821a9bc274f45958a345441204f3dafbeec76ba658
+  checksum: 10c0/14c61c6f50f09da8202fec64a46e3b5b81927872ee25695da209a2cc1cf7638049c9cd981a0be0cd51034479dfd3d921b851b0fa2809a4823095977b41954e6e
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fhardware-management-extension%40workspace%3Ahardware-management-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=ff5479&locator=%40janhq%2Fhardware-management-extension%40workspace%3Ahardware-management-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=b51c7a&locator=%40janhq%2Fhardware-management-extension%40workspace%3Ahardware-management-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/a9f5cc6b3e90eecef539a2036385dcdcb5988304a4c78d1bff4fe9e7e9910b319aa1efd92c395a0dabee98821a9bc274f45958a345441204f3dafbeec76ba658
+  checksum: 10c0/14c61c6f50f09da8202fec64a46e3b5b81927872ee25695da209a2cc1cf7638049c9cd981a0be0cd51034479dfd3d921b851b0fa2809a4823095977b41954e6e
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Finference-cortex-extension%40workspace%3Ainference-cortex-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=ff5479&locator=%40janhq%2Finference-cortex-extension%40workspace%3Ainference-cortex-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=b51c7a&locator=%40janhq%2Finference-cortex-extension%40workspace%3Ainference-cortex-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/a9f5cc6b3e90eecef539a2036385dcdcb5988304a4c78d1bff4fe9e7e9910b319aa1efd92c395a0dabee98821a9bc274f45958a345441204f3dafbeec76ba658
+  checksum: 10c0/14c61c6f50f09da8202fec64a46e3b5b81927872ee25695da209a2cc1cf7638049c9cd981a0be0cd51034479dfd3d921b851b0fa2809a4823095977b41954e6e
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fmodel-extension%40workspace%3Amodel-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=ff5479&locator=%40janhq%2Fmodel-extension%40workspace%3Amodel-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=b51c7a&locator=%40janhq%2Fmodel-extension%40workspace%3Amodel-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/a9f5cc6b3e90eecef539a2036385dcdcb5988304a4c78d1bff4fe9e7e9910b319aa1efd92c395a0dabee98821a9bc274f45958a345441204f3dafbeec76ba658
+  checksum: 10c0/14c61c6f50f09da8202fec64a46e3b5b81927872ee25695da209a2cc1cf7638049c9cd981a0be0cd51034479dfd3d921b851b0fa2809a4823095977b41954e6e
   languageName: node
   linkType: hard
 
@@ -755,6 +755,7 @@ __metadata:
     run-script-os: "npm:^1.1.6"
     ts-loader: "npm:^9.5.0"
     typescript: "npm:^5.3.3"
+    vitest: "npm:^3.0.6"
   languageName: unknown
   linkType: soft
 

--- a/joi/src/core/ScrollArea/styles.scss
+++ b/joi/src/core/ScrollArea/styles.scss
@@ -51,20 +51,3 @@
   flex-direction: column;
   height: 8px;
 }
-
-::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
-::-webkit-scrollbar-track,
-::-webkit-scrollbar-thumb {
-  background-clip: content-box;
-  border-radius: inherit;
-}
-::-webkit-scrollbar-track {
-  background: hsla(var(--scrollbar-tracker));
-}
-::-webkit-scrollbar-thumb {
-  background: hsla(var(--scrollbar-thumb));
-  border-radius: 20px;
-}

--- a/web/containers/Layout/index.tsx
+++ b/web/containers/Layout/index.tsx
@@ -42,6 +42,7 @@ import {
   productAnalyticAtom,
   productAnalyticPromptAtom,
   reduceTransparentAtom,
+  showScrollBarAtom,
 } from '@/helpers/atoms/Setting.atom'
 
 const BaseLayout = () => {
@@ -52,6 +53,7 @@ const BaseLayout = () => {
   const [productAnalyticPrompt, setProductAnalyticPrompt] = useAtom(
     productAnalyticPromptAtom
   )
+  const showScrollBar = useAtomValue(showScrollBarAtom)
   const [showProductAnalyticPrompt, setShowProductAnalyticPrompt] =
     useState(false)
 
@@ -150,7 +152,12 @@ const BaseLayout = () => {
       )}
     >
       <TopPanel />
-      <div className="relative top-9 flex h-[calc(100vh-(36px+36px))] w-screen">
+      <div
+        className={twMerge(
+          'relative top-9 flex h-[calc(100vh-(36px+36px))] w-screen',
+          showScrollBar && 'show-scroll-bar'
+        )}
+      >
         <RibbonPanel />
         <MainViewContainer />
         <LoadingModal />

--- a/web/containers/LeftPanelContainer/index.tsx
+++ b/web/containers/LeftPanelContainer/index.tsx
@@ -12,7 +12,10 @@ import { atom, useAtom, useAtomValue } from 'jotai'
 import { twMerge } from 'tailwind-merge'
 
 import { showLeftPanelAtom } from '@/helpers/atoms/App.atom'
-import { reduceTransparentAtom } from '@/helpers/atoms/Setting.atom'
+import {
+  reduceTransparentAtom,
+  showScrollBarAtom,
+} from '@/helpers/atoms/Setting.atom'
 
 type Props = PropsWithChildren
 
@@ -27,6 +30,7 @@ const LeftPanelContainer = ({ children }: Props) => {
   const [showLeftPanel, setShowLeftPanel] = useAtom(showLeftPanelAtom)
   const matches = useMediaQuery('(max-width: 880px)')
   const reduceTransparent = useAtomValue(reduceTransparentAtom)
+  const showScrollBar = useAtomValue(showScrollBarAtom)
 
   useClickOutside(
     () => matches && showLeftPanel && setShowLeftPanel(false),
@@ -101,7 +105,10 @@ const LeftPanelContainer = ({ children }: Props) => {
       style={{ width: showLeftPanel ? leftPanelWidth : 0 }}
       onMouseDown={(e) => isResizing && e.stopPropagation()}
     >
-      <ScrollArea className="h-full w-full">
+      <ScrollArea
+        type={showScrollBar ? 'always' : 'scroll'}
+        className="h-full w-full"
+      >
         {children}
         {showLeftPanel && !matches && (
           <Fragment>

--- a/web/containers/ListContainer/index.tsx
+++ b/web/containers/ListContainer/index.tsx
@@ -5,6 +5,7 @@ import { ScrollArea } from '@janhq/joi'
 import { useAtomValue } from 'jotai'
 
 import { activeThreadAtom } from '@/helpers/atoms/Thread.atom'
+import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
 
 const ListContainer = ({ children }: PropsWithChildren) => {
   const listRef = useRef<HTMLDivElement>(null)
@@ -12,6 +13,7 @@ const ListContainer = ({ children }: PropsWithChildren) => {
   const isUserManuallyScrollingUp = useRef(false)
   const activeThread = useAtomValue(activeThreadAtom)
   const prevActiveThread = useRef(activeThread)
+  const showScrollBar = useAtomValue(showScrollBarAtom)
 
   // Handle active thread changes
   useEffect(() => {
@@ -59,6 +61,7 @@ const ListContainer = ({ children }: PropsWithChildren) => {
 
   return (
     <ScrollArea
+      type={showScrollBar ? 'always' : 'scroll'}
       className="flex h-full w-full flex-col overflow-x-hidden"
       ref={listRef}
       onScroll={handleScroll}

--- a/web/containers/ListContainer/index.tsx
+++ b/web/containers/ListContainer/index.tsx
@@ -4,8 +4,8 @@ import { ScrollArea } from '@janhq/joi'
 
 import { useAtomValue } from 'jotai'
 
-import { activeThreadAtom } from '@/helpers/atoms/Thread.atom'
 import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
+import { activeThreadAtom } from '@/helpers/atoms/Thread.atom'
 
 const ListContainer = ({ children }: PropsWithChildren) => {
   const listRef = useRef<HTMLDivElement>(null)

--- a/web/containers/ModelDropdown/index.tsx
+++ b/web/containers/ModelDropdown/index.tsx
@@ -56,6 +56,7 @@ import {
   activeThreadAtom,
   setThreadModelParamsAtom,
 } from '@/helpers/atoms/Thread.atom'
+import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
 
 type Props = {
   chatInputMode?: boolean
@@ -74,6 +75,7 @@ const ModelDropdown = ({
   const [modelDropdownState, setModelDropdownState] = useAtom(
     modelDropdownStateAtom
   )
+  const showScrollBar = useAtomValue(showScrollBarAtom)
 
   const [searchFilter, setSearchFilter] = useState('local')
   const [searchText, setSearchText] = useState('')
@@ -384,7 +386,10 @@ const ModelDropdown = ({
               }
             />
           </div>
-          <ScrollArea className="h-[calc(100%-90px)] w-full">
+          <ScrollArea
+            type={showScrollBar ? 'always' : 'scroll'}
+            className="h-[calc(100%-90px)] w-full"
+          >
             {engineList
               .filter((e) => e.type === searchFilter)
               .filter(

--- a/web/containers/ModelDropdown/index.tsx
+++ b/web/containers/ModelDropdown/index.tsx
@@ -52,11 +52,11 @@ import {
   showEngineListModelAtom,
 } from '@/helpers/atoms/Model.atom'
 
+import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
 import {
   activeThreadAtom,
   setThreadModelParamsAtom,
 } from '@/helpers/atoms/Thread.atom'
-import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
 
 type Props = {
   chatInputMode?: boolean

--- a/web/containers/RightPanelContainer/index.tsx
+++ b/web/containers/RightPanelContainer/index.tsx
@@ -12,7 +12,10 @@ import { atom, useAtom, useAtomValue } from 'jotai'
 import { twMerge } from 'tailwind-merge'
 
 import { showRightPanelAtom } from '@/helpers/atoms/App.atom'
-import { reduceTransparentAtom } from '@/helpers/atoms/Setting.atom'
+import {
+  reduceTransparentAtom,
+  showScrollBarAtom,
+} from '@/helpers/atoms/Setting.atom'
 
 type Props = PropsWithChildren
 
@@ -28,6 +31,7 @@ const RightPanelContainer = ({ children }: Props) => {
     null
   )
   const reduceTransparent = useAtomValue(reduceTransparentAtom)
+  const showScrollBar = useAtomValue(showScrollBarAtom)
 
   const [showRightPanel, setShowRightPanel] = useAtom(showRightPanelAtom)
   const matches = useMediaQuery('(max-width: 880px)')
@@ -105,7 +109,10 @@ const RightPanelContainer = ({ children }: Props) => {
       style={{ width: showRightPanel ? rightPanelWidth : 0 }}
       onMouseDown={(e) => isResizing && e.preventDefault()}
     >
-      <ScrollArea className="h-full w-full">
+      <ScrollArea
+        type={showScrollBar ? 'always' : 'scroll'}
+        className="h-full w-full"
+      >
         {children}
         {showRightPanel && !matches && (
           <Fragment>

--- a/web/containers/ServerLogs/index.tsx
+++ b/web/containers/ServerLogs/index.tsx
@@ -14,6 +14,7 @@ import { useLogs } from '@/hooks/useLogs'
 import { usePath } from '@/hooks/usePath'
 
 import { serverEnabledAtom } from '@/helpers/atoms/LocalServer.atom'
+import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
 
 type ServerLogsProps = { limit?: number; withCopy?: boolean }
 
@@ -25,6 +26,7 @@ const ServerLogs = (props: ServerLogsProps) => {
   const listRef = useRef<HTMLDivElement>(null)
   const prevScrollTop = useRef(0)
   const isUserManuallyScrollingUp = useRef(false)
+  const showScrollBar = useAtomValue(showScrollBarAtom)
 
   const updateLogs = useCallback(
     () =>
@@ -136,6 +138,7 @@ const ServerLogs = (props: ServerLogsProps) => {
         )}
       </div>
       <ScrollArea
+        type={showScrollBar ? 'always' : 'scroll'}
         ref={listRef}
         className={twMerge(
           'h-[calc(100%-49px)] w-full p-4 py-0',

--- a/web/helpers/atoms/Setting.atom.ts
+++ b/web/helpers/atoms/Setting.atom.ts
@@ -11,6 +11,7 @@ export const janSettingScreenAtom = atom<SettingScreen[]>([])
 export const THEME = 'themeAppearance'
 export const REDUCE_TRANSPARENT = 'reduceTransparent'
 export const SPELL_CHECKING = 'spellChecking'
+export const SCROLL_BAR = 'scrollBar'
 export const PRODUCT_ANALYTIC = 'productAnalytic'
 export const PRODUCT_ANALYTIC_PROMPT = 'productAnalyticPrompt'
 export const THEME_DATA = 'themeData'
@@ -41,6 +42,12 @@ export const reduceTransparentAtom = atomWithStorage<boolean>(
 )
 export const spellCheckAtom = atomWithStorage<boolean>(
   SPELL_CHECKING,
+  false,
+  undefined,
+  { getOnInit: true }
+)
+export const showScrollBarAtom = atomWithStorage<boolean>(
+  SCROLL_BAR,
   false,
   undefined,
   { getOnInit: true }

--- a/web/screens/Hub/ModelPage/index.tsx
+++ b/web/screens/Hub/ModelPage/index.tsx
@@ -2,7 +2,7 @@ import Image from 'next/image'
 
 import { ModelSource } from '@janhq/core'
 import { Badge, Button, ScrollArea } from '@janhq/joi'
-import { useSetAtom } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 import {
   ArrowLeftIcon,
   DownloadIcon,
@@ -24,7 +24,10 @@ import { toGigabytes } from '@/utils/converter'
 import { extractModelName } from '@/utils/modelSource'
 
 import { mainViewStateAtom } from '@/helpers/atoms/App.atom'
-import { selectedSettingAtom } from '@/helpers/atoms/Setting.atom'
+import {
+  selectedSettingAtom,
+  showScrollBarAtom,
+} from '@/helpers/atoms/Setting.atom'
 
 type Props = {
   model: ModelSource
@@ -35,9 +38,14 @@ const ModelPage = ({ model, onGoBack }: Props) => {
   const setSelectedSetting = useSetAtom(selectedSettingAtom)
   const setMainViewState = useSetAtom(mainViewStateAtom)
   const { refreshingModels, refreshModels } = useRefreshModelList(model.id)
+  const showScrollBar = useAtomValue(showScrollBarAtom)
 
   return (
-    <ScrollArea data-testid="hub-container-test-id" className="h-full w-full">
+    <ScrollArea
+      type={showScrollBar ? 'always' : 'scroll'}
+      data-testid="hub-container-test-id"
+      className="h-full w-full"
+    >
       <div className="flex h-full w-full justify-center">
         <div className="flex w-full max-w-[800px] flex-col ">
           <div className="sticky top-0 flex h-12 items-center bg-[hsla(var(--app-bg))] px-4">

--- a/web/screens/Hub/index.tsx
+++ b/web/screens/Hub/index.tsx
@@ -51,8 +51,8 @@ import {
 } from '@/helpers/atoms/App.atom'
 import { modelDetailAtom } from '@/helpers/atoms/Model.atom'
 
-import { totalRamAtom } from '@/helpers/atoms/SystemBar.atom'
 import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
+import { totalRamAtom } from '@/helpers/atoms/SystemBar.atom'
 
 const sortMenus = [
   {

--- a/web/screens/Hub/index.tsx
+++ b/web/screens/Hub/index.tsx
@@ -52,6 +52,7 @@ import {
 import { modelDetailAtom } from '@/helpers/atoms/Model.atom'
 
 import { totalRamAtom } from '@/helpers/atoms/SystemBar.atom'
+import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
 
 const sortMenus = [
   {
@@ -94,6 +95,7 @@ const HubScreen = () => {
   const [selectedModel, setSelectedModel] = useState<ModelSource | undefined>(
     undefined
   )
+  const showScrollBar = useAtomValue(showScrollBarAtom)
   const [modelDetail, setModelDetail] = useAtom(modelDetailAtom)
   const setImportModelStage = useSetAtom(setImportModelStageAtom)
   const dropdownRef = useRef<HTMLDivElement>(null)
@@ -260,6 +262,7 @@ const HubScreen = () => {
       >
         {!selectedModel && (
           <ScrollArea
+            type={showScrollBar ? 'always' : 'scroll'}
             data-testid="hub-container-test-id"
             className="h-full w-full"
           >
@@ -311,7 +314,10 @@ const HubScreen = () => {
                           />
                         </div>
                         {hubBannerOption === 'gallery' && (
-                          <ScrollArea className="h-[350px] w-full">
+                          <ScrollArea
+                            type={showScrollBar ? 'always' : 'scroll'}
+                            className="h-[350px] w-full"
+                          >
                             {Array.from({ length: 30 }, (_, i) => i + 1).map(
                               (e) => {
                                 return (

--- a/web/screens/Settings/Advanced/ProxySettings/index.tsx
+++ b/web/screens/Settings/Advanced/ProxySettings/index.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useState } from 'react'
 
 import { Input, ScrollArea, Switch } from '@janhq/joi'
-import { useAtom } from 'jotai'
+import { useAtom, useAtomValue } from 'jotai'
 import { EyeIcon, EyeOffIcon, XIcon, ArrowLeftIcon } from 'lucide-react'
 import { useDebouncedCallback } from 'use-debounce'
 
@@ -18,6 +18,7 @@ import {
   proxyUsernameAtom,
   proxyPasswordAtom,
 } from '@/helpers/atoms/AppConfig.atom'
+import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
 
 const ProxySettings = ({ onBack }: { onBack: () => void }) => {
   const [proxy, setProxy] = useAtom(proxyAtom)
@@ -38,6 +39,7 @@ const ProxySettings = ({ onBack }: { onBack: () => void }) => {
   const [verifyPeerSSL, setVerifyPeerSSL] = useAtom(verifyPeerSslAtom)
   const [verifyHostSSL, setVerifyHostSSL] = useAtom(verifyHostSslAtom)
   const [showPassword, setShowPassword] = useState(false)
+  const showScrollBar = useAtomValue(showScrollBarAtom)
 
   const updatePullOptions = useDebouncedCallback(
     () => configurePullOptions(),
@@ -102,7 +104,10 @@ const ProxySettings = ({ onBack }: { onBack: () => void }) => {
   )
 
   return (
-    <ScrollArea className="h-full w-full">
+    <ScrollArea
+      type={showScrollBar ? 'always' : 'scroll'}
+      className="h-full w-full"
+    >
       {/* Header */}
       <div className="sticky top-0 z-10 flex h-12 items-center border-b border-[hsla(var(--app-border))] bg-[hsla(var(--app-bg))] px-4">
         <div className="flex items-center gap-2">

--- a/web/screens/Settings/Advanced/index.tsx
+++ b/web/screens/Settings/Advanced/index.tsx
@@ -29,6 +29,7 @@ import {
 import { ThreadModalAction } from '@/helpers/atoms/Thread.atom'
 
 import { modalActionThreadAtom } from '@/helpers/atoms/Thread.atom'
+import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
 
 /**
  * Advanced Settings Screen
@@ -38,6 +39,7 @@ const Advanced = ({ setSubdir }: { setSubdir: (subdir: string) => void }) => {
   const [experimentalEnabled, setExperimentalEnabled] = useAtom(
     experimentalFeatureEnabledAtom
   )
+  const showScrollBar = useAtomValue(showScrollBarAtom)
 
   const [proxyEnabled, setProxyEnabled] = useAtom(proxyEnabledAtom)
   const quickAskEnabled = useAtomValue(quickAskEnabledAtom)
@@ -94,7 +96,10 @@ const Advanced = ({ setSubdir }: { setSubdir: (subdir: string) => void }) => {
   }
 
   return (
-    <ScrollArea className="h-full w-full px-4">
+    <ScrollArea
+      type={showScrollBar ? 'always' : 'scroll'}
+      className="h-full w-full px-4"
+    >
       <div className="block w-full py-4">
         {/* Experimental */}
         <div className="flex w-full flex-row items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none">

--- a/web/screens/Settings/Advanced/index.tsx
+++ b/web/screens/Settings/Advanced/index.tsx
@@ -26,10 +26,10 @@ import {
   quickAskEnabledAtom,
 } from '@/helpers/atoms/AppConfig.atom'
 
+import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
 import { ThreadModalAction } from '@/helpers/atoms/Thread.atom'
 
 import { modalActionThreadAtom } from '@/helpers/atoms/Thread.atom'
-import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
 
 /**
  * Advanced Settings Screen

--- a/web/screens/Settings/Appearance/index.tsx
+++ b/web/screens/Settings/Appearance/index.tsx
@@ -14,6 +14,7 @@ import {
   chatWidthAtom,
   reduceTransparentAtom,
   selectedThemeIdAtom,
+  showScrollBarAtom,
   spellCheckAtom,
   themeDataAtom,
   themesOptionsAtom,
@@ -29,6 +30,7 @@ export default function AppearanceOptions() {
     reduceTransparentAtom
   )
   const [spellCheck, setSpellCheck] = useAtom(spellCheckAtom)
+  const [showScrollBar, setShowScrollBar] = useAtom(showScrollBarAtom)
   const [chatWidth, setChatWidth] = useAtom(chatWidthAtom)
 
   const chatWidthOption = [
@@ -191,6 +193,22 @@ export default function AppearanceOptions() {
           <Switch
             checked={spellCheck}
             onChange={(e) => setSpellCheck(e.target.checked)}
+          />
+        </div>
+      </div>
+      <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">
+        <div className="w-full space-y-1 lg:w-3/4">
+          <div className="flex gap-x-2">
+            <h6 className="font-semibold capitalize">Scrolling Bar</h6>
+          </div>
+          <p className=" font-medium leading-relaxed text-[hsla(var(--text-secondary))]">
+            Turn on to make scrolling bar visible across windows.
+          </p>
+        </div>
+        <div className="flex-shrink-0">
+          <Switch
+            checked={showScrollBar}
+            onChange={(e) => setShowScrollBar(e.target.checked)}
           />
         </div>
       </div>

--- a/web/screens/Settings/CoreExtensions/index.tsx
+++ b/web/screens/Settings/CoreExtensions/index.tsx
@@ -12,12 +12,14 @@ import { formatExtensionsName } from '@/utils/converter'
 
 import { extensionManager } from '@/extension'
 import Extension from '@/extension/Extension'
+import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
+import { useAtomValue } from 'jotai'
 
 const ExtensionCatalog = () => {
   const [coreActiveExtensions, setCoreActiveExtensions] = useState<Extension[]>(
     []
   )
-
+  const showScrollBar = useAtomValue(showScrollBarAtom)
   const [searchText, setSearchText] = useState('')
   const [showLoading, setShowLoading] = useState(false)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
@@ -103,7 +105,10 @@ const ExtensionCatalog = () => {
 
   return (
     <>
-      <ScrollArea className="h-full w-full">
+      <ScrollArea
+        type={showScrollBar ? 'always' : 'scroll'}
+        className="h-full w-full"
+      >
         <div className="flex w-full flex-col items-start justify-between gap-y-2 p-4 sm:flex-row">
           <div className="w-full sm:w-[300px]">
             <Input

--- a/web/screens/Settings/CoreExtensions/index.tsx
+++ b/web/screens/Settings/CoreExtensions/index.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect, useRef } from 'react'
 
 import { Button, ScrollArea, Badge, Input } from '@janhq/joi'
 
+import { useAtomValue } from 'jotai'
 import { SearchIcon } from 'lucide-react'
 import { Marked, Renderer } from 'marked'
 
@@ -13,7 +14,6 @@ import { formatExtensionsName } from '@/utils/converter'
 import { extensionManager } from '@/extension'
 import Extension from '@/extension/Extension'
 import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
-import { useAtomValue } from 'jotai'
 
 const ExtensionCatalog = () => {
   const [coreActiveExtensions, setCoreActiveExtensions] = useState<Extension[]>(

--- a/web/screens/Settings/Engines/LocalEngineSettings.tsx
+++ b/web/screens/Settings/Engines/LocalEngineSettings.tsx
@@ -9,7 +9,7 @@ import {
 } from '@janhq/core'
 import { Button, ScrollArea, Badge, Select, Progress } from '@janhq/joi'
 
-import { useAtom } from 'jotai'
+import { useAtom, useAtomValue } from 'jotai'
 import { twMerge } from 'tailwind-merge'
 
 import { useActiveModel } from '@/hooks/useActiveModel'
@@ -30,6 +30,7 @@ import ExtensionSetting from '../ExtensionSetting'
 import DeleteEngineVariant from './DeleteEngineVariant'
 
 import { LocalEngineDefaultVariantAtom } from '@/helpers/atoms/App.atom'
+import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
 const os = () => {
   switch (PLATFORM) {
     case 'win32':
@@ -53,6 +54,7 @@ const LocalEngineSettings = ({ engine }: { engine: InferenceEngine }) => {
     defaultEngineVariant?.version as string,
     os()
   )
+  const showScrollBar = useAtomValue(showScrollBarAtom)
   const [installingEngines, setInstallingEngines] = useState<
     Map<string, number>
   >(new Map())
@@ -169,7 +171,10 @@ const LocalEngineSettings = ({ engine }: { engine: InferenceEngine }) => {
   }
 
   return (
-    <ScrollArea className="h-full w-full">
+    <ScrollArea
+      type={showScrollBar ? 'always' : 'scroll'}
+      className="h-full w-full"
+    >
       <div className="block w-full px-4">
         <div className="mb-3 mt-4 border-b border-[hsla(var(--app-border))] pb-4">
           <div className="flex w-full flex-col items-start justify-between sm:flex-row">

--- a/web/screens/Settings/Engines/RemoteEngineSettings.tsx
+++ b/web/screens/Settings/Engines/RemoteEngineSettings.tsx
@@ -49,6 +49,7 @@ import {
   selectedModelAtom,
 } from '@/helpers/atoms/Model.atom'
 import { threadsAtom } from '@/helpers/atoms/Thread.atom'
+import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
 
 const RemoteEngineSettings = ({
   engine: name,
@@ -64,6 +65,7 @@ const RemoteEngineSettings = ({
   const customEngineLogo = getLogoEngine(name)
   const threads = useAtomValue(threadsAtom)
   const { refreshingModels, refreshModels } = useRefreshModelList(name)
+  const showScrollBar = useAtomValue(showScrollBarAtom)
 
   const engine =
     engines &&
@@ -150,7 +152,10 @@ const RemoteEngineSettings = ({
   if (!engine) return null
 
   return (
-    <ScrollArea className="h-full w-full">
+    <ScrollArea
+      type={showScrollBar ? 'always' : 'scroll'}
+      className="h-full w-full"
+    >
       <div className="block w-full px-4">
         <div className="mb-3 mt-4 border-b border-[hsla(var(--app-border))] pb-4">
           <div className="flex w-full flex-col items-start justify-between sm:flex-row">

--- a/web/screens/Settings/Engines/RemoteEngineSettings.tsx
+++ b/web/screens/Settings/Engines/RemoteEngineSettings.tsx
@@ -48,8 +48,8 @@ import {
   downloadedModelsAtom,
   selectedModelAtom,
 } from '@/helpers/atoms/Model.atom'
-import { threadsAtom } from '@/helpers/atoms/Thread.atom'
 import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
+import { threadsAtom } from '@/helpers/atoms/Thread.atom'
 
 const RemoteEngineSettings = ({
   engine: name,

--- a/web/screens/Settings/Engines/index.tsx
+++ b/web/screens/Settings/Engines/index.tsx
@@ -10,12 +10,18 @@ import { isLocalEngine } from '@/utils/modelEngine'
 import LocalEngineItems from './LocalEngineItem'
 import ModalAddRemoteEngine from './ModalAddRemoteEngine'
 import RemoteEngineItems from './RemoteEngineItem'
+import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
+import { useAtomValue } from 'jotai'
 
 const Engines = () => {
   const { engines } = useGetEngines()
+  const showScrollBar = useAtomValue(showScrollBarAtom)
 
   return (
-    <ScrollArea className="h-full w-full">
+    <ScrollArea
+      type={showScrollBar ? 'always' : 'scroll'}
+      className="h-full w-full"
+    >
       <div className="block w-full px-4">
         <div className="mb-3 mt-4 pb-4">
           <h6 className="text-xs text-[hsla(var(--text-secondary))]">

--- a/web/screens/Settings/Engines/index.tsx
+++ b/web/screens/Settings/Engines/index.tsx
@@ -3,6 +3,8 @@ import React from 'react'
 import { InferenceEngine } from '@janhq/core'
 import { ScrollArea } from '@janhq/joi'
 
+import { useAtomValue } from 'jotai'
+
 import { useGetEngines } from '@/hooks/useEngineManagement'
 
 import { isLocalEngine } from '@/utils/modelEngine'
@@ -10,8 +12,8 @@ import { isLocalEngine } from '@/utils/modelEngine'
 import LocalEngineItems from './LocalEngineItem'
 import ModalAddRemoteEngine from './ModalAddRemoteEngine'
 import RemoteEngineItems from './RemoteEngineItem'
+
 import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
-import { useAtomValue } from 'jotai'
 
 const Engines = () => {
   const { engines } = useGetEngines()

--- a/web/screens/Settings/Hardware/index.tsx
+++ b/web/screens/Settings/Hardware/index.tsx
@@ -29,6 +29,7 @@ import {
   usedRamAtom,
   gpusAtom,
 } from '@/helpers/atoms/SystemBar.atom'
+import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
 
 const orderGpusAtom = atomWithStorage<any>('orderGpus', [], undefined, {
   getOnInit: true,
@@ -44,7 +45,7 @@ const Hardware = () => {
   const totalRam = useAtomValue(totalRamAtom)
   const usedRam = useAtomValue(usedRamAtom)
   const ramUtilitized = useAtomValue(ramUtilitizedAtom)
-
+  const showScrollBar = useAtomValue(showScrollBarAtom)
   const [gpus, setGpus] = useAtom(gpusAtom)
 
   const [orderGpus, setOrderGpus] = useAtom(orderGpusAtom)
@@ -133,7 +134,10 @@ const Hardware = () => {
   }, [hardware?.gpus, setGpus])
 
   return (
-    <ScrollArea className="h-full w-full px-4">
+    <ScrollArea
+      type={showScrollBar ? 'always' : 'scroll'}
+      className="h-full w-full px-4"
+    >
       <div className="block w-full py-4">
         {/* CPU */}
         <div className="flex w-full flex-col items-start justify-between gap-4 border-b border-[hsla(var(--app-border))] py-4 first:pt-0 last:border-none sm:flex-row">

--- a/web/screens/Settings/Hardware/index.tsx
+++ b/web/screens/Settings/Hardware/index.tsx
@@ -22,6 +22,7 @@ import { toGigabytes } from '@/utils/converter'
 
 import { utilizedMemory } from '@/utils/memory'
 
+import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
 import {
   cpuUsageAtom,
   ramUtilitizedAtom,
@@ -29,7 +30,6 @@ import {
   usedRamAtom,
   gpusAtom,
 } from '@/helpers/atoms/SystemBar.atom'
-import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
 
 const orderGpusAtom = atomWithStorage<any>('orderGpus', [], undefined, {
   getOnInit: true,

--- a/web/screens/Settings/Hotkeys/index.tsx
+++ b/web/screens/Settings/Hotkeys/index.tsx
@@ -1,6 +1,7 @@
-import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
 import { ScrollArea, Badge } from '@janhq/joi'
 import { useAtomValue } from 'jotai'
+
+import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
 
 const availableHotkeys = [
   {

--- a/web/screens/Settings/Hotkeys/index.tsx
+++ b/web/screens/Settings/Hotkeys/index.tsx
@@ -1,4 +1,6 @@
+import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
 import { ScrollArea, Badge } from '@janhq/joi'
+import { useAtomValue } from 'jotai'
 
 const availableHotkeys = [
   {
@@ -42,8 +44,12 @@ const availableHotkeys = [
 ]
 
 const Hotkeys = () => {
+  const showScrollBar = useAtomValue(showScrollBarAtom)
   return (
-    <ScrollArea className="h-full w-full p-4">
+    <ScrollArea
+      type={showScrollBar ? 'always' : 'scroll'}
+      className="h-full w-full p-4"
+    >
       <div className="mb-2 flex flex-col items-center justify-center gap-2">
         <div className="hidden w-full gap-x-4 border-b border-[hsla(var(--app-border))] pb-2 sm:flex">
           <div className="w-1/2 pb-2">

--- a/web/screens/Settings/MyModels/index.tsx
+++ b/web/screens/Settings/MyModels/index.tsx
@@ -40,6 +40,7 @@ import {
   downloadedModelsAtom,
   showEngineListModelAtom,
 } from '@/helpers/atoms/Model.atom'
+import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
 
 const MyModels = () => {
   const downloadedModels = useAtomValue(downloadedModelsAtom)
@@ -49,6 +50,7 @@ const MyModels = () => {
   const [showEngineListModel, setShowEngineListModel] = useAtom(
     showEngineListModelAtom
   )
+  const showScrollBar = useAtomValue(showScrollBarAtom)
 
   const { engines } = useGetEngines()
 
@@ -124,7 +126,10 @@ const MyModels = () => {
 
   return (
     <div {...getRootProps()} className="h-full w-full">
-      <ScrollArea className="h-full w-full">
+      <ScrollArea
+        type={showScrollBar ? 'always' : 'scroll'}
+        className="h-full w-full"
+      >
         {isDragActive && (
           <div className="absolute z-50 mx-auto h-full w-full bg-[hsla(var(--app-bg))]/50 p-8 backdrop-blur-lg">
             <div

--- a/web/screens/Settings/Privacy/index.tsx
+++ b/web/screens/Settings/Privacy/index.tsx
@@ -10,7 +10,10 @@ import { toaster } from '@/containers/Toast'
 import { usePath } from '@/hooks/usePath'
 
 import { janDataFolderPathAtom } from '@/helpers/atoms/AppConfig.atom'
-import { productAnalyticAtom } from '@/helpers/atoms/Setting.atom'
+import {
+  productAnalyticAtom,
+  showScrollBarAtom,
+} from '@/helpers/atoms/Setting.atom'
 
 const Privacy = () => {
   /**
@@ -30,13 +33,16 @@ const Privacy = () => {
       type: 'success',
     })
   }
-
+  const showScrollBar = useAtomValue(showScrollBarAtom)
   const janDataFolderPath = useAtomValue(janDataFolderPathAtom)
   const { onRevealInFinder } = usePath()
   const [productAnalytic, setProductAnalytic] = useAtom(productAnalyticAtom)
 
   return (
-    <ScrollArea className="h-full w-full px-4">
+    <ScrollArea
+      type={showScrollBar ? 'always' : 'scroll'}
+      className="h-full w-full px-4"
+    >
       <div className="mb-4 mt-8 rounded-xl bg-[hsla(var(--tertiary-bg))] px-4 py-2 text-[hsla(var(--text-secondary))]">
         <p>
           We prioritize your control over your data. Learn more about our&nbsp;

--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/OnDeviceStarterScreen/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/OnDeviceStarterScreen/index.tsx
@@ -39,7 +39,10 @@ import {
   configuredModelsAtom,
   getDownloadingModelAtom,
 } from '@/helpers/atoms/Model.atom'
-import { selectedSettingAtom } from '@/helpers/atoms/Setting.atom'
+import {
+  selectedSettingAtom,
+  showScrollBarAtom,
+} from '@/helpers/atoms/Setting.atom'
 
 type Props = {
   isShowStarterScreen?: boolean
@@ -53,6 +56,7 @@ const OnDeviceStarterScreen = ({ isShowStarterScreen }: Props) => {
   const downloadStates = useAtomValue(modelDownloadStateAtom)
   const setSelectedSetting = useSetAtom(selectedSettingAtom)
   const { engines } = useGetEngines()
+  const showScrollBar = useAtomValue(showScrollBarAtom)
 
   const configuredModels = useAtomValue(configuredModelsAtom)
   const setMainViewState = useSetAtom(mainViewStateAtom)
@@ -113,6 +117,7 @@ const OnDeviceStarterScreen = ({ isShowStarterScreen }: Props) => {
   return (
     <CenterPanelContainer isShowStarterScreen={isShowStarterScreen}>
       <ScrollArea
+        type={showScrollBar ? 'always' : 'scroll'}
         className="flex h-full w-full items-center"
         data-testid="onboard-screen"
       >

--- a/web/styles/base/global.scss
+++ b/web/styles/base/global.scss
@@ -33,6 +33,7 @@
   }
 
   input[type='number'] {
+    appearance: textfield;
     -moz-appearance: textfield;
   }
 
@@ -40,5 +41,24 @@
   input::-webkit-inner-spin-button {
     -webkit-appearance: none;
     margin: 0;
+  }
+}
+
+.show-scroll-bar {
+  ::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+  ::-webkit-scrollbar-track,
+  ::-webkit-scrollbar-thumb {
+    background-clip: content-box;
+    border-radius: inherit;
+  }
+  ::-webkit-scrollbar-track {
+    background: hsla(var(--scrollbar-tracker));
+  }
+  ::-webkit-scrollbar-thumb {
+    background: hsla(var(--scrollbar-thumb));
+    border-radius: 20px;
   }
 }


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces a new feature to control the visibility of scrollbars throughout the application. It includes the addition of a `showScrollBarAtom` state and updates several components to use this state to conditionally display scrollbars. The most important changes are summarized below:

### Addition of `showScrollBarAtom`

* [`web/helpers/atoms/Setting.atom.ts`](diffhunk://#diff-fe970dc673b247de554e793d3e1a453f1456278107ae53a390229595621c4384R49-R54): Introduced the `showScrollBarAtom` to manage the scrollbar visibility state.

### Integration of `showScrollBarAtom` in Components

* [`web/containers/Layout/index.tsx`](diffhunk://#diff-14ae8afe09456109846de9e991341105e0d570a68d771860be34c3626c438f59R45): Added `showScrollBarAtom` and updated the layout to conditionally apply a CSS class for showing scrollbars. [[1]](diffhunk://#diff-14ae8afe09456109846de9e991341105e0d570a68d771860be34c3626c438f59R45) [[2]](diffhunk://#diff-14ae8afe09456109846de9e991341105e0d570a68d771860be34c3626c438f59R56) [[3]](diffhunk://#diff-14ae8afe09456109846de9e991341105e0d570a68d771860be34c3626c438f59L153-R160)
* [`web/containers/LeftPanelContainer/index.tsx`](diffhunk://#diff-4636603cad9d7b8529bfa8d04775cbc2a10dd993284bdfbc4c545ce91d168cd2L15-R18): Integrated `showScrollBarAtom` to conditionally set the `type` attribute of `ScrollArea` components. [[1]](diffhunk://#diff-4636603cad9d7b8529bfa8d04775cbc2a10dd993284bdfbc4c545ce91d168cd2L15-R18) [[2]](diffhunk://#diff-4636603cad9d7b8529bfa8d04775cbc2a10dd993284bdfbc4c545ce91d168cd2R33) [[3]](diffhunk://#diff-4636603cad9d7b8529bfa8d04775cbc2a10dd993284bdfbc4c545ce91d168cd2L104-R111)
* [`web/containers/RightPanelContainer/index.tsx`](diffhunk://#diff-d6c25a2264a24b9f6ab739745350aa9a93a1046d476864e84ada4e5245e18d4cL15-R18): Updated to use `showScrollBarAtom` for conditional scrollbar visibility. [[1]](diffhunk://#diff-d6c25a2264a24b9f6ab739745350aa9a93a1046d476864e84ada4e5245e18d4cL15-R18) [[2]](diffhunk://#diff-d6c25a2264a24b9f6ab739745350aa9a93a1046d476864e84ada4e5245e18d4cR34) [[3]](diffhunk://#diff-d6c25a2264a24b9f6ab739745350aa9a93a1046d476864e84ada4e5245e18d4cL108-R115)
* [`web/screens/Hub/index.tsx`](diffhunk://#diff-4acda36130f9ceb893281d73ffa88c92378b2a79c7b9a6c1b0704300cb2dd5d1R55): Modified to include `showScrollBarAtom` for conditional scrollbar rendering in multiple `ScrollArea` components. [[1]](diffhunk://#diff-4acda36130f9ceb893281d73ffa88c92378b2a79c7b9a6c1b0704300cb2dd5d1R55) [[2]](diffhunk://#diff-4acda36130f9ceb893281d73ffa88c92378b2a79c7b9a6c1b0704300cb2dd5d1R98) [[3]](diffhunk://#diff-4acda36130f9ceb893281d73ffa88c92378b2a79c7b9a6c1b0704300cb2dd5d1R266) [[4]](diffhunk://#diff-4acda36130f9ceb893281d73ffa88c92378b2a79c7b9a6c1b0704300cb2dd5d1L315-R321)

### Removal of Custom Scrollbar Styles

* [`joi/src/core/ScrollArea/styles.scss`](diffhunk://#diff-8c01d0838921ef8b109afbed8503e6f5e74c0fc153e9cc42b84ce28c522771e6L54-L70): Removed custom scrollbar styles to rely on the new conditional scrollbar visibility feature.

## Fixes Issues

- [x] Turn off by default 
- [x] When turned off, only show the scroll component when scrolling
- [x] When turned on, it always shows the scrolling component

https://github.com/user-attachments/assets/abecd1cd-e6a3-45fd-a61a-b03ac69b9e77


- Closes #4218 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
