### PR TITLE
fix: Typo in openapi JSON

### DIFF
--- a/src-tauri/static/openapi.json
+++ b/src-tauri/static/openapi.json
@@ -42,7 +42,7 @@
         }
       }
     },
-    "/chat/completion": {
+    "/chat/completions": {
       "post": {
         "summary": "Create chat completion",
         "description": "Generates a completion for the supplied prompt. Streaming mode is supported. All extra options described in the documentation are optional and follow the OpenAI‑compatible naming.",


### PR DESCRIPTION
## Describe Your Changes

- There was a typo in openapi.json, change it to correctly reflect the proper chat completions endpoint.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes typo in `openapi.json` by correcting endpoint path from `/chat/completion` to `/chat/completions`.
> 
>   - **Fix**:
>     - Corrects endpoint path typo in `openapi.json` from `/chat/completion` to `/chat/completions` for the chat completions endpoint.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 9f6b4f631c448ca6f66287f631b8b363cc3df05d. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->