### PR TITLE
fix: update career url

### DIFF
--- a/docs/src/components/FooterMenu/index.tsx
+++ b/docs/src/components/FooterMenu/index.tsx
@@ -95,7 +95,7 @@ const menus = [
       },
       {
         menu: 'Careers',
-        path: 'https://homebrew.bamboohr.com/careers',
+        path: 'https://menlo.bamboohr.com/careers',
         external: true,
       },
     ],

--- a/docs/src/pages/about/team.mdx
+++ b/docs/src/pages/about/team.mdx
@@ -20,7 +20,7 @@ import { Cards, Card } from 'nextra/components'
 
 We're a small, fully-remote team, mostly based in Southeast Asia. 
 
-We are committed to become a global company. You can check our [Careers page](https://homebrew.bamboohr.com/careers) if you'd like to join us on our adventure.
+We are committed to become a global company. You can check our [Careers page](https://menlo.bamboohr.com/careers) if you'd like to join us on our adventure.
 
 <Callout emoji="🌏">
 Ping us in [Discord](https://discord.gg/AAGQNpJQtH) if you're keen to talk to us!

--- a/docs/src/pages/docs/index.mdx
+++ b/docs/src/pages/docs/index.mdx
@@ -158,7 +158,7 @@ Jan has an extensible architecture like VSCode and Obsidian - you can build cust
 </FAQBox>
 
 <FAQBox title="Are you hiring?">
-  Yes! We love hiring from our community. Check out our open positions at [Careers](https://homebrew.bamboohr.com/careers).
+  Yes! We love hiring from our community. Check out our open positions at [Careers](https://menlo.bamboohr.com/careers).
 </FAQBox>
 
 


### PR DESCRIPTION
## Describe Your Changes

This pull request includes updates to the URLs for the Careers page across multiple files to reflect the new BambooHR link.

Changes to URLs for the Careers page:

* [`docs/src/components/FooterMenu/index.tsx`](diffhunk://#diff-e58b1b4f7af1e40a58d249fe32e4577e3dffb8b745d83782293d336afcb90b9fL98-R98): Updated the `path` for the 'Careers' menu item to `https://menlo.bamboohr.com/careers`.
* [`docs/src/pages/about/team.mdx`](diffhunk://#diff-bd822ebdf9bd6a0eca34e493d50136e5846eedfd6f8ff143d42b79dd92c28dbdL23-R23): Updated the Careers page link in the text to `https://menlo.bamboohr.com/careers`.
* [`docs/src/pages/docs/index.mdx`](diffhunk://#diff-d257e59fb0044ee1c82adfc6eeafb2054095eaa05670d6d07b97b80fadcf9db6L161-R161): Updated the Careers page link in the FAQ section to `https://menlo.bamboohr.com/careers`.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
