### PR TITLE
fix: resolve extensions conflict with correct path for web-app

### DIFF
--- a/web-app/vite.config.web.ts
+++ b/web-app/vite.config.web.ts
@@ -79,6 +79,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
+      '@janhq/conversational-extension': path.resolve(__dirname, '../extensions-web/src/conversational-web/index.ts'),
     },
   },
   define: {


### PR DESCRIPTION
## Describe Your Changes

- Web-app should return to use conversational-web extensions
- Resolve naming conflict for conversational-extensions on web version

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
