### PR TITLE
fix: csp including img.shields.io and cdn-uploads.huggingface.co in img-src directive

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -45,7 +45,7 @@
         "font-src": [
           "https://fonts.gstatic.com blob: data: tauri://localhost http://tauri.localhost"
         ],
-        "img-src": "'self' asset: http://asset.localhost blob: data: https://cdn.jsdelivr.net https://img.shields.io",
+        "img-src": "'self' asset: http://asset.localhost blob: data: https://cdn.jsdelivr.net https://img.shields.io https://cdn-uploads.huggingface.co",
         "style-src": "'unsafe-inline' 'self' https://fonts.googleapis.com",
         "script-src": "'self' asset: $APPDATA/**.* http://asset.localhost https://eu-assets.i.posthog.com https://posthog.com"
       },


### PR DESCRIPTION
This pull request updates the Content Security Policy (CSP) configuration in the `src-tauri/tauri.conf.json` file to allow additional image sources.

<img width="1123" height="836" alt="image" src="https://github.com/user-attachments/assets/e248d2cd-54ea-452a-bab3-0b22a632c2e0" />


### CSP Configuration Update:
* Updated the `img-src` directive to include `https://img.shields.io` and `https://cdn-uploads.huggingface.co` as an allowed source for images. This change ensures compatibility with external resources hosted on this domain.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update `img-src` directive in `tauri.conf.json` to include `https://img.shields.io` as an allowed image source.
> 
>   - **CSP Configuration Update**:
>     - Updated `img-src` directive in `tauri.conf.json` to include `https://img.shields.io` as an allowed image source.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 0a41b9b59ada061764207fc07291a3bdfa1245eb. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->