### PR TITLE
fix: attachment parsing error (exit gracefully)

### DIFF
--- a/extensions/llamacpp-extension/src/util.ts
+++ b/extensions/llamacpp-extension/src/util.ts
@@ -118,14 +118,14 @@ export type EmbedBatchResult = {
   usage?: EmbedUsage
 }
 
-export function estimateTokensFromText(text: string, charsPerToken = 3): number {
+export function estimateTokensFromText(text: string, charsPerToken = 2): number {
   return Math.max(1, Math.ceil(text.length / Math.max(charsPerToken, 1)))
 }
 
 export function buildEmbedBatches(
   inputs: string[],
   ubatchSize: number,
-  charsPerToken = 3
+  charsPerToken = 2
 ): EmbedBatch[] {
   const batches: EmbedBatch[] = []
   let current: string[] = []

--- a/src-tauri/plugins/tauri-plugin-rag/src/commands.rs
+++ b/src-tauri/plugins/tauri-plugin-rag/src/commands.rs
@@ -1,4 +1,5 @@
-use crate::{RagError, parser};
+use crate::{parser, RagError};
+use std::panic::{catch_unwind, AssertUnwindSafe};
 
 #[tauri::command]
 pub async fn parse_document<R: tauri::Runtime>(
@@ -7,6 +8,22 @@ pub async fn parse_document<R: tauri::Runtime>(
     file_type: String,
 ) -> Result<String, RagError> {
     log::info!("Parsing document: {} (type: {})", file_path, file_type);
-    let res = parser::parse_document(&file_path, &file_type);
-    res
+    let res = catch_unwind(AssertUnwindSafe(|| parser::parse_document(&file_path, &file_type)));
+    match res {
+        Ok(result) => result,
+        Err(payload) => {
+            let reason = if let Some(s) = payload.downcast_ref::<&str>() {
+                *s
+            } else if let Some(s) = payload.downcast_ref::<String>() {
+                s.as_str()
+            } else {
+                "unknown panic"
+            };
+            log::error!("Document parsing panicked: {}", reason);
+            Err(RagError::ParseError(format!(
+                "Document parsing failed unexpectedly: {}",
+                reason
+            )))
+        }
+    }
 }


### PR DESCRIPTION
## Describe Your Changes

- Gracefully handle error on parsing (prevent infinite loop)
- Update Token estimation to be more conservative (2 char = 1 token)

<img width="1025" height="797" alt="image" src="https://github.com/user-attachments/assets/a0ca2dcd-97bf-40bc-9ece-dad6a9d59a51" />

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
