### PR TITLE
fix: could not save image edit

### DIFF
--- a/web-app/src/containers/dialogs/EditMessageDialog.tsx
+++ b/web-app/src/containers/dialogs/EditMessageDialog.tsx
@@ -146,9 +146,9 @@ export function EditMessageDialog({
             </DialogClose>
             <Button
               disabled={
-                draft === message &&
-                JSON.stringify(imageUrls || []) ===
-                  JSON.stringify(keptImages) &&
+                (draft === message &&
+                  JSON.stringify(imageUrls || []) ===
+                  JSON.stringify(keptImages)) ||
                 !draft.trim()
               }
               onClick={handleSave}


### PR DESCRIPTION
## Describe Your Changes

This PR fixes an issue where users could not save message edits. Or rather, it shows the save button when the user has not made any changes.

Changes:
- Previously, the condition was to show the save button always when the message is not empty, which is wrong. Now it checks if the user edited the message, image, or if it's empty, then it disables the button.

1. User has not made any changes
<img width="1137" height="912" alt="Screenshot 2025-12-03 at 13 03 11" src="https://github.com/user-attachments/assets/ebaf1ba0-e9af-4dae-9197-b516b2dfefe8" />

2. User edited the message
<img width="1137" height="912" alt="Screenshot 2025-12-03 at 13 03 14" src="https://github.com/user-attachments/assets/c6f063b1-2bf9-476a-a4b2-8fea2d81a15b" />



## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
