### PR TITLE
chore: update api domain to jan.ai

### DIFF
--- a/.github/workflows/jan-server-web-ci-dev.yml
+++ b/.github/workflows/jan-server-web-ci-dev.yml
@@ -12,7 +12,7 @@ jobs:
   build-and-preview:
     runs-on: [ubuntu-24-04-docker]
     env:
-      MENLO_PLATFORM_BASE_URL: "https://api-dev.menlo.ai/v1"
+      MENLO_PLATFORM_BASE_URL: "https://api-dev.jan.ai/v1"
     permissions:
       pull-requests: write
       contents: write

--- a/.github/workflows/jan-server-web-ci-prod.yml
+++ b/.github/workflows/jan-server-web-ci-prod.yml
@@ -13,7 +13,7 @@ jobs:
       deployments: write
       pull-requests: write
     env:
-      MENLO_PLATFORM_BASE_URL: "https://api.menlo.ai/v1"
+      MENLO_PLATFORM_BASE_URL: "https://api.jan.ai/v1"
       GA_MEASUREMENT_ID: "G-YK53MX8M8M"
       CLOUDFLARE_PROJECT_NAME: "jan-server-web"
     steps:

--- a/.github/workflows/jan-server-web-ci-stag.yml
+++ b/.github/workflows/jan-server-web-ci-stag.yml
@@ -12,7 +12,7 @@ jobs:
   build-and-preview:
     runs-on: [ubuntu-24-04-docker]
     env:
-      MENLO_PLATFORM_BASE_URL: "https://api-stag.menlo.ai/v1"
+      MENLO_PLATFORM_BASE_URL: "https://api-stag.jan.ai/v1"
     permissions:
       pull-requests: write
       contents: write


### PR DESCRIPTION
This pull request updates the environment configuration in the GitHub Actions workflows to use the new `jan.ai` API endpoints instead of the old `menlo.ai` endpoints. This ensures that all CI/CD jobs point to the correct API base URLs for development, staging, and production environments.

**Workflow environment variable updates:**

* Updated `MENLO_PLATFORM_BASE_URL` in `.github/workflows/jan-server-web-ci-dev.yml` to use the `api-dev.jan.ai` endpoint.
* Updated `MENLO_PLATFORM_BASE_URL` in `.github/workflows/jan-server-web-ci-stag.yml` to use the `api-stag.jan.ai` endpoint.
* Updated `MENLO_PLATFORM_BASE_URL` in `.github/workflows/jan-server-web-ci-prod.yml` to use the `api.jan.ai` endpoint.