### PR TITLE
🐛 fix(updater): terminate sidecar processes before update to avoid file access errors

### DIFF
--- a/src-tauri/src/core/setup.rs
+++ b/src-tauri/src/core/setup.rs
@@ -291,6 +291,7 @@ pub fn setup_sidecar(app: &App) -> Result<(), String> {
                 } else {
                     log::warn!("Kill event received, but no active sidecar process found to kill.");
                 }
+                clean_up()
             });
         });
 


### PR DESCRIPTION
This pull request introduces a minor change to the `src-tauri/src/core/setup.rs` file. The change ensures that the `clean_up()` function is called when a kill event is received but no active sidecar process is found to kill.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Calls `clean_up()` in `setup.rs` when a kill event is received but no active sidecar process is found, ensuring termination of lingering sidecar processes.
> 
>   - **Behavior**:
>     - Calls `clean_up()` in `setup.rs` when a kill event is received but no active sidecar process is found.
>     - Ensures termination of lingering sidecar processes to prevent file access errors during updates.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for d60ded6e04637968d117f3df9bfe1981076f2a8d. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->