### PR TITLE
fix: Escape dollar signs followed by numbers in Markdown

### DIFF
--- a/web-app/src/containers/RenderMarkdown.tsx
+++ b/web-app/src/containers/RenderMarkdown.tsx
@@ -62,6 +62,10 @@ const normalizeLatex = (input: string): string => {
         (_, pre, inner) => `${pre}$${inner.trim()}$`
       )
 
+      // --- Escape $<number> to prevent Markdown from treating it as LaTeX
+      // Example: "$1" → "\$1"
+      s = s.replace(/\$(\d+)/g, '\\$$1')
+
       return s
     })
     .join('')


### PR DESCRIPTION
## Describe Your Changes

This commit introduces a change to prevent **Markdown** rendering issues where a dollar sign followed by a number (like **`$1`**) is incorrectly interpreted as **LaTeX** by the rendering engine.

The `normalizeLatex` function in `RenderMarkdown.tsx` now explicitly escapes these sequences (e.g., **`$1`** becomes **`\$1`**), ensuring they are displayed literally instead of being processed as mathematical expressions. This improves the fidelity of text that might contain currency or similar numerical notations.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
