### PR TITLE
ci: remove paths triggered for jan server

### DIFF
--- a/.github/workflows/jan-server-web-ci.yml
+++ b/.github/workflows/jan-server-web-ci.yml
@@ -3,26 +3,10 @@ name: Jan Web Server build image and push to Harbor Registry
 on:
   push:
     branches:
-      - dev-web
-    paths:
-      - '.github/workflows/jan-server-web-ci.yml'
-      - 'core/**'
-      - 'web-app/**'
-      - 'extensions-web/**'
-      - 'Makefile'
-      - 'package.json'
-      - 'Dockerfile'
+      - dev-web'
   pull_request:
     branches:
       - dev-web
-    paths:
-      - '.github/workflows/jan-server-web-ci.yml'
-      - 'core/**'
-      - 'web-app/**'
-      - 'extensions-web/**'
-      - 'Makefile'
-      - 'package.json'
-      - 'Dockerfile'
 
 jobs:
   build-and-preview:

--- a/.github/workflows/jan-server-web-cicd-prod.yml
+++ b/.github/workflows/jan-server-web-cicd-prod.yml
@@ -4,14 +4,6 @@ on:
   push:
     branches:
       - prod-web
-    paths:
-      - '.github/workflows/jan-server-web-cicd-prod.yml'
-      - 'core/**'
-      - 'web-app/**'
-      - 'extensions-web/**'
-      - 'Makefile'
-      - 'package.json'
-      - 'Dockerfile'
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
This pull request updates the workflow trigger configuration for the Jan Web Server CI/CD pipelines. The main change is the removal of the `paths` filter from both the development and production workflow YAML files, which broadens the conditions under which the workflows will run.

**Workflow trigger changes:**

* Removed the `paths` filter from the `push` and `pull_request` triggers in `.github/workflows/jan-server-web-ci.yml`, so the workflow will now run on any change to the `dev-web` branch, not just specific files or directories.
* Removed the `paths` filter from the `push` trigger in `.github/workflows/jan-server-web-cicd-prod.yml`, so the workflow will now run on any change to the `prod-web` branch.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `paths` filter from CI/CD workflow triggers for broader execution conditions on `dev-web` and `prod-web` branches.
> 
>   - **Workflow Trigger Changes**:
>     - Removed `paths` filter from `push` and `pull_request` triggers in `jan-server-web-ci.yml` for `dev-web` branch.
>     - Removed `paths` filter from `push` trigger in `jan-server-web-cicd-prod.yml` for `prod-web` branch.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 6c935132a98dabbeef0bca3159be1ebcfe3c3f73. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->