### PR TITLE
fix: ui glitch dots truncated

### DIFF
--- a/web-app/src/containers/ThreadList.tsx
+++ b/web-app/src/containers/ThreadList.tsx
@@ -103,7 +103,6 @@ const SortableItem = memo(({ thread }: { thread: Thread }) => {
     >
       <div className="py-1 pr-2 truncate">
         <span
-          className="text-left-panel-fg/90"
           dangerouslySetInnerHTML={{ __html: thread.title || 'New Thread' }}
         />
       </div>


### PR DESCRIPTION
## Describe Your Changes

![image](https://github.com/user-attachments/assets/ee2bfa87-37b9-4b6a-8c42-6f85af97cc90)

This pull request makes a small visual adjustment to the `ThreadList` component by removing a CSS class from the thread title.

* [`web-app/src/containers/ThreadList.tsx`](diffhunk://#diff-6ceb1386da0a5d583ee37e9a8b95bd364e9bcd2a11bb00ea36d3cfca42b9de7cL106): Removed the `text-left-panel-fg/90` CSS class from the `span` element rendering the thread title, simplifying the styling.

## Fixes Issues

![Screenshot 2025-06-09 at 13 34 19](https://github.com/user-attachments/assets/7fbbe4f1-d3cc-42a4-8eca-6019e76685c9)


- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `text-left-panel-fg/90` CSS class from `ThreadList.tsx` to fix thread title truncation issue.
> 
>   - **UI Fix**:
>     - Removed `text-left-panel-fg/90` CSS class from `span` in `ThreadList.tsx` to fix visual glitch where dots were truncated in thread titles.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 8befe190fa377ce4bcd96fae4c1fabd17ac2b1da. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->