### PR TITLE
fix: app blocks image input

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -46,7 +46,7 @@
         "system-monitor-window"
       ],
       "csp": {
-        "default-src": "'self' asset: customprotocol: asset: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*",
+        "default-src": "'self' customprotocol: asset: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*",
         "connect-src": "'self' asset: ipc: http://asset.localhost http://ipc.localhost http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* https: http:",
         "font-src": [
           "https://fonts.gstatic.com blob: data: tauri://localhost http://tauri.localhost"


### PR DESCRIPTION
## Describe Your Changes

Fixes https://github.com/janhq/jan/issues/6978 https://github.com/janhq/jan/issues/6980, where users could not input image in 0.7.3.

Root cause: 
- App tauri.config.json permission update.

## Fixes Issues

- Closes #6978
- Closes #6980

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
