### PR TITLE
fix: skip model verification on quick start

### DIFF
--- a/web-app/src/containers/SetupScreen.tsx
+++ b/web-app/src/containers/SetupScreen.tsx
@@ -13,7 +13,6 @@ import { PlatformFeatures } from '@/lib/platform/const'
 import { PlatformFeature } from '@/lib/platform'
 import { useDownloadStore } from '@/hooks/useDownloadStore'
 import { useServiceHub } from '@/hooks/useServiceHub'
-import { useGeneralSetting } from '@/hooks/useGeneralSetting'
 import { useEffect, useMemo, useCallback, useState, useRef } from 'react'
 import { Progress } from '@/components/ui/progress'
 import type { CatalogModel } from '@/services/models/types'
@@ -94,7 +93,6 @@ function SetupScreen() {
   const { downloads, localDownloadingModels, addLocalDownloadingModel } =
     useDownloadStore()
   const serviceHub = useServiceHub()
-  const { huggingfaceToken } = useGeneralSetting()
   const llamaProvider = getProviderByName('llamacpp')
   const [quickStartInitiated, setQuickStartInitiated] = useState(false)
   const [janModelV2, setJanModelV2] = useState<CatalogModel | null>(null)
@@ -111,7 +109,7 @@ function SetupScreen() {
     try {
       const repo = await serviceHub
         .models()
-        .fetchHuggingFaceRepo(JAN_MODEL_V2_HF_REPO, huggingfaceToken)
+        .fetchHuggingFaceRepo(JAN_MODEL_V2_HF_REPO)
 
       if (repo) {
         const catalogModel = serviceHub.models().convertHfRepoToCatalogModel(repo)
@@ -120,7 +118,7 @@ function SetupScreen() {
     } catch (error) {
       console.error('Error fetching Jan Model V2:', error)
     }
-  }, [serviceHub, huggingfaceToken])
+  }, [serviceHub])
 
   // Check model support for variants when janModelV2 is available
   useEffect(() => {
@@ -298,14 +296,14 @@ function SetupScreen() {
             (e) => e.model_id.toLowerCase() === 'mmproj-f16'
           ) || janModelV2.mmproj_models?.[0]
         )?.path,
-        huggingfaceToken
+        undefined, // No HF token needed for public model
+        true // Skip verification for faster download
       )
   }, [
     defaultVariant,
     janModelV2,
     addLocalDownloadingModel,
     serviceHub,
-    huggingfaceToken,
   ])
 
   useEffect(() => {

--- a/web-app/src/services/models/default.ts
+++ b/web-app/src/services/models/default.ts
@@ -199,7 +199,8 @@ export class DefaultModelsService implements ModelsService {
     id: string,
     modelPath: string,
     mmprojPath?: string,
-    hfToken?: string
+    hfToken?: string,
+    skipVerification?: boolean
   ): Promise<void> {
     let modelSha256: string | undefined
     let modelSize: number | undefined
@@ -212,7 +213,7 @@ export class DefaultModelsService implements ModelsService {
       /https:\/\/huggingface\.co\/([^/]+\/[^/]+)\/resolve\/main\/(.+)/
     )
 
-    if (modelUrlMatch) {
+    if (modelUrlMatch && !skipVerification) {
       const [, repoId, modelFilename] = modelUrlMatch
 
       try {

--- a/web-app/src/services/models/types.ts
+++ b/web-app/src/services/models/types.ts
@@ -113,7 +113,8 @@ export interface ModelsService {
     id: string,
     modelPath: string,
     mmprojPath?: string,
-    hfToken?: string
+    hfToken?: string,
+    skipVerification?: boolean
   ): Promise<void>
   abortDownload(id: string): Promise<void>
   deleteModel(id: string): Promise<void>


### PR DESCRIPTION
## Describe Your Changes

This PR improves the quick start UX by skipping model verification, which is always Jan V2. This will significantly reduce the time required to prepare the quick-start model.

Also removed HF Token for this as this is a public model.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
