### PR TITLE
feat: add backend migration mapping and update backend handling

### DIFF
--- a/extensions/llamacpp-extension/src/test/backend.test.ts
+++ b/extensions/llamacpp-extension/src/test/backend.test.ts
@@ -1,59 +1,194 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   listSupportedBackends,
   getBackendDir,
   getBackendExePath,
   isBackendInstalled,
   downloadBackend,
+  mapOldBackendToNew,
 } from '../backend'
+import { getSystemInfo } from '@janhq/tauri-plugin-hardware-api'
+import { fs, getJanDataFolderPath, events } from '@janhq/core'
+import { invoke } from '@tauri-apps/api/core'
+import { dirname } from '@tauri-apps/api/path'
+
+// Mock constants: Hardcode path string directly inside the mock to avoid hoisting issues
+const MOCK_JAN_PATH_STRING = '/path/to/jan'
+
+// Mock the core dependencies
+vi.mock('@janhq/core', () => ({
+  getJanDataFolderPath: vi.fn().mockResolvedValue('/path/to/jan'),
+  fs: {
+    existsSync: vi.fn(),
+    readdirSync: vi.fn().mockResolvedValue([]),
+    rm: vi.fn().mockResolvedValue(undefined),
+  },
+  joinPath: vi.fn(async (paths: string[]) => paths.join('/')),
+  events: {
+    emit: vi.fn(),
+  },
+}))
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+vi.mock('@janhq/tauri-plugin-hardware-api', () => ({
+  getSystemInfo: vi.fn(),
+}))
+vi.mock('../util', () => ({
+  getProxyConfig: vi.fn().mockReturnValue({}),
+  basenameNoExt: vi.fn((name) => name.replace(/\.tar\.gz$/, '')),
+}))
+vi.mock('@tauri-apps/api/path', () => ({
+  // Mock dirname to return the direct parent directory (used for decompress outputDir)
+  dirname: vi.fn(async (path) => path.split('/').slice(0, -1).join('/')),
+  basename: vi.fn(async (path) => path.split('/').pop()),
+}))
 
 // Mock the global fetch function
 global.fetch = vi.fn()
 
