### PR TITLE
fix: improve Hub download button UX for installed models

### DIFF
--- a/web-app/src/containers/DownloadButton.tsx
+++ b/web-app/src/containers/DownloadButton.tsx
@@ -137,11 +137,15 @@ export function DownloadButtonPlaceholder({
       )}
       {isDownloaded ? (
         <Button
+          variant="link"
           size="sm"
+          className="p-0"
           onClick={() => handleUseModel(modelId)}
           data-test-id={`hub-model-${modelId}`}
         >
-          {t('hub:use')}
+          <div className="rounded-sm hover:bg-main-view-fg/15 bg-main-view-fg/10 transition-all duration-200 ease-in-out px-2 py-1">
+            {t('hub:newChat')}
+          </div>
         </Button>
       ) : (
         <Button

--- a/web-app/src/containers/ModelDownloadAction.tsx
+++ b/web-app/src/containers/ModelDownloadAction.tsx
@@ -79,18 +79,17 @@ export const ModelDownloadAction = ({
 
   if (isDownloaded) {
     return (
-      <div
-        className="flex items-center justify-center rounded bg-main-view-fg/10"
+      <Button
+        variant="link"
+        size="sm"
+        className="p-0"
+        onClick={() => handleUseModel(variant.model_id)}
         title={t('hub:useModel')}
       >
-        <Button
-          variant="link"
-          size="sm"
-          onClick={() => handleUseModel(variant.model_id)}
-        >
-          {t('hub:use')}
-        </Button>
-      </div>
+        <div className="rounded-sm hover:bg-main-view-fg/15 bg-main-view-fg/10 transition-all duration-200 ease-in-out px-2 py-1">
+          {t('hub:newChat')}
+        </div>
+      </Button>
     )
   }
 

--- a/web-app/src/locales/cs/hub.json
+++ b/web-app/src/locales/cs/hub.json
@@ -1,7 +1,7 @@
 {
   "sortNewest": "Newest",
   "sortMostDownloaded": "Most downloaded",
-  "use": "Use",
+  "newChat": "Nový chat",
   "download": "Download",
   "downloaded": "Downloaded",
   "loadingModels": "Loading models...",

--- a/web-app/src/locales/de-DE/hub.json
+++ b/web-app/src/locales/de-DE/hub.json
@@ -1,7 +1,7 @@
 {
   "sortNewest": "Neueste",
   "sortMostDownloaded": "Meist heruntergeladen",
-  "use": "Nutzen",
+  "newChat": "Neuer Chat",
   "download": "Herunterladen",
   "downloaded": "Heruntergeladen",
   "loadingModels": "Lade Modelle...",

--- a/web-app/src/locales/en/hub.json
+++ b/web-app/src/locales/en/hub.json
@@ -1,7 +1,7 @@
 {
   "sortNewest": "Newest",
   "sortMostDownloaded": "Most downloaded",
-  "use": "Use",
+  "newChat": "New chat",
   "download": "Download",
   "downloaded": "Downloaded",
   "loadingModels": "Loading models...",

--- a/web-app/src/locales/fr/hub.json
+++ b/web-app/src/locales/fr/hub.json
@@ -1,7 +1,7 @@
 {
   "sortNewest": "Le plus récent",
   "sortMostDownloaded": "Le plus téléchargé",
-  "use": "Utiliser",
+  "newChat": "Nouvelle conversation",
   "download": "Télécharger",
   "downloaded": "Téléchargé",
   "loadingModels": "Chargement des modèles...",

--- a/web-app/src/locales/id/hub.json
+++ b/web-app/src/locales/id/hub.json
@@ -1,7 +1,7 @@
 {
   "sortNewest": "Terbaru",
   "sortMostDownloaded": "Paling Banyak Diunduh",
-  "use": "Gunakan",
+  "newChat": "Chat baru",
   "download": "Unduh",
   "downloaded": "Telah Diunduh",
   "loadingModels": "Memuat model...",

--- a/web-app/src/locales/ja/hub.json
+++ b/web-app/src/locales/ja/hub.json
@@ -1,7 +1,7 @@
 {
   "sortNewest": "新着順",
   "sortMostDownloaded": "ダウンロード数順",
-  "use": "使用",
+  "newChat": "新しいチャット",
   "download": "ダウンロード",
   "downloaded": "ダウンロード済み",
   "loadingModels": "モデルを読み込み中...",

--- a/web-app/src/locales/pl/hub.json
+++ b/web-app/src/locales/pl/hub.json
@@ -1,7 +1,7 @@
 {
   "sortNewest": "Najnowsze",
   "sortMostDownloaded": "Najczęściej pobierane",
-  "use": "Użyj",
+  "newChat": "Nowy czat",
   "download": "Pobierz",
   "downloaded": "Pobrany",
   "loadingModels": "Wczytywanie modeli…",

--- a/web-app/src/locales/pt-BR/hub.json
+++ b/web-app/src/locales/pt-BR/hub.json
@@ -1,7 +1,7 @@
 {
   "sortNewest": "Mais Recentes",
   "sortMostDownloaded": "Mais Baixados",
-  "use": "Usar",
+  "newChat": "Nova conversa",
   "download": "Baixar",
   "downloaded": "Baixado",
   "loadingModels": "Carregando modelos...",

--- a/web-app/src/locales/ru/hub.json
+++ b/web-app/src/locales/ru/hub.json
@@ -1,7 +1,7 @@
 {
   "sortNewest": "Самые новые",
   "sortMostDownloaded": "Наиболее загружаемые",
-  "use": "Использовать",
+  "newChat": "Новый чат",
   "download": "Загрузить",
   "downloaded": "Загруженные",
   "loadingModels": "Загрузка моделей…",

--- a/web-app/src/locales/vn/hub.json
+++ b/web-app/src/locales/vn/hub.json
@@ -1,7 +1,7 @@
 {
   "sortNewest": "Mới nhất",
   "sortMostDownloaded": "Tải nhiều nhất",
-  "use": "Sử dụng",
+  "newChat": "Cuộc trò chuyện mới",
   "download": "Tải xuống",
   "downloaded": "Đã tải xuống",
   "loadingModels": "Đang tải mô hình...",

--- a/web-app/src/locales/zh-CN/hub.json
+++ b/web-app/src/locales/zh-CN/hub.json
@@ -1,7 +1,7 @@
 {
   "sortNewest": "最新",
   "sortMostDownloaded": "最多下载",
-  "use": "使用",
+  "newChat": "新对话",
   "download": "下载",
   "downloaded": "已下载",
   "loadingModels": "正在加载模型...",

--- a/web-app/src/locales/zh-TW/hub.json
+++ b/web-app/src/locales/zh-TW/hub.json
@@ -1,7 +1,7 @@
 {
   "sortNewest": "最新",
   "sortMostDownloaded": "最多下載",
-  "use": "使用",
+  "newChat": "新對話",
   "download": "下載",
   "downloaded": "已下載",
   "loadingModels": "正在載入模型...",

--- a/web-app/src/routes/hub/$modelId.tsx
+++ b/web-app/src/routes/hub/$modelId.tsx
@@ -27,6 +27,7 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { useGeneralSetting } from '@/hooks/useGeneralSetting'
 import { ModelInfoHoverCard } from '@/containers/ModelInfoHoverCard'
+import { useTranslation } from '@/i18n'
 
 type SearchParams = {
   repo: string
@@ -50,6 +51,7 @@ function HubModelDetail() {
 }
 
 function HubModelDetailContent() {
+  const { t } = useTranslation()
   const { modelId } = useParams({ from: Route.id })
   const navigate = useNavigate()
   const { huggingfaceToken } = useGeneralSetting()
@@ -456,12 +458,16 @@ function HubModelDetailContent() {
                                   if (isDownloaded) {
                                     return (
                                       <Button
+                                        variant="link"
                                         size="sm"
+                                        className="p-0"
                                         onClick={() =>
                                           handleUseModel(variant.model_id)
                                         }
                                       >
-                                        Use
+                                        <div className="rounded-sm hover:bg-main-view-fg/15 bg-main-view-fg/10 transition-all duration-200 ease-in-out px-2 py-1">
+                                          {t('hub:newChat')}
+                                        </div>
                                       </Button>
                                     )
                                   }


### PR DESCRIPTION
## Describe Your Changes

When a model is downloaded in Hub, the "Download" button changes to "Use" — but it keeps the same primary button styling. This makes it hard to distinguish installed models at a glance, and "Use" doesn't clearly communicate what happens when you click it.

- Renamed button text from "Use" to "New chat" (with proper translations for all 12 locales)
- Changed button style to gray secondary pattern (matching Settings page buttons like "Check for Updates", "Change Location")

### Implementation:
Uses the existing secondary button pattern from Settings:

```
<Button variant="link" size="sm" className="p-0">
  <div className="rounded-sm hover:bg-main-view-fg/15 bg-main-view-fg/10 ...">
    {t('hub:use')}
  </div>
</Button>
```

### Files changed:

- `DownloadButton.tsx` — main Hub list button
- `hub/$modelId.tsx` — model detail page button
- `ModelDownloadAction.tsx` — variant action button
- 12 locale files with proper translations

### Test plan:

1. Download a model from Hub
2. Verify button changes to gray "New chat" (or localized equivalent)
3. Confirm hover state shows lighter gray
4. Click "New chat" → should navigate to new thread with model selected

## Fixes Issues

- 

## Self Checklist
- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
