### PR TITLE
feat: add Polish metainfo translation

### DIFF
--- a/flatpak/ai.jan.Jan.metainfo.xml
+++ b/flatpak/ai.jan.Jan.metainfo.xml
@@ -9,6 +9,7 @@
   <icon type="stock">ai.jan.Jan</icon>
 
   <summary>Private offline AI assistant</summary>
+  <summary xml:lang="pl">Prywatny asystent SI działający bez dostępu do sieci</summary>
 
   <categories>
     <category>Utility</category>
@@ -21,20 +22,38 @@
     <p>
       Jan is an open source alternative to ChatGPT that runs 100% offline on your computer.
     </p>
+    <p xml:lang="pl">
+      Jan to otwartoźródłowa alternatywa dla ChatGPT, która działa w 100% bez dostępu do sieci na Twoim komputerze.
+    </p>
 
     <p>Features</p>
     <ul>
       <li>Local AI models: Run LLMs such as Llama, Gemma, Qwen and others on your device</li>
+      <li xml:lang="pl">Lokalne modele SI: Uruchamiaj duże modele językowe, takie jak Llama, Gemma i Qwen, na swoim urządzeniu.</li>
+
       <li>Optional cloud access: Connect to services like OpenAI, Anthropic, Gemini and Groq when internet-based models are required</li>
+      <li xml:lang="pl">Opcjonalny dostęp do chmury: Łącz się z usługami, takimi jak OpenAI, Anthropic, Gemini i Groq, gdy wymagane są modele dostępne przez Internet.</li>
+
       <li>Custom assistants: Create tailored assistants for writing, coding, summarizing and more</li>
+      <li xml:lang="pl">Własne asystenty: Twórz asystenty wyspecjalizowane do pisania, kodowania, podsumowywania itd.</li>
+
       <li>OpenAI-compatible API: Includes a local API server at localhost:1337 for tools expecting the OpenAI format</li>
+      <li xml:lang="pl">Interfejs API kompatybilny z OpenAI: Jan posiada lokalny serwer API, dostępny pod adresem localhost:1337, dla narzędzi zgodnych z formatem OpenAI.</li>
+
       <li>MCP support: Integrates the Model Context Protocol for enhanced workflows and tooling</li>
+      <li xml:lang="pl">Obsługa MCP: Jan obsługuje Model Context Protocol dla lepszego przepływu pracy i obsługi narzędzi.</li>
+
       <li>Privacy-aware design: Jan works offline by default. Cloud access is optional and user-controlled</li>
+      <li xml:lang="pl">Projekt uwzględniający prywatność: Jan domyślnie działa w trybie bez dostępu do sieci. Dostęp do chmury jest opcjonalny i pozostaje pod kontrolą użytkownika.</li>
     </ul>
 
     <p>
       Jan is actively maintained by Menlo Research.  
       Feedback, bug reports and feature requests are welcomed through GitHub.
+    </p>
+    <p xml:lang="pl">
+      Aplikacja Jan jest aktywnie utrzymywana przez Menlo Research.
+      Informacje zwrotne, zgłoszenia błędów i prośby o nowe funkcje są mile widziane za pośrednictwem platformy GitHub.
     </p>
   </description>
 
@@ -43,26 +62,32 @@
   <screenshot>
     <image>https://catalog.jan.ai/flatpak/jan_screenshot_1.png</image>
     <caption>Blank Jan page with 0 threads</caption>
+    <caption xml:lang="pl">Pusta strona Jan bez żadnych wątków</caption>
   </screenshot>
   <screenshot type="default">
     <image>https://catalog.jan.ai/flatpak/jan_screenshot_2.png</image>
     <caption>Jan using a search MCP to gather information</caption>
+    <caption xml:lang="pl">Aplikacja Jan używająca wyszukiwania MCP celem zgromadzenia informacji</caption>
   </screenshot>
   <screenshot>
     <image>https://catalog.jan.ai/flatpak/jan_screenshot_3.png</image>
     <caption>Assistant creation screen</caption>
+    <caption xml:lang="pl">Ekran tworzenia asystenta</caption>
   </screenshot>
   <screenshot>
     <image>https://catalog.jan.ai/flatpak/jan_screenshot_4.png</image>
     <caption>Jan Hub</caption>
+    <caption xml:lang="pl">Centrum modeli Jan</caption>
   </screenshot>
   <screenshot>
     <image>https://catalog.jan.ai/flatpak/jan_screenshot_5.png</image>
     <caption>Llama.cpp screen showcasing the models</caption>
+    <caption xml:lang="pl">Ekran Llama.cpp z listą modeli</caption>
   </screenshot>
   <screenshot>
     <image>https://catalog.jan.ai/flatpak/jan_screenshot_6.png</image>
     <caption>MCP Settings</caption>
+    <caption xml:lang="pl">Ustawienia MCP</caption>
   </screenshot>
 </screenshots>
 
@@ -75,6 +100,7 @@
     <release version="0.7.3" date="2025-11-13">
       <description>
         <p>Enhanced Browser Control and Smarter Interactions</p>
+        <p xml:lang="pl">Ulepszona kontrola przeglądarki i bardziej inteligentne interakcje</p>
       </description>
     </release>
   </releases>


### PR DESCRIPTION
Adds Polish metainfo translation. This will result in Jan's Flathub page and on-device generated Linux `.desktop` file containing Polish translation.