### PR TITLE
fix: jan doc hotfix

### DIFF
--- a/docs/src/pages/docs/index.mdx
+++ b/docs/src/pages/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Jan
-description: Jan is an open-source AI assistant and self-hosted AI platform - build and run AI on your own desktop or server.
+description: Jan is an open-source ChatGPT-alternative and self-hosted AI platform - build and run AI on your own desktop or server.
 keywords:
   [
     Jan,

--- a/docs/src/pages/docs/quickstart.mdx
+++ b/docs/src/pages/docs/quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: Jan is an open-source AI assistant and self-hosted AI platform - build and run AI on your own desktop or server.
+description: Jan is an open-source ChatGPT-alternative and self-hosted AI platform - build and run AI on your own desktop or server.
 sidebar_position: 2
 keywords:
   [

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Jan: Open source ChatGPT-alternative that runs 100% offline"
-description: "Chat with AI without privacy concerns. Jan is an open-source alternative to ChatGPT, running AI models locally on your device."
+description: "Chat with AI without privacy concerns. Jan is an open-source ChatGPT-alternative, running AI models locally on your device."
 keywords:
   [
     Jan,


### PR DESCRIPTION
This pull request updates the descriptions across multiple documentation files to consistently refer to Jan as an "open-source ChatGPT-alternative." The changes aim to clarify Jan's positioning and improve its branding.

### Updates to descriptions in documentation:

* [`docs/src/pages/docs/index.mdx`](diffhunk://#diff-d257e59fb0044ee1c82adfc6eeafb2054095eaa05670d6d07b97b80fadcf9db6L3-R3): Updated the description to position Jan as an "open-source ChatGPT-alternative and self-hosted AI platform."
* [`docs/src/pages/docs/quickstart.mdx`](diffhunk://#diff-67baf4db3d0a4440d3b63a9b2699158cd6ad3737a6276bf590812adb308334a1L3-R3): Modified the description to align with the updated branding as a "ChatGPT-alternative and self-hosted AI platform."
* [`docs/src/pages/index.mdx`](diffhunk://#diff-b767a840009afddb58448e34770f019e417538eb855a8086a9ba80c5fc1040adL3-R3): Adjusted the description to emphasize Jan as an "open-source ChatGPT-alternative" running AI models locally.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates documentation to consistently describe Jan as an "open-source ChatGPT-alternative."
> 
>   - **Documentation Updates**:
>     - Updated description in `index.mdx` to position Jan as an "open-source ChatGPT-alternative and self-hosted AI platform."
>     - Modified description in `quickstart.mdx` to align with branding as a "ChatGPT-alternative and self-hosted AI platform."
>     - Adjusted description in `index.mdx` to emphasize Jan as an "open-source ChatGPT-alternative" running AI models locally.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for f3e7ee2f2f2d429b783ae5ae55d72a45850d7b35. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->