### PR TITLE
ci: fix typo in branch name for jan web

### DIFF
--- a/.github/workflows/jan-server-web-ci.yml
+++ b/.github/workflows/jan-server-web-ci.yml
@@ -3,7 +3,7 @@ name: Jan Web Server build image and push to Harbor Registry
 on:
   push:
     branches:
-      - dev-web'
+      - dev-web
   pull_request:
     branches:
       - dev-web


### PR DESCRIPTION
This pull request makes a minor fix to the `.github/workflows/jan-server-web-ci.yml` workflow configuration by correcting a typo in the branch name under the push trigger. The erroneous single quote at the end of `dev-web'` was removed to ensure the workflow runs correctly for pushes to the `dev-web` branch.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes typo in branch name in `.github/workflows/jan-server-web-ci.yml` to ensure correct workflow triggering.
> 
>   - **Fix**:
>     - Corrects typo in `.github/workflows/jan-server-web-ci.yml` by removing erroneous single quote in branch name `dev-web'` to `dev-web` under `push` trigger.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for b8ca6f5d76e0e8e23ae1a45a1bd1f473831c9063. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->