### PR TITLE
chore: deprecate webhook discord

### DIFF
--- a/.github/workflows/jan-tauri-build-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-nightly.yaml
@@ -168,62 +168,62 @@ jobs:
           AWS_DEFAULT_REGION: ${{ secrets.DELTA_AWS_REGION }}
           AWS_EC2_METADATA_DISABLED: 'true'
 
-  noti-discord-nightly-and-update-url-readme:
-    needs:
-      [
-        build-macos,
-        build-windows-x64,
-        build-linux-x64,
-        get-update-version,
-        set-public-provider,
-        sync-temp-to-latest,
-      ]
-    secrets: inherit
-    if: github.event_name == 'schedule'
-    uses: ./.github/workflows/template-noti-discord-and-update-url-readme.yml
-    with:
-      ref: refs/heads/dev
-      build_reason: Nightly
-      push_to_branch: dev
-      new_version: ${{ needs.get-update-version.outputs.new_version }}
+  # noti-discord-nightly-and-update-url-readme:
+  #   needs:
+  #     [
+  #       build-macos,
+  #       build-windows-x64,
+  #       build-linux-x64,
+  #       get-update-version,
+  #       set-public-provider,
+  #       sync-temp-to-latest,
+  #     ]
+  #   secrets: inherit
+  #   if: github.event_name == 'schedule'
+  #   uses: ./.github/workflows/template-noti-discord-and-update-url-readme.yml
+  #   with:
+  #     ref: refs/heads/dev
+  #     build_reason: Nightly
+  #     push_to_branch: dev
+  #     new_version: ${{ needs.get-update-version.outputs.new_version }}
 
-  noti-discord-pre-release-and-update-url-readme:
-    needs:
-      [
-        build-macos,
-        build-windows-x64,
-        build-linux-x64,
-        get-update-version,
-        set-public-provider,
-        sync-temp-to-latest,
-      ]
-    secrets: inherit
-    if: github.event_name == 'push'
-    uses: ./.github/workflows/template-noti-discord-and-update-url-readme.yml
-    with:
-      ref: refs/heads/dev
-      build_reason: Pre-release
-      push_to_branch: dev
-      new_version: ${{ needs.get-update-version.outputs.new_version }}
+  # noti-discord-pre-release-and-update-url-readme:
+  #   needs:
+  #     [
+  #       build-macos,
+  #       build-windows-x64,
+  #       build-linux-x64,
+  #       get-update-version,
+  #       set-public-provider,
+  #       sync-temp-to-latest,
+  #     ]
+  #   secrets: inherit
+  #   if: github.event_name == 'push'
+  #   uses: ./.github/workflows/template-noti-discord-and-update-url-readme.yml
+  #   with:
+  #     ref: refs/heads/dev
+  #     build_reason: Pre-release
+  #     push_to_branch: dev
+  #     new_version: ${{ needs.get-update-version.outputs.new_version }}
 
-  noti-discord-manual-and-update-url-readme:
-    needs:
-      [
-        build-macos,
-        build-windows-x64,
-        build-linux-x64,
-        get-update-version,
-        set-public-provider,
-        sync-temp-to-latest,
-      ]
-    secrets: inherit
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.public_provider == 'aws-s3'
-    uses: ./.github/workflows/template-noti-discord-and-update-url-readme.yml
-    with:
-      ref: refs/heads/dev
-      build_reason: Manual
-      push_to_branch: dev
-      new_version: ${{ needs.get-update-version.outputs.new_version }}
+  # noti-discord-manual-and-update-url-readme:
+  #   needs:
+  #     [
+  #       build-macos,
+  #       build-windows-x64,
+  #       build-linux-x64,
+  #       get-update-version,
+  #       set-public-provider,
+  #       sync-temp-to-latest,
+  #     ]
+  #   secrets: inherit
+  #   if: github.event_name == 'workflow_dispatch' && github.event.inputs.public_provider == 'aws-s3'
+  #   uses: ./.github/workflows/template-noti-discord-and-update-url-readme.yml
+  #   with:
+  #     ref: refs/heads/dev
+  #     build_reason: Manual
+  #     push_to_branch: dev
+  #     new_version: ${{ needs.get-update-version.outputs.new_version }}
 
   comment-pr-build-url:
     needs:


### PR DESCRIPTION
## Describe Your Changes

This pull request comments out three notification jobs in the `.github/workflows/jan-tauri-build-nightly.yaml` file that previously handled Discord notifications and README URL updates for nightly, pre-release, and manual builds. These jobs are now disabled and will not run as part of the workflow.

Workflow changes:

* Disabled the `noti-discord-nightly-and-update-url-readme` job, which sent Discord notifications and updated the README URL for nightly builds.
* Disabled the `noti-discord-pre-release-and-update-url-readme` job, which handled notifications and README updates for pre-release builds.
* Disabled the `noti-discord-manual-and-update-url-readme` job, which managed notifications and README updates for manual build triggers.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
