### PR TITLE
Update links in Jan's Handbook index

### DIFF
--- a/docs/src/pages/handbook/index.mdx
+++ b/docs/src/pages/handbook/index.mdx
@@ -18,6 +18,6 @@ Jan's Handbook is a [living document](https://en.wikipedia.org/wiki/Living_docum
 
 ## Why does Jan exist?
 
-- [Open Superintelligence](/handbook/open-superintelligence) - Building superintelligence that belongs to everyone, not just a few tech giants. We believe the future of AI should be open, accessible, and owned by the people who use it.
-- [Betting on Open-Source](/handbook/betting-on-open-source)
+- [Open Superintelligence](/handbook/why/open-superintelligence) - Building superintelligence that belongs to everyone, not just a few tech giants. We believe the future of AI should be open, accessible, and owned by the people who use it.
+- [Betting on Open-Source](/handbook/why/betting-on-open-source)
 Why we're betting on open-source as the future of AI and technology. Open-source has consistently won in the long term, and AI will be no different.


### PR DESCRIPTION
Fixing betting-on-open-source 404 on https://www.jan.ai/handbook

## Describe Your Changes
adding /why/ to handbook page links
-

## Fixes Issues

404 on betting-on-open-source link

## Self Checklist

Too easy
