### PR TITLE
chore: create event to track model provider and id model

### DIFF
--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -179,7 +179,7 @@ const ChatInput = ({
   const mcpExtension = extensionManager.get<MCPExtension>(ExtensionTypeEnum.MCP)
   const MCPToolComponent = mcpExtension?.getToolComponent?.()
 
-  const handleSendMesage = async (prompt: string) => {
+  const handleSendMessage = async (prompt: string) => {
     if (!selectedModel) {
       setMessage('Please select a model to start chatting.')
       return
@@ -630,7 +630,7 @@ const ChatInput = ({
                 ) {
                   e.preventDefault()
                   // Submit the message when Enter is pressed without Shift
-                  handleSendMesage(prompt)
+                  handleSendMessage(prompt)
                   // When Shift+Enter is pressed, a new line is added (default behavior)
                 }
               }}
@@ -859,7 +859,7 @@ const ChatInput = ({
                   size="icon"
                   disabled={!prompt.trim() && uploadedFiles.length === 0}
                   data-test-id="send-message-button"
-                  onClick={() => handleSendMesage(prompt)}
+                  onClick={() => handleSendMessage(prompt)}
                 >
                   {streamingContent ? (
                     <span className="animate-spin h-4 w-4 border-2 border-current border-t-transparent rounded-full" />


### PR DESCRIPTION
## Describe Your Changes

PS:
### We do not track any message content, only metadata (e.g., provider name and model ID) for analytics and product insights.

This pull request enhances the `ChatInput` component by adding product analytics tracking for sent messages and includes minor improvements to code structure and formatting. The key focus is on integrating PostHog analytics to capture message send events when analytics are enabled.

**Analytics Integration:**

* Added imports for `useAnalytic` and `posthog-js` to enable analytics tracking in `ChatInput.tsx`.
* Integrated a PostHog event capture in the `handleSendMesage` function to track when a user sends a message, including relevant model and provider information, and wrapped the tracking call in a try-catch for error safety. [[1]](diffhunk://#diff-e6927577dd0c5d682ae3ac9367b9a6b7df9f76df4cf35c5a05779e539749f417R93) [[2]](diffhunk://#diff-e6927577dd0c5d682ae3ac9367b9a6b7df9f76df4cf35c5a05779e539749f417R191-R203)

**Code Structure and Formatting:**

* Improved conditional rendering for the MCP tool component by reformatting and ensuring consistent prop usage. [[1]](diffhunk://#diff-e6927577dd0c5d682ae3ac9367b9a6b7df9f76df4cf35c5a05779e539749f417L706-R729) [[2]](diffhunk://#diff-e6927577dd0c5d682ae3ac9367b9a6b7df9f76df4cf35c5a05779e539749f417L772-R789)
* Minor code cleanup for spacing and readability.


## Fixes Issues
part of https://github.com/menloresearch/jan-internal/issues/91
Tracking when user send message, provider name and model id 

<img width="579" height="269" alt="82069" src="https://github.com/user-attachments/assets/d3340f89-864c-4a8a-bafc-863f362f5e67" />
<img width="1251" height="1073" alt="image" src="https://github.com/user-attachments/assets/8ec14ef4-5d2c-4193-9f20-5d3ddcd09852" />


- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
