### PR TITLE
Correct the "Why Open-Source" URL

### DIFF
--- a/docs/src/pages/handbook/index.mdx
+++ b/docs/src/pages/handbook/index.mdx
@@ -19,5 +19,5 @@ Jan's Handbook is a [living document](https://en.wikipedia.org/wiki/Living_docum
 ## Why does Jan exist?
 
 - [Open Superintelligence](/handbook/open-superintelligence) - Building superintelligence that belongs to everyone, not just a few tech giants. We believe the future of AI should be open, accessible, and owned by the people who use it.
-- [Betting on Open-Source](/handbook/betting-on-open-source)
+- [Betting on Open-Source](/handbook/why/betting-on-open-source)
 Why we're betting on open-source as the future of AI and technology. Open-source has consistently won in the long term, and AI will be no different.


### PR DESCRIPTION
Fix the broken link
<img width="761" height="543" alt="image" src="https://github.com/user-attachments/assets/a06c45b5-16bb-44f3-b3d6-f572903bab6a" />

## Describe Your Changes
Use "https://www.jan.ai/handbook/why/betting-on-open-source" instead of "https://www.jan.ai/handbook/betting-on-open-source"


## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [x] Updated docs (for bug fixes / features)
