### PR TITLE
feat: jan browser mcp as chat input shortcut

### DIFF
--- a/web-app/src/containers/DropdownModelProvider.tsx
+++ b/web-app/src/containers/DropdownModelProvider.tsx
@@ -460,7 +460,7 @@ const DropdownModelProvider = ({
 
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
-      <div className="bg-main-view-fg/5 hover:bg-main-view-fg/8 px-2 py-1 flex items-center gap-1.5 rounded-sm mr-2">
+      <div className="bg-main-view-fg/5 hover:bg-main-view-fg/8 px-2 py-1 flex items-center gap-1.5 rounded-sm">
         <PopoverTrigger asChild>
           <button
             type="button"

--- a/web-app/src/containers/DropdownToolsAvailable.tsx
+++ b/web-app/src/containers/DropdownToolsAvailable.tsx
@@ -34,7 +34,9 @@ export default function DropdownToolsAvailable({
   initialMessage = false,
   onOpenChange,
 }: DropdownToolsAvailableProps) {
-  const tools = useAppState((state) => state.tools)
+  const allTools = useAppState((state) => state.tools)
+  // Filter out Jan Browser MCP tools
+  const tools = allTools.filter((tool) => tool.server !== 'Jan Browser MCP')
   const [isOpen, setIsOpen] = useState(false)
   const { t } = useTranslation()
 


### PR DESCRIPTION
## Describe Your Changes

Users currently need to navigate through Settings → MCP Servers to enable Jan Browser MCP, creating friction and making the feature less discoverable.

## Changes

- Added a Browse button to the chat input toolbar that toggles Jan Browser MCP with one click. Features:
- One-click enable/disable Jan Browser MCP
- Visual state indicators: accent color when active, spinner during startup (~2s)
- Tooltip shows current state: "Browse" / "Browse (Active)" / "Starting..."
- Toast notifications for success/error

<img width="1137" height="912" alt="Screenshot 2025-12-01 at 16 05 19" src="https://github.com/user-attachments/assets/20a79bad-3fb2-4edc-ac22-e9a296d0825f" />

<img width="1137" height="912" alt="Screenshot 2025-12-01 at 16 06 35" src="https://github.com/user-attachments/assets/608d01cf-7d53-449f-b6c5-05a6fb684325" />

Action Items:
- [ ] Guide users through browser extension setup?

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
