### PR TITLE
fix: list space styled and hidden message toolbar when editmode

### DIFF
--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
@@ -133,7 +133,7 @@ const MessageContainer: React.FC<
             )}
           </div>
 
-          <MessageToolbar message={props} />
+          {editMessage !== props.id && <MessageToolbar message={props} />}
         </div>
         <div
           className={twMerge(

--- a/web/styles/components/marked.scss
+++ b/web/styles/components/marked.scss
@@ -94,15 +94,12 @@
 .markdown-content {
   ol,
   ul {
+    list-style: auto;
     padding-left: 16px;
+    white-space: normal;
+    list-style-position: inside;
     li {
       line-height: 2;
     }
-  }
-  ol {
-    list-style: number;
-  }
-  ul {
-    list-style: disc;
   }
 }


### PR DESCRIPTION
## Reported

![CleanShot 2025-03-03 at 13 58 27](https://github.com/user-attachments/assets/6e62bbb1-1217-4572-b882-9658afc7d192)
![image](https://github.com/user-attachments/assets/7f7dd54e-4a29-4245-a05b-0896d05c8004)

## Describe Your Changes

This pull request includes changes to the `web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx` and `web/styles/components/marked.scss` files to improve the user interface and styling of the message components. The most important changes include conditionally rendering the `MessageToolbar` component and updating the list styles in the markdown content.

Improvements to message components:

* [`web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx`](diffhunk://#diff-efce7749ad34c34cc3f189aea671b9975208995580033b9de787c3c96c878cccL136-R136): Conditionally render the `MessageToolbar` component only when the message is not being edited.

Styling updates:

* [`web/styles/components/marked.scss`](diffhunk://#diff-1b1f53e7a74b33e06c05954c28edd796aaa6576156a27e4e154d70e4c2bf2651R97-L107): Updated the list styles in the markdown content to use `auto` for `list-style`, `normal` for `white-space`, and `inside` for `list-style-position`. Removed specific styles for `ol` and `ul` elements.


## Fixes Issues

![CleanShot 2025-03-03 at 14 11 57](https://github.com/user-attachments/assets/11546b1f-cbb6-4a08-ab08-212ede73eea2)
![CleanShot 2025-03-03 at 14 02 25](https://github.com/user-attachments/assets/c563543a-ca45-425d-9c81-ad8cfe1ba50f)


- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
