### PR TITLE
ci: reduce upload concurrency to improve artifact reliability

### DIFF
--- a/.github/workflows/autoqa-template.yml
+++ b/.github/workflows/autoqa-template.yml
@@ -461,6 +461,8 @@ jobs:
         with:
           name: ${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-logs-${{ github.run_number }}-${{ runner.os }}
           path: autoqa/jan-logs/
+        env:
+          ACTIONS_ARTIFACT_UPLOAD_CONCURRENCY: 10
 
       - name: Cleanup after tests
         if: always()


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Set `ACTIONS_ARTIFACT_UPLOAD_CONCURRENCY` to 10 in `autoqa-template.yml` to improve artifact upload reliability.
> 
>   - **CI Configuration**:
>     - Set `ACTIONS_ARTIFACT_UPLOAD_CONCURRENCY: 10` in `.github/workflows/autoqa-template.yml` for the `Upload Jan logs` step to improve artifact upload reliability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 1f45c6dae22d9ead85c38b0fd48b3fdfa253c89e. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->