### PR TITLE
feat: add openai 4.5 preview and anthropic claude 3.7 sonnet models

### DIFF
--- a/extensions/engine-management-extension/models/anthropic.json
+++ b/extensions/engine-management-extension/models/anthropic.json
@@ -40,5 +40,19 @@
       "stream": true
     },
     "engine": "anthropic"
+  },
+  {
+    "model": "claude-3-7-sonnet-latest",
+    "object": "model",
+    "name": "Claude 3.7 Sonnet Latest",
+    "version": "1.0",
+    "description": "Claude 3.7 Sonnet is the first hybrid reasoning model on the market. It is the most intelligent model yet. It is faster, more cost effective, and more capable than any other model in its class.",
+    "inference_params": {
+      "max_tokens": 8192,
+      "temperature": 0.7,
+      "max_temperature": 1.0,
+      "stream": true
+    },
+    "engine": "anthropic"
   }
 ]

--- a/extensions/engine-management-extension/models/openai.json
+++ b/extensions/engine-management-extension/models/openai.json
@@ -1,5 +1,23 @@
 [
   {
+    "model": "gpt-4.5-preview",
+    "object": "model",
+    "name": "OpenAI GPT 4.5 Preview",
+    "version": "1.2",
+    "description": "OpenAI GPT 4.5 Preview is a research preview of GPT-4.5, our largest and most capable GPT model yet",
+    "format": "api",
+    "inference_params": {
+      "max_tokens": 16384,
+      "temperature": 0.7,
+      "top_p": 0.95,
+      "stream": true,
+      "stop": [],
+      "frequency_penalty": 0,
+      "presence_penalty": 0
+    },
+    "engine": "openai"
+  },
+  {
     "model": "gpt-4-turbo",
     "object": "model",
     "name": "OpenAI GPT 4 Turbo",


### PR DESCRIPTION
## Describe Your Changes

- Added new models:
    - OpenAI chatGPT-4.5-preview
    - Anthropic Claude-3.7-sonnet

<img width="1070" alt="image" src="https://github.com/user-attachments/assets/b9957098-fba6-45dc-a92e-5db1e2287cab" />

<img width="1120" alt="image" src="https://github.com/user-attachments/assets/3e5279e2-74b5-4433-972b-8528f56bb580" />
