### PR TITLE
chore: use latest tag for search-mcp-server

### DIFF
--- a/src-tauri/src/core/mcp/commands.rs
+++ b/src-tauri/src/core/mcp/commands.rs
@@ -365,7 +365,7 @@ pub async fn get_mcp_configs<R: Runtime>(app: AppHandle<R>) -> Result<String, St
             "Jan Browser MCP".to_string(),
             json!({
                 "command": "npx",
-                "args": ["-y", "search-mcp-server@0.13.1"],
+                "args": ["-y", "search-mcp-server@latest"],
                 "env": {
                     "BRIDGE_HOST": "127.0.0.1",
                     "BRIDGE_PORT": "17389"

--- a/src-tauri/src/core/mcp/constants.rs
+++ b/src-tauri/src/core/mcp/constants.rs
@@ -8,7 +8,7 @@ pub const DEFAULT_MCP_CONFIG: &str = r#"{
   "mcpServers": {
     "Jan Browser MCP": {
       "command": "npx",
-      "args": ["-y", "search-mcp-server@0.13.1"],
+      "args": ["-y", "search-mcp-server@latest"],
       "env": {
         "BRIDGE_HOST": "127.0.0.1",
         "BRIDGE_PORT": "17389"

--- a/src-tauri/src/core/setup.rs
+++ b/src-tauri/src/core/setup.rs
@@ -185,7 +185,7 @@ pub fn migrate_mcp_servers(
             "Jan Browser MCP".to_string(),
             serde_json::json!({
                 "command": "npx",
-                "args": ["-y", "search-mcp-server@0.13.1"],
+                "args": ["-y", "search-mcp-server@latest"],
                 "env": {
                     "BRIDGE_HOST": "127.0.0.1",
                     "BRIDGE_PORT": "17389"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3538,7 +3538,6 @@ __metadata:
     "@tanstack/router-plugin": "npm:1.117.0"
     "@tauri-apps/api": "npm:2.8.0"
     "@tauri-apps/plugin-deep-link": "npm:2.4.3"
-    "@tauri-apps/plugin-dialog": "npm:2.2.2"
     "@tauri-apps/plugin-http": "npm:2.5.0"
     "@tauri-apps/plugin-opener": "npm:2.5.2"
     "@tauri-apps/plugin-os": "npm:2.2.1"
@@ -7407,15 +7406,6 @@ __metadata:
   dependencies:
     "@tauri-apps/api": "npm:^2.8.0"
   checksum: 10c0/948959e217241345edd3d866aa12ccfe97c72d96ab2844c1df156ead89a96b6a32106944a77f114e6027547c79556cd95f14c2d303a70b307222cce350c67988
-  languageName: node
-  linkType: hard
-
-"@tauri-apps/plugin-dialog@npm:2.2.2":
-  version: 2.2.2
-  resolution: "@tauri-apps/plugin-dialog@npm:2.2.2"
-  dependencies:
-    "@tauri-apps/api": "npm:^2.0.0"
-  checksum: 10c0/d08a30c35d93bb99ac9f8a33c98d8e4bab83308346b8db0ecf54ad8dffc798623fc4db16fb4c40167b905d894012e04577106b96b2fcccb53960d5a9544e8ccd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe Your Changes

- Use @latest tag to force Jan Browser MCP to use the latest npm package
- No need for migration since the previous migration version is still not published yet

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
