### PR TITLE
refactor: replace toggle with chevron for show variants in Hub

### DIFF
--- a/web-app/src/routes/hub/index.tsx
+++ b/web-app/src/routes/hub/index.tsx
@@ -17,6 +17,8 @@ import { useModelProvider } from '@/hooks/useModelProvider'
 import { Card, CardItem } from '@/containers/Card'
 import { extractModelName, extractDescription } from '@/lib/models'
 import {
+  IconChevronDown,
+  IconChevronUp,
   IconDownload,
   IconFileCode,
   IconEye,
@@ -682,29 +684,36 @@ function HubContent() {
                                 </div>
                               )}
                             </div>
-                            {(filteredModels[virtualItem.index].quants?.length ?? 0) >
-                              1 && (
-                              <div className="flex items-center gap-2 hub-show-variants-step">
-                                <Switch
-                                  checked={
-                                    !!expandedModels[
-                                      filteredModels[virtualItem.index]
-                                        .model_name
-                                    ]
-                                  }
-                                  onCheckedChange={() =>
-                                    toggleModelExpansion(
-                                      filteredModels[virtualItem.index]
-                                        .model_name
-                                    )
-                                  }
-                                />
-                                <p className="text-muted-foreground">
-                                  {t('hub:showVariants')}
-                                </p>
-                              </div>
-                            )}
                           </div>
+                          {(filteredModels[virtualItem.index].quants?.length ?? 0) >
+                            1 && (
+                            <button
+                              className="flex items-center gap-1 hub-show-variants-step ml-auto"
+                              onClick={() =>
+                                toggleModelExpansion(
+                                  filteredModels[virtualItem.index]
+                                    .model_name
+                                )
+                              }
+                            >
+                              <span className="text-foreground">
+                                {t('hub:showVariants')}
+                              </span>
+                              {expandedModels[
+                                filteredModels[virtualItem.index].model_name
+                              ] ? (
+                                <IconChevronUp
+                                  size={18}
+                                  className="text-muted-foreground"
+                                />
+                              ) : (
+                                <IconChevronDown
+                                  size={18}
+                                  className="text-muted-foreground"
+                                />
+                              )}
+                            </button>
+                          )}
                         </div>
                         {expandedModels[
                           filteredModels[virtualItem.index].model_name


### PR DESCRIPTION
## Describe Your Changes

The "Show variants" toggle in Hub uses a Switch component, but toggle is not the right design pattern here. Toggles are for settings that apply immediately—in this context we're just expanding a layout to show more content.

Replaced the Switch with a clickable chevron:
- Text "Show variants" with chevron icon to the right
- Entire line is clickable, not just the icon
- Chevron points down when collapsed, up when expanded
- Matches styling of other icons in the row (size 18, `text-main-view-fg/50` color)

To test it:

1. Open Hub
2. Find a model with multiple variants (look for variant count > 1)
3. Click "Show variants" text or the chevron
4. Verify the variants list expands and chevron flips to point up
5. Click again to collapse

## Fixes Issues

-

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed