### PR TITLE
fix: cstdint patch flatpak

### DIFF
--- a/flatpak/ai.jan.Jan.yml
+++ b/flatpak/ai.jan.Jan.yml
@@ -72,6 +72,8 @@ modules:
         url: https://github.com/KhronosGroup/glslang.git
         commit: 142052fa30f9eca191aa9dcf65359fcaed09eeec
         dest: third_party/glslang
+      - type: patch
+        path: patches/fix-cstdint.patch
 
   - name: jan-binary
     buildsystem: simple

--- a/flatpak/patches/fix-cstdint.patch
+++ b/flatpak/patches/fix-cstdint.patch
@@ -1,0 +1,13 @@
+diff --git a/SPIRV/SpvBuilder.h b/SPIRV/SpvBuilder.h
+index a65a98e3..32ed8217 100644
+--- a/third_party/glslang/SPIRV/SpvBuilder.h
++++ b/third_party/glslang/SPIRV/SpvBuilder.h
+@@ -63,6 +63,7 @@ namespace spv {
+ #include <stack>
+ #include <unordered_map>
+ #include <map>
++#include <cstdint>
+ 
+ namespace spv {
+ 
+


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces a patch to the `glslang` dependency in the Flatpak build to address a missing include for `<cstdint>`, which can resolve build issues on some platforms.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
