### PR TITLE
fix: hub model list desc render

### DIFF
--- a/web/screens/Hub/ModelList/ModelItem/index.tsx
+++ b/web/screens/Hub/ModelList/ModelItem/index.tsx
@@ -4,6 +4,8 @@ import Image from 'next/image'
 
 import { ModelSource } from '@janhq/core'
 
+import rehypeRaw from 'rehype-raw'
+
 import { DownloadIcon, FileJson } from 'lucide-react'
 
 import ModelLabel from '@/containers/ModelLabel'
@@ -36,6 +38,7 @@ const ModelItem: React.FC<Props> = ({ model, onSelectedModel }) => {
             <Markdown
               className="md-short-desc line-clamp-3 max-w-full overflow-hidden font-light text-[hsla(var(--text-secondary))]"
               components={markdownComponents}
+              rehypePlugins={[rehypeRaw]}
             >
               {extractDescription(model.metadata?.description) || '-'}
             </Markdown>

--- a/web/screens/Hub/ModelList/ModelItem/index.tsx
+++ b/web/screens/Hub/ModelList/ModelItem/index.tsx
@@ -4,9 +4,8 @@ import Image from 'next/image'
 
 import { ModelSource } from '@janhq/core'
 
-import rehypeRaw from 'rehype-raw'
-
 import { DownloadIcon, FileJson } from 'lucide-react'
+import rehypeRaw from 'rehype-raw'
 
 import ModelLabel from '@/containers/ModelLabel'
 

--- a/web/utils/modelSource.ts
+++ b/web/utils/modelSource.ts
@@ -7,12 +7,19 @@ export const extractDescription = (text?: string) => {
   const normalizedText = removeYamlFrontMatter(text)
   const overviewPattern = /(?:##\s*Overview\s*\n)([\s\S]*?)(?=\n\s*##|$)/
   const matches = normalizedText?.match(overviewPattern)
-  if (matches && matches[1]) {
-    return matches[1].trim()
-  }
-  return normalizedText?.slice(0, 500).trim()
-}
+  let extractedText =
+    matches && matches[1]
+      ? matches[1].trim()
+      : normalizedText?.slice(0, 500).trim()
 
+  // Remove image markdown syntax ![alt text](image-url)
+  extractedText = extractedText?.replace(/!\[.*?\]\(.*?\)/g, '')
+
+  // Remove <img> HTML tags
+  extractedText = extractedText?.replace(/<img[^>]*>/g, '')
+
+  return extractedText
+}
 /**
  * Remove YAML (HF metadata) front matter from content
  * @param content


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces enhancements to the `ModelItem` component and the `extractDescription` utility function. The changes involve adding a new plugin for Markdown rendering and improving the text extraction logic by removing image tags.

Enhancements to the `ModelItem` component:

* [`web/screens/Hub/ModelList/ModelItem/index.tsx`](diffhunk://#diff-cb3e07a310eb449312da3731e3667aa9d92c0df386d0796454f4f2675b98e232R8): Added the `rehype-raw` plugin to the Markdown component to allow raw HTML rendering. [[1]](diffhunk://#diff-cb3e07a310eb449312da3731e3667aa9d92c0df386d0796454f4f2675b98e232R8) [[2]](diffhunk://#diff-cb3e07a310eb449312da3731e3667aa9d92c0df386d0796454f4f2675b98e232R40)

Improvements to the `extractDescription` utility function:

* [`web/utils/modelSource.ts`](diffhunk://#diff-518333fcebdc63cdbd5bf9a37623fa22f539f72e7be6992455e1219b9a7e6f6cL10-R22): Modified the `extractDescription` function to remove image markdown syntax and `<img>` HTML tags from the extracted text.

## Fixes Issues

![CleanShot 2025-03-11 at 15 09 24](https://github.com/user-attachments/assets/08b03e80-6e95-41b8-a2e3-1b37408d8f23)

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
