### PR TITLE
fix: `fileStat` returned object in JS

### DIFF
--- a/src-tauri/src/core/fs.rs
+++ b/src-tauri/src/core/fs.rs
@@ -54,7 +54,7 @@ pub fn exists_sync<R: Runtime>(
 #[serde(rename_all = "camelCase")]
 pub struct FileStat {
     pub is_directory: bool,
-    pub file_size: u64,
+    pub size: u64,
 }
 
 #[tauri::command]
@@ -69,11 +69,8 @@ pub fn file_stat<R: Runtime>(
     let path = resolve_path(app_handle, &args);
     let metadata = fs::metadata(&path).map_err(|e| e.to_string())?;
     let is_directory = metadata.is_dir();
-    let file_size = if is_directory { 0 } else { metadata.len() };
-    let file_stat = FileStat {
-        is_directory,
-        file_size,
-    };
+    let size = if is_directory { 0 } else { metadata.len() };
+    let file_stat = FileStat { is_directory, size };
     Ok(file_stat)
 }
 


### PR DESCRIPTION
## Describe Your Changes

Currently `fileStat` returns a string. This PR fixes that by returning a custom  `FileStat` struct in tauri that can be deserialized and serialized into JSON.
- `fileSize` is renamed to `size` to match JS's typedef

Before

<img width="380" alt="image" src="https://github.com/user-attachments/assets/c4d1a994-f8f3-4dea-81a7-75ec8b81dc79" />

After

<img width="324" alt="image" src="https://github.com/user-attachments/assets/84c32105-f14b-438d-a53f-48e159b767a3" />

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change `file_stat` return type to `FileStat` struct with `is_directory` and `file_size` fields in `fs.rs`.
> 
>   - **Behavior**:
>     - Change `file_stat` return type from `String` to `FileStat` struct in `fs.rs`.
>     - `FileStat` struct includes `is_directory` and `file_size` fields.
>   - **Structs**:
>     - Add `FileStat` struct with `serde::Serialize` in `fs.rs`.
>   - **Misc**:
>     - Update `file_stat` function to construct and return `FileStat` object instead of formatted string.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 3ce02712ca84619d60a41c21a222ee95b3d332ed. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->