### PR TITLE
refactor: clean up legacy vision model settings

### DIFF
--- a/extensions/model-extension/src/index.ts
+++ b/extensions/model-extension/src/index.ts
@@ -173,16 +173,16 @@ export default class JanModelExtension extends ModelExtension {
         toImportModels.map(async (model: Model & { file_path: string }) => {
           return this.importModel(
             model.id,
-            model.sources[0].url.startsWith('http') ||
-              !(await fs.existsSync(model.sources[0].url))
+            model.sources?.[0]?.url.startsWith('http') ||
+              !(await fs.existsSync(model.sources?.[0]?.url))
               ? await joinPath([
                   await dirName(model.file_path),
-                  model.sources[0]?.filename ??
+                  model.sources?.[0]?.filename ??
                     model.settings?.llama_model_path ??
-                    model.sources[0]?.url.split('/').pop() ??
+                    model.sources?.[0]?.url.split('/').pop() ??
                     model.id,
                 ]) // Copied models
-              : model.sources[0].url, // Symlink models,
+              : model.sources?.[0]?.url, // Symlink models,
             model.name
           )
             .then((e) => {


### PR DESCRIPTION
This pull request includes several changes to the `extensions/inference-cortex-extension` and `extensions/model-extension` modules. The most important changes involve removing legacy support for certain model settings and improving the handling of model file paths.

### Removal of Legacy Support:
* [`extensions/inference-cortex-extension/src/index.ts`](diffhunk://#diff-c7af858b5ac4edfb9d2aa937583d964a47e3d135c9f42dd1e858f19b0a59b86eL150-L179): Removed legacy chat model and clip vision model support by eliminating the conditional logic that handled `llama_model_path` and `mmproj` settings. These settings are now handled entirely by Cortex.
* [`extensions/inference-cortex-extension/src/index.ts`](diffhunk://#diff-c7af858b5ac4edfb9d2aa937583d964a47e3d135c9f42dd1e858f19b0a59b86eL337-L355): Deleted the `getModelFilePath` function, which was used for creating symlinks to model files under legacy support.

### Improved Handling of Model File Paths:
* [`extensions/model-extension/src/index.ts`](diffhunk://#diff-455462e3e0df5d294c62fe6a5c5913754f97422be9e8c47380907766ab6c9c61L176-R185): Updated the `importModel` method to use optional chaining for accessing model source URLs and filenames. This change ensures better handling of cases where these properties might be undefined.