### PR TITLE
fix: glibc linux

### DIFF
--- a/.github/workflows/jan-tauri-build-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-nightly.yaml
@@ -116,7 +116,7 @@ jobs:
         build-linux-x64,
         build-macos,
       ]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Getting the repo


### PR DESCRIPTION
## Describe Your Changes

- This PR is to fix the GLIBC issue `/lib/x86_64-linux-gnu/libc.so.6: version GLIBC_2.39 not found` on newer linux version so that it can work with old linux version

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
