### PR TITLE
fix: reduce app state left panel

### DIFF
--- a/web-app/src/containers/LeftPanel.tsx
+++ b/web-app/src/containers/LeftPanel.tsx
@@ -91,8 +91,6 @@ const LeftPanel = () => {
     return filteredThreads.filter((t) => !t.isFavorite)
   }, [filteredThreads])
 
-  const [openDropdown, setOpenDropdown] = useState(false)
-
   return (
     <aside
       className={cn(
@@ -211,15 +209,8 @@ const LeftPanel = () => {
                     {t('common.recents')}
                   </span>
                   <div className="relative">
-                    <Dialog
-                      onOpenChange={(open) => {
-                        if (!open) setOpenDropdown(false)
-                      }}
-                    >
-                      <DropdownMenu
-                        open={openDropdown}
-                        onOpenChange={(open) => setOpenDropdown(open)}
-                      >
+                    <Dialog>
+                      <DropdownMenu>
                         <DropdownMenuTrigger asChild>
                           <button
                             className="size-6 flex cursor-pointer items-center justify-center rounded hover:bg-left-panel-fg/10 transition-all duration-200 ease-in-out data-[state=open]:bg-left-panel-fg/10"


### PR DESCRIPTION
## Describe Your Changes

This pull request simplifies the `LeftPanel` component in the `web-app` by removing unnecessary state management and streamlining the dropdown menu logic.

### Codebase simplification:

* [`web-app/src/containers/LeftPanel.tsx`](diffhunk://#diff-8fe9510686bc63c447d596c9015da8053ef7172d644ed42f7daa12a2a794a706L94-L95): Removed the `openDropdown` state and its associated `useState` hook, simplifying the component's state management.
* [`web-app/src/containers/LeftPanel.tsx`](diffhunk://#diff-8fe9510686bc63c447d596c9015da8053ef7172d644ed42f7daa12a2a794a706L214-R213): Refactored the dropdown menu logic by eliminating the `onOpenChange` handlers and directly using the `Dialog` and `DropdownMenu` components without additional state tracking.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplifies `LeftPanel` component by removing `openDropdown` state and refactoring dropdown menu logic in `LeftPanel.tsx`.
> 
>   - **Codebase Simplification**:
>     - Removed `openDropdown` state and `useState` hook from `LeftPanel.tsx`.
>     - Refactored dropdown menu logic in `LeftPanel.tsx` by removing `onOpenChange` handlers and using `Dialog` and `DropdownMenu` directly.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 893a2862e168f2b3b727de83f60c5ee05c7d0604. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->