### PR TITLE
fix: disable JIT by default for npx mcp run

### DIFF
--- a/src-tauri/src/core/mcp/helpers.rs
+++ b/src-tauri/src/core/mcp/helpers.rs
@@ -670,6 +670,7 @@ async fn schedule_mcp_start_task<R: Runtime>(
             cmd = Command::new(bun_x_path.display().to_string());
             cmd.arg("x");
             cmd.env("BUN_INSTALL", cache_dir.to_str().unwrap());
+            cmd.env("BUN_JSC_useJIT", "0");
         }
 
         let uv_path = if cfg!(windows) {


### PR DESCRIPTION
## Describe Your Changes

There’s an issue with running MCP on Mac that limits memory allocation to 128 bytes, which is broken. Since MCP runs using npx (with the built-in bun), it shouldn’t run with JIT, so no issues are introduced.

## Fixes Issues
```
Failed to start MCP server Jan Browser MCP: Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile
Ran out of executable memory while allocating 128 bytes.
```
## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
