### PR TITLE
fix: cancel failed download task

### DIFF
--- a/src-tauri/src/core/downloads/commands.rs
+++ b/src-tauri/src/core/downloads/commands.rs
@@ -18,8 +18,9 @@ pub async fn download_files<R: Runtime>(
     let cancel_token = CancellationToken::new();
     {
         let mut download_manager = state.download_manager.lock().await;
-        if download_manager.cancel_tokens.contains_key(task_id) {
-            return Err(format!("task_id {task_id} exists"));
+        if let Some(existing_token) = download_manager.cancel_tokens.remove(task_id) {
+            log::info!("Cancelling existing download task: {task_id}");
+            existing_token.cancel();
         }
         download_manager
             .cancel_tokens


### PR DESCRIPTION
## Describe Your Changes

When the quickstart fails downloading for an unexpected reason. Use should be able to cancel and retry the download.
- Cancel previous download token on purpose first before retry
- Allow re-download from the beginning with the same task_id = model_id

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
