### PR TITLE
fix: image upload button does not work - refresh models list persist current selected engine

### DIFF
--- a/web/hooks/useEngineManagement.ts
+++ b/web/hooks/useEngineManagement.ts
@@ -477,20 +477,23 @@ export const useRefreshModelList = (engine: string) => {
   const [refreshingModels, setRefreshingModels] = useState(false)
   const { mutate: fetchRemoteModels } = useGetRemoteModels(engine)
 
-  const refreshModels = useCallback(() => {
-    setRefreshingModels(true)
-    fetchRemoteModels()
-      .then((remoteModelList) =>
-        Promise.all(
-          remoteModelList?.data?.map((model: { id?: string }) =>
-            model?.id
-              ? addRemoteEngineModel(model.id, engine).catch(() => {})
-              : {}
-          ) ?? []
+  const refreshModels = useCallback(
+    (engine: string) => {
+      setRefreshingModels(true)
+      fetchRemoteModels()
+        .then((remoteModelList) =>
+          Promise.all(
+            remoteModelList?.data?.map((model: { id?: string }) =>
+              model?.id
+                ? addRemoteEngineModel(model.id, engine).catch(() => {})
+                : {}
+            ) ?? []
+          )
         )
-      )
-      .finally(() => setRefreshingModels(false))
-  }, [fetchRemoteModels])
+        .finally(() => setRefreshingModels(false))
+    },
+    [fetchRemoteModels]
+  )
 
   return { refreshingModels, refreshModels }
 }

--- a/web/screens/Hub/ModelPage/RemoteModelRefresh.tsx
+++ b/web/screens/Hub/ModelPage/RemoteModelRefresh.tsx
@@ -6,15 +6,15 @@ import Spinner from '@/containers/Loader/Spinner'
 
 import { useRefreshModelList } from '@/hooks/useEngineManagement'
 
-function RemoteModelRefresh({ id }: { id: string }) {
-  const { refreshingModels, refreshModels } = useRefreshModelList(id)
+function RemoteModelRefresh({ engine }: { engine: string }) {
+  const { refreshingModels, refreshModels } = useRefreshModelList(engine)
 
   return (
     <Button
       theme={'ghost'}
       variant={'outline'}
       className="h-7 px-2"
-      onClick={() => refreshModels()}
+      onClick={() => refreshModels(engine)}
     >
       {refreshingModels ? (
         <Spinner size={16} strokeWidth={2} className="mr-2" />

--- a/web/screens/Hub/ModelPage/index.tsx
+++ b/web/screens/Hub/ModelPage/index.tsx
@@ -158,7 +158,7 @@ const ModelPage = ({ model, onGoBack }: Props) => {
                       )}
                       <th className="w-[120px]">
                         {model.type === 'cloud' && (
-                          <RemoteModelRefresh id={model.id} />
+                          <RemoteModelRefresh engine={model.id} />
                         )}
                       </th>
                     </tr>

--- a/web/screens/Hub/index.tsx
+++ b/web/screens/Hub/index.tsx
@@ -368,10 +368,10 @@ const HubScreen = () => {
                         {hubBannerOption === 'upload' && (
                           <div
                             className={`mx-2 mb-2 flex h-[172px] cursor-pointer items-center justify-center rounded-md border`}
+                            {...getRootProps()}
                             onClick={() => {
                               imageInputRef.current?.click()
                             }}
-                            {...getRootProps()}
                           >
                             <div className="flex flex-col items-center justify-center">
                               <div className="mx-auto inline-flex h-10 w-10 items-center justify-center rounded-full bg-gray-200">

--- a/web/screens/Settings/Engines/RemoteEngineSettings.tsx
+++ b/web/screens/Settings/Engines/RemoteEngineSettings.tsx
@@ -52,25 +52,25 @@ import { showScrollBarAtom } from '@/helpers/atoms/Setting.atom'
 import { threadsAtom } from '@/helpers/atoms/Thread.atom'
 
 const RemoteEngineSettings = ({
-  engine: name,
+  engine: engineName,
 }: {
   engine: InferenceEngine
 }) => {
   const { engines, mutate } = useGetEngines()
   const downloadedModels = useAtomValue(downloadedModelsAtom)
   const [showApiKey, setShowApiKey] = useState(false)
-  const remoteModels = downloadedModels.filter((e) => e.engine === name)
+  const remoteModels = downloadedModels.filter((e) => e.engine === engineName)
   const [isActiveAdvanceSetting, setisActiveAdvanceSetting] = useState(false)
   const setSelectedModel = useSetAtom(selectedModelAtom)
-  const customEngineLogo = getLogoEngine(name)
+  const customEngineLogo = getLogoEngine(engineName)
   const threads = useAtomValue(threadsAtom)
-  const { refreshingModels, refreshModels } = useRefreshModelList(name)
+  const { refreshingModels, refreshModels } = useRefreshModelList(engineName)
   const showScrollBar = useAtomValue(showScrollBarAtom)
 
   const engine =
     engines &&
     Object.entries(engines)
-      .filter(([key]) => key === name)
+      .filter(([key]) => key === engineName)
       .flatMap(([_, engineArray]) => engineArray as EngineConfig)[0]
 
   const debounceRef = useRef<NodeJS.Timeout | null>(null)
@@ -92,12 +92,12 @@ const RemoteEngineSettings = ({
       debounceRef.current = setTimeout(async () => {
         const updatedEngine = { ...engine }
         set(updatedEngine, field, value)
-        await updateEngine(name, updatedEngine)
+        await updateEngine(engineName, updatedEngine)
         mutate()
         events.emit(EngineEvent.OnEngineUpdate, {})
       }, 300)
     },
-    [engine, name, mutate]
+    [engine, engineName, mutate]
   )
 
   const [data, setData] = useState({
@@ -237,7 +237,7 @@ const RemoteEngineSettings = ({
                   <Button
                     theme={'ghost'}
                     variant={'outline'}
-                    onClick={() => refreshModels()}
+                    onClick={() => refreshModels(engineName)}
                   >
                     {refreshingModels ? (
                       <Spinner size={16} strokeWidth={2} className="mr-2" />
@@ -246,7 +246,7 @@ const RemoteEngineSettings = ({
                     )}
                     Refresh
                   </Button>
-                  <ModalAddModel engine={name} />
+                  <ModalAddModel engine={engineName} />
                 </div>
               </div>
 


### PR DESCRIPTION
This pull request includes changes to improve the consistency and clarity of the codebase by standardizing the naming of the `engine` parameter across multiple files. The most important changes include updating the `useRefreshModelList` hook, modifying the `RemoteModelRefresh` component, and adjusting the `RemoteEngineSettings` component.

Standardization of `engine` parameter:

* [`web/hooks/useEngineManagement.ts`](diffhunk://#diff-2be7333c9d57e11689071fc1bf5aa7eaf12b907ebc5236ed5abbdb53b031201aL480-R481): Updated the `useRefreshModelList` hook to include `engine` as a parameter in the `refreshModels` function. [[1]](diffhunk://#diff-2be7333c9d57e11689071fc1bf5aa7eaf12b907ebc5236ed5abbdb53b031201aL480-R481) [[2]](diffhunk://#diff-2be7333c9d57e11689071fc1bf5aa7eaf12b907ebc5236ed5abbdb53b031201aL493-R496)

* [`web/screens/Hub/ModelPage/RemoteModelRefresh.tsx`](diffhunk://#diff-770296458653cce6e3b8e366a1d2af5e4e68ee8ff52fc0aa2b7a37169a84b139L9-R17): Modified the `RemoteModelRefresh` component to use `engine` instead of `id` and updated the `onClick` handler to pass the `engine` parameter.

* [`web/screens/Hub/ModelPage/index.tsx`](diffhunk://#diff-02e81029a62de211929358113c60a101efd0bd0f7ce9b2237fa4cfabecba0a21L161-R161): Updated the `RemoteModelRefresh` component usage to pass `engine` instead of `id`.

* [`web/screens/Settings/Engines/RemoteEngineSettings.tsx`](diffhunk://#diff-d8d84f4f488f0d35b2751fee2cad04a83f6661a0f11b2b6a2355ac0e70aec575L55-R73): Standardized the naming of the `engine` parameter to `engineName` throughout the `RemoteEngineSettings` component and updated related function calls and state variables. [[1]](diffhunk://#diff-d8d84f4f488f0d35b2751fee2cad04a83f6661a0f11b2b6a2355ac0e70aec575L55-R73) [[2]](diffhunk://#diff-d8d84f4f488f0d35b2751fee2cad04a83f6661a0f11b2b6a2355ac0e70aec575L95-R100) [[3]](diffhunk://#diff-d8d84f4f488f0d35b2751fee2cad04a83f6661a0f11b2b6a2355ac0e70aec575L240-R240) [[4]](diffhunk://#diff-d8d84f4f488f0d35b2751fee2cad04a83f6661a0f11b2b6a2355ac0e70aec575L249-R249)

Minor UI adjustment:

* [`web/screens/Hub/index.tsx`](diffhunk://#diff-4acda36130f9ceb893281d73ffa88c92378b2a79c7b9a6c1b0704300cb2dd5d1R371-L374): Moved the `getRootProps` spread operator to the correct position within the JSX structure for better readability.