### PR TITLE
fix: prevent CUDA backend install failure by removing invalid fs.mkdir args

### DIFF
--- a/extensions/llamacpp-extension/src/backend.ts
+++ b/extensions/llamacpp-extension/src/backend.ts
@@ -498,7 +498,7 @@ async function _isCudaInstalled(
     // Ensure target directory exists
     const targetDir = await joinPath([backendDir, 'build', 'bin'])
     if (!(await fs.existsSync(targetDir))) {
-      await fs.mkdir(targetDir, { recursive: true })
+      await fs.mkdir(targetDir)
     }
 
     try {


### PR DESCRIPTION
## Describe Your Changes
The llama.cpp CUDA backend installation was failing because `_isCudaInstalled()` called `fs.mkdir()` with a second parameter (`{ recursive: true }`), which is not supported in this codepath. This caused a parameter mismatch exception and prevented the backend from building.

Replaced the call with `fs.mkdir(targetDir)` so the directory is created using the correct function signature.

This fixes the critical installation failure on CUDA-enabled llama.cpp builds.

## Fixes Issues

- Closes #7121
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
