### PR TITLE
chore: update project page title too long

### DIFF
--- a/web-app/src/routes/project/index.tsx
+++ b/web-app/src/routes/project/index.tsx
@@ -134,25 +134,22 @@ function ProjectContent() {
                       className="bg-main-view-fg/3 py-2 px-4 rounded-lg"
                       key={folder.id}
                     >
-                      <div className="flex items-center gap-4">
-                        <div className="flex items-start gap-3 flex-1">
+                      <div className="flex items-center gap-4 min-w-0">
+                        <div className="flex items-start gap-3 flex-1 min-w-0">
                           <div className="shrink-0 w-8 h-8 relative flex items-center justify-center bg-main-view-fg/4 rounded-md">
                             <IconFolder
                               size={16}
                               className="text-main-view-fg/50"
                             />
                           </div>
-                          <div className="flex-1 min-w-0">
-                            <div className="flex items-center gap-2">
-                              <h3 className="text-base font-medium text-main-view-fg/80 line-clamp-1">
+                          <div className="flex-1 min-w-0 overflow-hidden">
+                            <div className="flex items-center gap-2 min-w-0">
+                              <h3
+                                className="text-base font-medium text-main-view-fg/80 truncate flex-1 min-w-0"
+                                title={folder.name}
+                              >
                                 {folder.name}
                               </h3>
-                              <span className="text-xs bg-main-view-fg/10 text-main-view-fg/60 px-2 py-0.5 rounded-full">
-                                {projectThreads.length}{' '}
-                                {projectThreads.length === 1
-                                  ? t('projects.thread')
-                                  : t('projects.threads')}
-                              </span>
                             </div>
                             <p className="text-main-view-fg/50 text-xs line-clamp-2 mt-0.5">
                               {t('projects.updated')}{' '}
@@ -161,6 +158,12 @@ function ProjectContent() {
                           </div>
                         </div>
                         <div className="flex items-center">
+                          <span className="text-xs mr-4 bg-main-view-fg/10 text-main-view-fg/60 px-2 py-0.5 rounded-full shrink-0 whitespace-nowrap">
+                            {projectThreads.length}{' '}
+                            {projectThreads.length === 1
+                              ? t('projects.thread')
+                              : t('projects.threads')}
+                          </span>
                           {projectThreads.length > 0 && (
                             <button
                               className="size-8 cursor-pointer flex items-center justify-center rounded-md hover:bg-main-view-fg/10 transition-all duration-200 ease-in-out mr-1"


### PR DESCRIPTION
## Describe Your Changes

<img width="1232" height="1122" alt="21899" src="https://github.com/user-attachments/assets/d48b05c8-d3bf-4379-8372-bf984856e749" />


## Fixes Issues

<img width="874" height="361" alt="Screenshot 2025-09-26 at 14 58 32" src="https://github.com/user-attachments/assets/fd138e35-0028-4e93-baeb-fdd4d2e12655" />


- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improves handling of long project titles in `ProjectContent` by truncating with ellipsis and adding hover tooltips.
> 
>   - **UI Changes**:
>     - In `ProjectContent` function in `index.tsx`, added `truncate` class and `title` attribute to `<h3>` element for project names to handle long titles.
>     - Moved thread count display to a separate `<span>` element with `shrink-0` and `whitespace-nowrap` classes for better alignment.
>   - **Behavior**:
>     - Long project titles are now truncated with ellipsis and full title is shown on hover via `title` attribute.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 3d224f8cff96d02e5eb3f9452b69e44ac775edf0. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->