### PR TITLE
chore: do not symlink engine on linux

### DIFF
--- a/extensions/engine-management-extension/src/node/index.ts
+++ b/extensions/engine-management-extension/src/node/index.ts
@@ -24,7 +24,7 @@ const symlinkEngines = async () => {
     'cortex.llamacpp'
   )
   const variantFolders = await readdir(sourceEnginePath)
-  const isAppImage = !!process.env.APPIMAGE
+  const isStandalone = process.platform === 'linux'
   
   for (const variant of variantFolders) {
     const targetVariantPath = path.join(
@@ -48,7 +48,7 @@ const symlinkEngines = async () => {
       continue
     }
 
-    if (isAppImage) {
+    if (isStandalone) {
       // Copy files for AppImage environments instead of symlinking
       await cp(targetVariantPath, symlinkVariantPath, { recursive: true }).catch(
         (error) => log(JSON.stringify(error))


### PR DESCRIPTION
This pull request includes changes to the `symlinkEngines` function in the `extensions/engine-management-extension/src/node/index.ts` file. The changes improve the handling of standalone Linux environments by updating the condition checks and related logic.

Improvements to Linux environment handling:

* Changed the `isAppImage` variable to `isStandalone` to better reflect its purpose, checking if the platform is Linux.
* Updated the condition to use `isStandalone` instead of `isAppImage` for copying files in standalone environments.