### PR TITLE
fix: should not show vulkan options in cpu only mode

### DIFF
--- a/web-app/src/routes/settings/hardware.tsx
+++ b/web-app/src/routes/settings/hardware.tsx
@@ -282,13 +282,17 @@ function Hardware() {
                 title="Usage"
                 actions={
                   <div className="flex items-center gap-2">
-                    <Progress
-                      value={hardwareData.cpu?.usage}
-                      className="h-2 w-10"
-                    />
-                    <span className="text-main-view-fg/80">
-                      {hardwareData.cpu?.usage?.toFixed(2)}%
-                    </span>
+                    {hardwareData.cpu?.usage > 0 && (
+                      <>
+                        <Progress
+                          value={hardwareData.cpu?.usage}
+                          className="h-2 w-10"
+                        />
+                        <span className="text-main-view-fg/80">
+                          {hardwareData.cpu?.usage?.toFixed(2)}%
+                        </span>
+                      </>
+                    )}
                   </div>
                 }
               />
@@ -316,24 +320,28 @@ function Hardware() {
                 title="Usage"
                 actions={
                   <div className="flex items-center gap-2">
-                    <Progress
-                      value={
-                        ((hardwareData.ram?.total -
-                          hardwareData.ram?.available) /
-                          hardwareData.ram?.total) *
-                        100
-                      }
-                      className="h-2 w-10"
-                    />
-                    <span className="text-main-view-fg/80">
-                      {(
-                        ((hardwareData.ram?.total -
-                          hardwareData.ram?.available) /
-                          hardwareData.ram?.total) *
-                        100
-                      ).toFixed(2)}
-                      %
-                    </span>
+                    {hardwareData.ram?.total > 0 && (
+                      <>
+                        <Progress
+                          value={
+                            ((hardwareData.ram?.total -
+                              hardwareData.ram?.available) /
+                              hardwareData.ram?.total) *
+                            100
+                          }
+                          className="h-2 w-10"
+                        />
+                        <span className="text-main-view-fg/80">
+                          {(
+                            ((hardwareData.ram?.total -
+                              hardwareData.ram?.available) /
+                              hardwareData.ram?.total) *
+                            100
+                          ).toFixed(2)}
+                          %
+                        </span>
+                      </>
+                    )}
                   </div>
                 }
               />


### PR DESCRIPTION
## Fix Hardware Page Display Issues

### Summary

This PR addresses two critical display issues in the Hardware settings page that could cause visual glitches and incorrect information display.

### Changes Made

#### 1. Hide Vulkan Settings in CPU-Only Mode (598bf353b)

- __Problem__: Vulkan settings were being displayed even when no GPUs were available, which is misleading since Vulkan requires GPU hardware
- __Solution__: Added conditional rendering to only show the Vulkan settings card when GPUs are detected
- __Implementation__: Wrapped the Vulkan Card component with `{hardwareData.gpus.length > 0 && (...)}`

#### 2. Fix NaN Display Issues (2a48a3752)

- __Problem__: CPU and RAM usage displays were showing "NaN%" when hardware data was unavailable or zero, creating a poor user experience

- __Solution__: Added proper validation checks before rendering usage statistics

- __Implementation__:

  - CPU Usage: Added `{hardwareData.cpu?.usage > 0 && (...)}` check before displaying progress bar and percentage
  - RAM Usage: Added `{hardwareData.ram?.total > 0 && (...)}` check before displaying memory usage calculations

###


![CleanShot 2025-06-06 at 23 52 59@2x](https://github.com/user-attachments/assets/902d47cd-5d9a-44bf-915b-6da3ea3d16c1)

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Conditionally render Vulkan settings and CPU/RAM usage in `hardware.tsx` based on available hardware data.
> 
>   - **Behavior**:
>     - In `hardware.tsx`, Vulkan settings are now conditionally rendered only if `hardwareData.gpus.length > 0`.
>     - CPU usage display is now conditional on `hardwareData.cpu?.usage > 0`.
>     - RAM usage display is now conditional on `hardwareData.ram?.total > 0`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 2a48a37523605af0b4fd351c825d7a78e3acfa12. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->