### PR TITLE
ci: add upload msi installer for windows

### DIFF
--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -54,6 +54,8 @@ on:
         value: ${{ jobs.build-windows-x64.outputs.WIN_SIG }}
       FILE_NAME:
         value: ${{ jobs.build-windows-x64.outputs.FILE_NAME }}
+      MSI_FILE_NAME:
+        value: ${{ jobs.build-windows-x64.outputs.MSI_FILE_NAME }}
 
 jobs:
   build-windows-x64:
@@ -61,6 +63,7 @@ jobs:
     outputs:
       WIN_SIG: ${{ steps.metadata.outputs.WIN_SIG }}
       FILE_NAME: ${{ steps.metadata.outputs.FILE_NAME }}
+      MSI_FILE_NAME: ${{ steps.metadata.outputs.MSI_FILE_NAME }}
     permissions:
       contents: write
     steps:
@@ -207,13 +210,18 @@ jobs:
           if [ "${{ inputs.channel }}" != "stable" ]; then
             FILE_NAME=Jan-${{ inputs.channel }}_${{ inputs.new_version }}_x64-setup.exe
             WIN_SIG=$(cat Jan-${{ inputs.channel }}_${{ inputs.new_version }}_x64-setup.exe.sig)
+
+            MSI_FILE="Jan-${{ inputs.channel }}_${{ inputs.new_version }}_x64_en-US.msi"
           else
             FILE_NAME=Jan_${{ inputs.new_version }}_x64-setup.exe
             WIN_SIG=$(cat Jan_${{ inputs.new_version }}_x64-setup.exe.sig)
+            
+            MSI_FILE="Jan_${{ inputs.new_version }}_x64_en-US.msi"
           fi
 
           echo "::set-output name=WIN_SIG::$WIN_SIG"
           echo "::set-output name=FILE_NAME::$FILE_NAME"
+          echo "::set-output name=MSI_FILE_NAME::$MSI_FILE"
         id: metadata
 
       ## Upload to s3 for nightly and beta
@@ -226,6 +234,8 @@ jobs:
           # Upload for tauri updater
           aws s3 cp ./${{ steps.metadata.outputs.FILE_NAME }} s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/${{ steps.metadata.outputs.FILE_NAME }}
           aws s3 cp ./${{ steps.metadata.outputs.FILE_NAME }}.sig s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/${{ steps.metadata.outputs.FILE_NAME }}.sig
+
+          aws s3 cp ./src-tauri/target/release/bundle/msi/${{ steps.metadata.outputs.MSI_FILE_NAME }} s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/${{ steps.metadata.outputs.MSI_FILE_NAME }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.DELTA_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.DELTA_AWS_SECRET_ACCESS_KEY }}
@@ -241,4 +251,14 @@ jobs:
           upload_url: ${{ inputs.upload_url }}
           asset_path: ./src-tauri/target/release/bundle/nsis/${{ steps.metadata.outputs.FILE_NAME }}
           asset_name: ${{ steps.metadata.outputs.FILE_NAME }}
+          asset_content_type: application/octet-stream
+      - name: Upload release assert if public provider is github
+        if: inputs.public_provider == 'github'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: ./src-tauri/target/release/bundle/msi/${{ steps.metadata.outputs.MSI_FILE_NAME  }}
+          asset_name: ${{ steps.metadata.outputs.MSI_FILE_NAME  }}
           asset_content_type: application/octet-stream


### PR DESCRIPTION
This pull request updates the Windows x64 build workflow to add support for handling and uploading MSI installer files in addition to the existing NSIS `.exe` installer. The changes ensure that MSI files are properly named, outputted, and uploaded to both S3 and GitHub releases when applicable.