### PR TITLE
fix: Markdown bullet list incorrectly converted in numbered list

### DIFF
--- a/web-app/src/styles/markdown.css
+++ b/web-app/src/styles/markdown.css
@@ -77,6 +77,10 @@
     list-style-type: disc;
   }
 
+  ul > li {
+    list-style-type: circle;
+  }
+
   ol {
     list-style-type: decimal;
   }


### PR DESCRIPTION
## Describe Your Changes
When questions in a thread contain bullet lists written in Markdown syntax, they will be displayed as numbered list.
This is neither Jan or `react-markdown` doing. It is due to Tailwind taking out all default styles applied to html elements.
To fix, in the stylesheet for Markdown content, I added a `list-style-type` property to any `<li>` element that is a direct child of `<ul>`.

```
ul > li {
  list-style-type: circle;
}
```

## Fixes Issues

- Closes #6407 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes issue #6407 by adding a CSS rule in `markdown.css` to display bullet lists as circles.
> 
>   - **Styles**:
>     - Added `ul > li { list-style-type: circle; }` to `markdown.css` to ensure bullet lists are displayed correctly as circles instead of numbers.
>   - **Fixes**:
>     - Resolves issue #6407 where bullet lists were incorrectly displayed as numbered lists due to Tailwind CSS resetting default styles.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for b603e79ff0fde772963c6060ca14694b6c9c8a88. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->