### PR TITLE
fix: image preview overlap toolbar message

### DIFF
--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/ImageMessage.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/ImageMessage.tsx
@@ -4,7 +4,7 @@ import { RelativeImage } from '../TextMessage/RelativeImage'
 
 const ImageMessage = ({ image }: { image: string }) => {
   return (
-    <div className="group/file relative mb-2 inline-flex overflow-hidden rounded-xl">
+    <div className="group/file relative mb-2 mt-1 inline-flex overflow-hidden rounded-xl">
       <RelativeImage src={image} />
     </div>
   )

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
@@ -111,7 +111,10 @@ const MessageContainer: React.FC<
           className={twMerge(
             'absolute right-0 order-1 flex cursor-pointer items-center justify-start gap-x-2 transition-all',
             isUser
-              ? 'hidden group-hover:absolute group-hover:right-4 group-hover:top-4 group-hover:flex'
+              ? twMerge(
+                  'hidden group-hover:absolute group-hover:right-4 group-hover:top-4 group-hover:z-50 group-hover:flex',
+                  image && 'group-hover:-top-2'
+                )
               : 'relative left-0 order-2 flex w-full justify-between opacity-0 group-hover:opacity-100',
             props.isCurrentMessage && 'opacity-100'
           )}


### PR DESCRIPTION
## Describe Your Changes

This pull request includes changes to improve the layout and behavior of image messages in the thread center panel of the web application. The most important changes are:

Layout adjustments:

* [`web/screens/Thread/ThreadCenterPanel/TextMessage/ImageMessage.tsx`](diffhunk://#diff-ad16689fb40e6158413a43ebf918322e8b6e55f9f456d22b00a6c4f7a0ce92cdL7-R7): Added a top margin to the image message container for better spacing.

Behavior improvements:

* [`web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx`](diffhunk://#diff-efce7749ad34c34cc3f189aea671b9975208995580033b9de787c3c96c878cccL114-R117): Modified the `MessageContainer` class to adjust the positioning and z-index of the message container when hovered, ensuring it is displayed correctly over other elements. Additionally, added conditional styling for image messages to adjust the top position on hover.

## Fixes Issues

![CleanShot 2025-03-10 at 15 53 46](https://github.com/user-attachments/assets/d6a96656-b8e4-4f69-850d-ed41e39e25a9)
![CleanShot 2025-03-10 at 15 53 38](https://github.com/user-attachments/assets/786d8e65-2c65-4523-8daa-3a5e930e11eb)

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
