### PR TITLE
chore: remove migration setting-interface

### DIFF
--- a/web-app/src/hooks/__tests__/useInterfaceSettings.test.ts
+++ b/web-app/src/hooks/__tests__/useInterfaceSettings.test.ts
@@ -6,7 +6,7 @@ import { THREAD_SCROLL_BEHAVIOR } from '@/constants/threadScroll'
 // Mock constants
 vi.mock('@/constants/localStorage', () => ({
   localStorageKey: {
-    settingInterface: 'setting-interface',
+    settingGeneral: 'setting-general',
   },
 }))
 


### PR DESCRIPTION
## Describe Your Changes

This pull request updates how interface settings are stored and migrated in local storage, focusing on consolidating and simplifying the storage key usage and migration logic. The changes remove support for legacy storage keys, standardize the use of a single constant for the storage key, and ensure migration only occurs from the current general settings key.

**Local storage key updates and migration logic:**

* Replaced all usage of `localStorageKey.settingInterface` with a new constant `INTERFACE_STORAGE_KEY` set to `'setting-appearance'`, ensuring consistent reference to the interface settings storage key throughout the codebase. [[1]](diffhunk://#diff-4209ce6a7274adf41e346906422b54ccddf8ba2767954a8cdad1770c3f1017b6L44-R44) [[2]](diffhunk://#diff-4209ce6a7274adf41e346906422b54ccddf8ba2767954a8cdad1770c3f1017b6L824-R812) [[3]](diffhunk://#diff-4209ce6a7274adf41e346906422b54ccddf8ba2767954a8cdad1770c3f1017b6L328-R320) [[4]](diffhunk://#diff-4209ce6a7274adf41e346906422b54ccddf8ba2767954a8cdad1770c3f1017b6L292-R279)
* Removed the legacy migration function and logic for the old `'setting-appearance'` key, so migration now only occurs from the general settings key (`setting-general`). [[1]](diffhunk://#diff-4209ce6a7274adf41e346906422b54ccddf8ba2767954a8cdad1770c3f1017b6L253-L265) [[2]](diffhunk://#diff-4209ce6a7274adf41e346906422b54ccddf8ba2767954a8cdad1770c3f1017b6L328-R320)
* Updated the storage and migration logic to use the new `INTERFACE_STORAGE_KEY` consistently when reading from or writing to local storage. [[1]](diffhunk://#diff-4209ce6a7274adf41e346906422b54ccddf8ba2767954a8cdad1770c3f1017b6L292-R279) [[2]](diffhunk://#diff-4209ce6a7274adf41e346906422b54ccddf8ba2767954a8cdad1770c3f1017b6L328-R320) [[3]](diffhunk://#diff-4209ce6a7274adf41e346906422b54ccddf8ba2767954a8cdad1770c3f1017b6L824-R812)

**Test updates:**

* Updated the test mock for local storage keys to use `settingGeneral` instead of `settingInterface`, reflecting the updated migration logic.

## Fixes Issues

- Closes #6939
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
