### PR TITLE
fix: solid background for linux and web

### DIFF
--- a/web-app/src/containers/ColorPickerAppBgColor.tsx
+++ b/web-app/src/containers/ColorPickerAppBgColor.tsx
@@ -16,38 +16,38 @@ export function ColorPickerAppBgColor() {
       r: 20,
       g: 20,
       b: 20,
-      a: 0.4,
+      a: IS_LINUX || !IS_TAURI ? 1 : 0.4,
     },
     {
       r: 250,
       g: 250,
       b: 250,
-      a: 0.4,
+      a: IS_LINUX || !IS_TAURI ? 1 : 0.4,
     },
     {
       r: 70,
       g: 79,
       b: 229,
-      a: 0.5,
+      a: IS_LINUX || !IS_TAURI ? 1 : 0.5,
     },
     {
       r: 238,
       g: 130,
       b: 238,
-      a: 0.5,
+      a: IS_LINUX || !IS_TAURI ? 1 : 0.5,
     },
 
     {
       r: 255,
       g: 99,
       b: 71,
-      a: 0.5,
+      a: IS_LINUX || !IS_TAURI ? 1 : 0.5,
     },
     {
       r: 255,
       g: 165,
       b: 0,
-      a: 0.5,
+      a: IS_LINUX || !IS_TAURI ? 1 : 0.5,
     },
   ]
 
@@ -64,7 +64,7 @@ export function ColorPickerAppBgColor() {
             key={i}
             className={cn(
               'size-4 rounded-full border border-main-view-fg/20',
-              isSelected && 'ring-2 ring-blue-500 border-none'
+              isSelected && 'ring-2 ring-accent border-none'
             )}
             onClick={() => {
               setAppBgColor(item)

--- a/web-app/src/hooks/useAppearance.ts
+++ b/web-app/src/hooks/useAppearance.ts
@@ -40,8 +40,18 @@ export const fontSizeOptions = [
 
 // Default appearance settings
 const defaultFontSize: FontSize = '15px'
-const defaultAppBgColor: RgbaColor = { r: 0, g: 0, b: 0, a: 0.4 }
-const defaultLightAppBgColor: RgbaColor = { r: 255, g: 255, b: 255, a: 0.4 }
+const defaultAppBgColor: RgbaColor = {
+  r: 0,
+  g: 0,
+  b: 0,
+  a: IS_LINUX || !IS_TAURI ? 1 : 0.4,
+}
+const defaultLightAppBgColor: RgbaColor = {
+  r: 255,
+  g: 255,
+  b: 255,
+  a: IS_LINUX || !IS_TAURI ? 1 : 0.4,
+}
 const defaultAppMainViewBgColor: RgbaColor = { r: 25, g: 25, b: 25, a: 1 }
 const defaultLightAppMainViewBgColor: RgbaColor = {
   r: 250,

--- a/web-app/src/providers/AppearanceProvider.tsx
+++ b/web-app/src/providers/AppearanceProvider.tsx
@@ -35,6 +35,22 @@ export function AppearanceProvider() {
     // Apply font size
     document.documentElement.style.setProperty('--font-size-base', fontSize)
 
+    // Hide alpha slider when IS_LINUX || !IS_TAURI
+    const shouldHideAlpha = IS_LINUX || !IS_TAURI
+    let alphaStyleElement = document.getElementById('alpha-slider-style')
+
+    if (shouldHideAlpha) {
+      if (!alphaStyleElement) {
+        alphaStyleElement = document.createElement('style')
+        alphaStyleElement.id = 'alpha-slider-style'
+        document.head.appendChild(alphaStyleElement)
+      }
+      alphaStyleElement.textContent =
+        '.react-colorful__alpha { display: none !important; }'
+    } else if (alphaStyleElement) {
+      alphaStyleElement.remove()
+    }
+
     // Apply app background color
     // Import culori functions dynamically to avoid SSR issues
     import('culori').then(({ rgb, oklch, formatCss }) => {
@@ -44,7 +60,7 @@ export function AppearanceProvider() {
         r: appBgColor.r / 255,
         g: appBgColor.g / 255,
         b: appBgColor.b / 255,
-        alpha: appBgColor.a,
+        alpha: IS_LINUX || !IS_TAURI ? 1 : appBgColor.a,
       })
 
       const culoriRgbMainView = rgb({


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces platform-specific adjustments to the appearance settings of the web application, particularly targeting Linux and non-Tauri environments. The changes ensure consistent behavior across platforms by modifying alpha values and UI elements accordingly.

### Platform-specific appearance adjustments:

* [`web-app/src/containers/ColorPickerAppBgColor.tsx`](diffhunk://#diff-7958fb1de7301d9fb22dbcbc84207ea2a2731eb8ed8f85ee5f196e189db68679L19-R50): Updated the alpha (`a`) value for background colors to `1` when `IS_LINUX || !IS_TAURI`, otherwise retaining the original values.
* [`web-app/src/hooks/useAppearance.ts`](diffhunk://#diff-b3a596905019c5a1b08c73f84b4214bef88030db1785f9ee82df0fad34fab8fdL43-R54): Adjusted the default background colors (`defaultAppBgColor` and `defaultLightAppBgColor`) to set alpha to `1` for Linux or non-Tauri environments.
* [`web-app/src/providers/AppearanceProvider.tsx`](diffhunk://#diff-0543886931db889e6ef8ffaa6fc2bd4f38f7c43326010192deb14e9d5f144db5R38-R53): Added logic to hide the alpha slider in the color picker UI when `IS_LINUX || !IS_TAURI`, ensuring platform-specific UI consistency.

### UI enhancements:

* [`web-app/src/containers/ColorPickerAppBgColor.tsx`](diffhunk://#diff-7958fb1de7301d9fb22dbcbc84207ea2a2731eb8ed8f85ee5f196e189db68679L67-R67): Changed the ring color for selected items in the color picker from `ring-blue-500` to `ring-accent` for improved visual consistency.

### Dynamic alpha handling:

* [`web-app/src/providers/AppearanceProvider.tsx`](diffhunk://#diff-0543886931db889e6ef8ffaa6fc2bd4f38f7c43326010192deb14e9d5f144db5L47-R63): Dynamically adjusted the alpha value for background color calculations based on the platform (`IS_LINUX || !IS_TAURI`).

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Platform-specific UI adjustments for Linux and non-Tauri environments, setting alpha to `1` and hiding alpha slider in color picker.
> 
>   - **Platform-specific adjustments**:
>     - `ColorPickerAppBgColor.tsx`: Set alpha to `1` for background colors when `IS_LINUX || !IS_TAURI`.
>     - `useAppearance.ts`: Default background colors have alpha set to `1` for Linux or non-Tauri.
>     - `AppearanceProvider.tsx`: Hide alpha slider in color picker UI when `IS_LINUX || !IS_TAURI`.
>   - **UI enhancements**:
>     - `ColorPickerAppBgColor.tsx`: Change ring color for selected items from `ring-blue-500` to `ring-accent`.
>   - **Dynamic alpha handling**:
>     - `AppearanceProvider.tsx`: Adjust alpha value for background color calculations based on platform.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for edacdbcdafc91b3a2f5fcfae786755ca864c7b85. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->