### PR TITLE
fix: render new line for user message

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -74,6 +74,7 @@
     "react-textarea-autosize": "^8.5.9",
     "rehype-katex": "^7.0.1",
     "rehype-raw": "^7.0.0",
+    "remark-breaks": "^4.0.0",
     "remark-emoji": "^5.0.1",
     "remark-gfm": "^4.0.1",
     "remark-math": "^6.0.0",

--- a/web-app/src/containers/RenderMarkdown.tsx
+++ b/web-app/src/containers/RenderMarkdown.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown, { Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkEmoji from 'remark-emoji'
 import remarkMath from 'remark-math'
+import remarkBreaks from 'remark-breaks'
 import rehypeKatex from 'rehype-katex'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import * as prismStyles from 'react-syntax-highlighter/dist/cjs/styles/prism'
@@ -162,8 +163,13 @@ function RenderMarkdownComponent({
   // Memoize the remarkPlugins to prevent unnecessary re-renders
   const remarkPlugins = useMemo(() => {
     // Using a simpler configuration to avoid TypeScript errors
-    return [remarkGfm, remarkMath, remarkEmoji]
-  }, [])
+    const basePlugins = [remarkGfm, remarkMath, remarkEmoji]
+    // Add remark-breaks for user messages to handle single newlines as line breaks
+    if (isUser) {
+      basePlugins.push(remarkBreaks)
+    }
+    return basePlugins
+  }, [isUser])
 
   // Memoize the rehypePlugins to prevent unnecessary re-renders
   const rehypePlugins = useMemo(() => {


### PR DESCRIPTION
## Describe Your Changes

This pull request updates how Markdown is rendered in user messages by adding support for single line breaks. The main change is the conditional inclusion of the `remark-breaks` plugin for user-authored content, ensuring that single newlines are displayed as line breaks, improving readability for user messages.

Markdown rendering improvements:

* Added the `remark-breaks` dependency to `package.json` to enable single newline support in Markdown.
* Imported the `remark-breaks` plugin and updated the `RenderMarkdown` component to include `remark-breaks` in the list of plugins when rendering user messages, so single newlines are treated as line breaks. [[1]](diffhunk://#diff-2aadad5ab406cb9001e841638f8152ce553a86d396405e88db6de94df8e768dfR6) [[2]](diffhunk://#diff-2aadad5ab406cb9001e841638f8152ce553a86d396405e88db6de94df8e768dfL165-R172)

## Fixes Issues

<img width="1049" height="833" alt="Screenshot 2025-09-11 at 10 29 56" src="https://github.com/user-attachments/assets/d075736d-5f87-4f66-a595-1191d496c731" />

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `remark-breaks` to render single newlines as line breaks in user messages, improving readability.
> 
>   - **Markdown Rendering**:
>     - Add `remark-breaks` to `package.json` for single newline support.
>     - Update `RenderMarkdown.tsx` to include `remark-breaks` in `remarkPlugins` for user messages, treating single newlines as line breaks.
>   - **Behavior**:
>     - Improves readability of user messages by rendering single newlines as line breaks when `isUser` is true.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 9e592b2aca074c6025792e8050ab1bee4af2c014. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->