### PR TITLE
fix: Incorrect proactive icon display

### DIFF
--- a/web-app/src/containers/Capabilities.tsx
+++ b/web-app/src/containers/Capabilities.tsx
@@ -21,9 +21,20 @@ interface CapabilitiesProps {
 const Capabilities = ({ capabilities }: CapabilitiesProps) => {
   if (!capabilities.length) return null
 
+  const filteredCapabilities = capabilities.filter((capability) => {
+    if (capability === 'proactive') {
+      return (
+        capabilities.includes('tools') &&
+        capabilities.includes('vision') &&
+        capabilities.includes('proactive')
+      )
+    }
+    return true
+  })
+
   return (
     <div className="flex gap-1">
-      {capabilities.map((capability: string, capIndex: number) => {
+      {filteredCapabilities.map((capability: string, capIndex: number) => {
         let icon = null
 
         if (capability === 'vision') {

--- a/web-app/src/containers/__tests__/Capabilities.test.tsx
+++ b/web-app/src/containers/__tests__/Capabilities.test.tsx
@@ -35,8 +35,15 @@ describe('Capabilities', () => {
     expect(toolIcon).toBeInTheDocument()
   })
 
-  it('should render proactive capability with sparkles icon', () => {
+  it('should NOT render proactive icon without tools and vision', () => {
     render(<Capabilities capabilities={['proactive']} />)
+
+    const sparklesIcon = screen.queryByTestId('icon-sparkles')
+    expect(sparklesIcon).not.toBeInTheDocument()
+  })
+
+  it('should render proactive capability with sparkles icon when tools and vision are present', () => {
+    render(<Capabilities capabilities={['tools', 'vision', 'proactive']} />)
 
     const sparklesIcon = screen.getByTestId('icon-sparkles')
     expect(sparklesIcon).toBeInTheDocument()
@@ -94,8 +101,8 @@ describe('Capabilities', () => {
     expect(container).toBeInTheDocument()
   })
 
-  it('should display proactive tooltip with correct text', () => {
-    render(<Capabilities capabilities={['proactive']} />)
+  it('should display proactive tooltip with correct text when all requirements met', () => {
+    render(<Capabilities capabilities={['tools', 'vision', 'proactive']} />)
 
     // The tooltip content should be 'Proactive'
     expect(screen.getByTestId('icon-sparkles')).toBeInTheDocument()
@@ -114,11 +121,25 @@ describe('Capabilities', () => {
   })
 
   it('should apply correct CSS classes to proactive icon', () => {
-    render(<Capabilities capabilities={['proactive']} />)
+    render(<Capabilities capabilities={['tools', 'vision', 'proactive']} />)
 
     const sparklesIcon = screen.getByTestId('icon-sparkles')
     expect(sparklesIcon).toBeInTheDocument()
     // Icon should have size-3.5 class (same as tools, reasoning, etc.)
     expect(sparklesIcon.parentElement).toBeInTheDocument()
+  })
+
+  it('should NOT show proactive icon when only tools capability is present', () => {
+    render(<Capabilities capabilities={['tools', 'proactive']} />)
+
+    const sparklesIcon = screen.queryByTestId('icon-sparkles')
+    expect(sparklesIcon).not.toBeInTheDocument()
+  })
+
+  it('should NOT show proactive icon when only vision capability is present', () => {
+    render(<Capabilities capabilities={['vision', 'proactive']} />)
+
+    const sparklesIcon = screen.queryByTestId('icon-sparkles')
+    expect(sparklesIcon).not.toBeInTheDocument()
   })
 })

--- a/web-app/src/hooks/useChat.ts
+++ b/web-app/src/hooks/useChat.ts
@@ -421,7 +421,10 @@ export const useChat = () => {
           : []
 
         // Check if proactive mode is enabled
-        const isProactiveMode = selectedModel?.capabilities?.includes('proactive') ?? false
+        const isProactiveMode =
+          (selectedModel?.capabilities?.includes('tools') ?? false) &&
+          (selectedModel?.capabilities?.includes('vision') ?? false) &&
+          (selectedModel?.capabilities?.includes('proactive') ?? false)
 
         // Proactive mode: Capture initial screenshot/snapshot before first LLM call
         if (isProactiveMode && availableTools.length > 0 && !abortController.signal.aborted) {
@@ -718,7 +721,10 @@ export const useChat = () => {
           builder.addAssistantMessage(accumulatedText, undefined, toolCalls)
 
           // Check if proactive mode is enabled for this model
-          const isProactiveMode = selectedModel?.capabilities?.includes('proactive') ?? false
+          const isProactiveMode =
+            (selectedModel?.capabilities?.includes('tools') ?? false) &&
+            (selectedModel?.capabilities?.includes('vision') ?? false) &&
+            (selectedModel?.capabilities?.includes('proactive') ?? false)
 
           const updatedMessage = await postMessageProcessing(
             toolCalls,


### PR DESCRIPTION
## Describe Your Changes

- The proactive icon was incorrectly display if we deactivate tools or vision capability
- The icon should only appear in the condition that all 3 toggles for tools, vision, and proactive are ON at once

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
