### PR TITLE
fix: tauri path env

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -51,6 +51,7 @@ sysinfo = "0.34.2"
 ash = "0.38.0"
 nvml-wrapper = "0.10.0"
 tauri-plugin-deep-link = "2"
+fix-path-env = { git = "https://github.com/tauri-apps/fix-path-env-rs" }
 
 [target.'cfg(windows)'.dependencies]
 libloading = "0.8.7"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -2,5 +2,6 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    let _ = fix_path_env::fix();
     app_lib::run();
 }


### PR DESCRIPTION
## Describe Your Changes

This PR is to fix an issue where app does not inherit PATH env by default so that MCP servers could not be turned on.

![CleanShot 2025-06-10 at 17 58 02@2x](https://github.com/user-attachments/assets/e0fde85d-0b5b-4578-84f5-94c027cff8a0)

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes PATH environment inheritance issue by adding `fix-path-env` dependency and calling `fix_path_env::fix()` in `main.rs`.
> 
>   - **Behavior**:
>     - Fixes issue where app does not inherit PATH env by default, affecting MCP server activation.
>     - Adds `fix_path_env::fix()` call in `main.rs` to resolve PATH inheritance.
>   - **Dependencies**:
>     - Adds `fix-path-env` dependency in `Cargo.toml` from GitHub repository `tauri-apps/fix-path-env-rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for a5cfeb1a3e6a869baf6dee719f689be73afce8e1. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->