### PR TITLE
fix: add mcp tool call timeout config

### DIFF
--- a/src-tauri/src/core/mcp/constants.rs
+++ b/src-tauri/src/core/mcp/constants.rs
@@ -1,10 +1,8 @@
-use std::time::Duration;
-
-// MCP Constants
-pub const MCP_TOOL_CALL_TIMEOUT: Duration = Duration::from_secs(30);
-pub const MCP_BASE_RESTART_DELAY_MS: u64 = 1000; // Start with 1 second
-pub const MCP_MAX_RESTART_DELAY_MS: u64 = 30000; // Cap at 30 seconds
-pub const MCP_BACKOFF_MULTIPLIER: f64 = 2.0; // Double the delay each time
+// Default MCP runtime settings
+pub const DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECS: u64 = 30;
+pub const DEFAULT_MCP_BASE_RESTART_DELAY_MS: u64 = 1000; // Start with 1 second
+pub const DEFAULT_MCP_MAX_RESTART_DELAY_MS: u64 = 30000; // Cap at 30 seconds
+pub const DEFAULT_MCP_BACKOFF_MULTIPLIER: f64 = 2.0; // Double the delay each time
 
 pub const DEFAULT_MCP_CONFIG: &str = r#"{
   "mcpServers": {
@@ -48,5 +46,11 @@ pub const DEFAULT_MCP_CONFIG: &str = r#"{
       "env": {},
       "active": false
     }
+  },
+  "mcpSettings": {
+    "toolCallTimeoutSeconds": 30,
+    "baseRestartDelayMs": 1000,
+    "maxRestartDelayMs": 30000,
+    "backoffMultiplier": 2.0
   }
 }"#;

--- a/src-tauri/src/core/mcp/helpers.rs
+++ b/src-tauri/src/core/mcp/helpers.rs
@@ -17,12 +17,9 @@ use tokio::{
     time::{sleep, timeout},
 };
 
-use super::constants::{
-    MCP_BACKOFF_MULTIPLIER, MCP_BASE_RESTART_DELAY_MS, MCP_MAX_RESTART_DELAY_MS,
-};
 use crate::core::{
     app::commands::get_jan_data_folder_path,
-    mcp::models::McpServerConfig,
+    mcp::models::{McpServerConfig, McpSettings},
     state::{AppState, RunningServiceEnum, SharedMcpServers},
 };
 use jan_utils::{can_override_npx, can_override_uvx};
@@ -33,16 +30,25 @@ use jan_utils::{can_override_npx, can_override_uvx};
 /// * `attempt` - The current restart attempt number (1-based)
 ///
 /// # Returns
