### PR TITLE
ci: reproduce linter test out of space on ubuntu

### DIFF
--- a/.github/workflows/jan-linter-and-test.yml
+++ b/.github/workflows/jan-linter-and-test.yml
@@ -16,7 +16,6 @@ on:
       - 'extensions/**'
       - '!README.md'
       - 'Makefile'
-  
 
   pull_request:
     branches:
@@ -184,6 +183,17 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false 
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
 
       - name: Installing node
         uses: actions/setup-node@v3


### PR DESCRIPTION
## Describe Your Changes

This PR is to fix linter & test CI out of space while running on Ubuntu

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
