### PR TITLE
chore: update build appimage script

### DIFF
--- a/src-tauri/build-utils/buildAppImage.sh
+++ b/src-tauri/build-utils/buildAppImage.sh
@@ -3,7 +3,7 @@ APPIMAGETOOL="./.cache/build-tools/appimagetool"
 RELEASE_CHANNEL=${RELEASE_CHANNEL:-"stable"}
 
 mkdir -p ./.cache/build-tools
-wget https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage -O "${APPIMAGETOOL}"
+wget https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage -O "${APPIMAGETOOL}" || { echo "Failed to download appimagetool."; exit 1; }
 chmod +x "${APPIMAGETOOL}"
 
 if [ "${RELEASE_CHANNEL}" != "stable" ]; then


### PR DESCRIPTION
This pull request simplifies the `buildAppImage.sh` script by removing unnecessary conditional logic and ensuring the `appimagetool` is always downloaded. 

Key changes to the script:

* Removed the conditional check for the existence of the `appimagetool` file and the associated comment, ensuring that the tool is always downloaded. (`src-tauri/build-utils/buildAppImage.sh`, [src-tauri/build-utils/buildAppImage.shL5-L10](diffhunk://#diff-25da3dfeca3b239cc3842e2a21d86ff99a6f0af8e134e7e0b2f2892e8811176eL5-L10))
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Simplifies `buildAppImage.sh` by always downloading `appimagetool`, removing unnecessary conditional logic.
> 
>   - **Script Simplification**:
>     - Removed conditional check for `appimagetool` existence in `buildAppImage.sh`, ensuring it is always downloaded.
>     - Deleted associated comment and logic, simplifying the script.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 6dd65aba29e0cbef433700a200119e4fe903679a. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->