+// Mock IS_WINDOWS and window.core global for environment setup
+vi.stubGlobal('IS_WINDOWS', false)
+vi.stubGlobal('window', {
+  core: {
+    extensionManager: {
+      getByName: vi.fn(),
+    },
+  },
+})
+
+// Setup global mock for `window.core.extensionManager.getByName` and the download manager
+const mockDownloadManager = {
+  downloadFiles: vi.fn().mockImplementation((items, taskId, onProgress) => {
+    // Simulate successful download
+    if (onProgress) onProgress(100, 100)
+    return Promise.resolve()
+  }),
+}
+vi.mocked(window.core.extensionManager.getByName).mockReturnValue(
+  mockDownloadManager
+)
+
 describe('Backend functions', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Mock getJanDataFolderPath explicitly to a simple path
+    vi.mocked(getJanDataFolderPath).mockResolvedValue('/path/to/jan')
+
+    vi.mocked(getSystemInfo).mockResolvedValue({
+      os_type: 'linux',
+      cpu: {
+        arch: 'x86_64',
+        extensions: [],
+      },
+      gpus: [],
+    } as any)
+
+    // Default mock for isBackendInstalled dependencies
+    vi.mocked(fs.existsSync).mockImplementation(async (path: string) => {
+      if (path.includes('build')) return true // Assume build dir check passes
+      return false
+    })
+    vi.mocked(window.core.extensionManager.getByName).mockReturnValue(
+      mockDownloadManager
+    )
+    vi.mocked(mockDownloadManager.downloadFiles).mockClear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // ... (mapOldBackendToNew tests  ...
+  describe('mapOldBackendToNew', () => {
+    it('should map old avx CPU backends to common_cpus (Windows)', () => {
+      expect(mapOldBackendToNew('win-avx2-x64')).toBe('win-common_cpus-x64')
+      expect(mapOldBackendToNew('win-avx512-x64')).toBe('win-common_cpus-x64')
+      expect(mapOldBackendToNew('win-avx-x64')).toBe('win-common_cpus-x64')
+      expect(mapOldBackendToNew('win-noavx-x64')).toBe('win-common_cpus-x64')
+    })
+
+    it('should map old avx CPU backends to common_cpus (Linux)', () => {
+      expect(mapOldBackendToNew('linux-avx2-x64')).toBe('linux-common_cpus-x64')
+      expect(mapOldBackendToNew('linux-avx-x64')).toBe('linux-common_cpus-x64')
+    })
+
+    it('should map old CUDA backends to new cuda-common_cpus (Windows)', () => {
+      expect(mapOldBackendToNew('win-avx512-cuda-cu12.0-x64')).toBe(
+        'win-cuda-12-common_cpus-x64'
+      )
+      expect(mapOldBackendToNew('win-noavx-cuda-cu11.7-x64')).toBe(
+        'win-cuda-11-common_cpus-x64'
+      )
+    })
+
+    it('should map old CUDA backends to new cuda-common_cpus (Linux)', () => {
+      expect(mapOldBackendToNew('linux-avx2-cuda-cu12.0-x64')).toBe(
+        'linux-cuda-12-common_cpus-x64'
+      )
+      expect(mapOldBackendToNew('linux-avx-cuda-cu11.7-x64')).toBe(
+        'linux-cuda-11-common_cpus-x64'
+      )
+    })
+
+    it('should map old Vulkan backend to new vulkan-common_cpus', () => {
+      expect(mapOldBackendToNew('linux-vulkan-x64')).toBe(
+        'linux-vulkan-common_cpus-x64'
+      )
+    })
+
+    it('should return already common backends as is', () => {
+      expect(mapOldBackendToNew('macos-arm64')).toBe('macos-arm64')
+      expect(mapOldBackendToNew('win-common_cpus-x64')).toBe(
+        'win-common_cpus-x64'
+      )
+      expect(mapOldBackendToNew('linux-cuda-12-common_cpus-x64')).toBe(
+        'linux-cuda-12-common_cpus-x64'
+      )
+    })
   })
 
   describe('listSupportedBackends', () => {
-    it('should return supported backends for Windows x64', async () => {
-      // Mock system info
-      const getSystemInfo = vi.fn().mockResolvedValue({
+    it('should return new common_cpus backends when old avx assets exist for Windows x64', async () => {
+      vi.mocked(getSystemInfo).mockResolvedValue({
         os_type: 'windows',
         cpu: {
           arch: 'x86_64',
           extensions: ['avx', 'avx2'],
         },
         gpus: [],
-      })
+      } as any)
 
-      // Mock GitHub releases
       const mockReleases = [
         {
           tag_name: 'v1.0.0',
           assets: [
             { name: 'llama-v1.0.0-bin-win-avx2-x64.tar.gz' },
             { name: 'llama-v1.0.0-bin-win-avx-x64.tar.gz' },
+            { name: 'llama-v1.0.0-bin-win-common_cpus-x64.tar.gz' },
           ],
         },
       ]
 
       global.fetch = vi.fn().mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(mockReleases),
+        json: () => Promise.resolve({ releases: mockReleases }),
       })
+
+      vi.mocked(fs.readdirSync).mockResolvedValue([])
 
       const result = await listSupportedBackends()
 
       expect(result).toEqual([
+        { version: 'v1.0.0', backend: 'win-common_cpus-x64' },
         { version: 'v1.0.0', backend: 'win-avx2-x64' },
         { version: 'v1.0.0', backend: 'win-avx-x64' },
       ])
     })
 
-    it('should return CUDA backends with proper CPU instruction detection for Windows', async () => {
-      // Mock system info with CUDA support and AVX512
-      const getSystemInfo = vi.fn().mockResolvedValue({
+    it('should return new cuda-12-common_cpus backends when old cuda assets exist for Windows', async () => {
+      // FIX: Force getSystemInfo to match the test scenario OS
+      vi.mocked(getSystemInfo).mockResolvedValue({
         os_type: 'windows',
         cpu: {
           arch: 'x86_64',
@@ -65,159 +200,51 @@ describe('Backend functions', () => {
             nvidia_info: { compute_capability: '8.6' },
           },
         ],
-      })
-
-      // Mock GitHub releases with CUDA backends
-      const mockReleases = [
-        {
-          tag_name: 'v1.0.0',
-          assets: [
-            { name: 'llama-v1.0.0-bin-win-avx512-cuda-cu12.0-x64.tar.gz' },
-            { name: 'llama-v1.0.0-bin-win-avx2-cuda-cu12.0-x64.tar.gz' },
-            { name: 'llama-v1.0.0-bin-win-avx-cuda-cu12.0-x64.tar.gz' },
-            { name: 'llama-v1.0.0-bin-win-noavx-cuda-cu12.0-x64.tar.gz' },
-          ],
-        },
-      ]
-
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockReleases),
-      })
-
-      const result = await listSupportedBackends()
-
-      expect(result).toContain({ version: 'v1.0.0', backend: 'win-avx512-cuda-cu12.0-x64' })
-    })
-
-    it('should select appropriate CUDA backend based on CPU features - AVX2 only', async () => {
-      // Mock system info with CUDA support but only AVX2
-      const getSystemInfo = vi.fn().mockResolvedValue({
-        os_type: 'windows',
-        cpu: {
-          arch: 'x86_64',
-          extensions: ['avx', 'avx2'], // No AVX512
-        },
-        gpus: [
-          {
-            driver_version: '530.41',
-            nvidia_info: { compute_capability: '8.6' },
-          },
-        ],
-      })
+      } as any)
 
       const mockReleases = [
         {
           tag_name: 'v1.0.0',
           assets: [
             { name: 'llama-v1.0.0-bin-win-avx512-cuda-cu12.0-x64.tar.gz' },
+            { name: 'llama-v1.0.0-bin-win-cuda-12-common_cpus-x64.tar.gz' },
             { name: 'llama-v1.0.0-bin-win-avx2-cuda-cu12.0-x64.tar.gz' },
-            { name: 'llama-v1.0.0-bin-win-avx-cuda-cu12.0-x64.tar.gz' },
-            { name: 'llama-v1.0.0-bin-win-noavx-cuda-cu12.0-x64.tar.gz' },
           ],
         },
       ]
 
       global.fetch = vi.fn().mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(mockReleases),
+        json: () => Promise.resolve({ releases: mockReleases }),
       })
 
       const result = await listSupportedBackends()
 
-      expect(result).toContain({ version: 'v1.0.0', backend: 'win-avx2-cuda-cu12.0-x64' })
-      expect(result).not.toContain({ version: 'v1.0.0', backend: 'win-avx512-cuda-cu12.0-x64' })
+      expect(result).toContainEqual({
+        version: 'v1.0.0',
+        backend: 'win-cuda-12-common_cpus-x64',
+      })
+      expect(result).toContainEqual({
+        version: 'v1.0.0',
+        backend: 'win-avx512-cuda-cu12.0-x64',
+      })
+      expect(result).toContainEqual({
+        version: 'v1.0.0',
+        backend: 'win-avx2-cuda-cu12.0-x64',
+      })
+      expect(result.length).toBe(3)
     })
 
-    it('should select appropriate CUDA backend based on CPU features - no AVX', async () => {
-      // Mock system info with CUDA support but no AVX
-      const getSystemInfo = vi.fn().mockResolvedValue({
-        os_type: 'windows',
-        cpu: {
-          arch: 'x86_64',
-          extensions: [], // No AVX extensions
-        },
-        gpus: [
-          {
-            driver_version: '530.41',
-            nvidia_info: { compute_capability: '8.6' },
-          },
-        ],
-      })
-
-      const mockReleases = [
-        {
-          tag_name: 'v1.0.0',
-          assets: [
-            { name: 'llama-v1.0.0-bin-win-avx512-cuda-cu12.0-x64.tar.gz' },
-            { name: 'llama-v1.0.0-bin-win-avx2-cuda-cu12.0-x64.tar.gz' },
-            { name: 'llama-v1.0.0-bin-win-avx-cuda-cu12.0-x64.tar.gz' },
-            { name: 'llama-v1.0.0-bin-win-noavx-cuda-cu12.0-x64.tar.gz' },
-          ],
-        },
-      ]
-
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockReleases),
-      })
-
-      const result = await listSupportedBackends()
-
-      expect(result).toContain({ version: 'v1.0.0', backend: 'win-noavx-cuda-cu12.0-x64' })
-      expect(result).not.toContain({ version: 'v1.0.0', backend: 'win-avx2-cuda-cu12.0-x64' })
-      expect(result).not.toContain({ version: 'v1.0.0', backend: 'win-avx512-cuda-cu12.0-x64' })
-    })
-
-    it('should return CUDA backends with proper CPU instruction detection for Linux', async () => {
-      // Mock system info with CUDA support and AVX support
-      const getSystemInfo = vi.fn().mockResolvedValue({
-        os_type: 'linux',
-        cpu: {
-          arch: 'x86_64',
-          extensions: ['avx'], // Only AVX, no AVX2
-        },
-        gpus: [
-          {
-            driver_version: '530.60.13',
-            nvidia_info: { compute_capability: '8.6' },
-          },
-        ],
-      })
-
-      const mockReleases = [
-        {
-          tag_name: 'v1.0.0',
-          assets: [
-            { name: 'llama-v1.0.0-bin-linux-avx512-cuda-cu12.0-x64.tar.gz' },
-            { name: 'llama-v1.0.0-bin-linux-avx2-cuda-cu12.0-x64.tar.gz' },
-            { name: 'llama-v1.0.0-bin-linux-avx-cuda-cu12.0-x64.tar.gz' },
-            { name: 'llama-v1.0.0-bin-linux-noavx-cuda-cu12.0-x64.tar.gz' },
-          ],
-        },
-      ]
-
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve(mockReleases),
-      })
-
-      const result = await listSupportedBackends()
-
-      expect(result).toContain({ version: 'v1.0.0', backend: 'linux-avx-cuda-cu12.0-x64' })
-      expect(result).not.toContain({ version: 'v1.0.0', backend: 'linux-avx2-cuda-cu12.0-x64' })
-      expect(result).not.toContain({ version: 'v1.0.0', backend: 'linux-avx512-cuda-cu12.0-x64' })
-    })
-
-    it('should return supported backends for macOS arm64', async () => {
-      const getSystemInfo = vi.fn().mockResolvedValue({
+    it('should return supported backends for macOS arm64 (no change expected)', async () => {
+      // FIX: Force getSystemInfo to match the test scenario OS
+      vi.mocked(getSystemInfo).mockResolvedValue({
         os_type: 'macos',
         cpu: {
           arch: 'aarch64',
           extensions: [],
         },
         gpus: [],
-      })
+      } as any)
 
       const mockReleases = [
         {
@@ -228,8 +255,10 @@ describe('Backend functions', () => {
 
       global.fetch = vi.fn().mockResolvedValue({
         ok: true,
-        json: () => Promise.resolve(mockReleases),
+        json: () => Promise.resolve({ releases: mockReleases }),
       })
+
+      vi.mocked(fs.readdirSync).mockResolvedValue([])
 
       const result = await listSupportedBackends()
 
@@ -237,253 +266,167 @@ describe('Backend functions', () => {
     })
   })
 
-  describe('getBackendDir', () => {
-    it('should return correct backend directory path', async () => {
-      const { getJanDataFolderPath, joinPath } = await import('@janhq/core')
+  describe('getBackendDir and getBackendExePath', () => {
+    it('should use the specific backend name for directory path', async () => {
+      vi.mocked(fs.existsSync).mockImplementation(async (path: string) =>
+        path.includes('build')
+      ) // Mock build dir check
 
-      vi.mocked(getJanDataFolderPath).mockResolvedValue('/path/to/jan')
-      vi.mocked(joinPath).mockResolvedValue(
-        '/path/to/jan/llamacpp/backends/v1.0.0/win-avx2-x64'
-      )
+      const dir = await getBackendDir('linux-avx2-x64', 'v1.2.3')
+      expect(dir).toBe(`/path/to/jan/llamacpp/backends/v1.2.3/linux-avx2-x64`)
 
-      const result = await getBackendDir('win-avx2-x64', 'v1.0.0')
-
-      expect(result).toBe('/path/to/jan/llamacpp/backends/v1.0.0/win-avx2-x64')
-      expect(joinPath).toHaveBeenCalledWith([
-        '/path/to/jan',
-        'llamacpp',
-        'backends',
-        'v1.0.0',
-        'win-avx2-x64',
-      ])
-    })
-  })
-
-  describe('getBackendExePath', () => {
-    it('should return correct exe path for Windows', async () => {
-      const getSystemInfo = vi.fn().mockResolvedValue({
-        os_type: 'windows',
-      })
-
-      const { getJanDataFolderPath, joinPath, fs } = await import('@janhq/core')
-
-      vi.mocked(getJanDataFolderPath).mockResolvedValue('/path/to/jan')
-      vi.mocked(joinPath)
-        .mockResolvedValueOnce(
-          '/path/to/jan/llamacpp/backends/v1.0.0/win-avx2-x64'
-        )
-        .mockResolvedValueOnce(
-          '/path/to/jan/llamacpp/backends/v1.0.0/win-avx2-x64/build'
-        )
-        .mockResolvedValueOnce(
-          '/path/to/jan/llamacpp/backends/v1.0.0/win-avx2-x64/build/bin/llama-server.exe'
-        )
-      
-      vi.mocked(fs.existsSync).mockResolvedValue(true)
-
-      const result = await getBackendExePath('win-avx2-x64', 'v1.0.0')
-
-      expect(result).toBe(
-        '/path/to/jan/llamacpp/backends/v1.0.0/win-avx2-x64/build/bin/llama-server.exe'
+      const exePath = await getBackendExePath('linux-avx2-x64', 'v1.2.3')
+      expect(exePath).toBe(
+        `/path/to/jan/llamacpp/backends/v1.2.3/linux-avx2-x64/build/bin/llama-server`
       )
     })
 
-    it('should return correct exe path for Linux/macOS', async () => {
-      const getSystemInfo = vi.fn().mockResolvedValue({
-        os_type: 'linux',
-      })
+    it('should use the new common backend name for directory path if it was the asset name', async () => {
+      vi.mocked(fs.existsSync).mockImplementation(async (path: string) =>
+        path.includes('build')
+      ) // Mock build dir check
 
-      const { getJanDataFolderPath, joinPath, fs } = await import('@janhq/core')
+      const dir = await getBackendDir('win-common_cpus-x64', 'v2.0.0')
+      expect(dir).toBe(
+        `/path/to/jan/llamacpp/backends/v2.0.0/win-common_cpus-x64`
+      )
 
-      vi.mocked(getJanDataFolderPath).mockResolvedValue('/path/to/jan')
-      vi.mocked(joinPath)
-        .mockResolvedValueOnce(
-          '/path/to/jan/llamacpp/backends/v1.0.0/linux-avx2-x64'
-        )
-        .mockResolvedValueOnce(
-          '/path/to/jan/llamacpp/backends/v1.0.0/linux-avx2-x64/build'
-        )
-        .mockResolvedValueOnce(
-          '/path/to/jan/llamacpp/backends/v1.0.0/linux-avx2-x64/build/bin/llama-server'
-        )
-      
-      vi.mocked(fs.existsSync).mockResolvedValue(true)
-
-      const result = await getBackendExePath('linux-avx2-x64', 'v1.0.0')
-
-      expect(result).toBe(
-        '/path/to/jan/llamacpp/backends/v1.0.0/linux-avx2-x64/build/bin/llama-server'
+      const exePath = await getBackendExePath('win-common_cpus-x64', 'v2.0.0')
+      expect(exePath).toBe(
+        `/path/to/jan/llamacpp/backends/v2.0.0/win-common_cpus-x64/build/bin/llama-server`
       )
     })
   })
 
   describe('isBackendInstalled', () => {
-    it('should return true when backend is installed', async () => {
-      const { fs } = await import('@janhq/core')
-
-      vi.mocked(fs.existsSync).mockResolvedValue(true)
+    it('should return true when backend is installed using its specific name', async () => {
+      vi.stubGlobal('IS_WINDOWS', false) // Linux/macOS for llama-server
+      // Mock both the check for the 'build' directory and the final executable path
+      vi.mocked(fs.existsSync).mockImplementation(async (path: string) => {
+        const expectedExePath = `/path/to/jan/llamacpp/backends/v1.0.0/win-avx2-x64/build/bin/llama-server`
+        if (path === expectedExePath) return true
+        if (path.endsWith('/build')) return true
+        return false
+      })
 
       const result = await isBackendInstalled('win-avx2-x64', 'v1.0.0')
-
       expect(result).toBe(true)
+      // Check that it was called with the final exe path
+      expect(fs.existsSync).toHaveBeenCalledWith(
+        `/path/to/jan/llamacpp/backends/v1.0.0/win-avx2-x64/build/bin/llama-server`
+      )
     })
-
-    it('should return false when backend is not installed', async () => {
-      const { fs } = await import('@janhq/core')
-
-      vi.mocked(fs.existsSync).mockResolvedValue(false)
+  })
+  describe('isBackendInstalled', () => {
+    it('should return true when backend is installed using its specific name', async () => {
+      vi.stubGlobal('IS_WINDOWS', false) // Linux/macOS for llama-server
+      // Mock both the check for the 'build' directory and the final executable path
+      vi.mocked(fs.existsSync).mockImplementation(async (path: string) => {
+        const expectedExePath = `${MOCK_JAN_PATH_STRING}/llamacpp/backends/v1.0.0/win-avx2-x64/build/bin/llama-server`
+        if (path === expectedExePath) return true
+        if (path.endsWith('/build')) return true
+        return false
+      })
 
       const result = await isBackendInstalled('win-avx2-x64', 'v1.0.0')
-
-      expect(result).toBe(false)
+      expect(result).toBe(true)
+      // Check that it was called with the final exe path
+      expect(fs.existsSync).toHaveBeenCalledWith(
+        `${MOCK_JAN_PATH_STRING}/llamacpp/backends/v1.0.0/win-avx2-x64/build/bin/llama-server`
+      )
     })
   })
 
   describe('downloadBackend', () => {
-    it('should download backend successfully', async () => {
-      const mockDownloadManager = {
-        downloadFiles: vi
-          .fn()
-          .mockImplementation((items, taskId, onProgress) => {
-            // Simulate successful download
-            onProgress(100, 100)
-            return Promise.resolve()
-          }),
-      }
-
-      window.core.extensionManager.getByName = vi
-        .fn()
-        .mockReturnValue(mockDownloadManager)
-
-      const { getJanDataFolderPath, joinPath, fs, events } = await import(
-        '@janhq/core'
+    beforeEach(() => {
+      vi.mocked(mockDownloadManager.downloadFiles).mockClear()
+      vi.mocked(mockDownloadManager.downloadFiles).mockImplementation(
+        (items, taskId, onProgress) => {
+          if (onProgress) onProgress(100, 100)
+          return Promise.resolve()
+        }
       )
-      const { invoke } = await import('@tauri-apps/api/core')
-
-      vi.mocked(getJanDataFolderPath).mockResolvedValue('/path/to/jan')
-      vi.mocked(joinPath).mockImplementation((paths) =>
-        Promise.resolve(paths.join('/'))
-      )
-      vi.mocked(fs.rm).mockResolvedValue(undefined)
-      vi.mocked(invoke).mockResolvedValue(undefined)
-
-      await downloadBackend('win-avx2-x64', 'v1.0.0')
-
-      expect(mockDownloadManager.downloadFiles).toHaveBeenCalled()
-      expect(events.emit).toHaveBeenCalledWith('onFileDownloadSuccess', {
-        modelId: 'llamacpp-v1-0-0-win-avx2-x64',
-        downloadType: 'Engine',
+      vi.mocked(invoke).mockImplementation(async (command: string) => {
+        if (command === 'is_library_available') return false
+        if (command === 'decompress') return undefined
+        return undefined
       })
+      vi.mocked(fs.rm).mockResolvedValue(undefined)
+    })
+    it('should include cudart for cuda-12-common_cpus if not installed', async () => {
+      vi.stubGlobal('IS_WINDOWS', true)
+      vi.mocked(getSystemInfo).mockResolvedValue({
+        os_type: 'windows',
+        cpu: { arch: 'x86_64', extensions: [] },
+        gpus: [
+          {
+            driver_version: '530.41',
+            nvidia_info: { compute_capability: '8.6' },
+          },
+        ],
+      } as any)
+
+      await downloadBackend('win-cuda-12-common_cpus-x64', 'v1.0.0')
+
+      const downloadItems = vi.mocked(mockDownloadManager.downloadFiles).mock
+        .calls[0][0]
+      expect(downloadItems.length).toBe(2)
+      expect(downloadItems[0].url).toContain(
+        'win-cuda-12-common_cpus-x64.tar.gz'
+      )
+      expect(downloadItems[1].url).toContain(
+        'cudart-llama-bin-win-cu12.0-x64.tar.gz'
+      )
     })
 
-    it('should handle download errors', async () => {
-      const mockDownloadManager = {
-        downloadFiles: vi.fn().mockRejectedValue(new Error('Download failed')),
-      }
+    it('should include cudart for old cuda-cu11.7 if not installed', async () => {
+      vi.stubGlobal('IS_WINDOWS', false)
+      vi.mocked(getSystemInfo).mockResolvedValue({
+        os_type: 'linux',
+        cpu: { arch: 'x86_64', extensions: [] },
+        gpus: [
+          {
+            driver_version: '452.39',
+            nvidia_info: { compute_capability: '7.0' },
+          },
+        ],
+      } as any)
 
-      window.core.extensionManager.getByName = vi
-        .fn()
-        .mockReturnValue(mockDownloadManager)
+      // Downloading old name asset
+      await downloadBackend('linux-avx2-cuda-cu11.7-x64', 'v1.0.0')
 
-      const { events } = await import('@janhq/core')
-
-      await expect(downloadBackend('win-avx2-x64', 'v1.0.0')).rejects.toThrow(
-        'Download failed'
+      const downloadItems = vi.mocked(mockDownloadManager.downloadFiles).mock
+        .calls[0][0]
+      expect(downloadItems.length).toBe(2)
+      expect(downloadItems[0].url).toContain(
+        'linux-avx2-cuda-cu11.7-x64.tar.gz'
       )
-
-      expect(events.emit).toHaveBeenCalledWith('onFileDownloadError', {
-        modelId: 'llamacpp-v1-0-0-win-avx2-x64',
-        downloadType: 'Engine',
-      })
+      expect(downloadItems[1].url).toContain(
+        'cudart-llama-bin-linux-cu11.7-x64.tar.gz'
+      )
     })
 
     it('should correctly extract parent directory from Windows paths', async () => {
-      const { dirname } = await import('@tauri-apps/api/path')
+      vi.stubGlobal('IS_WINDOWS', true)
 
-      // Mock dirname to simulate Windows path handling
-      vi.mocked(dirname).mockResolvedValue('C:\\path\\to\\backend')
+      // Mock getSystemInfo for Windows/x64
+      vi.mocked(getSystemInfo).mockResolvedValue({
+        os_type: 'windows',
+        cpu: { arch: 'x86_64', extensions: [] },
+        gpus: [],
+      } as any)
 
-      const mockDownloadManager = {
-        downloadFiles: vi
-          .fn()
-          .mockImplementation((items, taskId, onProgress) => {
-            onProgress(100, 100)
-            return Promise.resolve()
-          }),
-      }
-
-      window.core.extensionManager.getByName = vi
-        .fn()
-        .mockReturnValue(mockDownloadManager)
-
-      const { getJanDataFolderPath, joinPath, fs, events } = await import(
-        '@janhq/core'
+      // Mock dirname to return Windows-style path components (for dirname mock)
+      vi.mocked(dirname).mockResolvedValue(
+        `${MOCK_JAN_PATH_STRING}/llamacpp/backends/v1.0.0/win-avx2-x64`
       )
-      const { invoke } = await import('@tauri-apps/api/core')
-
-      vi.mocked(getJanDataFolderPath).mockResolvedValue('C:\\path\\to\\jan')
-      vi.mocked(joinPath).mockImplementation((paths) =>
-        Promise.resolve(paths.join('\\'))
-      )
-      vi.mocked(fs.rm).mockResolvedValue(undefined)
-      vi.mocked(invoke).mockResolvedValue(undefined)
 
       await downloadBackend('win-avx2-x64', 'v1.0.0')
 
-      // Verify that dirname was called for path extraction
-      expect(dirname).toHaveBeenCalledWith(
-        'C:\\path\\to\\jan\\llamacpp\\backends\\v1.0.0\\win-avx2-x64\\backend.tar.gz'
-      )
-
       // Verify decompress was called with correct parent directory
       expect(invoke).toHaveBeenCalledWith('decompress', {
-        path: 'C:\\path\\to\\jan\\llamacpp\\backends\\v1.0.0\\win-avx2-x64\\backend.tar.gz',
-        outputDir: 'C:\\path\\to\\backend',
-      })
-    })
-
-    it('should correctly extract parent directory from Unix paths', async () => {
-      const { dirname } = await import('@tauri-apps/api/path')
-
-      // Mock dirname to simulate Unix path handling
-      vi.mocked(dirname).mockResolvedValue('/path/to/backend')
-
-      const mockDownloadManager = {
-        downloadFiles: vi
-          .fn()
-          .mockImplementation((items, taskId, onProgress) => {
-            onProgress(100, 100)
-            return Promise.resolve()
-          }),
-      }
-
-      window.core.extensionManager.getByName = vi
-        .fn()
-        .mockReturnValue(mockDownloadManager)
-
-      const { getJanDataFolderPath, joinPath, fs, events } = await import(
-        '@janhq/core'
-      )
-      const { invoke } = await import('@tauri-apps/api/core')
-
-      vi.mocked(getJanDataFolderPath).mockResolvedValue('/path/to/jan')
-      vi.mocked(joinPath).mockImplementation((paths) =>
-        Promise.resolve(paths.join('/'))
-      )
-      vi.mocked(fs.rm).mockResolvedValue(undefined)
-      vi.mocked(invoke).mockResolvedValue(undefined)
-
-      await downloadBackend('linux-avx2-x64', 'v1.0.0')
-
-      // Verify that dirname was called for path extraction
-      expect(dirname).toHaveBeenCalledWith(
-        '/path/to/jan/llamacpp/backends/v1.0.0/linux-avx2-x64/backend.tar.gz'
-      )
-
-      // Verify decompress was called with correct parent directory
-      expect(invoke).toHaveBeenCalledWith('decompress', {
-        path: '/path/to/jan/llamacpp/backends/v1.0.0/linux-avx2-x64/backend.tar.gz',
-        outputDir: '/path/to/backend',
+        path: `${MOCK_JAN_PATH_STRING}/llamacpp/backends/v1.0.0/win-avx2-x64/backend.tar.gz`,
+        outputDir: `${MOCK_JAN_PATH_STRING}/llamacpp/backends/v1.0.0/win-avx2-x64`,
       })
     })
   })


### PR DESCRIPTION
## Describe Your Changes

Added `mapOldBackendToNew` to translate legacy backend strings (e.g., `win-avx2-x64`, `win-avx512-cuda-cu12.0-x64`) into the new unified names (`win-common_cpus-x64`, `win-cuda-12-common_cpus-x64`). Updated backend selection, installation, and download logic to use the mapper, ensuring consistent naming across the extension and tests. Updated tests to verify the mapping, new download items, and correct extraction paths. Minor formatting updates to the Tauri command file for clearer logging. This change enables smoother migration for stored user preferences and reduces duplicate asset handling.

Also included support for llama.cpp forks installations through installBackend using prefixes to backend string and update parameters and error monitoring

## Fixes Issues

- Closes #6896 (maybe)
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
