### PR TITLE
fix: create new provider should not have previous settings

### DIFF
--- a/web-app/src/containers/ProvidersMenu.tsx
+++ b/web-app/src/containers/ProvidersMenu.tsx
@@ -17,6 +17,8 @@ import { Button } from '@/components/ui/button'
 import { useCallback, useState } from 'react'
 import { openAIProviderSettings } from '@/mock/data'
 import ProvidersAvatar from '@/containers/ProvidersAvatar'
+import cloneDeep from 'lodash/cloneDeep'
+import { toast } from 'sonner'
 
 const ProvidersMenu = ({
   stepSetupRemoteProvider,
@@ -28,14 +30,21 @@ const ProvidersMenu = ({
   const matches = useMatches()
   const [name, setName] = useState('')
   const createProvider = useCallback(() => {
-    addProvider({
+    if (providers.some((e) => e.provider === name)) {
+      toast.error(
+        `Provider with name "${name}" already exists. Please choose a different name.`
+      )
+      return
+    }
+    const newProvider = {
       provider: name,
       active: true,
       models: [],
-      settings: openAIProviderSettings as ProviderSetting[],
+      settings: cloneDeep(openAIProviderSettings) as ProviderSetting[],
       api_key: '',
       base_url: 'https://api.openai.com/v1',
-    })
+    }
+    addProvider(newProvider)
     setTimeout(() => {
       navigate({
         to: route.settings.providers,
@@ -44,7 +53,7 @@ const ProvidersMenu = ({
         },
       })
     }, 0)
-  }, [name, addProvider, navigate])
+  }, [providers, name, addProvider, navigate])
 
   return (
     <div className="w-44 py-2 border-r border-main-view-fg/5 pb-10 overflow-y-auto">


### PR DESCRIPTION
## Describe Your Changes

This PR addresses the issue where creating a new provider doesn't inherit the cached settings from a previously created provider.

Also gated creating duplicated providers.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes provider creation in `ProvidersMenu` to prevent inheriting settings and disallows duplicate names.
> 
>   - **Behavior**:
>     - Fixes issue in `ProvidersMenu` where new providers inherited settings from previous ones by using `cloneDeep` on `openAIProviderSettings`.
>     - Adds check in `createProvider` to prevent duplicate provider names, showing error toast if name exists.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 2753a829972a6ea4253d251de8658a27bc9cc33a. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->