### PR TITLE
chore: revert track event posthog

### DIFF
--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -40,8 +40,6 @@ import { useShallow } from 'zustand/react/shallow'
 import { McpExtensionToolLoader } from './McpExtensionToolLoader'
 import { ExtensionTypeEnum, MCPExtension } from '@janhq/core'
 import { ExtensionManager } from '@/lib/extension'
-import { useAnalytic } from '@/hooks/useAnalytic'
-import posthog from 'posthog-js'
 
 type ChatInputProps = {
   className?: string
@@ -90,7 +88,6 @@ const ChatInput = ({
   const selectedModel = useModelProvider((state) => state.selectedModel)
   const selectedProvider = useModelProvider((state) => state.selectedProvider)
   const sendMessage = useChat()
-  const { productAnalytic } = useAnalytic()
   const [message, setMessage] = useState('')
   const [dropdownToolsAvailable, setDropdownToolsAvailable] = useState(false)
   const [tooltipToolsAvailable, setTooltipToolsAvailable] = useState(false)
@@ -191,18 +188,6 @@ const ChatInput = ({
       return
     }
     setMessage('')
-
-    // Track message send event with PostHog (only if product analytics is enabled)
-    if (productAnalytic && selectedModel && selectedProvider) {
-      try {
-        posthog.capture('message_sent', {
-          model_provider: selectedProvider,
-          model_id: selectedModel.id,
-        })
-      } catch (error) {
-        console.debug('Failed to track message send event:', error)
-      }
-    }
 
     sendMessage(
       prompt,


### PR DESCRIPTION
## Describe Your Changes

This pull request simplifies the `ChatInput` component by removing all product analytics tracking logic related to PostHog. The changes focus on cleaning up unnecessary imports and code for tracking message send events.

Code cleanup:

* Removed imports of `useAnalytic` and `posthog-js` from `ChatInput.tsx`, as analytics tracking is no longer needed.
* Removed the `productAnalytic` hook and all related logic for tracking message send events with PostHog, including the conditional event capture and error handling. [[1]](diffhunk://#diff-e6927577dd0c5d682ae3ac9367b9a6b7df9f76df4cf35c5a05779e539749f417L93) [[2]](diffhunk://#diff-e6927577dd0c5d682ae3ac9367b9a6b7df9f76df4cf35c5a05779e539749f417L195-L206)

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
