### PR TITLE
fix: Persist 'Auto-Unload Old Models' setting in llama.cpp

### DIFF
--- a/extensions/llamacpp-extension/settings.json
+++ b/extensions/llamacpp-extension/settings.json
@@ -17,7 +17,7 @@
     "controllerProps": { "value": true }
   },
   {
-    "key": "auto_unload_models",
+    "key": "auto_unload",
     "title": "Auto-Unload Old Models",
     "description": "Automatically unloads models that are not in use to free up memory. Ensure only one model is loaded at a time.",
     "controllerType": "checkbox",


### PR DESCRIPTION
The 'Auto-Unload Old Models' setting in the llama.cpp extension failed to persist due to a typo in its key name within `settings.json`. The key was incorrectly `auto_unload_models` instead of `auto_unload`.

This commit corrects the key name to `auto_unload`, ensuring that user-configured changes to this setting are properly saved, retrieved, and persist across application restarts.

This resolves the issue where the setting would change and remain to its previous value after being changed.


## Fixes Issues

- Closes #5895 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes persistence issue of 'Auto-Unload Old Models' setting by correcting key name in `settings.json`.
> 
>   - **Fix**:
>     - Corrects key name from `auto_unload_models` to `auto_unload` in `settings.json` to ensure persistence of 'Auto-Unload Old Models' setting.
>   - **Issue**:
>     - Resolves issue #5895 where the setting failed to persist across application restarts due to the incorrect key.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for dcd635db5b5c53187ad93ac35aaea2d5d1394f10. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->