### PR TITLE
fix: re-enable Vulkan backend in integrated GPUs with enough memory

### DIFF
--- a/extensions/llamacpp-extension/src/backend.ts
+++ b/extensions/llamacpp-extension/src/backend.ts
@@ -264,7 +264,6 @@ async function _getSupportedFeatures() {
     // Vulkan support check - only discrete GPUs with 6GB+ VRAM
     if (
       gpuInfo.vulkan_info?.api_version &&
-      gpuInfo.vulkan_info?.device_type === 'DISCRETE_GPU' &&
       gpuInfo.total_memory >= 6 * 1024
     ) {
       // 6GB (total_memory is in MB)


### PR DESCRIPTION
## Describe Your Changes
This commit re-enables the Vulkan backend for integrated GPUs, provided they meet the minimum memory requirement of 6GB.

The Vulkan backend was previously disabled for integrated GPUs to prevent system hangs. This issue occurred when a model's size exceeded the integrated GPU's shared memory, leading to system instability.

This fix removes the check for DISCRETE_GPU, allowing integrated GPUs to utilize the Vulkan backend as long as they have at least 6GB of available memory. This ensures that users with high-end integrated GPUs can take advantage of the performance benefits of Vulkan without risking system instability.

Further work will be done in #6000 to make sure we don't load model larger than what a system is capable of. Then we can safely enable Vulkan in all iGPUs.

## Fixes Issues

- Closes #6191 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes `DISCRETE_GPU` check in `backend.ts` to enable Vulkan backend for integrated GPUs with 6GB+ memory, closing issue #6191.
> 
>   - **Behavior**:
>     - Removes `DISCRETE_GPU` check in `_getSupportedFeatures()` in `backend.ts`, allowing integrated GPUs with 6GB+ memory to use Vulkan backend.
>   - **Fixes**:
>     - Closes issue #6191 by enabling Vulkan for high-memory integrated GPUs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 61bd68b9bb1e64c26cf1766923651e81fb966e1c. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->