-/// * `u64` - Delay in milliseconds, capped at MCP_MAX_RESTART_DELAY_MS
-pub fn calculate_exponential_backoff_delay(attempt: u32) -> u64 {
+/// * `u64` - Delay in milliseconds, capped at configured maximum
+pub fn calculate_exponential_backoff_delay(attempt: u32, settings: &McpSettings) -> u64 {
     use std::cmp;
+
+    let attempt = attempt.max(1);
+    let base_delay_ms = settings.base_restart_delay_ms.max(1);
+    let max_delay_ms = settings.max_restart_delay_ms.max(base_delay_ms);
+    let backoff_multiplier = if settings.backoff_multiplier <= 0.0 {
+        1.0
+    } else {
+        settings.backoff_multiplier
+    };
 
     // Calculate base exponential delay: base_delay * multiplier^(attempt-1)
     let exponential_delay =
-        (MCP_BASE_RESTART_DELAY_MS as f64) * MCP_BACKOFF_MULTIPLIER.powi((attempt - 1) as i32);
+        (base_delay_ms as f64) * backoff_multiplier.powi((attempt - 1) as i32);
 
     // Cap the delay at maximum
-    let capped_delay = cmp::min(exponential_delay as u64, MCP_MAX_RESTART_DELAY_MS);
+    let capped_delay = cmp::min(exponential_delay.round() as u64, max_delay_ms);
 
     // Add jitter (±25% randomness) to prevent thundering herd
     let jitter_range = (capped_delay as f64 * 0.25) as u64;
@@ -62,7 +68,9 @@ pub fn calculate_exponential_backoff_delay(attempt: u32) -> u64 {
     };
 
     // Apply jitter while ensuring delay stays positive and within bounds
-    ((capped_delay as i64 + jitter) as u64).clamp(100, MCP_MAX_RESTART_DELAY_MS)
+    let min_delay_ms = cmp::min(base_delay_ms, max_delay_ms).max(100);
+    let upper_bound = cmp::max(max_delay_ms, min_delay_ms);
+    ((capped_delay as i64 + jitter) as u64).clamp(min_delay_ms, upper_bound)
 }
 
 /// Runs MCP commands by reading configuration from a JSON file and initializing servers
@@ -89,6 +97,18 @@ pub async fn run_mcp_commands<R: Runtime>(
 
     let mcp_servers: serde_json::Value = serde_json::from_str(&config_content)
         .map_err(|e| format!("Failed to parse config: {e}"))?;
+
+    // Update runtime MCP settings from config
+    {
+        let settings = mcp_servers
+            .get("mcpSettings")
+            .and_then(|value| serde_json::from_value::<McpSettings>(value.clone()).ok())
+            .unwrap_or_default();
+
+        let app_state = app.state::<AppState>();
+        let mut guard = app_state.mcp_settings.lock().await;
+        *guard = settings;
+    }
 
     let server_map = mcp_servers
         .get("mcpServers")
@@ -241,6 +261,7 @@ pub async fn start_mcp_server_with_restart<R: Runtime>(
     let restart_counts = app_state.mcp_restart_counts.clone();
     let active_servers_state = app_state.mcp_active_servers.clone();
     let successfully_connected = app_state.mcp_successfully_connected.clone();
+    let mcp_settings = app_state.mcp_settings.clone();
 
     // Store active server config for restart purposes
     store_active_server_config(&active_servers_state, &name, &config).await;
@@ -274,12 +295,13 @@ pub async fn start_mcp_server_with_restart<R: Runtime>(
                     app,
                     servers_state,
                     name,
-                    config,
-                    max_restarts,
-                    restart_counts,
-                    successfully_connected,
-                )
-                .await;
+                config,
+                max_restarts,
+                restart_counts,
+                successfully_connected,
+                mcp_settings,
+            )
+            .await;
 
                 Ok(())
             } else {
@@ -308,6 +330,7 @@ pub async fn start_restart_loop<R: Runtime>(
     max_restarts: u32,
     restart_counts: Arc<Mutex<HashMap<String, u32>>>,
     successfully_connected: Arc<Mutex<HashMap<String, bool>>>,
+    mcp_settings: Arc<Mutex<McpSettings>>,
 ) {
     loop {
         let current_restart_count = {
@@ -338,7 +361,12 @@ pub async fn start_restart_loop<R: Runtime>(
         );
 
         // Calculate exponential backoff delay
-        let delay_ms = calculate_exponential_backoff_delay(current_restart_count);
+        let settings_snapshot = {
+            let settings_guard = mcp_settings.lock().await;
+            settings_guard.clone()
+        };
+        let delay_ms =
+            calculate_exponential_backoff_delay(current_restart_count, &settings_snapshot);
         log::info!(
             "Waiting {delay_ms}ms before restart attempt {current_restart_count} for MCP server {name}"
         );
@@ -854,11 +882,13 @@ pub async fn spawn_server_monitoring_task<R: Runtime>(
     max_restarts: u32,
     restart_counts: Arc<Mutex<HashMap<String, u32>>>,
     successfully_connected: Arc<Mutex<HashMap<String, bool>>>,
+    mcp_settings: Arc<Mutex<McpSettings>>,
 ) {
     let app_clone = app.clone();
     let servers_clone = servers_state.clone();
     let name_clone = name.clone();
     let config_clone = config.clone();
+    let mcp_settings_clone = mcp_settings.clone();
 
     tauri::async_runtime::spawn(async move {
         // Monitor the server using RunningService's JoinHandle<QuitReason>
@@ -880,6 +910,7 @@ pub async fn spawn_server_monitoring_task<R: Runtime>(
                 max_restarts,
                 restart_counts,
                 successfully_connected,
+                mcp_settings_clone.clone(),
             )
             .await;
         }

--- a/src-tauri/src/core/mcp/models.rs
+++ b/src-tauri/src/core/mcp/models.rs
@@ -15,6 +15,54 @@ pub struct McpServerConfig {
     pub headers: serde_json::Map<String, Value>,
 }
 
+fn default_tool_call_timeout_seconds() -> u64 {
+    super::constants::DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECS
+}
+
+fn default_base_restart_delay_ms() -> u64 {
+    super::constants::DEFAULT_MCP_BASE_RESTART_DELAY_MS
+}
+
+fn default_max_restart_delay_ms() -> u64 {
+    super::constants::DEFAULT_MCP_MAX_RESTART_DELAY_MS
+}
+
+fn default_backoff_multiplier() -> f64 {
+    super::constants::DEFAULT_MCP_BACKOFF_MULTIPLIER
+}
+
+/// Runtime MCP settings that can be adjusted via UI
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct McpSettings {
+    #[serde(default = "default_tool_call_timeout_seconds")]
+    pub tool_call_timeout_seconds: u64,
+    #[serde(default = "default_base_restart_delay_ms")]
+    pub base_restart_delay_ms: u64,
+    #[serde(default = "default_max_restart_delay_ms")]
+    pub max_restart_delay_ms: u64,
+    #[serde(default = "default_backoff_multiplier")]
+    pub backoff_multiplier: f64,
+}
+
+impl Default for McpSettings {
+    fn default() -> Self {
+        Self {
+            tool_call_timeout_seconds: super::constants::DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECS,
+            base_restart_delay_ms: super::constants::DEFAULT_MCP_BASE_RESTART_DELAY_MS,
+            max_restart_delay_ms: super::constants::DEFAULT_MCP_MAX_RESTART_DELAY_MS,
+            backoff_multiplier: super::constants::DEFAULT_MCP_BACKOFF_MULTIPLIER,
+        }
+    }
+}
+
+impl McpSettings {
+    /// Returns the tool call timeout duration, enforcing a minimum of 1 second to avoid zero-duration timeouts.
+    pub fn tool_call_timeout_duration(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(self.tool_call_timeout_seconds.max(1))
+    }
+}
+
 /// Tool with server information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolWithServer {

--- a/src-tauri/src/core/mcp/tests.rs
+++ b/src-tauri/src/core/mcp/tests.rs
@@ -1,17 +1,24 @@
 use super::helpers::{add_server_config, add_server_config_with_path, run_mcp_commands};
 use crate::core::app::commands::get_jan_data_folder_path;
-use crate::core::state::SharedMcpServers;
+use crate::core::state::{AppState, SharedMcpServers};
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tauri::test::mock_app;
+use tauri::{test::mock_app, Manager};
 use tokio::sync::Mutex;
 
 #[tokio::test]
 async fn test_run_mcp_commands() {
     let app = mock_app();
+
+    // Register AppState so state::<AppState>() calls succeed
+    let servers_state: SharedMcpServers = Arc::new(Mutex::new(HashMap::new()));
+    app.manage(AppState {
+        mcp_servers: servers_state.clone(),
+        ..Default::default()
+    });
 
     // Get the app path where the config should be created
     let app_path = get_jan_data_folder_path(app.handle().clone());
@@ -28,7 +35,6 @@ async fn test_run_mcp_commands() {
         .expect("Failed to write to config file");
 
     // Call the run_mcp_commands function
-    let servers_state: SharedMcpServers = Arc::new(Mutex::new(HashMap::new()));
     let result = run_mcp_commands(app.handle(), servers_state).await;
 
     // Assert that the function returns Ok(())

--- a/src-tauri/src/core/state.rs
+++ b/src-tauri/src/core/state.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use crate::core::downloads::models::DownloadManagerState;
+use crate::core::{downloads::models::DownloadManagerState, mcp::models::McpSettings};
 use rmcp::{
     model::{CallToolRequestParam, CallToolResult, InitializeRequestParam, Tool},
     service::RunningService,
@@ -28,6 +28,7 @@ pub struct AppState {
     pub mcp_successfully_connected: Arc<Mutex<HashMap<String, bool>>>,
     pub server_handle: Arc<Mutex<Option<ServerHandle>>>,
     pub tool_call_cancellations: Arc<Mutex<HashMap<String, oneshot::Sender<()>>>>,
+    pub mcp_settings: Arc<Mutex<McpSettings>>,
 }
 
 impl RunningServiceEnum {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,7 +2,7 @@ mod core;
 use core::{
     app::commands::get_jan_data_folder_path,
     downloads::models::DownloadManagerState,
-    mcp::helpers::clean_up_mcp_servers,
+    mcp::{helpers::clean_up_mcp_servers, models::McpSettings},
     setup::{self, setup_mcp},
     state::AppState,
 };
@@ -120,6 +120,7 @@ pub fn run() {
             mcp_successfully_connected: Arc::new(Mutex::new(HashMap::new())),
             server_handle: Arc::new(Mutex::new(None)),
             tool_call_cancellations: Arc::new(Mutex::new(HashMap::new())),
+            mcp_settings: Arc::new(Mutex::new(McpSettings::default())),
         })
         .setup(|app| {
             app.handle().plugin(

--- a/web-app/src/containers/__tests__/ChatInput.test.tsx
+++ b/web-app/src/containers/__tests__/ChatInput.test.tsx
@@ -111,6 +111,7 @@ const mockGetConnectedServers = vi.fn(() => Promise.resolve(['server1']))
 const mockGetTools = vi.fn(() => Promise.resolve([]))
 const mockStopAllModels = vi.fn()
 const mockCheckMmprojExists = vi.fn(() => Promise.resolve(true))
+const mockGetActiveModels = vi.fn(() => Promise.resolve([]))
 
 const mockListen = vi.fn(() => Promise.resolve(() => {}))
 
@@ -122,6 +123,7 @@ const mockServiceHub = {
   models: () => ({
     stopAllModels: mockStopAllModels,
     checkMmprojExists: mockCheckMmprojExists,
+    getActiveModels: mockGetActiveModels,
   }),
   events: () => ({
     listen: mockListen,

--- a/web-app/src/containers/dialogs/EditJsonMCPserver.tsx
+++ b/web-app/src/containers/dialogs/EditJsonMCPserver.tsx
@@ -7,17 +7,25 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
-import { MCPServerConfig } from '@/hooks/useMCPServers'
+import { MCPServerConfig, MCPServers, MCPSettings } from '@/hooks/useMCPServers'
 import CodeEditor from '@uiw/react-textarea-code-editor'
 import '@uiw/react-textarea-code-editor/dist.css'
 import { useTranslation } from '@/i18n/react-i18next-compat'
+
+type MCPConfigJson =
+  | MCPServerConfig
+  | MCPServers
+  | {
+      mcpServers: MCPServers
+      mcpSettings?: MCPSettings
+    }
 
 interface EditJsonMCPserverProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   serverName: string | null // null means editing all servers
-  initialData: MCPServerConfig | Record<string, MCPServerConfig>
-  onSave: (data: MCPServerConfig | Record<string, MCPServerConfig>) => void
+  initialData: MCPConfigJson
+  onSave: (data: MCPConfigJson) => void
 }
 
 export default function EditJsonMCPserver({
@@ -50,7 +58,7 @@ export default function EditJsonMCPserver({
 
   const handleSave = () => {
     try {
-      const parsedData = JSON.parse(jsonContent)
+      const parsedData = JSON.parse(jsonContent) as MCPConfigJson
       onSave(parsedData)
       onOpenChange(false)
       setError(null)

--- a/web-app/src/hooks/useMCPServers.ts
+++ b/web-app/src/hooks/useMCPServers.ts
@@ -18,9 +18,24 @@ export type MCPServers = {
   [key: string]: MCPServerConfig
 }
 
+export type MCPSettings = {
+  toolCallTimeoutSeconds: number
+  baseRestartDelayMs: number
+  maxRestartDelayMs: number
+  backoffMultiplier: number
+}
+
+export const DEFAULT_MCP_SETTINGS: MCPSettings = {
+  toolCallTimeoutSeconds: 30,
+  baseRestartDelayMs: 1000,
+  maxRestartDelayMs: 30000,
+  backoffMultiplier: 2,
+}
+
 type MCPServerStoreState = {
   open: boolean
   mcpServers: MCPServers
+  settings: MCPSettings
   loading: boolean
   deletedServerKeys: string[]
   getServerConfig: (key: string) => MCPServerConfig | undefined
@@ -34,6 +49,8 @@ type MCPServerStoreState = {
   ) => void
   deleteServer: (key: string) => void
   setServers: (servers: MCPServers) => void
+  setSettings: (settings: MCPSettings) => void
+  updateSettings: (partial: Partial<MCPSettings>) => void
   syncServers: () => Promise<void>
   syncServersAndRestart: () => Promise<void>
 }
@@ -41,6 +58,7 @@ type MCPServerStoreState = {
 export const useMCPServers = create<MCPServerStoreState>()((set, get) => ({
   open: true,
   mcpServers: {}, // Start with empty object
+  settings: { ...DEFAULT_MCP_SETTINGS },
   loading: false,
   deletedServerKeys: [],
   setLeftPanel: (value) => set({ open: value }),
@@ -94,6 +112,20 @@ export const useMCPServers = create<MCPServerStoreState>()((set, get) => ({
       const mcpServers = { ...state.mcpServers, ...servers }
       return { mcpServers }
     }),
+  setSettings: (settings) =>
+    set(() => ({
+      settings: {
+        ...DEFAULT_MCP_SETTINGS,
+        ...settings,
+      },
+    })),
+  updateSettings: (partial) =>
+    set((state) => ({
+      settings: {
+        ...state.settings,
+        ...partial,
+      },
+    })),
   // Delete an MCP server by key
   deleteServer: (key) =>
     set((state) => {
@@ -110,18 +142,20 @@ export const useMCPServers = create<MCPServerStoreState>()((set, get) => ({
       }
     }),
   syncServers: async () => {
-    const mcpServers = get().mcpServers
+    const { mcpServers, settings } = get()
     await getServiceHub().mcp().updateMCPConfig(
       JSON.stringify({
         mcpServers,
+        mcpSettings: settings,
       })
     )
   },
   syncServersAndRestart: async () => {
-    const mcpServers = get().mcpServers
+    const { mcpServers, settings } = get()
     await getServiceHub().mcp().updateMCPConfig(
       JSON.stringify({
         mcpServers,
+        mcpSettings: settings,
       })
     ).then(() => getServiceHub().mcp().restartMCPServers())
   },

--- a/web-app/src/locales/de-DE/mcp-servers.json
+++ b/web-app/src/locales/de-DE/mcp-servers.json
@@ -43,5 +43,11 @@
   "args": "Argumente",
   "env": "Umgebung",
   "serverStatusActive": "Server {{serverKey}} erfolgreich aktiviert",
-  "serverStatusInactive": "Server {{serverKey}} erfolgreich deaktiviert"
+  "serverStatusInactive": "Server {{serverKey}} erfolgreich deaktiviert",
+  "runtimeSettings": {
+    "title": "Laufzeiteinstellungen",
+    "description": "Konfiguriere, wie Jan MCP-Server verwaltet und erneut versucht.",
+    "toolCallTimeout": "Zeitlimit für Tool-Aufruf (Sekunden)",
+    "toolCallTimeoutDesc": "Maximale Wartezeit auf eine Antwort eines MCP-Tools, bevor abgebrochen wird."
+  }
 }

--- a/web-app/src/locales/en/mcp-servers.json
+++ b/web-app/src/locales/en/mcp-servers.json
@@ -43,5 +43,11 @@
   "args": "Args",
   "env": "Env",
   "serverStatusActive": "Server {{serverKey}} activated successfully",
-  "serverStatusInactive": "Server {{serverKey}} deactivated successfully"
+  "serverStatusInactive": "Server {{serverKey}} deactivated successfully",
+  "runtimeSettings": {
+    "title": "Runtime Settings",
+    "description": "Configure how Jan manages and retries MCP servers.",
+    "toolCallTimeout": "Tool call timeout (seconds)",
+    "toolCallTimeoutDesc": "Maximum time to wait for an MCP tool response before timing out."
+  }
 }

--- a/web-app/src/locales/id/mcp-servers.json
+++ b/web-app/src/locales/id/mcp-servers.json
@@ -43,5 +43,11 @@
   "args": "Argumen",
   "env": "Lingkungan",
   "serverStatusActive": "Server {{serverKey}} berhasil diaktifkan",
-  "serverStatusInactive": "Server {{serverKey}} berhasil dinonaktifkan"
+  "serverStatusInactive": "Server {{serverKey}} berhasil dinonaktifkan",
+  "runtimeSettings": {
+    "title": "Pengaturan Runtime",
+    "description": "Atur bagaimana Jan mengelola dan mencoba ulang server MCP.",
+    "toolCallTimeout": "Batas waktu pemanggilan alat (detik)",
+    "toolCallTimeoutDesc": "Waktu maksimum menunggu respons alat MCP sebelum waktu habis."
+  }
 }

--- a/web-app/src/locales/ja/mcp-servers.json
+++ b/web-app/src/locales/ja/mcp-servers.json
@@ -43,5 +43,11 @@
   "args": "引数",
   "env": "環境変数",
   "serverStatusActive": "サーバー {{serverKey}} が正常にアクティブ化されました",
-  "serverStatusInactive": "サーバー {{serverKey}} が正常に非アクティブ化されました"
+  "serverStatusInactive": "サーバー {{serverKey}} が正常に非アクティブ化されました",
+  "runtimeSettings": {
+    "title": "ランタイム設定",
+    "description": "JanがMCPサーバーを管理し再試行する方法を設定します。",
+    "toolCallTimeout": "ツール呼び出しタイムアウト（秒）",
+    "toolCallTimeoutDesc": "MCPツールの応答を待機する最大時間（タイムアウトまで）。"
+  }
 }

--- a/web-app/src/locales/pl/mcp-servers.json
+++ b/web-app/src/locales/pl/mcp-servers.json
@@ -43,5 +43,11 @@
   "args": "Argumenty",
   "env": "Zmienne Środowiskowe",
   "serverStatusActive": "Pomyślnie aktywowano serwer {{serverKey}}",
-  "serverStatusInactive": "Pomyślnie dezaktywowano serwer {{serverKey}}"
+  "serverStatusInactive": "Pomyślnie dezaktywowano serwer {{serverKey}}",
+  "runtimeSettings": {
+    "title": "Ustawienia środowiska uruchomieniowego",
+    "description": "Skonfiguruj, jak Jan zarządza i ponawia próby połączenia z serwerami MCP.",
+    "toolCallTimeout": "Limit czasu wywołania narzędzia (sekundy)",
+    "toolCallTimeoutDesc": "Maksymalny czas oczekiwania na odpowiedź narzędzia MCP przed przekroczeniem limitu czasu."
+  }
 }

--- a/web-app/src/locales/pt-BR/mcp-servers.json
+++ b/web-app/src/locales/pt-BR/mcp-servers.json
@@ -43,5 +43,11 @@
   "args": "Args",
   "env": "Env",
   "serverStatusActive": "Servidor {{serverKey}} ativado com sucesso",
-  "serverStatusInactive": "Servidor {{serverKey}} desativado com sucesso"
+  "serverStatusInactive": "Servidor {{serverKey}} desativado com sucesso",
+  "runtimeSettings": {
+    "title": "Configurações de Execução",
+    "description": "Configure como o Jan gerencia e tenta novamente os servidores MCP.",
+    "toolCallTimeout": "Tempo limite de chamada da ferramenta (segundos)",
+    "toolCallTimeoutDesc": "Tempo máximo de espera por uma resposta da ferramenta MCP antes de atingir o tempo limite."
+  }
 }

--- a/web-app/src/locales/vn/mcp-servers.json
+++ b/web-app/src/locales/vn/mcp-servers.json
@@ -43,5 +43,11 @@
   "args": "Đối số",
   "env": "Môi trường",
   "serverStatusActive": "Máy chủ {{serverKey}} đã được kích hoạt thành công",
-  "serverStatusInactive": "Máy chủ {{serverKey}} đã được hủy kích hoạt thành công"
+  "serverStatusInactive": "Máy chủ {{serverKey}} đã được hủy kích hoạt thành công",
+  "runtimeSettings": {
+    "title": "Cài đặt thời gian chạy",
+    "description": "Cấu hình cách Jan quản lý và thử lại các máy chủ MCP.",
+    "toolCallTimeout": "Thời gian chờ lệnh (giây)",
+    "toolCallTimeoutDesc": "Thời gian tối đa chờ phản hồi từ công cụ MCP trước khi hết thời gian."
+  }
 }

--- a/web-app/src/locales/zh-CN/mcp-servers.json
+++ b/web-app/src/locales/zh-CN/mcp-servers.json
@@ -43,5 +43,11 @@
   "args": "参数",
   "env": "环境",
   "serverStatusActive": "服务器 {{serverKey}} 激活成功",
-  "serverStatusInactive": "服务器 {{serverKey}} 停用成功"
+  "serverStatusInactive": "服务器 {{serverKey}} 停用成功",
+  "runtimeSettings": {
+    "title": "运行时设置",
+    "description": "配置 Jan 如何管理和重试 MCP 服务器。",
+    "toolCallTimeout": "工具调用超时时间（秒）",
+    "toolCallTimeoutDesc": "在超时前等待 MCP 工具响应的最长时间。"
+  }
 }

--- a/web-app/src/locales/zh-TW/mcp-servers.json
+++ b/web-app/src/locales/zh-TW/mcp-servers.json
@@ -43,5 +43,11 @@
   "args": "參數",
   "env": "環境",
   "serverStatusActive": "伺服器 {{serverKey}} 啟用成功",
-  "serverStatusInactive": "伺服器 {{serverKey}} 停用成功"
+  "serverStatusInactive": "伺服器 {{serverKey}} 停用成功",
+  "runtimeSettings": {
+    "title": "執行階段設定",
+    "description": "設定 Jan 如何管理及重試 MCP 伺服器。",
+    "toolCallTimeout": "工具呼叫逾時（秒）",
+    "toolCallTimeoutDesc": "等待 MCP 工具回應的最長時間，超過即逾時。"
+  }
 }

--- a/web-app/src/providers/DataProvider.tsx
+++ b/web-app/src/providers/DataProvider.tsx
@@ -3,7 +3,7 @@ import { useModelProvider } from '@/hooks/useModelProvider'
 import { useAppUpdater } from '@/hooks/useAppUpdater'
 import { useServiceHub } from '@/hooks/useServiceHub'
 import { useEffect } from 'react'
-import { useMCPServers } from '@/hooks/useMCPServers'
+import { useMCPServers, DEFAULT_MCP_SETTINGS } from '@/hooks/useMCPServers'
 import { useAssistant } from '@/hooks/useAssistant'
 import { useNavigate } from '@tanstack/react-router'
 import { route } from '@/constants/routes'
@@ -19,7 +19,7 @@ export function DataProvider() {
     useModelProvider()
 
   const { checkForUpdate } = useAppUpdater()
-  const { setServers } = useMCPServers()
+  const { setServers, setSettings } = useMCPServers()
   const { setAssistants, initializeWithLastUsed } = useAssistant()
   const { setThreads } = useThreads()
   const navigate = useNavigate()
@@ -46,7 +46,10 @@ export function DataProvider() {
     serviceHub
       .mcp()
       .getMCPConfig()
-      .then((data) => setServers(data.mcpServers ?? {}))
+      .then((data) => {
+        setServers(data.mcpServers ?? {})
+        setSettings(data.mcpSettings ?? DEFAULT_MCP_SETTINGS)
+      })
     serviceHub
       .assistants()
       .getAssistants()

--- a/web-app/src/providers/__tests__/DataProvider.test.tsx
+++ b/web-app/src/providers/__tests__/DataProvider.test.tsx
@@ -45,6 +45,7 @@ vi.mock('@/hooks/useAppUpdater', () => ({
 vi.mock('@/hooks/useMCPServers', () => ({
   useMCPServers: vi.fn(() => ({
     setServers: vi.fn(),
+    setSettings: vi.fn(),
   })),
 }))
 

--- a/web-app/src/services/__tests__/mcp.test.ts
+++ b/web-app/src/services/__tests__/mcp.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { TauriMCPService } from '../mcp/tauri'
 import { MCPTool } from '@/types/completion'
+import { DEFAULT_MCP_SETTINGS } from '@/hooks/useMCPServers'
 
 // Mock the global window.core.api
 const mockCore = {
@@ -111,8 +112,11 @@ describe('TauriMCPService', () => {
     it('should get and parse MCP config correctly', async () => {
       const mockConfigString = '{"server1": {"path": "/path/to/server"}, "server2": {"command": "node server.js"}}'
       const expectedConfig = {
-        server1: { path: '/path/to/server' },
-        server2: { command: 'node server.js' },
+        mcpServers: {
+          server1: { path: '/path/to/server' },
+          server2: { command: 'node server.js' },
+        },
+        mcpSettings: { ...DEFAULT_MCP_SETTINGS },
       }
 
       mockCore.api.getMcpConfigs.mockResolvedValue(mockConfigString)
@@ -123,28 +127,37 @@ describe('TauriMCPService', () => {
       expect(result).toEqual(expectedConfig)
     })
 
-    it('should return empty object when config is null', async () => {
+    it('should return default config when config is null', async () => {
       mockCore.api.getMcpConfigs.mockResolvedValue(null)
 
       const result = await mcpService.getMCPConfig()
 
-      expect(result).toEqual({})
+      expect(result).toEqual({
+        mcpServers: {},
+        mcpSettings: { ...DEFAULT_MCP_SETTINGS },
+      })
     })
 
-    it('should return empty object when config is undefined', async () => {
+    it('should return default config when config is undefined', async () => {
       mockCore.api.getMcpConfigs.mockResolvedValue(undefined)
 
       const result = await mcpService.getMCPConfig()
 
-      expect(result).toEqual({})
+      expect(result).toEqual({
+        mcpServers: {},
+        mcpSettings: { ...DEFAULT_MCP_SETTINGS },
+      })
     })
 
-    it('should return empty object when config is empty string', async () => {
+    it('should return default config when config is empty string', async () => {
       mockCore.api.getMcpConfigs.mockResolvedValue('')
 
       const result = await mcpService.getMCPConfig()
 
-      expect(result).toEqual({})
+      expect(result).toEqual({
+        mcpServers: {},
+        mcpSettings: { ...DEFAULT_MCP_SETTINGS },
+      })
     })
 
     it('should handle invalid JSON gracefully', async () => {

--- a/web-app/src/services/mcp/types.ts
+++ b/web-app/src/services/mcp/types.ts
@@ -3,10 +3,11 @@
  */
 
 import { MCPTool, MCPToolCallResult } from '@janhq/core'
-import type { MCPServerConfig, MCPServers } from '@/hooks/useMCPServers'
+import type { MCPServerConfig, MCPServers, MCPSettings } from '@/hooks/useMCPServers'
 
 export interface MCPConfig {
   mcpServers?: MCPServers
+  mcpSettings?: MCPSettings
 }
 
 export interface ToolCallWithCancellationResult {

--- a/web-app/src/test/setup.ts
+++ b/web-app/src/test/setup.ts
@@ -117,6 +117,7 @@ const mockServiceHub = {
     deleteModel: vi.fn().mockResolvedValue(undefined),
     updateModel: vi.fn().mockResolvedValue(undefined),
     startModel: vi.fn().mockResolvedValue(undefined),
+    getActiveModels: vi.fn().mockResolvedValue([]),
     isModelSupported: vi.fn().mockResolvedValue('GREEN'),
     checkMmprojExists: vi.fn().mockResolvedValue(true), // cspell: disable-line
     stopAllModels: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Describe Your Changes
This pull request introduces a new runtime MCP (Multi-Component Platform) settings system that allows key operational parameters—such as tool call timeouts and server restart backoff—to be dynamically configured and persisted. The changes replace previously hardcoded constants with settings loaded from and saved to the MCP config file, and ensure these settings are accessible and updatable at runtime. The codebase is refactored to use these settings throughout all relevant MCP server operations, improving flexibility and maintainability.

<img width="1136" height="912" alt="Screenshot 2025-11-05 at 17 29 39" src="https://github.com/user-attachments/assets/0297cb30-1bc6-4b8e-b35d-57e5ce67ff00" />


**Key changes:**

### Runtime MCP Settings Infrastructure

* Introduced a new `McpSettings` struct to encapsulate runtime-configurable MCP settings (tool call timeout, restart delays, backoff multiplier), with sensible defaults and serialization support. This struct is stored in `AppState` and is accessible throughout the MCP subsystem. [[1]](diffhunk://#diff-3df77cba3d6059e8afdeeaae79355b5c291ed8c8ff4f7ad2f2b62776019b128bR18-R65) [[2]](diffhunk://#diff-eeed548080bd3ab28caa94c47410e4b2f0be271e64063e5abab0807210889724L3-R3) [[3]](diffhunk://#diff-eeed548080bd3ab28caa94c47410e4b2f0be271e64063e5abab0807210889724R31) [[4]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cL5-R5) [[5]](diffhunk://#diff-eabcebd0ae5c9b77a5247e1bdbdb88b1869fc0c932d0ef0cf2ecf9ee5221be7cR123)

### Config File Management

* Updated MCP config file handling to read, validate, and persist the new `mcpSettings` section. The config file is now automatically upgraded to include missing settings or sections, and in-memory state is synchronized with file contents. [[1]](diffhunk://#diff-b3d962ba3e009a8a62d3e49f04df34f7ed2ffe79860089d9e045b588beb35d3cR305-R313) [[2]](diffhunk://#diff-b3d962ba3e009a8a62d3e49f04df34f7ed2ffe79860089d9e045b588beb35d3cL303-R416) [[3]](diffhunk://#diff-156c62e76a2cf98418b03b50ac81481bd3e16bed8edc96394f8202f847a2dfc7R49-R54)

### Tool Call Timeout Logic

* All tool call operations now use the timeout value from `McpSettings` rather than a hardcoded constant. This affects tool listing and invocation, making timeouts dynamically adjustable. [[1]](diffhunk://#diff-b3d962ba3e009a8a62d3e49f04df34f7ed2ffe79860089d9e045b588beb35d3cL2-R28) [[2]](diffhunk://#diff-b3d962ba3e009a8a62d3e49f04df34f7ed2ffe79860089d9e045b588beb35d3cR157-R169) [[3]](diffhunk://#diff-b3d962ba3e009a8a62d3e49f04df34f7ed2ffe79860089d9e045b588beb35d3cR212) [[4]](diffhunk://#diff-b3d962ba3e009a8a62d3e49f04df34f7ed2ffe79860089d9e045b588beb35d3cL231-R250) [[5]](diffhunk://#diff-b3d962ba3e009a8a62d3e49f04df34f7ed2ffe79860089d9e045b588beb35d3cL245-R263)

### Server Restart Backoff

* Refactored exponential backoff logic for MCP server restarts to use values from `McpSettings`. The restart delay, maximum delay, and multiplier are now runtime-configurable, and the logic is updated to use these settings in all restart and monitoring tasks. [[1]](diffhunk://#diff-9db711d7873fbd223bab6af8a8c4b7454bf433a63ef035cf8f2599f758106de2L20-R22) [[2]](diffhunk://#diff-9db711d7873fbd223bab6af8a8c4b7454bf433a63ef035cf8f2599f758106de2L36-R51) [[3]](diffhunk://#diff-9db711d7873fbd223bab6af8a8c4b7454bf433a63ef035cf8f2599f758106de2L65-R73) [[4]](diffhunk://#diff-9db711d7873fbd223bab6af8a8c4b7454bf433a63ef035cf8f2599f758106de2R101-R112) [[5]](diffhunk://#diff-9db711d7873fbd223bab6af8a8c4b7454bf433a63ef035cf8f2599f758106de2R264) [[6]](diffhunk://#diff-9db711d7873fbd223bab6af8a8c4b7454bf433a63ef035cf8f2599f758106de2R302) [[7]](diffhunk://#diff-9db711d7873fbd223bab6af8a8c4b7454bf433a63ef035cf8f2599f758106de2R333) [[8]](diffhunk://#diff-9db711d7873fbd223bab6af8a8c4b7454bf433a63ef035cf8f2599f758106de2L341-R369) [[9]](diffhunk://#diff-9db711d7873fbd223bab6af8a8c4b7454bf433a63ef035cf8f2599f758106de2R885-R891) [[10]](diffhunk://#diff-9db711d7873fbd223bab6af8a8c4b7454bf433a63ef035cf8f2599f758106de2R913)

### Constants Refactoring

* Removed hardcoded MCP constants and replaced them with default values used by `McpSettings`, ensuring all defaults are centralized and easily adjustable.

These changes make it much easier to tune MCP server behavior without code changes, and lay the groundwork for exposing these settings in a user interface.

## Fixes Issues

- Closes #6733

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
