### PR TITLE
fix: flow app updater manual check from native menu

### DIFF
--- a/electron/handlers/update.ts
+++ b/electron/handlers/update.ts
@@ -25,14 +25,6 @@ export function handleAppUpdates() {
     )
   })
 
-  /* New Update Not Available */
-  autoUpdater.on('update-not-available', async (_info: UpdateInfo) => {
-    windowManager.mainWindow?.webContents.send(
-      AppEvent.onAppUpdateNotAvailable,
-      {}
-    )
-  })
-
   /* App Update Completion Message */
   autoUpdater.on('update-downloaded', async (_info: UpdateDownloadedEvent) => {
     windowManager.mainWindow?.webContents.send(

--- a/electron/utils/menu.ts
+++ b/electron/utils/menu.ts
@@ -28,9 +28,10 @@ const template: (Electron.MenuItemConstructorOptions | Electron.MenuItem)[] = [
                 !updateCheckResult?.updateInfo ||
                 updateCheckResult?.updateInfo.version === app.getVersion()
               ) {
-                dialog.showMessageBox({
-                  message: `No updates available.`,
-                })
+                windowManager.mainWindow?.webContents.send(
+                  AppEvent.onAppUpdateNotAvailable,
+                  {}
+                )
                 return
               }
             })


### PR DESCRIPTION
## Describe Your Changes

This pull request includes changes to the `electron` module, specifically focusing on handling app updates and user notifications. The most important changes include the removal of an event listener for updates not being available and the modification of the menu update check to notify the main window instead of showing a dialog box.

### App Update Handling:

* Removed the event listener for `update-not-available` in `handleAppUpdates` function, which previously sent a message to the main window when no updates were available. (`electron/handlers/update.ts`)

### User Notification:

* Modified the menu update check to send a message to the main window when no updates are available, replacing the previous behavior of showing a message box. (`electron/utils/menu.ts`)

## Fixes Issues

- Closes #1471 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
