### PR TITLE
fix: model import name should be filename instead of GGUF baseName

### DIFF
--- a/web-app/src/containers/dialogs/ImportVisionModelDialog.tsx
+++ b/web-app/src/containers/dialogs/ImportVisionModelDialog.tsx
@@ -18,6 +18,7 @@ import {
   IconCheck,
   IconAlertTriangle,
 } from '@tabler/icons-react'
+import { basename } from 'path'
 
 type ImportVisionModelDialogProps = {
   provider: ModelProvider
@@ -66,12 +67,7 @@ export const ImportVisionModelDialog = ({
               const architecture =
                 result.metadata.metadata?.['general.architecture']
 
-              // Extract baseName and use it as model name if available
-              const baseName = result.metadata.metadata?.['general.basename']
-
-              if (baseName) {
-                setModelName(baseName)
-              }
+              setModelName(basename(filePath))
 
               // Model files should NOT be clip
               if (architecture === 'clip') {


### PR DESCRIPTION
## Describe Your Changes

This PR fixes an issue where app uses GGUF base name to set model name, hence models with the same GGUF base name will not be imported. Users often distinguish imported models by the file name instead.

Some of the models use very unclear base name, such as Jan V2 VL has base name "checkpoint".

<img width="1137" height="912" alt="Screenshot 2025-12-03 at 11 55 45" src="https://github.com/user-attachments/assets/49f7daf9-aeaa-4c20-8b27-82eab5f4f953" />


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
