### PR TITLE
fix: hub ui no result search found

### DIFF
--- a/web/screens/Hub/ModelList/index.tsx
+++ b/web/screens/Hub/ModelList/index.tsx
@@ -5,18 +5,29 @@ import ModelItem from '@/screens/Hub/ModelList/ModelItem'
 type Props = {
   models: ModelSource[]
   onSelectedModel: (model: ModelSource) => void
+  filterOption?: string
 }
 
-const ModelList = ({ models, onSelectedModel }: Props) => {
+const ModelList = ({ models, onSelectedModel, filterOption }: Props) => {
   return (
     <div className="w-full">
-      {models.map((model) => (
-        <ModelItem
-          key={model.id}
-          model={model}
-          onSelectedModel={() => onSelectedModel(model)}
-        />
-      ))}
+      {models.length === 0 && filterOption === 'on-device' ? (
+        <div className="my-4 p-2 text-center">
+          <span className="text-[hsla(var(--text-tertiary))]">
+            No results found
+          </span>
+        </div>
+      ) : (
+        <>
+          {models.map((model) => (
+            <ModelItem
+              key={model.id}
+              model={model}
+              onSelectedModel={() => onSelectedModel(model)}
+            />
+          ))}
+        </>
+      )}
     </div>
   )
 }

--- a/web/screens/Hub/index.tsx
+++ b/web/screens/Hub/index.tsx
@@ -404,34 +404,44 @@ const HubScreen = () => {
                       <div
                         className={twMerge(
                           'invisible absolute mt-2 w-full overflow-hidden rounded-lg border border-[hsla(var(--app-border))] bg-[hsla(var(--app-bg))] shadow-lg',
-                          searchedModels.length > 0 && 'visible'
+                          searchValue.length > 0 && 'visible'
                         )}
                       >
-                        {searchedModels.map((model) => (
-                          <div
-                            key={model.id}
-                            className="z-10 flex cursor-pointer items-center space-x-2 px-4 py-2 hover:bg-[hsla(var(--dropdown-menu-hover-bg))]"
-                            onClick={(e) => {
-                              setSelectedModel(model)
-                              e.stopPropagation()
-                            }}
-                          >
-                            <span className="text-bold flex flex-row text-[hsla(var(--app-text-primary))]">
-                              {searchValue.includes('huggingface.co') && (
-                                <>
-                                  <Image
-                                    src={'icons/huggingFace.svg'}
-                                    width={16}
-                                    height={16}
-                                    className="mr-2"
-                                    alt=""
-                                  />{' '}
-                                </>
-                              )}
-                              {extractModelRepo(model.id)}
+                        {searchedModels.length === 0 ? (
+                          <div className="p-2 text-center">
+                            <span className="text-[hsla(var(--text-tertiary))]">
+                              No results found
                             </span>
                           </div>
-                        ))}
+                        ) : (
+                          <>
+                            {searchedModels.map((model) => (
+                              <div
+                                key={model.id}
+                                className="z-10 flex cursor-pointer items-center space-x-2 px-4 py-2 hover:bg-[hsla(var(--dropdown-menu-hover-bg))]"
+                                onClick={(e) => {
+                                  setSelectedModel(model)
+                                  e.stopPropagation()
+                                }}
+                              >
+                                <span className="text-bold flex flex-row text-[hsla(var(--app-text-primary))]">
+                                  {searchValue.includes('huggingface.co') && (
+                                    <>
+                                      <Image
+                                        src={'icons/huggingFace.svg'}
+                                        width={16}
+                                        height={16}
+                                        className="mr-2"
+                                        alt=""
+                                      />{' '}
+                                    </>
+                                  )}
+                                  {extractModelRepo(model.id)}
+                                </span>
+                              </div>
+                            ))}
+                          </>
+                        )}
                       </div>
                     </div>
                   </div>
@@ -523,6 +533,7 @@ const HubScreen = () => {
                       <ModelList
                         models={sortedModels}
                         onSelectedModel={(model) => setSelectedModel(model)}
+                        filterOption={filterOption}
                       />
                     )}
                     {(filterOption === 'cloud' || filterOption === 'all') && (


### PR DESCRIPTION
## Describe Your Changes

This pull request includes changes to add a "No results found" message when there are no models to display in the Hub screens. The most important changes include adding a `filterOption` prop to `ModelList` and updating the `HubScreen` to handle cases where no models are found.

Changes to handle "No results found" message:

* [`web/screens/Hub/ModelList/index.tsx`](diffhunk://#diff-e9ff40c6dc139ce515749a2557984b01897bf63c652838149612849151c1f4a3R8-R30): Added `filterOption` prop to `ModelList` and updated the component to display a "No results found" message when there are no models and the filter option is 'on-device'.

Updates to `HubScreen`:

* [`web/screens/Hub/index.tsx`](diffhunk://#diff-4acda36130f9ceb893281d73ffa88c92378b2a79c7b9a6c1b0704300cb2dd5d1L407-R417): Updated the visibility condition of the search results container to use `searchValue.length > 0` instead of `searchedModels.length > 0`. Added a "No results found" message when there are no searched models. [[1]](diffhunk://#diff-4acda36130f9ceb893281d73ffa88c92378b2a79c7b9a6c1b0704300cb2dd5d1L407-R417) [[2]](diffhunk://#diff-4acda36130f9ceb893281d73ffa88c92378b2a79c7b9a6c1b0704300cb2dd5d1R443-R444)
* [`web/screens/Hub/index.tsx`](diffhunk://#diff-4acda36130f9ceb893281d73ffa88c92378b2a79c7b9a6c1b0704300cb2dd5d1R536): Passed the `filterOption` prop to the `ModelList` component.

## Fixes Issues

![CleanShot 2025-02-26 at 13 17 15](https://github.com/user-attachments/assets/b94bf59c-23d8-454c-a0c0-b704fbee8045)
![CleanShot 2025-02-26 at 12 55 37](https://github.com/user-attachments/assets/97609da4-2c62-4499-910e-06ef7516a793)


- Closes #https://discord.com/channels/1107178041848909847/1324288562237149254/1344145350977650769
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
