### PR TITLE
chore: handle list number and disc readme hgf

### DIFF
--- a/web/screens/Hub/index.tsx
+++ b/web/screens/Hub/index.tsx
@@ -493,8 +493,15 @@ const HubScreen = () => {
                       onClick={() => {
                         setCtxLenFilter(0)
                         setMinModelSizeFilter(0)
-                        setMaxModelSizeFilter(Number(largestModel?.size))
-                        setCompatible(false)
+                        setMaxModelSizeFilter(
+                          Number(
+                            toGigabytes(Number(largestModel?.size), {
+                              hideUnit: true,
+                              toFixed: 0,
+                            })
+                          )
+                        )
+                        setCompatible(true)
                       }}
                     >
                       Reset

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
@@ -112,7 +112,7 @@ const MessageContainer: React.FC<
             'absolute right-0 order-1 mt-2 flex cursor-pointer items-center justify-start gap-x-2 transition-all',
             isUser
               ? 'hidden group-hover:absolute group-hover:right-4 group-hover:top-4 group-hover:flex'
-              : 'relative left-0 order-2 -mt-1 flex w-full justify-between opacity-0 group-hover:opacity-100'
+              : 'relative left-0 order-2 flex w-full justify-between opacity-0 group-hover:opacity-100'
           )}
         >
           <div>

--- a/web/styles/components/marked.scss
+++ b/web/styles/components/marked.scss
@@ -90,3 +90,19 @@
   margin: 16px 0px;
   border-color: hsla(var(--app-border));
 }
+
+.markdown-content {
+  ol,
+  ul {
+    padding-left: 16px;
+    li {
+      line-height: 2;
+    }
+  }
+  ol {
+    list-style: number;
+  }
+  ul {
+    list-style: disc;
+  }
+}


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a small change to the `web/styles/components/marked.scss` file. The change adds specific styles for ordered and unordered lists within the `.markdown-content` class.

Styling changes:

* [`web/styles/components/marked.scss`](diffhunk://#diff-1b1f53e7a74b33e06c05954c28edd796aaa6576156a27e4e154d70e4c2bf2651R93-R108): Added padding and list-style specifications for `ol` and `ul` elements, and adjusted `li` line-height within the `.markdown-content` class.

## Fixes Issues
![CleanShot 2025-02-27 at 20 50 18](https://github.com/user-attachments/assets/cfc90ffb-752f-4ba8-a141-3ef5b487fd65)

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
