### PR TITLE
chore: update hub UI 

### DIFF
--- a/web/containers/ModelDownloadButton/index.tsx
+++ b/web/containers/ModelDownloadButton/index.tsx
@@ -3,6 +3,8 @@ import { useCallback, useMemo } from 'react'
 import { Button, Tooltip } from '@janhq/joi'
 import { useAtomValue, useSetAtom } from 'jotai'
 
+import { twMerge } from 'tailwind-merge'
+
 import { MainViewState } from '@/constants/screens'
 
 import { useCreateNewThread } from '@/hooks/useCreateNewThread'
@@ -17,7 +19,6 @@ import {
   downloadedModelsAtom,
   getDownloadingModelAtom,
 } from '@/helpers/atoms/Model.atom'
-import { twMerge } from 'tailwind-merge'
 
 interface Props {
   id: string

--- a/web/containers/ModelDownloadButton/index.tsx
+++ b/web/containers/ModelDownloadButton/index.tsx
@@ -17,13 +17,15 @@ import {
   downloadedModelsAtom,
   getDownloadingModelAtom,
 } from '@/helpers/atoms/Model.atom'
+import { twMerge } from 'tailwind-merge'
 
 interface Props {
   id: string
   theme?: 'primary' | 'ghost' | 'icon' | 'destructive' | undefined
   variant?: 'solid' | 'soft' | 'outline' | undefined
+  className?: string
 }
-const ModelDownloadButton = ({ id, theme, variant }: Props) => {
+const ModelDownloadButton = ({ id, theme, variant, className }: Props) => {
   const { downloadModel } = useDownloadModel()
   const downloadingModels = useAtomValue(getDownloadingModelAtom)
   const downloadedModels = useAtomValue(downloadedModelsAtom)
@@ -59,7 +61,8 @@ const ModelDownloadButton = ({ id, theme, variant }: Props) => {
   const defaultButton = (
     <Button
       theme={theme ? theme : 'primary'}
-      variant={variant ? variant : 'solid'}
+      // variant={variant ? variant : 'solid'}
+      className={twMerge('min-w-[70px]', className)}
       onClick={(e) => {
         e.stopPropagation()
         onDownloadClick()

--- a/web/screens/Hub/ModelList/ModelHeader/index.tsx
+++ b/web/screens/Hub/ModelList/ModelHeader/index.tsx
@@ -1,11 +1,12 @@
 import { useCallback, useMemo } from 'react'
 
-import { ModelSource } from '@janhq/core'
+import { InferenceEngine, ModelSource } from '@janhq/core'
 
 import { Button, Tooltip, Dropdown, Badge } from '@janhq/joi'
 
 import { useAtomValue, useSetAtom } from 'jotai'
 import { ChevronDownIcon } from 'lucide-react'
+import Image from 'next/image'
 
 import ModalCancelDownload from '@/containers/ModalCancelDownload'
 
@@ -35,6 +36,8 @@ import {
   nvidiaTotalVramAtom,
   totalRamAtom,
 } from '@/helpers/atoms/SystemBar.atom'
+import { getLogoEngine } from '@/utils/modelEngine'
+import { twMerge } from 'tailwind-merge'
 
 type Props = {
   model: ModelSource
@@ -167,9 +170,23 @@ const ModelItemHeader = ({ model, onSelectedModel }: Props) => {
       <div className="flex items-center justify-between py-2">
         <div className="group flex cursor-pointer items-center gap-2">
           <span
-            className="line-clamp-1 text-base font-medium capitalize group-hover:text-blue-500 group-hover:underline"
+            className={twMerge(
+              'line-clamp-1 text-base font-medium capitalize group-hover:text-blue-500 group-hover:underline',
+              model.type === 'cloud' && 'flex items-center gap-x-2'
+            )}
             onClick={onSelectedModel}
           >
+            {model.type === 'cloud' && (
+              <>
+                <Image
+                  className="h-6 w-6 flex-shrink-0"
+                  width={48}
+                  height={48}
+                  src={getLogoEngine(model.id as InferenceEngine) || ''}
+                  alt="logo"
+                />
+              </>
+            )}
             {extractModelName(model.metadata?.id)}
           </span>
         </div>

--- a/web/screens/Hub/ModelList/ModelHeader/index.tsx
+++ b/web/screens/Hub/ModelList/ModelHeader/index.tsx
@@ -1,12 +1,15 @@
 import { useCallback, useMemo } from 'react'
 
+import Image from 'next/image'
+
 import { InferenceEngine, ModelSource } from '@janhq/core'
 
 import { Button, Tooltip, Dropdown, Badge } from '@janhq/joi'
 
 import { useAtomValue, useSetAtom } from 'jotai'
 import { ChevronDownIcon } from 'lucide-react'
-import Image from 'next/image'
+
+import { twMerge } from 'tailwind-merge'
 
 import ModalCancelDownload from '@/containers/ModalCancelDownload'
 
@@ -19,6 +22,7 @@ import { useSettings } from '@/hooks/useSettings'
 
 import { toGigabytes } from '@/utils/converter'
 
+import { getLogoEngine } from '@/utils/modelEngine'
 import { extractModelName } from '@/utils/modelSource'
 
 import { fuzzySearch } from '@/utils/search'
@@ -36,8 +40,6 @@ import {
   nvidiaTotalVramAtom,
   totalRamAtom,
 } from '@/helpers/atoms/SystemBar.atom'
-import { getLogoEngine } from '@/utils/modelEngine'
-import { twMerge } from 'tailwind-merge'
 
 type Props = {
   model: ModelSource

--- a/web/screens/Hub/ModelPage/index.tsx
+++ b/web/screens/Hub/ModelPage/index.tsx
@@ -14,6 +14,8 @@ import {
 import Spinner from '@/containers/Loader/Spinner'
 import ModelDownloadButton from '@/containers/ModelDownloadButton'
 
+import ModelLabel from '@/containers/ModelLabel'
+
 import { MainViewState } from '@/constants/screens'
 
 import { useRefreshModelList } from '@/hooks/useEngineManagement'
@@ -28,7 +30,6 @@ import {
   selectedSettingAtom,
   showScrollBarAtom,
 } from '@/helpers/atoms/Setting.atom'
-import ModelLabel from '@/containers/ModelLabel'
 
 type Props = {
   model: ModelSource

--- a/web/screens/Hub/ModelPage/index.tsx
+++ b/web/screens/Hub/ModelPage/index.tsx
@@ -28,6 +28,7 @@ import {
   selectedSettingAtom,
   showScrollBarAtom,
 } from '@/helpers/atoms/Setting.atom'
+import ModelLabel from '@/containers/ModelLabel'
 
 type Props = {
   model: ModelSource
@@ -146,6 +147,7 @@ const ModelPage = ({ model, onGoBack }: Props) => {
                       </th>
                       {model.type !== 'cloud' && (
                         <>
+                          <th></th>
                           <th className="hidden max-w-32 px-6 py-3 text-left text-sm font-semibold sm:table-cell">
                             Format
                           </th>
@@ -201,6 +203,9 @@ const ModelPage = ({ model, onGoBack }: Props) => {
                           </td>
                           {model.type !== 'cloud' && (
                             <>
+                              <td>
+                                <ModelLabel size={item.size} compact />
+                              </td>
                               <td className="hidden px-6 py-4 sm:table-cell">
                                 GGUF
                               </td>
@@ -215,7 +220,11 @@ const ModelPage = ({ model, onGoBack }: Props) => {
                               <ModelDownloadButton
                                 id={item.id}
                                 theme={i === 0 ? 'primary' : 'ghost'}
-                                variant={i === 0 ? 'solid' : 'outline'}
+                                className={
+                                  i !== 0
+                                    ? '!bg-[hsla(var(--secondary-bg))]'
+                                    : ''
+                                }
                               />
                             )}
                           </td>

--- a/web/screens/Hub/index.tsx
+++ b/web/screens/Hub/index.tsx
@@ -79,7 +79,7 @@ const filterOptions = [
   },
 ]
 
-const hubCompatibleAtom = atom(false)
+const hubCompatibleAtom = atom(true)
 
 const HubScreen = () => {
   const { sources } = useGetModelSources()
@@ -450,7 +450,7 @@ const HubScreen = () => {
               {/* Filters and Model List */}
               <div className="ml-4 mt-8 flex h-full w-full flex-row">
                 {/* Filters */}
-                <div className="sticky top-10 mr-6 hidden h-full w-[200px] shrink-0 flex-col md:flex">
+                <div className="sticky top-8 mr-6 hidden h-full w-[200px] shrink-0 flex-col md:flex">
                   <div className="flex w-full flex-row justify-between">
                     Filters
                     <button

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/MarkdownTextMessage.tsx
@@ -107,7 +107,6 @@ export const MarkdownTextMessage = memo(
                       'code-block',
                       'group/item',
                       'relative',
-                      'my-4',
                       'overflow-auto',
                     ],
                   },

--- a/web/styles/components/code-block.scss
+++ b/web/styles/components/code-block.scss
@@ -60,7 +60,6 @@
   border-bottom-left-radius: 0.4rem;
   border-bottom-right-radius: 0.4rem;
   color: #f8f8f2;
-  background: hsla(var(--app-code-block)) !important;
 }
 
 pre {

--- a/web/styles/components/marked.scss
+++ b/web/styles/components/marked.scss
@@ -51,6 +51,8 @@
   overflow-x: auto;
   font-size: 0.9rem;
   margin: 1rem 0;
+  padding: 16px;
+  background-color: hsla(var(--app-code-block)) !important;
 }
 
 /* Tables */

--- a/web/styles/components/message.scss
+++ b/web/styles/components/message.scss
@@ -28,4 +28,10 @@
   blockquote {
     @apply inline-flex flex-col border-s-4 border-[hsla(var(--primary-bg))] bg-[hsla(var(--primary-bg-soft))] px-4 py-2;
   }
+
+  .markdown-content pre {
+    margin-top: 0 !important;
+    border-top-left-radius: 0 !important;
+    border-top-right-radius: 0 !important;
+  }
 }


### PR DESCRIPTION
## Describe Your Changes

This pull request includes several changes to improve the styling and functionality of the `ModelDownloadButton`, `ModelHeader`, `ModelPage`, and `HubScreen` components. The most important changes include the addition of the `twMerge` utility for merging Tailwind CSS classes, the introduction of the `className` prop in `ModelDownloadButton`, and updates to the `ModelPage` component to include a new `ModelLabel` component.

Styling improvements:

* [`web/containers/ModelDownloadButton/index.tsx`](diffhunk://#diff-cb17fb15f4023177e3e5c8ade2c6f9f289a7ad0d48398b025c8a83ef41c25b58R6-R7): Added `twMerge` utility for merging Tailwind CSS classes and introduced the `className` prop in `ModelDownloadButton` to allow custom styling. [[1]](diffhunk://#diff-cb17fb15f4023177e3e5c8ade2c6f9f289a7ad0d48398b025c8a83ef41c25b58R6-R7) [[2]](diffhunk://#diff-cb17fb15f4023177e3e5c8ade2c6f9f289a7ad0d48398b025c8a83ef41c25b58R27-R29) [[3]](diffhunk://#diff-cb17fb15f4023177e3e5c8ade2c6f9f289a7ad0d48398b025c8a83ef41c25b58L62-R66)
* [`web/screens/Hub/ModelList/ModelHeader/index.tsx`](diffhunk://#diff-c12507244d72ba8a5e975aa7ed41cdc8d996e3030a5248237aa84dd5f9da02a4L3-R13): Added `twMerge` utility and updated the `ModelItemHeader` component to conditionally render an image for cloud models. [[1]](diffhunk://#diff-c12507244d72ba8a5e975aa7ed41cdc8d996e3030a5248237aa84dd5f9da02a4L3-R13) [[2]](diffhunk://#diff-c12507244d72ba8a5e975aa7ed41cdc8d996e3030a5248237aa84dd5f9da02a4L170-R191)

Component enhancements:

* [`web/screens/Hub/ModelPage/index.tsx`](diffhunk://#diff-02e81029a62de211929358113c60a101efd0bd0f7ce9b2237fa4cfabecba0a21R17-R18): Introduced the `ModelLabel` component and updated the `ModelPage` component to include it, along with additional styling changes for the `ModelDownloadButton`. [[1]](diffhunk://#diff-02e81029a62de211929358113c60a101efd0bd0f7ce9b2237fa4cfabecba0a21R17-R18) [[2]](diffhunk://#diff-02e81029a62de211929358113c60a101efd0bd0f7ce9b2237fa4cfabecba0a21R151) [[3]](diffhunk://#diff-02e81029a62de211929358113c60a101efd0bd0f7ce9b2237fa4cfabecba0a21R207-R209) [[4]](diffhunk://#diff-02e81029a62de211929358113c60a101efd0bd0f7ce9b2237fa4cfabecba0a21L218-R228)

Functional changes:

* [`web/screens/Hub/index.tsx`](diffhunk://#diff-4acda36130f9ceb893281d73ffa88c92378b2a79c7b9a6c1b0704300cb2dd5d1L82-R82): Changed the default value of `hubCompatibleAtom` to `true` and adjusted the top margin of the filters container. [[1]](diffhunk://#diff-4acda36130f9ceb893281d73ffa88c92378b2a79c7b9a6c1b0704300cb2dd5d1L82-R82) [[2]](diffhunk://#diff-4acda36130f9ceb893281d73ffa88c92378b2a79c7b9a6c1b0704300cb2dd5d1L453-R453)

## Fixes Issues

![CleanShot 2025-02-25 at 13 36 19](https://github.com/user-attachments/assets/316cecb9-ae1e-41be-b8d9-60c18195f5be)
![CleanShot 2025-02-25 at 11 26 52](https://github.com/user-attachments/assets/43c96e36-ae56-4390-857b-877720c7165f)
![CleanShot 2025-02-25 at 11 11 29](https://github.com/user-attachments/assets/a5cf3d8c-e358-41f3-b9a6-1d7ffceb8a6a)
![CleanShot 2025-02-25 at 11 07 20](https://github.com/user-attachments/assets/55397c2d-3c70-4ed2-8841-513e661930c9)


- Closes #https://discord.com/channels/1107178041848909847/1324288562237149254/1343510706397646961
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
