### PR TITLE
fix: app image - could not load model

### DIFF
--- a/extensions/engine-management-extension/src/node/index.ts
+++ b/extensions/engine-management-extension/src/node/index.ts
@@ -4,11 +4,12 @@ import {
   getJanDataFolderPath,
   log,
 } from '@janhq/core/node'
-import { mkdir, readdir, symlink } from 'fs/promises'
-
+import { mkdir, readdir, symlink, cp } from 'fs/promises'
+import { existsSync } from 'fs'
 
 /**
  * Create symlink to each variant for the default bundled version
+ * If running in AppImage environment, copy files instead of creating symlinks
  */
 const symlinkEngines = async () => {
   const sourceEnginePath = path.join(
@@ -23,6 +24,8 @@ const symlinkEngines = async () => {
     'cortex.llamacpp'
   )
   const variantFolders = await readdir(sourceEnginePath)
+  const isAppImage = !!process.env.APPIMAGE
+  
   for (const variant of variantFolders) {
     const targetVariantPath = path.join(
       sourceEnginePath,
@@ -39,10 +42,25 @@ const symlinkEngines = async () => {
       recursive: true,
     }).catch((error) => log(JSON.stringify(error)))
 
-    await symlink(targetVariantPath, symlinkVariantPath, 'junction').catch(
-      (error) => log(JSON.stringify(error))
-    )
-    console.log(`Symlink created: ${targetVariantPath} -> ${symlinkEnginePath}`)
+    // Skip if already exists
+    if (existsSync(symlinkVariantPath)) {
+      console.log(`Target already exists: ${symlinkVariantPath}`)
+      continue
+    }
+
+    if (isAppImage) {
+      // Copy files for AppImage environments instead of symlinking
+      await cp(targetVariantPath, symlinkVariantPath, { recursive: true }).catch(
+        (error) => log(JSON.stringify(error))
+      )
+      console.log(`Files copied: ${targetVariantPath} -> ${symlinkVariantPath}`)
+    } else {
+      // Create symlink for other environments
+      await symlink(targetVariantPath, symlinkVariantPath, 'junction').catch(
+        (error) => log(JSON.stringify(error))
+      )
+      console.log(`Symlink created: ${targetVariantPath} -> ${symlinkVariantPath}`)
+    }
   }
 }
 


### PR DESCRIPTION
This pull request includes updates to the `symlinkEngines` function in the `extensions/engine-management-extension/src/node/index.ts` file to handle AppImage environments more effectively. The changes introduce the use of the `cp` function for copying files instead of creating symlinks in AppImage environments, and add checks to skip existing targets.

Key changes include:

* Added `cp` and `existsSync` imports from `fs/promises` and `fs` respectively.
* Introduced a check for the AppImage environment using `process.env.APPIMAGE`.
* Implemented logic to skip the creation of symlinks if the target already exists.
* Added functionality to copy files instead of creating symlinks when running in an AppImage environment.