### PR TITLE
fix: disable context menu list projects

### DIFF
--- a/web-app/src/containers/LeftPanel.tsx
+++ b/web-app/src/containers/LeftPanel.tsx
@@ -428,6 +428,9 @@ const LeftPanel = () => {
                                 'rounded hover:bg-left-panel-fg/10 flex items-center justify-between gap-2 px-1.5 group/project-list transition-all cursor-pointer',
                                 isProjectActive && 'bg-left-panel-fg/10'
                               )}
+                              onContextMenu={(e) => {
+                                e.preventDefault()
+                              }}
                             >
                               <Link
                                 to="/project/$projectId"


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces a minor UI behavior change to the `LeftPanel` component. It prevents the default context menu from appearing when a user right-clicks on a project list item.

- UI behavior update:
  * [`LeftPanel.tsx`](diffhunk://#diff-8fe9510686bc63c447d596c9015da8053ef7172d644ed42f7daa12a2a794a706R431-R433): Added an `onContextMenu` handler to project list items to prevent the default browser context menu from showing on right-click.

## Fixes Issues

Before 
<img width="188" height="132" alt="Screenshot 2025-11-27 at 15 07 07" src="https://github.com/user-attachments/assets/1055d3a1-d807-48fa-ad0b-7ef8d8386dfb" />

After
Should not have context menu

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
