### PR TITLE
chore: correct channel name to ask for help

### DIFF
--- a/docs/src/pages/docs/troubleshooting.mdx
+++ b/docs/src/pages/docs/troubleshooting.mdx
@@ -393,7 +393,7 @@ The "Unexpected token" error usually relates to OpenAI API authentication or reg
 ## Need Further Support?
 If you can't find what you need in our troubleshooting guide, feel free reach out to us for extra help:
 - **Copy** your [app logs](/docs/troubleshooting#how-to-get-error-logs)
-- Go to our [Discord](https://discord.com/invite/FTk2MvZwJH) & send it to **#🆘|get-help** channel for further support.
+- Go to our [Discord](https://discord.com/invite/FTk2MvZwJH) & send it to **#🆘|jan-help** channel for further support.
 
 
 <Callout type="info">


### PR DESCRIPTION
- Update Jan doc to reflect the corresponding channel to ask for help

<img width="1429" alt="image" src="https://github.com/user-attachments/assets/088ec441-eb0c-4dd9-9439-fda73285cf45" />
