### PR TITLE
fix: disable tool step limit in assistant

### DIFF
--- a/web-app/src/containers/dialogs/AddEditAssistant.tsx
+++ b/web-app/src/containers/dialogs/AddEditAssistant.tsx
@@ -63,7 +63,7 @@ export default function AddEditAssistant({
   const emojiPickerRef = useRef<HTMLDivElement>(null)
   const emojiPickerTriggerRef = useRef<HTMLDivElement>(null)
   const [nameError, setNameError] = useState<string | null>(null)
-  const [toolStepsInput, setToolStepsInput] = useState('20')
+  // const [toolStepsInput, setToolStepsInput] = useState('20')
 
   // Handle click outside emoji picker or trigger
   useEffect(() => {
@@ -95,7 +95,7 @@ export default function AddEditAssistant({
       setDescription(initialData.description)
       setInstructions(initialData.instructions)
       setShowEmojiPicker(false)
-      setToolStepsInput(String(initialData.tool_steps ?? 20))
+      // setToolStepsInput(String(initialData.tool_steps ?? 20))
 
       // Convert parameters object to arrays of keys and values
       const keys = Object.keys(initialData.parameters || {})
@@ -128,7 +128,7 @@ export default function AddEditAssistant({
     setParamsTypes(['string'])
     setNameError(null)
     setShowEmojiPicker(false)
-    setToolStepsInput('20')
+    // setToolStepsInput('20')
   }
 
   const handleParameterChange = (
@@ -223,7 +223,7 @@ export default function AddEditAssistant({
       }
     })
 
-    const parsedToolSteps = Number(toolStepsInput)
+    // const parsedToolSteps = Number(toolStepsInput)
     const assistant: Assistant = {
       avatar,
       id: initialData?.id || Math.random().toString(36).substring(7),
@@ -232,7 +232,7 @@ export default function AddEditAssistant({
       description,
       instructions,
       parameters: parameters || {},
-      tool_steps: isNaN(parsedToolSteps) ? 20 : parsedToolSteps,
+      // tool_steps: isNaN(parsedToolSteps) ? 20 : parsedToolSteps,
     }
     onSave(assistant)
     onOpenChange(false)
@@ -348,7 +348,7 @@ export default function AddEditAssistant({
             <div className="flex items-center justify-between">
               <label className="text-sm">{t('common:settings')}</label>
             </div>
-            <div className="flex justify-between items-center gap-2">
+            {/* <div className="flex justify-between items-center gap-2">
               <div className="w-full">
                 <p className="text-sm">{t('assistants:maxToolSteps')}</p>
               </div>
@@ -363,7 +363,7 @@ export default function AddEditAssistant({
                 placeholder="20"
                 className="w-18 text-right"
               />
-            </div>
+            </div> */}
           </div>
 
           <div className="space-y-2 my-4">

--- a/web-app/src/hooks/useChat.ts
+++ b/web-app/src/hooks/useChat.ts
@@ -796,7 +796,7 @@ export const useChat = () => {
           }
         }
 
-        let assistantLoopSteps = 0
+        // let assistantLoopSteps = 0
 
         while (
           !isCompleted &&
@@ -809,7 +809,7 @@ export const useChat = () => {
           const modelConfig = activeProvider.models.find(
             (m) => m.id === selectedModel?.id
           )
-          assistantLoopSteps += 1
+          // assistantLoopSteps += 1
 
           const modelSettings = modelConfig?.settings
             ? Object.fromEntries(
@@ -998,12 +998,12 @@ export const useChat = () => {
           )
 
           isCompleted = !toolCalls.length
-          // Do not create agent loop if there is no need for it
-          // Check if assistant loop steps are within limits
-          if (assistantLoopSteps >= (currentAssistant?.tool_steps ?? 20)) {
-            // Stop the assistant tool call if it exceeds the maximum steps
-            availableTools = []
-          }
+          // // Do not create agent loop if there is no need for it
+          // // Check if assistant loop steps are within limits
+          // if (assistantLoopSteps >= (currentAssistant?.tool_steps ?? 20)) {
+          //   // Stop the assistant tool call if it exceeds the maximum steps
+          //   availableTools = []
+          // }
         }
 
         // IMPORTANT: Check if aborted AFTER the while loop exits

--- a/web-app/src/types/threads.d.ts
+++ b/web-app/src/types/threads.d.ts
@@ -62,7 +62,7 @@ type Assistant = {
   description?: string
   instructions: string
   parameters: Record<string, unknown>
-  tool_steps?: number
+  // tool_steps?: number
 }
 
 type TokenSpeed = {


### PR DESCRIPTION
## Describe Your Changes

Models nowadays can perform long-horizontal tasks really well. This PR is to remove `fixed 20 tool step` from Assistant. Assistant should also be simplified into thread / project instructions or more complex like agents.

Q: How about tool call loop?
A:
1. Users decide when to stop
2. Users can reject tool call whenever needed

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
