### PR TITLE
fix: simplify backend exe path resolution and clean up debug log

### DIFF
--- a/extensions/llamacpp-extension/src/backend.ts
+++ b/extensions/llamacpp-extension/src/backend.ts
@@ -102,12 +102,7 @@ export async function getBackendExePath(
     sysInfo.os_type === 'windows' ? 'llama-server.exe' : 'llama-server'
   const backendDir = await getBackendDir(backend, version)
   let exePath: string
-  const buildDir = await joinPath([backendDir, 'build'])
-  if (await fs.existsSync(buildDir)) {
-    exePath = await joinPath([backendDir, 'build', 'bin', exe_name])
-  } else {
-    exePath = await joinPath([backendDir, exe_name])
-  }
+  exePath = await joinPath([backendDir, 'build', 'bin', exe_name])
   return exePath
 }
 

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -1027,7 +1027,6 @@ export default class llamacpp_extension extends AIEngine {
     }
     const baseUrl = `http://localhost:${sessionInfo.port}/v1`
     const url = `${baseUrl}/chat/completions`
-    console.log('Session Info:', sessionInfo, sessionInfo.api_key)
     const headers = {
       'Content-Type': 'application/json',
       'Authorization': `Bearer ${sessionInfo.api_key}`,

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Jan"
-version = "0.6.904"
+version = "0.6.599"
 description = "Use offline LLMs with your own data. Run open source models like Llama2 or Falcon on your internal computers/servers."
 authors = ["Jan <service@jan.ai>"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Jan",
-  "version": "0.6.904",
+  "version": "0.6.599",
   "identifier": "jan.ai.app",
   "build": {
     "frontendDist": "../web-app/dist",


### PR DESCRIPTION
- Always resolve the backend executable to build/bin/llama-server(.exe), removing fallback to root backendDir. This simplifies the logic and ensures consistent backend structure and ensures library path is resolved correctly in load() (even on Linux).
- Removed a leftover console.log from chat completion API request.
- Reverted version number from 0.6.904 to 0.6.599 in Cargo.toml and tauri.conf.json to maintain version consistency since we are shipping llamacpp-extension in 0.6.6.

Linux test: Okay
Need to test on Windows cc @louis-menlo 

may resolve #5815 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplifies backend executable path resolution, cleans up debug log, and reverts version numbers for consistency.
> 
>   - **Behavior**:
>     - Simplifies backend executable path resolution in `getBackendExePath()` in `backend.ts` to always use `build/bin/llama-server(.exe)`, removing fallback to root `backendDir`.
>     - Removes console log from chat completion API request in `index.ts`.
>   - **Versioning**:
>     - Reverts version number from `0.6.904` to `0.6.599` in `Cargo.toml` and `tauri.conf.json` for consistency with `llamacpp-extension` version `0.6.6`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for e0e4566daa6efc1a6d8a0c19865a5a467c1a49e5. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->