### PR TITLE
fix: resolve issue #6025 - default color selection in appearance page

### DIFF
--- a/web-app/src/containers/ColorPickerAppAccentColor.tsx
+++ b/web-app/src/containers/ColorPickerAppAccentColor.tsx
@@ -1,4 +1,4 @@
-import { useAppearance } from '@/hooks/useAppearance'
+import { useAppearance, isDefaultColorAccent } from '@/hooks/useAppearance'
 import { cn } from '@/lib/utils'
 import { RgbaColor, RgbaColorPicker } from 'react-colorful'
 import { IconColorPicker } from '@tabler/icons-react'
@@ -37,10 +37,11 @@ export function ColorPickerAppAccentColor() {
     <div className="flex items-center gap-1.5">
       {predefineAppAccentBgColor.map((item, i) => {
         const isSelected =
-          item.r === appAccentBgColor.r &&
+          (item.r === appAccentBgColor.r &&
           item.g === appAccentBgColor.g &&
           item.b === appAccentBgColor.b &&
-          item.a === appAccentBgColor.a
+          item.a === appAccentBgColor.a) ||
+          (isDefaultColorAccent(appAccentBgColor) && isDefaultColorAccent(item))
         return (
           <div
             key={i}

--- a/web-app/src/containers/ColorPickerAppBgColor.tsx
+++ b/web-app/src/containers/ColorPickerAppBgColor.tsx
@@ -1,4 +1,4 @@
-import { useAppearance } from '@/hooks/useAppearance'
+import { useAppearance, isDefaultColor } from '@/hooks/useAppearance'
 import { cn } from '@/lib/utils'
 import { RgbaColor, RgbaColorPicker } from 'react-colorful'
 import { IconColorPicker } from '@tabler/icons-react'
@@ -57,10 +57,11 @@ export function ColorPickerAppBgColor() {
     <div className="flex items-center gap-1.5">
       {predefineAppBgColor.map((item, i) => {
         const isSelected =
-          item.r === appBgColor.r &&
+          (item.r === appBgColor.r &&
           item.g === appBgColor.g &&
           item.b === appBgColor.b &&
-          item.a === appBgColor.a
+          item.a === appBgColor.a) ||
+          (isDefaultColor(appBgColor) && isDefaultColor(item))
         return (
           <div
             key={i}

--- a/web-app/src/containers/ColorPickerAppDestructiveColor.tsx
+++ b/web-app/src/containers/ColorPickerAppDestructiveColor.tsx
@@ -1,4 +1,4 @@
-import { useAppearance } from '@/hooks/useAppearance'
+import { useAppearance, isDefaultColorDestructive } from '@/hooks/useAppearance'
 import { cn } from '@/lib/utils'
 import { RgbaColor, RgbaColorPicker } from 'react-colorful'
 import { IconColorPicker } from '@tabler/icons-react'
@@ -42,10 +42,11 @@ export function ColorPickerAppDestructiveColor() {
     <div className="flex items-center gap-1.5">
       {predefineAppDestructiveBgColor.map((item, i) => {
         const isSelected =
-          item.r === appDestructiveBgColor.r &&
+          (item.r === appDestructiveBgColor.r &&
           item.g === appDestructiveBgColor.g &&
           item.b === appDestructiveBgColor.b &&
-          item.a === appDestructiveBgColor.a
+          item.a === appDestructiveBgColor.a) ||
+          (isDefaultColorDestructive(appDestructiveBgColor) && isDefaultColorDestructive(item))
         return (
           <div
             key={i}

--- a/web-app/src/containers/ColorPickerAppMainView.tsx
+++ b/web-app/src/containers/ColorPickerAppMainView.tsx
@@ -1,4 +1,4 @@
-import { useAppearance } from '@/hooks/useAppearance'
+import { useAppearance, isDefaultColorMainView } from '@/hooks/useAppearance'
 import { cn } from '@/lib/utils'
 import { RgbaColor, RgbaColorPicker } from 'react-colorful'
 import { IconColorPicker } from '@tabler/icons-react'
@@ -30,10 +30,11 @@ export function ColorPickerAppMainView() {
     <div className="flex items-center gap-1.5">
       {predefineAppMainViewBgColor.map((item, i) => {
         const isSelected =
-          item.r === appMainViewBgColor.r &&
+          (item.r === appMainViewBgColor.r &&
           item.g === appMainViewBgColor.g &&
           item.b === appMainViewBgColor.b &&
-          item.a === appMainViewBgColor.a
+          item.a === appMainViewBgColor.a) ||
+          (isDefaultColorMainView(appMainViewBgColor) && isDefaultColorMainView(item))
         return (
           <div
             key={i}

--- a/web-app/src/containers/ColorPickerAppPrimaryColor.tsx
+++ b/web-app/src/containers/ColorPickerAppPrimaryColor.tsx
@@ -1,4 +1,4 @@
-import { useAppearance } from '@/hooks/useAppearance'
+import { useAppearance, isDefaultColorPrimary } from '@/hooks/useAppearance'
 import { cn } from '@/lib/utils'
 import { RgbaColor, RgbaColorPicker } from 'react-colorful'
 import { IconColorPicker } from '@tabler/icons-react'
@@ -42,10 +42,11 @@ export function ColorPickerAppPrimaryColor() {
     <div className="flex items-center gap-1.5">
       {predefineappPrimaryBgColor.map((item, i) => {
         const isSelected =
-          item.r === appPrimaryBgColor.r &&
+          (item.r === appPrimaryBgColor.r &&
           item.g === appPrimaryBgColor.g &&
           item.b === appPrimaryBgColor.b &&
-          item.a === appPrimaryBgColor.a
+          item.a === appPrimaryBgColor.a) ||
+          (isDefaultColorPrimary(appPrimaryBgColor) && isDefaultColorPrimary(item))
         return (
           <div
             key={i}


### PR DESCRIPTION
## Summary
Fixes #6025

This PR resolves the issue where default colors in the appearance settings page were not showing as selected when they should be the active defaults.

## Changes Made
- Fixed selection logic in all color picker components:
  - `ColorPickerAppPrimaryColor.tsx`
  - `ColorPickerAppAccentColor.tsx` 
  - `ColorPickerAppDestructiveColor.tsx`
  - `ColorPickerAppMainView.tsx`
  - `ColorPickerAppBgColor.tsx`
- Updated `isSelected` logic to use existing helper functions (`isDefaultColor`, `isDefaultColorPrimary`, etc.)
- Ensures default colors are properly highlighted with ring selection when active

## Testing
- [x] Tested locally with fresh appearance settings
- [x] Verified default colors show as selected on page load
- [x] Confirmed custom color selection still works correctly
- [x] All existing functionality preserved

## Technical Details
The issue was caused by exact RGBA value matching between predefined color arrays and stored default values. The fix leverages existing helper functions in `useAppearance.ts` that properly handle theme-aware default color detection.

🤖 Generated with [Claude Code](https://claude.ai/code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes default color selection logic in appearance settings by using helper functions for theme-aware detection.
> 
>   - **Behavior**:
>     - Fixes default color selection logic in `ColorPickerAppPrimaryColor.tsx`, `ColorPickerAppAccentColor.tsx`, and `ColorPickerAppDestructiveColor.tsx`.
>     - Uses helper functions like `isDefaultColor`, `isDefaultColorPrimary`, etc., to determine if a color is selected.
>     - Ensures default colors are highlighted with a ring when active.
>   - **Technical Details**:
>     - Replaces exact RGBA value matching with theme-aware default color detection using helper functions from `useAppearance.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 38b020236573113fa897fccca73e7b79e84efe67. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->