### PR TITLE
fix: correct app data folder name

### DIFF
--- a/src-tauri/src/core/cmd.rs
+++ b/src-tauri/src/core/cmd.rs
@@ -185,10 +185,8 @@ pub fn get_configuration_file_path<R: Runtime>(app_handle: tauri::AppHandle<R>) 
 
 #[tauri::command]
 pub fn default_data_folder_path<R: Runtime>(app_handle: tauri::AppHandle<R>) -> String {
-    let mut path = app_handle.path().app_data_dir().unwrap();
+    let mut path = app_handle.path().data_dir().unwrap();
 
-    path.pop(); // Remove the last path component (default to jan.ai.app) path.
-                // Use process env APP_NAME or default to app's product name (e.g. Jan, Jan-beta, etc.)
     let app_name = std::env::var("APP_NAME")
         .unwrap_or_else(|_| app_handle.config().product_name.clone().unwrap());
     path.push(app_name);


### PR DESCRIPTION
## Describe Your Changes
This is to correct the default folder path for the app data folder for the first launch. Instead of using the app identifier as the default folder name, we should use the folder name we defined previously.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Corrects app data folder path construction in `default_data_folder_path` in `cmd.rs` using `APP_NAME` or `product_name`.
> 
>   - **Behavior**:
>     - `default_data_folder_path` in `cmd.rs` now constructs the path using `APP_NAME` or `product_name` and appends 'data'.
>     - Strips ".ai.app" suffix if present in the path.
>   - **Misc**:
>     - Minor formatting fix in `get_active_extensions` in `cmd.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for eefdecd78d1f4889bfcf16deddfbf2fa782335cf. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->