### PR TITLE
fix: MCP server should not spawn shell window

### DIFF
--- a/src-tauri/src/core/mcp.rs
+++ b/src-tauri/src/core/mcp.rs
@@ -117,7 +117,7 @@ async fn start_mcp_server<R: Runtime>(
             cmd.env("UV_CACHE_DIR", cache_dir.to_str().unwrap().to_string());
         }
         #[cfg(windows)] {
-            cmd.creation_flags(0x08000000);
+            cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW: prevents shell window on Windows
         }
         let app_path_str = app_path.to_str().unwrap().to_string();
         let log_file_path = format!("{}/logs/app.log", app_path_str);


### PR DESCRIPTION
## Describe Your Changes

Fixed an issue where MCP server spawns a shell window on start.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Prevent shell window from appearing on Windows when starting MCP server by adding a creation flag in `start_mcp_server()` in `mcp.rs`.
> 
>   - **Behavior**:
>     - Prevents shell window from appearing on Windows when starting MCP server by adding `cmd.creation_flags(0x08000000)` in `start_mcp_server()` in `mcp.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for e9a858cd007f9d93eee7b43590410c94ea269fe3. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->