### PR TITLE
fix: Gracefully handle offline mode during backend check

### DIFF
--- a/extensions/llamacpp-extension/src/backend.ts
+++ b/extensions/llamacpp-extension/src/backend.ts
@@ -156,8 +156,13 @@ export async function listSupportedBackends(): Promise<
     supportedBackends.push('macos-arm64')
   }
   // get latest backends from Github
-  const remoteBackendVersions =
+  let remoteBackendVersions = []
+  try {
+    remoteBackendVersions =
     await fetchRemoteSupportedBackends(supportedBackends)
+  } catch (e) {
+      console.debug(`Not able to get remote backends, Jan might be offline or network problem: ${String(e)}`)
+  }
 
   // Get locally installed versions
   const localBackendVersions = await getLocalInstalledBackends()


### PR DESCRIPTION
## Describe Your Changes

The `listSupportedBackends` function now includes error handling for the `fetchRemoteSupportedBackends` call.

This addresses an issue where an error thrown during the remote fetch (e.g., due to no network connection in offline mode) would prevent the subsequent loading of locally installed or manually provided llama.cpp backends.

The remote backend versions array will now default to empty if the fetch fails, allowing the rest of the backend initialization process to proceed as expected.


## Fixes Issues

- Closes #6623 


## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
