### PR TITLE
fix: first message padding is off

### DIFF
--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
@@ -167,6 +167,7 @@ const ChatBody = memo(
                   key={messages[virtualRow.index]?.id ?? virtualRow.index}
                   data-index={virtualRow.index}
                   ref={virtualizer.measureElement}
+                  className="first:mt-4"
                 >
                   {loadModelError && virtualRow.index === count - 1 ? (
                     <LoadModelError />

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
@@ -109,10 +109,11 @@ const MessageContainer: React.FC<
       <div className="flex w-full flex-col ">
         <div
           className={twMerge(
-            'absolute right-0 order-1 mt-2 flex cursor-pointer items-center justify-start gap-x-2 transition-all',
+            'absolute right-0 order-1 flex cursor-pointer items-center justify-start gap-x-2 transition-all',
             isUser
               ? 'hidden group-hover:absolute group-hover:right-4 group-hover:top-4 group-hover:flex'
-              : 'relative left-0 order-2 flex w-full justify-between opacity-0 group-hover:opacity-100'
+              : 'relative left-0 order-2 flex w-full justify-between opacity-0 group-hover:opacity-100',
+            props.isCurrentMessage && 'opacity-100'
           )}
         >
           <div>


### PR DESCRIPTION
This pull request includes changes to the `web/screens/Thread/ThreadCenterPanel` directory to improve the user interface and enhance the chat experience. The most important changes include adding a new class for margin-top styling in `ChatBody` and modifying the `MessageContainer` component to handle the current message state more effectively.

![CleanShot 2025-02-28 at 21 23 02@2x](https://github.com/user-attachments/assets/a17f0c4e-fbf9-4eeb-a0f4-dea77fdef866)


User Interface Improvements:

* [`web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx`](diffhunk://#diff-3f5d1c0b7af75f2f221b9504d3f50f0cb42b683d7eb7b565caf7ced16b2c765fR170): Added a new class `first:mt-4` to provide margin-top styling for the first element in the chat body.

Enhancements to Message Handling:

* [`web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx`](diffhunk://#diff-efce7749ad34c34cc3f189aea671b9975208995580033b9de787c3c96c878cccL112-R116): Modified the `MessageContainer` component to include `props.isCurrentMessage` for better handling of the current message state, ensuring it is always fully visible.