### PR TITLE
fix: handle conditional UI regenerate resp

### DIFF
--- a/web-app/src/containers/ThreadContent.tsx
+++ b/web-app/src/containers/ThreadContent.tsx
@@ -40,6 +40,7 @@ import TokenSpeedIndicator from '@/containers/TokenSpeedIndicator'
 import CodeEditor from '@uiw/react-textarea-code-editor'
 import '@uiw/react-textarea-code-editor/dist.css'
 import { useTranslation } from '@/i18n/react-i18next-compat'
+import { useModelProvider } from '@/hooks/useModelProvider'
 
 const CopyButton = ({ text }: { text: string }) => {
   const [copied, setCopied] = useState(false)
@@ -152,6 +153,7 @@ export const ThreadContent = memo(
     }
   ) => {
     const { t } = useTranslation()
+    const { selectedModel } = useModelProvider()
 
     // Use useMemo to stabilize the components prop
     const linkComponents = useMemo(
@@ -517,7 +519,7 @@ export const ThreadContent = memo(
                       </DialogContent>
                     </Dialog>
 
-                    {item.isLastMessage && (
+                    {item.isLastMessage && selectedModel && (
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <button


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces a minor enhancement to the `ThreadContent` component by ensuring that the `TokenSpeedIndicator` is only displayed when a model is selected. The change adds a check for `selectedModel` before rendering the indicator, improving UI accuracy and preventing potential errors.

UI logic improvement:

* Added a dependency on `useModelProvider` to access the `selectedModel` state in `ThreadContent.tsx`. [[1]](diffhunk://#diff-4ce0228019e3fd7b3b4f414c7fb8f5906ff86fb8c333841826df78ae8decc461R43) [[2]](diffhunk://#diff-4ce0228019e3fd7b3b4f414c7fb8f5906ff86fb8c333841826df78ae8decc461R156)
* Updated the conditional rendering for `TokenSpeedIndicator` to require both `item.isLastMessage` and `selectedModel` to be true, ensuring the indicator only appears when appropriate.

## Fixes Issues

- Closes #6308 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure `TokenSpeedIndicator` in `ThreadContent.tsx` only displays when a model is selected by checking `selectedModel` state.
> 
>   - **UI Logic Improvement**:
>     - In `ThreadContent.tsx`, added `useModelProvider` to access `selectedModel` state.
>     - Updated `TokenSpeedIndicator` rendering to require `item.isLastMessage` and `selectedModel` to be true.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 5fcf36ed8eeef865c4d8b8db4cbb420ea5aa37ec. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->