### PR TITLE
fix: model import issue on Windows

### DIFF
--- a/web-app/src/containers/dialogs/ImportVisionModelDialog.tsx
+++ b/web-app/src/containers/dialogs/ImportVisionModelDialog.tsx
@@ -18,7 +18,6 @@ import {
   IconCheck,
   IconAlertTriangle,
 } from '@tabler/icons-react'
-import { basename } from 'path'
 
 type ImportVisionModelDialogProps = {
   provider: ModelProvider
@@ -67,7 +66,7 @@ export const ImportVisionModelDialog = ({
               const architecture =
                 result.metadata.metadata?.['general.architecture']
 
-              setModelName(basename(filePath))
+              setModelName(await serviceHub.path().basename(filePath))
 
               // Model files should NOT be clip
               if (architecture === 'clip') {

--- a/web-app/src/services/__tests__/path.test.ts
+++ b/web-app/src/services/__tests__/path.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { TauriPathService } from '../path/tauri'
+
+// Mock the @tauri-apps/api/path module
+const mockBasename = vi.fn()
+const mockDirname = vi.fn()
+const mockExtname = vi.fn()
+const mockJoin = vi.fn()
+const mockSep = vi.fn()
+
+vi.mock('@tauri-apps/api/path', () => ({
+  basename: (...args: any[]) => mockBasename(...args),
+  dirname: (...args: any[]) => mockDirname(...args),
+  extname: (...args: any[]) => mockExtname(...args),
+  join: (...args: any[]) => mockJoin(...args),
+  sep: (...args: any[]) => mockSep(...args),
+}))
+
+describe('TauriPathService', () => {
+  let pathService: TauriPathService
+
+  beforeEach(() => {
+    pathService = new TauriPathService()
+    vi.clearAllMocks()
+  })
+
+  describe('sep', () => {
+    it('should return separator from Tauri API', () => {
+      mockSep.mockReturnValue('/')
+      const result = pathService.sep()
+      expect(result).toBe('/')
+    })
+
+    it('should return default separator on error', () => {
+      mockSep.mockImplementation(() => {
+        throw new Error('Test error')
+      })
+      const result = pathService.sep()
+      expect(result).toBe('/')
+    })
+  })
+
+  describe('join', () => {
+    it('should join path segments using Tauri API', async () => {
+      mockJoin.mockResolvedValue('/path/to/file')
+      const result = await pathService.join('path', 'to', 'file')
+      expect(result).toBe('/path/to/file')
+      expect(mockJoin).toHaveBeenCalledWith('path', 'to', 'file')
+    })
+
+    it('should fallback to slash joining on error', async () => {
+      mockJoin.mockRejectedValue(new Error('Test error'))
+      const result = await pathService.join('path', 'to', 'file')
+      expect(result).toBe('path/to/file')
+    })
+  })
+
+  describe('dirname', () => {
+    it('should get directory name using Tauri API', async () => {
+      mockDirname.mockResolvedValue('/path/to')
+      const result = await pathService.dirname('/path/to/file.txt')
+      expect(result).toBe('/path/to')
+      expect(mockDirname).toHaveBeenCalledWith('/path/to/file.txt')
+    })
+
+    it('should fallback to manual dirname extraction on error', async () => {
+      mockDirname.mockRejectedValue(new Error('Test error'))
+      const result = await pathService.dirname('/path/to/file.txt')
+      expect(result).toBe('/path/to')
+    })
+
+    it('should return dot for paths without directory', async () => {
+      mockDirname.mockRejectedValue(new Error('Test error'))
+      const result = await pathService.dirname('file.txt')
+      expect(result).toBe('.')
+    })
+  })
+
+  describe('basename', () => {
+    it('should get basename using Tauri API for Unix paths', async () => {
+      mockBasename.mockResolvedValue('file.txt')
+      const result = await pathService.basename('/path/to/file.txt')
+      expect(result).toBe('file.txt')
+      expect(mockBasename).toHaveBeenCalledWith('/path/to/file.txt')
+    })
+
+    it('should fallback to manual extraction for Windows paths with backslashes', async () => {
+      mockBasename.mockRejectedValue(new Error('Test error'))
+      const result = await pathService.basename('C:\\Users\\John\\model.gguf')
+      expect(result).toBe('model.gguf')
+    })
+
+    it('should handle mixed slashes in Windows paths in fallback', async () => {
+      mockBasename.mockRejectedValue(new Error('Test error'))
+      const result = await pathService.basename('C:\\Users/John\\Documents/model.gguf')
+      expect(result).toBe('model.gguf')
+    })
+
+    it('should handle Unix paths in fallback', async () => {
+      mockBasename.mockRejectedValue(new Error('Test error'))
+      const result = await pathService.basename('/home/user/models/model.gguf')
+      expect(result).toBe('model.gguf')
+    })
+
+    it('should return empty string for path ending with slash in fallback', async () => {
+      mockBasename.mockRejectedValue(new Error('Test error'))
+      const result = await pathService.basename('/path/to/directory/')
+      expect(result).toBe('')
+    })
+
+    it('should return empty string for empty path in fallback', async () => {
+      mockBasename.mockRejectedValue(new Error('Test error'))
+      const result = await pathService.basename('')
+      expect(result).toBe('')
+    })
+
+    it('should handle path with only filename in fallback', async () => {
+      mockBasename.mockRejectedValue(new Error('Test error'))
+      const result = await pathService.basename('model.gguf')
+      expect(result).toBe('model.gguf')
+    })
+
+    it('should handle Windows drive letter paths in fallback', async () => {
+      mockBasename.mockRejectedValue(new Error('Test error'))
+      const result = await pathService.basename('D:\\model.gguf')
+      expect(result).toBe('model.gguf')
+    })
+
+    it('should handle UNC paths in fallback', async () => {
+      mockBasename.mockRejectedValue(new Error('Test error'))
+      const result = await pathService.basename('\\\\server\\share\\folder\\file.txt')
+      expect(result).toBe('file.txt')
+    })
+
+    it('should handle paths with spaces in fallback', async () => {
+      mockBasename.mockRejectedValue(new Error('Test error'))
+      const result = await pathService.basename('C:\\Program Files\\Jan\\my model.gguf')
+      expect(result).toBe('my model.gguf')
+    })
+
+    it('should handle paths with special characters in fallback', async () => {
+      mockBasename.mockRejectedValue(new Error('Test error'))
+      const result = await pathService.basename('/path/to/model-v1.0_final (1).gguf')
+      expect(result).toBe('model-v1.0_final (1).gguf')
+    })
+  })
+
+  describe('extname', () => {
+    it('should get file extension using Tauri API', async () => {
+      mockExtname.mockResolvedValue('.txt')
+      const result = await pathService.extname('/path/to/file.txt')
+      expect(result).toBe('.txt')
+      expect(mockExtname).toHaveBeenCalledWith('/path/to/file.txt')
+    })
+
+    it('should fallback to manual extension extraction on error', async () => {
+      mockExtname.mockRejectedValue(new Error('Test error'))
+      const result = await pathService.extname('/path/to/file.txt')
+      expect(result).toBe('.txt')
+    })
+
+    it('should return empty string for files without extension in fallback', async () => {
+      mockExtname.mockRejectedValue(new Error('Test error'))
+      const result = await pathService.extname('/path/to/file')
+      expect(result).toBe('')
+    })
+
+    it('should handle multiple dots in filename in fallback', async () => {
+      mockExtname.mockRejectedValue(new Error('Test error'))
+      const result = await pathService.extname('/path/to/archive.tar.gz')
+      expect(result).toBe('.gz')
+    })
+
+    it('should return empty string when dot is before last slash in fallback', async () => {
+      mockExtname.mockRejectedValue(new Error('Test error'))
+      const result = await pathService.extname('/path.old/to/file')
+      expect(result).toBe('')
+    })
+  })
+})

--- a/web-app/src/services/path/tauri.ts
+++ b/web-app/src/services/path/tauri.ts
@@ -40,8 +40,8 @@ export class TauriPathService extends DefaultPathService {
       return await basename(path)
     } catch (error) {
       console.error('Error getting basename in Tauri:', error)
-      const lastSlash = path.lastIndexOf('/')
-      return lastSlash >= 0 ? path.substring(lastSlash + 1) : path
+      const normalizedPath = path.replace(/\\/g, '/')
+      return normalizedPath.split('/').pop() || ''
     }
   }
 


### PR DESCRIPTION
## Describe Your Changes

This pull request improves cross-platform path handling in the model import dialog and adds comprehensive tests for the Tauri-based path service. The main focus is on ensuring robust extraction of file and directory names, especially for Windows paths, and increasing test coverage for fallback logic.

### Path handling improvements

* Updated the fallback implementation of `basename` in `TauriPathService` to normalize Windows backslashes and use a safer split/pop method, ensuring correct filename extraction on all platforms.
* Changed the vision model import dialog to use the Tauri-based `basename` method instead of Node's `path.basename`, improving compatibility with Tauri apps. [[1]](diffhunk://#diff-91a4cdd8e95997bdb7430c7f66052d929815f6b445ed2783e77109de9e08d316L21) [[2]](diffhunk://#diff-91a4cdd8e95997bdb7430c7f66052d929815f6b445ed2783e77109de9e08d316L70-R69)

### Test coverage

* Added extensive unit tests for the Tauri path service in `path.test.ts`, covering normal and fallback behavior for `basename`, `dirname`, `extname`, `join`, and `sep`, including edge cases for Windows and Unix paths.