### PR TITLE
fix: app check available update

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -85,9 +85,9 @@ app
   .then(setupExtensions)
   .then(setupMenu)
   .then(handleIPCs)
-  .then(handleAppUpdates)
   .then(() => process.env.CI !== 'e2e' && createQuickAskWindow())
   .then(createMainWindow)
+  .then(handleAppUpdates)
   .then(registerGlobalShortcuts)
   .then(() => {
     if (!app.isPackaged) {


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a small change to the `electron/main.ts` file. The change reorders the `handleAppUpdates` function call to occur after the `createMainWindow` function call.

* [`electron/main.ts`](diffhunk://#diff-13ee644059574b054a4e5ec081666a03579b28da03a50331215908f8d0ef7cfdL88-R90): Moved `handleAppUpdates` to occur after `createMainWindow` in the promise chain.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
