### PR TITLE
fix(#6902): update Bun download link darwin-86x -> darwin-64x

### DIFF
--- a/scripts/download-bin.mjs
+++ b/scripts/download-bin.mjs
@@ -132,7 +132,7 @@ function getPlatformArch() {
   let bunPlatform, uvPlatform
 
   if (platform === 'darwin') {
-    bunPlatform = arch === 'arm64' ? 'darwin-aarch64' : 'darwin-x86'
+    bunPlatform = arch === 'arm64' ? 'darwin-aarch64' : 'darwin-x64'
     uvPlatform =
       arch === 'arm64' ? 'aarch64-apple-darwin' : 'x86_64-apple-darwin'
   } else if (platform === 'linux') {


### PR DESCRIPTION
## Describe Your Changes

Update Bun download link from `darwin-86x` -> `darwin-64x`. 

Bun release page: https://github.com/oven-sh/bun/releases/tag/bun-v1.3.1 (you will find `bun-darwin-64x` here, not `bun-darwin-86x`) 

## Fixes Issues

- Closes #6902