### PR TITLE
fix: code generation more than 300 line

### DIFF
--- a/web-app/src/containers/RenderMarkdown.tsx
+++ b/web-app/src/containers/RenderMarkdown.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable react-hooks/exhaustive-deps */
 import ReactMarkdown, { Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -8,7 +7,6 @@ import rehypeKatex from 'rehype-katex'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import * as prismStyles from 'react-syntax-highlighter/dist/cjs/styles/prism'
 import { memo, useState, useMemo } from 'react'
-import virtualizedRenderer from 'react-syntax-highlighter-virtualized-renderer'
 import { getReadableLanguageName } from '@/lib/utils'
 import { cn } from '@/lib/utils'
 import { useCodeblock } from '@/hooks/useCodeblock'
@@ -74,8 +72,6 @@ function RenderMarkdownComponent({
 
         // Generate a stable ID based on code content and language
         const codeId = `code-${hashString(code.substring(0, 40) + language)}`
-
-        const shouldVirtualize = code.split('\n').length > 300
 
         return !isInline && !isUser ? (
           <div className="relative overflow-hidden border rounded-md border-main-view-fg/2">
@@ -147,11 +143,6 @@ function RenderMarkdownComponent({
                 overflow: 'auto',
                 border: 'none',
               }}
-              renderer={
-                shouldVirtualize
-                  ? (virtualizedRenderer() as (props: any) => React.ReactNode)
-                  : undefined
-              }
               PreTag="div"
               CodeTag={'code'}
               {...props}


### PR DESCRIPTION
## Describe Your Changes

This pull request simplifies the code in the `RenderMarkdown.tsx` container by removing support for virtualized code block rendering, which was previously used for very large code snippets. The main goal is to streamline the code and remove unnecessary complexity.

Codebase simplification:

* Removed the import and usage of `react-syntax-highlighter-virtualized-renderer`, eliminating virtualization logic for code blocks with more than 300 lines. (`web-app/src/containers/RenderMarkdown.tsx`) [[1]](diffhunk://#diff-2aadad5ab406cb9001e841638f8152ce553a86d396405e88db6de94df8e768dfL11) [[2]](diffhunk://#diff-2aadad5ab406cb9001e841638f8152ce553a86d396405e88db6de94df8e768dfL78-L79) [[3]](diffhunk://#diff-2aadad5ab406cb9001e841638f8152ce553a86d396405e88db6de94df8e768dfL150-L154)
* Removed the unused ESLint directive for explicit `any` types at the top of the file. (`web-app/src/containers/RenderMarkdown.tsx`)

## Fixes Issues


<img width="861" height="931" alt="Screenshot 2025-08-28 at 00 13 18" src="https://github.com/user-attachments/assets/f1ad0ea8-f5fe-4e7d-9dd8-258d025dd03b" />

- Closes #6311 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Simplifies `RenderMarkdown.tsx` by removing virtualization for large code blocks and unused ESLint directive.
> 
>   - **Code Simplification**:
>     - Removed `react-syntax-highlighter-virtualized-renderer` import and usage in `RenderMarkdown.tsx`, eliminating virtualization for code blocks over 300 lines.
>     - Removed unused ESLint directive for explicit `any` types in `RenderMarkdown.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for ca208285322711ceda745abc27becd9e9f8238f5. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->