### PR TITLE
fix: LocalAPI server trusted host should accept asterisk

### DIFF
--- a/src-tauri/utils/src/http.rs
+++ b/src-tauri/utils/src/http.rs
@@ -6,6 +6,10 @@ pub fn is_cors_header(header_name: &str) -> bool {
 
 /// Validates if host is in trusted hosts list
 pub fn is_valid_host(host: &str, trusted_hosts: &[Vec<String>]) -> bool {
+    if trusted_hosts.iter().any(|hosts| hosts.contains(&"*".to_string())) {
+        return true;
+    }
+
     if host.is_empty() {
         return false;
     }


### PR DESCRIPTION
## Describe Your Changes

This pull request updates the host validation logic to improve how trusted hosts are handled. Now, if the trusted hosts list contains a wildcard `"*"`, any host will be considered valid.

Host validation improvements:
* Updated `is_valid_host` in `src-tauri/utils/src/http.rs` to immediately return `true` if the trusted hosts list contains `"*"`, allowing all hosts to be accepted in this case.

## Fixes Issues

- Closes #6471 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances `is_valid_host` in `http.rs` to accept all hosts if `trusted_hosts` contains a wildcard `"*"`.
> 
>   - **Behavior**:
>     - `is_valid_host` in `http.rs` now returns `true` if `trusted_hosts` contains `"*"`, allowing all hosts.
>   - **Fixes**:
>     - Closes issue #6471.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for a2dde7ca7765269ae8cec4a7f7a7921af3585e98. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->