### PR TITLE
fix: ci remove pr review trigger

### DIFF
--- a/.github/workflows/jan-electron-build-nightly.yml
+++ b/.github/workflows/jan-electron-build-nightly.yml
@@ -188,28 +188,28 @@ jobs:
       new_version: ${{ needs.get-update-version.outputs.new_version }}
 
 
-  comment-pr-build-url:
-    needs: [
-      build-tauri-macos,
-      build-tauri-windows-x64,
-      build-tauri-linux-x64,
-      get-update-version,
-      set-public-provider,
-      sync-temp-to-latest
-    ]
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request_review'
-    steps:
-      - name: Set up GitHub CLI
-        run: |
-          curl -sSL https://github.com/cli/cli/releases/download/v2.33.0/gh_2.33.0_linux_amd64.tar.gz | tar xz
-          sudo cp gh_2.33.0_linux_amd64/bin/gh /usr/local/bin/
+  # comment-pr-build-url:
+  #   needs: [
+  #     build-tauri-macos,
+  #     build-tauri-windows-x64,
+  #     build-tauri-linux-x64,
+  #     get-update-version,
+  #     set-public-provider,
+  #     sync-temp-to-latest
+  #   ]
+  #   runs-on: ubuntu-latest
+  #   if: github.event_name == 'pull_request_review'
+  #   steps:
+  #     - name: Set up GitHub CLI
+  #       run: |
+  #         curl -sSL https://github.com/cli/cli/releases/download/v2.33.0/gh_2.33.0_linux_amd64.tar.gz | tar xz
+  #         sudo cp gh_2.33.0_linux_amd64/bin/gh /usr/local/bin/
 
-      - name: Comment build URL on PR
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          PR_URL=${{ github.event.pull_request.html_url }}
-          RUN_ID=${{ github.run_id }}
-          COMMENT="This is the build for this pull request. You can download it from the Artifacts section here: [Build URL](https://github.com/${{ github.repository }}/actions/runs/${RUN_ID})."
-          gh pr comment $PR_URL --body "$COMMENT"
+  #     - name: Comment build URL on PR
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       run: |
+  #         PR_URL=${{ github.event.pull_request.html_url }}
+  #         RUN_ID=${{ github.run_id }}
+  #         COMMENT="This is the build for this pull request. You can download it from the Artifacts section here: [Build URL](https://github.com/${{ github.repository }}/actions/runs/${RUN_ID})."
+  #         gh pr comment $PR_URL --body "$COMMENT"


### PR DESCRIPTION
This pull request modifies the GitHub Actions workflow file `.github/workflows/jan-electron-build-nightly.yml` to streamline the triggering conditions for the workflow.

Workflow trigger updates:

* Removed the `pull_request_review` trigger that activated the workflow on review submission. The workflow now triggers only for `pull_request` events targeting branches matching the `release/**` pattern.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Removed `pull_request_review` trigger and related job from GitHub Actions workflow to streamline triggers for `release/**` branches.
> 
>   - **Workflow Trigger Updates**:
>     - Removed `pull_request_review` trigger from `.github/workflows/jan-electron-build-nightly.yml`.
>     - Workflow now triggers only on `pull_request` events for `release/**` branches.
>   - **Job Removal**:
>     - Commenting job `comment-pr-build-url` is commented out, which was dependent on `pull_request_review` events.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for b9fbb7a17c1be6ce02ca64b29d17975d5d151547. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->