### PR TITLE
fix: keep the untouched properties after modifying mcp settings

### DIFF
--- a/web-app/src/containers/dialogs/AddEditMCPServer.tsx
+++ b/web-app/src/containers/dialogs/AddEditMCPServer.tsx
@@ -351,6 +351,7 @@ export default function AddEditMCPServer({
     const filteredArgs = args.map((arg) => arg.trim()).filter((arg) => arg)
 
     const config: MCPServerConfig = {
+      ...(initialData || {}),
       command: transportType === 'stdio' ? command.trim() : '',
       args: transportType === 'stdio' ? filteredArgs : [],
       env: transportType === 'stdio' ? envObj : {},


### PR DESCRIPTION
## Describe Your Changes

- Keep untouched properties after modifying an MCP server settings
- Add tests

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
