### PR TITLE
fix: tool call block spacing

### DIFF
--- a/web-app/src/containers/ToolCallBlock.tsx
+++ b/web-app/src/containers/ToolCallBlock.tsx
@@ -37,10 +37,10 @@ const ToolCallBlock = ({ id, name, result, loading }: Props) => {
 
   return (
     <div
-      className="mx-auto w-full cursor-pointer mt-4 break-words"
+      className="mx-auto w-full cursor-pointer break-words"
       onClick={handleClick}
     >
-      <div className="mb-4 rounded-lg bg-main-view-fg/4 border border-dashed border-main-view-fg/10">
+      <div className="rounded-lg bg-main-view-fg/4 border border-dashed border-main-view-fg/10">
         <div className="flex items-center gap-3 p-2">
           {loading && (
             <Loader className="size-4 animate-spin text-main-view-fg/60" />


### PR DESCRIPTION
## Issue

![Screenshot 2025-05-29 at 21 30 46](https://github.com/user-attachments/assets/c5b0c151-b48a-4b56-9070-36d7a6c77a55)

## Describe Your Changes

This pull request makes minor adjustments to the styling of the `ToolCallBlock` component in `web-app/src/containers/ToolCallBlock.tsx`. The changes involve removing unnecessary spacing and margins.

Styling adjustments:

* Removed the `mt-4` class from the outermost `div` to eliminate the top margin.
* Removed the `mb-4` class from the inner `div` to eliminate the bottom margin.

## Fixes Issues

![Screenshot 2025-05-29 at 21 34 53](https://github.com/user-attachments/assets/3fa0bb7e-5959-45de-8604-3f1d73c64fa3)


- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove unnecessary top and bottom margins in `ToolCallBlock` component in `ToolCallBlock.tsx`.
> 
>   - **Styling Adjustments**:
>     - Removed `mt-4` class from the outermost `div` in `ToolCallBlock.tsx` to eliminate top margin.
>     - Removed `mb-4` class from the inner `div` in `ToolCallBlock.tsx` to eliminate bottom margin.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for a30648bc7c7fd60314791a247ea547872aa81bea. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->