### PR TITLE
fix: Jan Quick Ask window capture input issues

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -31,6 +31,7 @@ import { registerGlobalShortcuts } from './utils/shortcut'
 import { registerLogger } from './utils/logger'
 
 const preloadPath = join(__dirname, 'preload.js')
+const preloadQuickAskPath = join(__dirname, 'preload.quickask.js')
 const rendererPath = join(__dirname, '..', 'renderer')
 const quickAskPath = join(rendererPath, 'search.html')
 const mainPath = join(rendererPath, 'index.html')
@@ -133,7 +134,7 @@ function createQuickAskWindow() {
   // Feature Toggle for Quick Ask
   if (!getAppConfigurations().quick_ask) return
   const startUrl = app.isPackaged ? `file://${quickAskPath}` : quickAskUrl
-  windowManager.createQuickAskWindow(preloadPath, startUrl)
+  windowManager.createQuickAskWindow(preloadQuickAskPath, startUrl)
 }
 
 /**

--- a/electron/managers/quickAskWindowConfig.ts
+++ b/electron/managers/quickAskWindowConfig.ts
@@ -13,10 +13,10 @@ export const quickAskWindowConfig: Electron.BrowserWindowConstructorOptions = {
   fullscreenable: false,
   resizable: false,
   center: true,
-  movable: false,
+  movable: true,
   maximizable: false,
   focusable: true,
-  transparent: true,
+  transparent: false,
   frame: false,
   type: 'panel',
 }

--- a/electron/managers/window.ts
+++ b/electron/managers/window.ts
@@ -141,6 +141,9 @@ class WindowManager {
     return this._quickAskWindow?.isDestroyed() ?? true
   }
 
+  /**
+   * Expand the quick ask window
+   */
   expandQuickAskWindow(heightOffset: number): void {
     const width = quickAskWindowConfig.width!
     const height = quickAskWindowConfig.height! + heightOffset
@@ -148,6 +151,9 @@ class WindowManager {
     this._quickAskWindow?.setSize(width, height, true)
   }
 
+  /**
+   * Send the selected text to the quick ask window.
+   */
   sendQuickAskSelectedText(selectedText: string): void {
     this._quickAskWindow?.webContents.send(
       AppEvent.onSelectedText,
@@ -180,6 +186,9 @@ class WindowManager {
     }
   }
 
+  /**
+   * Clean up all windows.
+   */
   cleanUp(): void {
     if (!this.mainWindow?.isDestroyed()) {
       this.mainWindow?.close()

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -13,10 +13,7 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className="h-screen font-sans text-sm antialiased">
-        <div className="dragable-bar" />
-        {children}
-      </body>
+      <body className="h-screen font-sans text-sm antialiased">{children}</body>
     </html>
   )
 }

--- a/web/app/search/UserInput.tsx
+++ b/web/app/search/UserInput.tsx
@@ -66,7 +66,7 @@ const UserInput = () => {
           <LogoMark width={28} height={28} className="mx-auto" />
           <input
             ref={inputRef}
-            className="flex-1 bg-transparent font-bold focus:outline-none"
+            className="flex-1 bg-transparent font-bold text-[hsla(var(--text-primary))] focus:outline-none"
             type="text"
             value={inputValue}
             onChange={handleChange}

--- a/web/app/search/layout.tsx
+++ b/web/app/search/layout.tsx
@@ -8,9 +8,6 @@ import { useSetAtom } from 'jotai'
 
 import ClipboardListener from '@/containers/Providers/ClipboardListener'
 
-import JotaiWrapper from '@/containers/Providers/Jotai'
-import ThemeWrapper from '@/containers/Providers/Theme'
-
 import { useLoadTheme } from '@/hooks/useLoadTheme'
 
 import { setupCoreServices } from '@/services/coreService'
@@ -48,15 +45,9 @@ export default function RootLayout() {
   useLoadTheme()
 
   return (
-    <html lang="en" suppressHydrationWarning>
-      <body className="font-sans antialiased">
-        <JotaiWrapper>
-          <ThemeWrapper>
-            <ClipboardListener />
-            <Search />
-          </ThemeWrapper>
-        </JotaiWrapper>
-      </body>
-    </html>
+    <>
+      <ClipboardListener />
+      <Search />
+    </>
   )
 }

--- a/web/app/search/page.tsx
+++ b/web/app/search/page.tsx
@@ -5,6 +5,7 @@ import UserInput from './UserInput'
 const Search = () => {
   return (
     <div className="h-screen w-screen overflow-hidden bg-[hsla(var(--app-bg))]">
+      <div className={'draggable-bar h-[10px]'} />
       <UserInput />
     </div>
   )

--- a/web/containers/ModelDropdown/index.tsx
+++ b/web/containers/ModelDropdown/index.tsx
@@ -35,10 +35,7 @@ import useDownloadModel from '@/hooks/useDownloadModel'
 import { modelDownloadStateAtom } from '@/hooks/useDownloadState'
 import { useGetEngines } from '@/hooks/useEngineManagement'
 
-import {
-  useGetModelSources,
-  useGetFeaturedSources,
-} from '@/hooks/useModelSource'
+import { useGetFeaturedSources } from '@/hooks/useModelSource'
 import useRecommendedModel from '@/hooks/useRecommendedModel'
 
 import useUpdateModelParameters from '@/hooks/useUpdateModelParameters'
@@ -91,7 +88,6 @@ const ModelDropdown = ({
   const [toggle, setToggle] = useState<HTMLDivElement | null>(null)
   const [selectedModel, setSelectedModel] = useAtom(selectedModelAtom)
   const { recommendedModel, downloadedModels } = useRecommendedModel()
-  const { sources } = useGetModelSources()
   const [dropdownOptions, setDropdownOptions] = useState<HTMLDivElement | null>(
     null
   )

--- a/web/containers/Providers/QuickAskConfigurator.tsx
+++ b/web/containers/Providers/QuickAskConfigurator.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { PropsWithChildren, useEffect, useState } from 'react'
+
+import { setupCoreServices } from '@/services/coreService'
+
+export const QuickAskConfigurator = ({ children }: PropsWithChildren) => {
+  const [setupCore, setSetupCore] = useState(false)
+
+  // Services Setup
+  useEffect(() => {
+    setupCoreServices()
+    setSetupCore(true)
+  }, [])
+
+  return <>{setupCore && <>{children}</>}</>
+}

--- a/web/containers/Providers/index.tsx
+++ b/web/containers/Providers/index.tsx
@@ -14,28 +14,39 @@ import DataLoader from './DataLoader'
 
 import DeepLinkListener from './DeepLinkListener'
 import KeyListener from './KeyListener'
+import { QuickAskConfigurator } from './QuickAskConfigurator'
 import Responsive from './Responsive'
 
 import SWRConfigProvider from './SWRConfigProvider'
 import SettingsHandler from './SettingsHandler'
 
 const Providers = ({ children }: PropsWithChildren) => {
+  const isQuickAsk =
+    typeof window !== 'undefined' && window.electronAPI?.isQuickAsk()
   return (
     <SWRConfigProvider>
       <ThemeWrapper>
         <JotaiWrapper>
-          <CoreConfigurator>
+          {isQuickAsk && (
             <>
-              <Responsive />
-              <KeyListener />
-              <EventListener />
-              <DataLoader />
-              <SettingsHandler />
-              <DeepLinkListener />
-              <Toaster />
-              {children}
+              <QuickAskConfigurator> {children} </QuickAskConfigurator>
             </>
-          </CoreConfigurator>
+          )}
+          {!isQuickAsk && (
+            <CoreConfigurator>
+              <>
+                <Responsive />
+                <KeyListener />
+                <EventListener />
+                <DataLoader />
+                <SettingsHandler />
+                <DeepLinkListener />
+                <Toaster />
+                <div className={'draggable-bar h-[32px]'} />
+                {children}
+              </>
+            </CoreConfigurator>
+          )}
         </JotaiWrapper>
       </ThemeWrapper>
     </SWRConfigProvider>

--- a/web/hooks/useApp.ts
+++ b/web/hooks/useApp.ts
@@ -1,0 +1,10 @@
+import { extensionManager } from '@/extension'
+
+export function useApp() {
+  async function relaunch() {
+    const extensions = extensionManager.getAll()
+    await Promise.all(extensions.map((e) => e.onUnload()))
+    window.core?.api?.relaunch()
+  }
+  return { relaunch }
+}

--- a/web/hooks/useModelSource.ts
+++ b/web/hooks/useModelSource.ts
@@ -43,7 +43,7 @@ export function useGetFeaturedSources() {
   const { sources, error, mutate } = useGetModelSources()
 
   return {
-    sources: sources?.filter((e) => e.metadata?.tags.includes('featured')),
+    sources: sources?.filter((e) => e.metadata?.tags?.includes('featured')),
     error,
     mutate,
   }

--- a/web/screens/Settings/Advanced/DataFolder/index.tsx
+++ b/web/screens/Settings/Advanced/DataFolder/index.tsx
@@ -9,6 +9,8 @@ import Loader from '@/containers/Loader'
 
 export const SUCCESS_SET_NEW_DESTINATION = 'successSetNewDestination'
 
+import { useApp } from '@/hooks/useApp'
+
 import ModalChangeDirectory, {
   showDirectoryConfirmModalAtom,
 } from './ModalChangeDirectory'
@@ -32,6 +34,7 @@ const DataFolder = () => {
 
   const [destinationPath, setDestinationPath] = useState(undefined)
   const janDataFolderPath = useAtomValue(janDataFolderPathAtom)
+  const { relaunch } = useApp()
 
   const onChangeFolderClick = useCallback(async () => {
     const destFolder = await window.core?.api?.selectDirectory()
@@ -78,7 +81,7 @@ const DataFolder = () => {
       setTimeout(() => {
         setShowLoader(false)
       }, 1200)
-      await window.core?.api?.relaunch()
+      await relaunch()
     } catch (e) {
       console.error(e)
       setShowLoader(false)

--- a/web/screens/Settings/Advanced/index.tsx
+++ b/web/screens/Settings/Advanced/index.tsx
@@ -13,6 +13,7 @@ import { useDebouncedCallback } from 'use-debounce'
 
 import { toaster } from '@/containers/Toast'
 
+import { useApp } from '@/hooks/useApp'
 import { useConfigurations } from '@/hooks/useConfigurations'
 
 import ModalDeleteAllThreads from '@/screens/Thread/ThreadLeftPanel/ModalDeleteAllThreads'
@@ -47,6 +48,7 @@ const Advanced = ({ setSubdir }: { setSubdir: (subdir: string) => void }) => {
   const { configurePullOptions } = useConfigurations()
 
   const setModalActionThread = useSetAtom(modalActionThreadAtom)
+  const { relaunch } = useApp()
 
   /**
    * There could be a case where the state update is not synced
@@ -66,13 +68,13 @@ const Advanced = ({ setSubdir }: { setSubdir: (subdir: string) => void }) => {
    */
   const updateQuickAskEnabled = async (
     e: boolean,
-    relaunch: boolean = true
+    relaunchApp: boolean = true
   ) => {
     const appConfiguration: AppConfiguration =
       await window.core?.api?.getAppConfigurations()
     appConfiguration.quick_ask = e
     await window.core?.api?.updateAppConfiguration(appConfiguration)
-    if (relaunch) window.core?.api?.relaunch()
+    if (relaunchApp) relaunch()
   }
 
   /**
@@ -92,7 +94,7 @@ const Advanced = ({ setSubdir }: { setSubdir: (subdir: string) => void }) => {
     // It affects other settings, so we need to reset them
     const isRelaunch = quickAskEnabled
     if (quickAskEnabled) await updateQuickAskEnabled(false, false)
-    if (isRelaunch) window.core?.api?.relaunch()
+    if (isRelaunch) relaunch()
   }
 
   return (

--- a/web/screens/Settings/CoreExtensions/index.tsx
+++ b/web/screens/Settings/CoreExtensions/index.tsx
@@ -9,6 +9,8 @@ import { Marked, Renderer } from 'marked'
 
 import Loader from '@/containers/Loader'
 
+import { useApp } from '@/hooks/useApp'
+
 import { formatExtensionsName } from '@/utils/converter'
 
 import { extensionManager } from '@/extension'
@@ -23,6 +25,7 @@ const ExtensionCatalog = () => {
   const [searchText, setSearchText] = useState('')
   const [showLoading, setShowLoading] = useState(false)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const { relaunch } = useApp()
 
   useEffect(() => {
     const getAllSettings = async () => {
@@ -74,7 +77,7 @@ const ExtensionCatalog = () => {
     // Send the filename of the to be installed extension
     // to the main process for installation
     const installed = await extensionManager.install([extensionFile])
-    if (installed) window.core?.api?.relaunch()
+    if (installed) relaunch()
   }
 
   /**
@@ -87,7 +90,7 @@ const ExtensionCatalog = () => {
     // Send the filename of the to be uninstalled extension
     // to the main process for removal
     const res = await extensionManager.uninstall([name])
-    if (res) window.core?.api?.relaunch()
+    if (res) relaunch()
   }
 
   /**

--- a/web/styles/base/global.scss
+++ b/web/styles/base/global.scss
@@ -7,18 +7,18 @@
     text-decoration: underline;
   }
 
-  .dragable-bar {
+  .draggable-bar {
     position: absolute;
     left: 0px;
     top: 0px;
     width: 100%;
-    height: 32px;
-    user-select: none;
     -webkit-app-region: drag;
   }
 
   .unset-drag {
+    user-select: inherit;
     -webkit-app-region: no-drag;
+    pointer-events: all; /* Ensure it receives input events */
   }
 
   .unselect {


### PR DESCRIPTION
This pull request includes several changes to enhance the Quick Ask feature, improve configuration handling, and clean up the codebase. The most important changes include the addition of a new preload script for Quick Ask, updates to the window configuration, and the introduction of a new hook for application relaunch.

Key  updates:
- Fixed cortex.cpp dangling process issue on app relaunch to apply some of the configurations.
- Quick App window does not responds to mouse capture (input and send button)
- Quick App window is not movable.
- Quick App window executes redundant operations on launch.
- App craches due to missing model tags in metadata

- Closes #4674 
- Closes #4206

Enhancements to Quick Ask feature:

* [`electron/main.ts`](diffhunk://#diff-13ee644059574b054a4e5ec081666a03579b28da03a50331215908f8d0ef7cfdR34): Added `preload.quickask.js` path and updated `createQuickAskWindow` to use this new preload path. [[1]](diffhunk://#diff-13ee644059574b054a4e5ec081666a03579b28da03a50331215908f8d0ef7cfdR34) [[2]](diffhunk://#diff-13ee644059574b054a4e5ec081666a03579b28da03a50331215908f8d0ef7cfdL136-R137)
* [`electron/preload.quickask.ts`](diffhunk://#diff-184a7747c63fbee2bcd91ec9adb06591d64a3f4cd2a5c19030df131b791536a1R1-R32): Introduced a new preload script to expose APIs to the renderer process for Quick Ask.
* [`electron/managers/quickAskWindowConfig.ts`](diffhunk://#diff-f856b8feb2d1d385c56c079f2cf05a75dfed376357a7bca5e9ab026c9db6518bL16-R19): Made the Quick Ask window movable and non-transparent.

Configuration and application relaunch improvements:

* [`web/hooks/useApp.ts`](diffhunk://#diff-37092ef45a42cd2bb2ed9ef3ee349e06df677df0bb37166a1ae871485479c158R1-R10): Added a new hook, `useApp`, to handle application relaunch logic.
* [`web/screens/Settings/Advanced/index.tsx`](diffhunk://#diff-8d119b4ddbfcbb13597702a44730e486bc4c02dc630069686effa3333ab90411L69-R77): Updated the logic for enabling/disabling Quick Ask to use the new `relaunch` function from `useApp`. [[1]](diffhunk://#diff-8d119b4ddbfcbb13597702a44730e486bc4c02dc630069686effa3333ab90411L69-R77) [[2]](diffhunk://#diff-8d119b4ddbfcbb13597702a44730e486bc4c02dc630069686effa3333ab90411L95-R97)

Codebase cleanup and refactoring:

* [`web/containers/Providers/index.tsx`](diffhunk://#diff-3751b9c6d61b9f56f79a87dace31d394cbfbe1b7ab311196d1cb49e03eb8a3d4R17-R35): Added `QuickAskConfigurator` to conditionally wrap children based on Quick Ask status. [[1]](diffhunk://#diff-3751b9c6d61b9f56f79a87dace31d394cbfbe1b7ab311196d1cb49e03eb8a3d4R17-R35) [[2]](diffhunk://#diff-3751b9c6d61b9f56f79a87dace31d394cbfbe1b7ab311196d1cb49e03eb8a3d4R45-R49)
* [`web/screens/Settings/CoreExtensions/index.tsx`](diffhunk://#diff-d70c5e9520ecfdf6441e0eb266a16a1c08ce155998f1d6327f11b5e9d5ed776eR28): Updated extension installation logic to use the new `relaunch` function from `useApp`. [[1]](diffhunk://#diff-d70c5e9520ecfdf6441e0eb266a16a1c08ce155998f1d6327f11b5e9d5ed776eR28) [[2]](diffhunk://#diff-d70c5e9520ecfdf6441e0eb266a16a1c08ce155998f1d6327f11b5e9d5ed776eL77-R80)
* [`electron/preload.ts`](diffhunk://#diff-17fc44a47be3f3309d4ce97948f68135a3ca438711a75d645a0e3710aa92098bL6-R6): Removed unused imports and cleaned up the code for better readability. [[1]](diffhunk://#diff-17fc44a47be3f3309d4ce97948f68135a3ca438711a75d645a0e3710aa92098bL6-R6) [[2]](diffhunk://#diff-17fc44a47be3f3309d4ce97948f68135a3ca438711a75d645a0e3710aa92098bL18) [[3]](diffhunk://#diff-17fc44a47be3f3309d4ce97948f68135a3ca438711a75d645a0e3710aa92098bL29-R31) [[4]](diffhunk://#diff-17fc44a47be3f3309d4ce97948f68135a3ca438711a75d645a0e3710aa92098bL50-R50) [[5]](diffhunk://#diff-17fc44a47be3f3309d4ce97948f68135a3ca438711a75d645a0e3710aa92098bR59)
