### PR TITLE
fix: disable autocorrect in model search input

### DIFF
--- a/web-app/src/containers/ModelCombobox.tsx
+++ b/web-app/src/containers/ModelCombobox.tsx
@@ -406,6 +406,10 @@ export function ModelCombobox({
           placeholder={placeholder}
           disabled={disabled}
           className="pr-16"
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
         />
 
         {/* Input action buttons */}


### PR DESCRIPTION
There's annoying behavior when entering model names in "Add model" modal in the Settings that corrects model id's to dictionary words like "gpt" → "got"

This fix disables autocorrect, autocomplete, and spell check in the model search input to prevent model IDs from being auto-corrected to unrelated words in the "Add new model" modal (Settings > Model providers)

Added the following attributes to the Input component in ModelCombobox.tsx:
`autoComplete="off"` - disables browser autocomplete
`autoCorrect="off"` - disables macOS autocorrect  
`autoCapitalize="off"` - disables auto-capitalization
`spellCheck={false}` - disables spell checking

To test it:
1. Open Settings → Model providers
2. Click "Add new model" on any provider
3. Type a model ID in the search field (e.g., "gpt" that often corrects to "got")
4. Verify autocorrect doesn't interfere with the input
5. Test on macOS to confirm autocorrect is disabled