### PR TITLE
enhancement: mcp disable save button when server name still empty

### DIFF
--- a/web-app/src/containers/dialogs/AddEditMCPServer.tsx
+++ b/web-app/src/containers/dialogs/AddEditMCPServer.tsx
@@ -373,14 +373,14 @@ export default function AddEditMCPServer({
                   value={jsonContent}
                   language="json"
                   placeholder={`{
-                    "serverName": {
-                      "command": "command",
-                      "args": ["arg1", "arg2"],
-                      "env": {
-                        "KEY": "value"
-                      }
-                    }
-                  }`}
+  "serverName": {
+    "command": "command",
+    "args": ["arg1", "arg2"],
+    "env": {
+      "KEY": "value"
+    }
+  }
+}`}
                   onChange={(e) => {
                     setJsonContent(e.target.value)
                     setError(null)
@@ -633,8 +633,8 @@ export default function AddEditMCPServer({
           <Button variant="link" onClick={() => onOpenChange(false)}>
             {t('common:cancel')}
           </Button>
-          <Button 
-            onClick={handleSave} 
+          <Button
+            onClick={handleSave}
             disabled={!isToggled && serverName.trim() === ''}
           >
             {t('mcp-servers:save')}


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces a small but important usability improvement to the `AddEditMCPServer` dialog. The "Save" button is now disabled when the server name is empty and a certain toggle (`isToggled`) is not active, preventing users from submitting incomplete forms.

* Disabled the "Save" button in `AddEditMCPServer` when the server name field is empty and `isToggled` is false, ensuring users cannot submit invalid data.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Disable "Save" button in `AddEditMCPServer` when server name is empty and toggle is inactive to prevent incomplete form submission.
> 
>   - **Behavior**:
>     - Disable "Save" button in `AddEditMCPServer` when `serverName` is empty and `isToggled` is false, preventing submission of incomplete forms.
>   - **Code Changes**:
>     - Modify `Button` in `AddEditMCPServer.tsx` to include `disabled` prop based on `serverName` and `isToggled`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 1eb1bb91cea1a6af6e176299cd7f89dc6cee650f. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->