### PR TITLE
feat: migrate assistant screen into setting

### DIFF
--- a/web-app/src/constants/routes.ts
+++ b/web-app/src/constants/routes.ts
@@ -2,7 +2,6 @@ export const route = {
   // home as new chat or thread
   home: '/',
   appLogs: '/logs',
-  assistant: '/assistant',
   project: '/project',
   projectDetail: '/project/$projectId',
   settings: {
@@ -19,6 +18,7 @@ export const route = {
     mcp_servers: '/settings/mcp-servers',
     https_proxy: '/settings/https-proxy',
     hardware: '/settings/hardware',
+    assistant: '/settings/assistant',
   },
   hub: {
     index: '/hub/',

--- a/web-app/src/containers/LeftPanel.tsx
+++ b/web-app/src/containers/LeftPanel.tsx
@@ -12,7 +12,6 @@ import {
   IconApps,
   IconX,
   IconSearch,
-  IconClipboardSmile,
   IconFolder,
   IconPencil,
   IconTrash,
@@ -62,12 +61,6 @@ const mainMenus = [
 ]
 
 const secondaryMenus = [
-  {
-    title: 'common:assistants',
-    icon: IconClipboardSmile,
-    route: route.assistant,
-    isEnabled: PlatformFeatures[PlatformFeature.ASSISTANTS],
-  },
   {
     title: 'common:hub',
     icon: IconApps,
@@ -407,94 +400,97 @@ const LeftPanel = () => {
           {projectsEnabled &&
             filteredProjects.length > 0 &&
             !(IS_IOS || IS_ANDROID) && (
-            <div className="space-y-1 py-1">
-              <div className="flex items-center justify-between mb-2">
-                <span className="block text-xs text-left-panel-fg/50 px-1 font-semibold">
-                  {t('common:projects.title')}
-                </span>
-              </div>
-              <div className="flex flex-col max-h-[140px] overflow-y-scroll">
-                {filteredProjects
-                  .slice()
-                  .sort((a, b) => b.updated_at - a.updated_at)
-                  .map((folder) => {
-                    const ProjectItem = () => {
-                      const [openDropdown, setOpenDropdown] = useState(false)
-                      const isProjectActive =
-                        currentPath === `/project/${folder.id}`
+              <div className="space-y-1 py-1">
+                <div className="flex items-center justify-between mb-2">
+                  <span className="block text-xs text-left-panel-fg/50 px-1 font-semibold">
+                    {t('common:projects.title')}
+                  </span>
+                </div>
+                <div className="flex flex-col max-h-[140px] overflow-y-scroll">
+                  {filteredProjects
+                    .slice()
+                    .sort((a, b) => b.updated_at - a.updated_at)
+                    .map((folder) => {
+                      const ProjectItem = () => {
+                        const [openDropdown, setOpenDropdown] = useState(false)
+                        const isProjectActive =
+                          currentPath === `/project/${folder.id}`
 
-                      return (
-                        <div key={folder.id} className="mb-1">
-                          <div
-                            className={cn(
-                              'rounded hover:bg-left-panel-fg/10 flex items-center justify-between gap-2 px-1.5 group/project-list transition-all cursor-pointer',
-                              isProjectActive && 'bg-left-panel-fg/10'
-                            )}
-                          >
-                            <Link
-                              to="/project/$projectId"
-                              params={{ projectId: folder.id }}
-                              onClick={() =>
-                                isSmallScreen && setLeftPanel(false)
-                              }
-                              className="py-1 pr-2 truncate flex items-center gap-2 flex-1"
+                        return (
+                          <div key={folder.id} className="mb-1">
+                            <div
+                              className={cn(
+                                'rounded hover:bg-left-panel-fg/10 flex items-center justify-between gap-2 px-1.5 group/project-list transition-all cursor-pointer',
+                                isProjectActive && 'bg-left-panel-fg/10'
+                              )}
                             >
-                              <IconFolder
-                                size={16}
-                                className="text-left-panel-fg/70 shrink-0"
-                              />
-                              <span className="text-sm text-left-panel-fg/90 truncate">
-                                {folder.name}
-                              </span>
-                            </Link>
-                            <div className="flex items-center">
-                              <DropdownMenu
-                                open={openDropdown}
-                                onOpenChange={(open) => setOpenDropdown(open)}
+                              <Link
+                                to="/project/$projectId"
+                                params={{ projectId: folder.id }}
+                                onClick={() =>
+                                  isSmallScreen && setLeftPanel(false)
+                                }
+                                className="py-1 pr-2 truncate flex items-center gap-2 flex-1"
                               >
-                                <DropdownMenuTrigger asChild>
-                                  <IconDots
-                                    size={14}
-                                    className="text-left-panel-fg/60 shrink-0 cursor-pointer px-0.5 -mr-1 data-[state=open]:bg-left-panel-fg/10 rounded group-hover/project-list:data-[state=closed]:size-5 size-5 data-[state=closed]:size-0"
-                                    onClick={(e) => {
-                                      e.preventDefault()
-                                      e.stopPropagation()
-                                    }}
-                                  />
-                                </DropdownMenuTrigger>
-                                <DropdownMenuContent side="bottom" align="end">
-                                  <DropdownMenuItem
-                                    onClick={(e) => {
-                                      e.stopPropagation()
-                                      setEditingProjectKey(folder.id)
-                                      setProjectDialogOpen(true)
-                                    }}
+                                <IconFolder
+                                  size={16}
+                                  className="text-left-panel-fg/70 shrink-0"
+                                />
+                                <span className="text-sm text-left-panel-fg/90 truncate">
+                                  {folder.name}
+                                </span>
+                              </Link>
+                              <div className="flex items-center">
+                                <DropdownMenu
+                                  open={openDropdown}
+                                  onOpenChange={(open) => setOpenDropdown(open)}
+                                >
+                                  <DropdownMenuTrigger asChild>
+                                    <IconDots
+                                      size={14}
+                                      className="text-left-panel-fg/60 shrink-0 cursor-pointer px-0.5 -mr-1 data-[state=open]:bg-left-panel-fg/10 rounded group-hover/project-list:data-[state=closed]:size-5 size-5 data-[state=closed]:size-0"
+                                      onClick={(e) => {
+                                        e.preventDefault()
+                                        e.stopPropagation()
+                                      }}
+                                    />
+                                  </DropdownMenuTrigger>
+                                  <DropdownMenuContent
+                                    side="bottom"
+                                    align="end"
                                   >
-                                    <IconPencil size={16} />
-                                    <span>Edit</span>
-                                  </DropdownMenuItem>
-                                  <DropdownMenuItem
-                                    onClick={(e) => {
-                                      e.stopPropagation()
-                                      handleProjectDelete(folder.id)
-                                    }}
-                                  >
-                                    <IconTrash size={16} />
-                                    <span>Delete</span>
-                                  </DropdownMenuItem>
-                                </DropdownMenuContent>
-                              </DropdownMenu>
+                                    <DropdownMenuItem
+                                      onClick={(e) => {
+                                        e.stopPropagation()
+                                        setEditingProjectKey(folder.id)
+                                        setProjectDialogOpen(true)
+                                      }}
+                                    >
+                                      <IconPencil size={16} />
+                                      <span>Edit</span>
+                                    </DropdownMenuItem>
+                                    <DropdownMenuItem
+                                      onClick={(e) => {
+                                        e.stopPropagation()
+                                        handleProjectDelete(folder.id)
+                                      }}
+                                    >
+                                      <IconTrash size={16} />
+                                      <span>Delete</span>
+                                    </DropdownMenuItem>
+                                  </DropdownMenuContent>
+                                </DropdownMenu>
+                              </div>
                             </div>
                           </div>
-                        </div>
-                      )
-                    }
+                        )
+                      }
 
-                    return <ProjectItem key={folder.id} />
-                  })}
+                      return <ProjectItem key={folder.id} />
+                    })}
+                </div>
               </div>
-            </div>
-          )}
+            )}
 
           <div className="flex flex-col h-full overflow-y-scroll w-[calc(100%+6px)]">
             <div className="flex flex-col w-full h-full overflow-y-auto overflow-x-hidden mb-3">

--- a/web-app/src/containers/SettingsMenu.tsx
+++ b/web-app/src/containers/SettingsMenu.tsx
@@ -98,6 +98,12 @@ const SettingsMenu = () => {
       isEnabled: PlatformFeatures[PlatformFeature.MODEL_PROVIDER_SETTINGS],
     },
     {
+      title: 'common:assistants',
+      route: route.settings.assistant,
+      hasSubMenu: false,
+      isEnabled: PlatformFeatures[PlatformFeature.ASSISTANTS],
+    },
+    {
       title: 'common:keyboardShortcuts',
       route: route.settings.shortcuts,
       hasSubMenu: false,

--- a/web-app/src/routeTree.gen.ts
+++ b/web-app/src/routeTree.gen.ts
@@ -13,7 +13,6 @@
 import { Route as rootRoute } from './routes/__root'
 import { Route as SystemMonitorImport } from './routes/system-monitor'
 import { Route as LogsImport } from './routes/logs'
-import { Route as AssistantImport } from './routes/assistant'
 import { Route as IndexImport } from './routes/index'
 import { Route as ProjectIndexImport } from './routes/project/index'
 import { Route as HubIndexImport } from './routes/hub/index'
@@ -28,6 +27,7 @@ import { Route as SettingsHardwareImport } from './routes/settings/hardware'
 import { Route as SettingsGeneralImport } from './routes/settings/general'
 import { Route as SettingsExtensionsImport } from './routes/settings/extensions'
 import { Route as SettingsAttachmentsImport } from './routes/settings/attachments'
+import { Route as SettingsAssistantImport } from './routes/settings/assistant'
 import { Route as ProjectProjectIdImport } from './routes/project/$projectId'
 import { Route as LocalApiServerLogsImport } from './routes/local-api-server/logs'
 import { Route as HubModelIdImport } from './routes/hub/$modelId'
@@ -46,12 +46,6 @@ const SystemMonitorRoute = SystemMonitorImport.update({
 const LogsRoute = LogsImport.update({
   id: '/logs',
   path: '/logs',
-  getParentRoute: () => rootRoute,
-} as any)
-
-const AssistantRoute = AssistantImport.update({
-  id: '/assistant',
-  path: '/assistant',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -139,6 +133,12 @@ const SettingsAttachmentsRoute = SettingsAttachmentsImport.update({
   getParentRoute: () => rootRoute,
 } as any)
 
+const SettingsAssistantRoute = SettingsAssistantImport.update({
+  id: '/settings/assistant',
+  path: '/settings/assistant',
+  getParentRoute: () => rootRoute,
+} as any)
+
 const ProjectProjectIdRoute = ProjectProjectIdImport.update({
   id: '/project/$projectId',
   path: '/project/$projectId',
@@ -187,13 +187,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof IndexImport
       parentRoute: typeof rootRoute
     }
-    '/assistant': {
-      id: '/assistant'
-      path: '/assistant'
-      fullPath: '/assistant'
-      preLoaderRoute: typeof AssistantImport
-      parentRoute: typeof rootRoute
-    }
     '/logs': {
       id: '/logs'
       path: '/logs'
@@ -227,6 +220,13 @@ declare module '@tanstack/react-router' {
       path: '/project/$projectId'
       fullPath: '/project/$projectId'
       preLoaderRoute: typeof ProjectProjectIdImport
+      parentRoute: typeof rootRoute
+    }
+    '/settings/assistant': {
+      id: '/settings/assistant'
+      path: '/settings/assistant'
+      fullPath: '/settings/assistant'
+      preLoaderRoute: typeof SettingsAssistantImport
       parentRoute: typeof rootRoute
     }
     '/settings/attachments': {
@@ -348,12 +348,12 @@ declare module '@tanstack/react-router' {
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
-  '/assistant': typeof AssistantRoute
   '/logs': typeof LogsRoute
   '/system-monitor': typeof SystemMonitorRoute
   '/hub/$modelId': typeof HubModelIdRoute
   '/local-api-server/logs': typeof LocalApiServerLogsRoute
   '/project/$projectId': typeof ProjectProjectIdRoute
+  '/settings/assistant': typeof SettingsAssistantRoute
   '/settings/attachments': typeof SettingsAttachmentsRoute
   '/settings/extensions': typeof SettingsExtensionsRoute
   '/settings/general': typeof SettingsGeneralRoute
@@ -374,12 +374,12 @@ export interface FileRoutesByFullPath {
 
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
-  '/assistant': typeof AssistantRoute
   '/logs': typeof LogsRoute
   '/system-monitor': typeof SystemMonitorRoute
   '/hub/$modelId': typeof HubModelIdRoute
   '/local-api-server/logs': typeof LocalApiServerLogsRoute
   '/project/$projectId': typeof ProjectProjectIdRoute
+  '/settings/assistant': typeof SettingsAssistantRoute
   '/settings/attachments': typeof SettingsAttachmentsRoute
   '/settings/extensions': typeof SettingsExtensionsRoute
   '/settings/general': typeof SettingsGeneralRoute
@@ -401,12 +401,12 @@ export interface FileRoutesByTo {
 export interface FileRoutesById {
   __root__: typeof rootRoute
   '/': typeof IndexRoute
-  '/assistant': typeof AssistantRoute
   '/logs': typeof LogsRoute
   '/system-monitor': typeof SystemMonitorRoute
   '/hub/$modelId': typeof HubModelIdRoute
   '/local-api-server/logs': typeof LocalApiServerLogsRoute
   '/project/$projectId': typeof ProjectProjectIdRoute
+  '/settings/assistant': typeof SettingsAssistantRoute
   '/settings/attachments': typeof SettingsAttachmentsRoute
   '/settings/extensions': typeof SettingsExtensionsRoute
   '/settings/general': typeof SettingsGeneralRoute
@@ -429,12 +429,12 @@ export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
     | '/'
-    | '/assistant'
     | '/logs'
     | '/system-monitor'
     | '/hub/$modelId'
     | '/local-api-server/logs'
     | '/project/$projectId'
+    | '/settings/assistant'
     | '/settings/attachments'
     | '/settings/extensions'
     | '/settings/general'
@@ -454,12 +454,12 @@ export interface FileRouteTypes {
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
-    | '/assistant'
     | '/logs'
     | '/system-monitor'
     | '/hub/$modelId'
     | '/local-api-server/logs'
     | '/project/$projectId'
+    | '/settings/assistant'
     | '/settings/attachments'
     | '/settings/extensions'
     | '/settings/general'
@@ -479,12 +479,12 @@ export interface FileRouteTypes {
   id:
     | '__root__'
     | '/'
-    | '/assistant'
     | '/logs'
     | '/system-monitor'
     | '/hub/$modelId'
     | '/local-api-server/logs'
     | '/project/$projectId'
+    | '/settings/assistant'
     | '/settings/attachments'
     | '/settings/extensions'
     | '/settings/general'
@@ -506,12 +506,12 @@ export interface FileRouteTypes {
 
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
-  AssistantRoute: typeof AssistantRoute
   LogsRoute: typeof LogsRoute
   SystemMonitorRoute: typeof SystemMonitorRoute
   HubModelIdRoute: typeof HubModelIdRoute
   LocalApiServerLogsRoute: typeof LocalApiServerLogsRoute
   ProjectProjectIdRoute: typeof ProjectProjectIdRoute
+  SettingsAssistantRoute: typeof SettingsAssistantRoute
   SettingsAttachmentsRoute: typeof SettingsAttachmentsRoute
   SettingsExtensionsRoute: typeof SettingsExtensionsRoute
   SettingsGeneralRoute: typeof SettingsGeneralRoute
@@ -532,12 +532,12 @@ export interface RootRouteChildren {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
-  AssistantRoute: AssistantRoute,
   LogsRoute: LogsRoute,
   SystemMonitorRoute: SystemMonitorRoute,
   HubModelIdRoute: HubModelIdRoute,
   LocalApiServerLogsRoute: LocalApiServerLogsRoute,
   ProjectProjectIdRoute: ProjectProjectIdRoute,
+  SettingsAssistantRoute: SettingsAssistantRoute,
   SettingsAttachmentsRoute: SettingsAttachmentsRoute,
   SettingsExtensionsRoute: SettingsExtensionsRoute,
   SettingsGeneralRoute: SettingsGeneralRoute,
@@ -567,12 +567,12 @@ export const routeTree = rootRoute
       "filePath": "__root.tsx",
       "children": [
         "/",
-        "/assistant",
         "/logs",
         "/system-monitor",
         "/hub/$modelId",
         "/local-api-server/logs",
         "/project/$projectId",
+        "/settings/assistant",
         "/settings/attachments",
         "/settings/extensions",
         "/settings/general",
@@ -594,9 +594,6 @@ export const routeTree = rootRoute
     "/": {
       "filePath": "index.tsx"
     },
-    "/assistant": {
-      "filePath": "assistant.tsx"
-    },
     "/logs": {
       "filePath": "logs.tsx"
     },
@@ -611,6 +608,9 @@ export const routeTree = rootRoute
     },
     "/project/$projectId": {
       "filePath": "project/$projectId.tsx"
+    },
+    "/settings/assistant": {
+      "filePath": "settings/assistant.tsx"
     },
     "/settings/attachments": {
       "filePath": "settings/attachments.tsx"

--- a/web-app/src/routes/settings/assistant.tsx
+++ b/web-app/src/routes/settings/assistant.tsx
@@ -13,9 +13,10 @@ import { useTranslation } from '@/i18n/react-i18next-compat'
 import { PlatformGuard } from '@/lib/platform/PlatformGuard'
 import { PlatformFeature } from '@/lib/platform/types'
 import { Button } from '@/components/ui/button'
+import SettingsMenu from '@/containers/SettingsMenu'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const Route = createFileRoute(route.assistant as any)({
+export const Route = createFileRoute(route.settings.assistant as any)({
   component: Assistant,
 })
 
@@ -77,8 +78,9 @@ function AssistantContent() {
           </Button>
         </div>
       </HeaderPage>
-      <div className="h-full p-4 w-3/4 mx-auto overflow-y-auto mt-2">
-        <div className="space-y-3">
+      <div className="flex h-full w-full">
+        <SettingsMenu />
+        <div className="space-y-3 p-4">
           {assistants
             .slice()
             .sort((a, b) => a.created_at - b.created_at)


### PR DESCRIPTION
## Describe Your Changes

This pull request refactors the navigation and routing for the "Assistants" feature in the web app. The main change is moving the "Assistants" route and menu entry from a top-level location to under the Settings section, both in the navigation UI and in the routing structure. The implementation also updates related imports and UI components to reflect this new organization.

Key changes include:

**Routing and Navigation Structure:**
- Removed the top-level `/assistant` route and added a new `/settings/assistant` route in both `routes.ts` and the generated `routeTree.gen.ts`. All references and types related to the old route have been updated or removed. [[1]](diffhunk://#diff-85174d9cc0307ab14cb1ad7801566e9347ab57c6976b3c2ad05ad5782a1a670dL5) [[2]](diffhunk://#diff-85174d9cc0307ab14cb1ad7801566e9347ab57c6976b3c2ad05ad5782a1a670dR21) [[3]](diffhunk://#diff-e529fa0c42f9a963f765fe8bdfd6a13b9be86716d09d33d8091c368a5b232408L16) [[4]](diffhunk://#diff-e529fa0c42f9a963f765fe8bdfd6a13b9be86716d09d33d8091c368a5b232408R30) [[5]](diffhunk://#diff-e529fa0c42f9a963f765fe8bdfd6a13b9be86716d09d33d8091c368a5b232408L52-L57) [[6]](diffhunk://#diff-e529fa0c42f9a963f765fe8bdfd6a13b9be86716d09d33d8091c368a5b232408R136-R141) [[7]](diffhunk://#diff-e529fa0c42f9a963f765fe8bdfd6a13b9be86716d09d33d8091c368a5b232408L190-L196) [[8]](diffhunk://#diff-e529fa0c42f9a963f765fe8bdfd6a13b9be86716d09d33d8091c368a5b232408R225-R231) [[9]](diffhunk://#diff-e529fa0c42f9a963f765fe8bdfd6a13b9be86716d09d33d8091c368a5b232408L351-R356) [[10]](diffhunk://#diff-e529fa0c42f9a963f765fe8bdfd6a13b9be86716d09d33d8091c368a5b232408L377-R382) [[11]](diffhunk://#diff-e529fa0c42f9a963f765fe8bdfd6a13b9be86716d09d33d8091c368a5b232408L404-R409) [[12]](diffhunk://#diff-e529fa0c42f9a963f765fe8bdfd6a13b9be86716d09d33d8091c368a5b232408L432-R437) [[13]](diffhunk://#diff-e529fa0c42f9a963f765fe8bdfd6a13b9be86716d09d33d8091c368a5b232408L457-R462) [[14]](diffhunk://#diff-e529fa0c42f9a963f765fe8bdfd6a13b9be86716d09d33d8091c368a5b232408L482-R487) [[15]](diffhunk://#diff-e529fa0c42f9a963f765fe8bdfd6a13b9be86716d09d33d8091c368a5b232408L509-R514) [[16]](diffhunk://#diff-e529fa0c42f9a963f765fe8bdfd6a13b9be86716d09d33d8091c368a5b232408L535-R540) [[17]](diffhunk://#diff-e529fa0c42f9a963f765fe8bdfd6a13b9be86716d09d33d8091c368a5b232408L570-R575) [[18]](diffhunk://#diff-e529fa0c42f9a963f765fe8bdfd6a13b9be86716d09d33d8091c368a5b232408L597-L599) [[19]](diffhunk://#diff-e529fa0c42f9a963f765fe8bdfd6a13b9be86716d09d33d8091c368a5b232408R612-R614)

**UI and Menu Updates:**
- Removed the "Assistants" entry from the secondary sidebar menu and added it to the Settings menu, so it now appears as a settings subpage rather than a main navigation item. [[1]](diffhunk://#diff-8fe9510686bc63c447d596c9015da8053ef7172d644ed42f7daa12a2a794a706L15) [[2]](diffhunk://#diff-8fe9510686bc63c447d596c9015da8053ef7172d644ed42f7daa12a2a794a706L65-L70) [[3]](diffhunk://#diff-eb4a7fc3d9bb5534630af85a0977f4ab52c006391daa07bb7dd3c4ce00963a8bR100-R105)
- Updated the Assistant page component to use the new route and to display the `SettingsMenu` sidebar for consistency with other settings pages. [[1]](diffhunk://#diff-27aab4e61a55396c1340eefec40b93e68b1acf5776fcf269dad20419ff42404aR16-R19) [[2]](diffhunk://#diff-27aab4e61a55396c1340eefec40b93e68b1acf5776fcf269dad20419ff42404aL80-R83)

**Other Minor Adjustments:**
- Minor formatting fixes and alignment changes in dropdown menus for consistency.

These changes collectively improve the organization and discoverability of the Assistants feature by grouping it with other settings, resulting in a clearer and more intuitive navigation experience.

## Fixes Issues
<img width="2146" height="1714" alt="Screenshot 2025-11-17 at 13 53 28" src="https://github.com/user-attachments/assets/47452ef8-60ca-439a-bce0-e947d102a095" />
<img width="2154" height="1690" alt="Screenshot 2025-11-17 at 13 53 17" src="https://github.com/user-attachments/assets/2e2bfccc-6b63-4367-a516-c99c203a6de6" />
<img width="2158" height="1708" alt="Screenshot 2025-11-17 at 13 50 38" src="https://github.com/user-attachments/assets/f0ac06fb-b401-46c5-b55a-7f9d4c7f4c78" />

- Closes #6931
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
