### PR TITLE
ci: add job condition for auto assign milestone

### DIFF
--- a/.github/workflows/auto-assign-milestone.yml
+++ b/.github/workflows/auto-assign-milestone.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   assign_milestone:
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       pull-requests: write
       issues: write


### PR DESCRIPTION
This pull request introduces a small but important update to the `auto-assign-milestone.yml` GitHub Actions workflow. The change ensures that the workflow only runs for pull requests originating from the same repository

* Workflow execution is now restricted to pull requests where the source repository matches the target repository, by adding a conditional check to the `assign_milestone` job in `.github/workflows/auto-assign-milestone.yml`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a condition to `auto-assign-milestone.yml` to restrict workflow execution to pull requests from the same repository.
> 
>   - **Workflow Update**:
>     - Adds a conditional check to `assign_milestone` job in `auto-assign-milestone.yml` to ensure it only runs for pull requests from the same repository.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 2000fc31b5f289b37e8a4d3f4ac369ea047e242f. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->