### PR TITLE
fix: include lm_head and embedding layers in totalLayers count

### DIFF
--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -2042,7 +2042,7 @@ export default class llamacpp_extension extends AIEngine {
   ): Promise<{ layerSize: number; totalLayers: number }> {
     const modelSize = await this.getModelSize(path)
     const arch = meta['general.architecture']
-    const totalLayers = Number(meta[`${arch}.block_count`])
+    const totalLayers = Number(meta[`${arch}.block_count`]) + 2 // 1 for lm_head layer and 1 for embedding layer
     if (!totalLayers) throw new Error('Invalid metadata: block_count not found')
     return { layerSize: modelSize / totalLayers, totalLayers }
   }


### PR DESCRIPTION
## Describe Your Changes
The original calculation used only the `block_count` from the model metadata, which excludes the final LM head and the embedding layer. This caused an underestimation of the total number of layers and consequently an incorrect `layerSize` value. Adding `+2` accounts for these two missing layers, ensuring accurate model size metrics.


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `totalLayers` calculation in `index.ts` to include LM head and embedding layer for accurate model size metrics.
> 
>   - **Behavior**:
>     - Fixes `totalLayers` calculation in `getLayerSize()` in `index.ts` by adding 2 to include LM head and embedding layer.
>     - Ensures accurate `layerSize` and `totalLayers` values for model size metrics.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for e3466d8abdf462a4d4cf2c89a6594ac5def59cc4. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->