### PR TITLE
fix: hub button download 

### DIFF
--- a/web/containers/ModelDownloadButton/index.tsx
+++ b/web/containers/ModelDownloadButton/index.tsx
@@ -19,16 +19,19 @@ import {
   downloadedModelsAtom,
   getDownloadingModelAtom,
 } from '@/helpers/atoms/Model.atom'
+import { serverEnabledAtom } from '@/helpers/atoms/LocalServer.atom'
 
 interface Props {
   id: string
   theme?: 'primary' | 'ghost' | 'icon' | 'destructive' | undefined
   variant?: 'solid' | 'soft' | 'outline' | undefined
   className?: string
+  hideProgress?: boolean
 }
-const ModelDownloadButton = ({ id, theme, variant, className }: Props) => {
+const ModelDownloadButton = ({ id, theme, className, hideProgress }: Props) => {
   const { downloadModel } = useDownloadModel()
   const downloadingModels = useAtomValue(getDownloadingModelAtom)
+  const serverEnabled = useAtomValue(serverEnabledAtom)
   const downloadedModels = useAtomValue(downloadedModelsAtom)
   const assistants = useAtomValue(assistantsAtom)
   const setMainViewState = useSetAtom(mainViewStateAtom)
@@ -62,7 +65,6 @@ const ModelDownloadButton = ({ id, theme, variant, className }: Props) => {
   const defaultButton = (
     <Button
       theme={theme ? theme : 'primary'}
-      // variant={variant ? variant : 'solid'}
       className={twMerge('min-w-[70px]', className)}
       onClick={(e) => {
         e.stopPropagation()
@@ -72,7 +74,10 @@ const ModelDownloadButton = ({ id, theme, variant, className }: Props) => {
       Download
     </Button>
   )
-  const downloadingButton = <ModalCancelDownload modelId={id} />
+  const downloadingButton = !hideProgress && (
+    <ModalCancelDownload modelId={id} />
+  )
+
   const downloadedButton = (
     <Tooltip
       trigger={
@@ -82,11 +87,13 @@ const ModelDownloadButton = ({ id, theme, variant, className }: Props) => {
           variant="outline"
           theme="ghost"
           className="min-w-[70px]"
+          disabled={serverEnabled}
         >
           Use
         </Button>
       }
       content="Threads are disabled while the server is running"
+      disabled={!serverEnabled}
     />
   )
   return (

--- a/web/containers/ModelDownloadButton/index.tsx
+++ b/web/containers/ModelDownloadButton/index.tsx
@@ -15,11 +15,11 @@ import ModalCancelDownload from '../ModalCancelDownload'
 import { mainViewStateAtom } from '@/helpers/atoms/App.atom'
 import { assistantsAtom } from '@/helpers/atoms/Assistant.atom'
 
+import { serverEnabledAtom } from '@/helpers/atoms/LocalServer.atom'
 import {
   downloadedModelsAtom,
   getDownloadingModelAtom,
 } from '@/helpers/atoms/Model.atom'
-import { serverEnabledAtom } from '@/helpers/atoms/LocalServer.atom'
 
 interface Props {
   id: string

--- a/web/screens/Hub/ModelPage/index.tsx
+++ b/web/screens/Hub/ModelPage/index.tsx
@@ -71,7 +71,10 @@ const ModelPage = ({ model, onGoBack }: Props) => {
               </span>
               <div className="inline-flex items-center space-x-2">
                 {model.type !== 'cloud' ? (
-                  <ModelDownloadButton id={model.models?.[0].id} />
+                  <ModelDownloadButton
+                    id={model.models?.[0].id}
+                    hideProgress={true}
+                  />
                 ) : (
                   <>
                     {!model.metadata?.apiKey?.length ? (


### PR DESCRIPTION
## Describe Your Changes

This pull request includes changes to the `ModelDownloadButton` component to enhance its functionality and improve user experience. The most important changes include adding a new property to hide the progress indicator, conditionally rendering the download button based on the server status, and disabling certain buttons when the server is enabled.

Enhancements to `ModelDownloadButton`:

* Added `serverEnabledAtom` to manage the state of the local server. (`web/containers/ModelDownloadButton/index.tsx`)
* Introduced a new `hideProgress` property to the `Props` interface and used it to conditionally render the progress indicator. (`web/containers/ModelDownloadButton/index.tsx`) [[1]](diffhunk://#diff-cb17fb15f4023177e3e5c8ade2c6f9f289a7ad0d48398b025c8a83ef41c25b58R29-R34) [[2]](diffhunk://#diff-cb17fb15f4023177e3e5c8ade2c6f9f289a7ad0d48398b025c8a83ef41c25b58L75-R80)
* Disabled the "Use" button when the server is enabled and added a tooltip to inform users about the server status. (`web/containers/ModelDownloadButton/index.tsx`)

Codebase simplification:

* Removed the commented-out `variant` property from the default button. (`web/containers/ModelDownloadButton/index.tsx`)

Usage update:

* Updated `ModelPage` to pass the new `hideProgress` property to the `ModelDownloadButton` component. (`web/screens/Hub/ModelPage/index.tsx`)

## Fixes Issues
![CleanShot 2025-02-26 at 15 05 07](https://github.com/user-attachments/assets/7e4b8d39-ffe7-4edc-9a05-44b11dd2fef2)

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
