### PR TITLE
ci: add paths for jan server web

### DIFF
--- a/.github/workflows/jan-server-web-ci.yml
+++ b/.github/workflows/jan-server-web-ci.yml
@@ -53,7 +53,6 @@ jobs:
             && sudo mkdir -p -m 755 /etc/apt/sources.list.d \
             && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
             && sudo apt update
-          sudo apt-get update
           sudo apt-get install -y jq gettext
       
       - name: Set image tag and service name


### PR DESCRIPTION
This pull request updates the workflow trigger conditions in `.github/workflows/jan-server-web-ci.yml` to make the CI pipeline more efficient by only running on relevant file changes. The main change is the addition of `paths` filters for both `push` and `pull_request` events, ensuring that the workflow only runs when specific files or directories are modified.

Workflow trigger improvements:

* Added `paths` filters to the `push` event so the workflow only runs when changes are made to key files and directories such as `.github/workflows/jan-server-web-ci.yaml`, `src-tauri/**`, `core/**`, `web-app/**`, `extensions/**`, `scripts/**`, `pre-install/**`, `Makefile`, `package.json`, and `mise.toml`.
* Added the same `paths` filters to the `pull_request` event, restricting workflow runs to changes in the same set of files and directories.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds path filters to CI workflow triggers and replaces custom PR comment script with a GitHub action in `jan-server-web-ci.yml`.
> 
>   - **Workflow Trigger Improvements**:
>     - Added `paths` filters to `push` and `pull_request` events in `.github/workflows/jan-server-web-ci.yml` to run only on changes to specific files and directories like `core/**`, `web-app/**`, `Makefile`, `package.json`, and `Dockerfile`.
>   - **Misc**:
>     - Replaced custom script for commenting preview URLs on PRs with `mshick/add-pr-comment@v2` action in `jan-server-web-ci.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 354cda8c35d053155492cb4a330bf2cd68dd4bd4. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->