### PR TITLE
feat: add build args jan web

### DIFF
--- a/.github/workflows/jan-server-web-newui-ci-dev.yml
+++ b/.github/workflows/jan-server-web-newui-ci-dev.yml
@@ -14,7 +14,8 @@ jobs:
   build-and-preview:
     runs-on: [ubuntu-24-04-docker]
     env:
-      JAN_BASE_URL: "https://api-dev.jan.ai"
+      JAN_BASE_URL: "https://api-dev.jan.ai/v1"
+      JAN_API_BASE_URL: "https://api-dev.jan.ai/"
       ENVIRONMENT: "dev"
       VITE_AUTH_URL: "https://auth-dev.jan.ai"
       VITE_AUTH_REALM: "jan"
@@ -61,6 +62,7 @@ jobs:
         run: |
           docker build \
             --build-arg JAN_BASE_URL=${{ env.JAN_BASE_URL }} \
+            --build-arg JAN_API_BASE_URL=${{ env.JAN_API_BASE_URL }} \
             --build-arg ENVIRONMENT=${{ env.ENVIRONMENT }} \
             --build-arg VITE_AUTH_URL=${{ env.VITE_AUTH_URL }} \
             --build-arg VITE_AUTH_REALM=${{ env.VITE_AUTH_REALM }} \

--- a/.github/workflows/jan-server-web-newui-ci-prod.yml
+++ b/.github/workflows/jan-server-web-newui-ci-prod.yml
@@ -13,7 +13,8 @@ jobs:
       deployments: write
       pull-requests: write
     env:
-      JAN_BASE_URL: "https://api.jan.ai"
+      JAN_BASE_URL: "https://api.jan.ai/v1"
+      JAN_API_BASE_URL: "https://api.jan.ai/"
       GA_MEASUREMENT_ID: "G-5HCJWQTZLD"
       VITE_AUTH_URL: "https://auth.jan.ai"
       VITE_AUTH_REALM: "jan"
@@ -49,6 +50,7 @@ jobs:
         run: make config-yarn && yarn install && yarn build:core && make build-web-app-newui
         env:
           JAN_BASE_URL: ${{ env.JAN_BASE_URL }}
+          JAN_API_BASE_URL: ${{ env.JAN_API_BASE_URL }}
           GA_MEASUREMENT_ID: ${{ env.GA_MEASUREMENT_ID }}
           ENVIRONMENT: ${{ env.ENVIRONMENT }}
           VITE_AUTH_URL: ${{ env.VITE_AUTH_URL }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM node:20-alpine AS builder
 ARG JAN_BASE_URL=https://api-dev.jan.ai/v1
 ENV JAN_BASE_URL=$JAN_BASE_URL
 
+ARG JAN_API_BASE_URL=https://api-dev.jan.ai/
+ENV JAN_API_BASE_URL=$JAN_API_BASE_URL
+
 ARG ENVIRONMENT=dev
 ENV ENVIRONMENT=$ENVIRONMENT
 


### PR DESCRIPTION
## Describe Your Changes

This pull request updates environment variable handling for API base URLs in both development and production workflows, as well as in the Dockerfile. The main goal is to introduce a new `JAN_API_BASE_URL` variable (distinct from the existing `JAN_BASE_URL`, which now includes the `/v1` path), and ensure it is correctly passed through CI workflows and into the Docker build process.

**Environment variable updates:**

* Added `JAN_API_BASE_URL` variable to both the development and production GitHub Actions workflow files (`.github/workflows/jan-server-web-newui-ci-dev.yml`, `.github/workflows/jan-server-web-newui-ci-prod.yml`). This variable is set to the root API URL, while `JAN_BASE_URL` now points to the `/v1` endpoint. [[1]](diffhunk://#diff-434be3334aeac5262150bd855266f533eead8f50800bfb31adf914c85e77929bL17-R18) [[2]](diffhunk://#diff-2b6f73da96a19539f308e72b753c57c4848dc60c8d359c113125d557659f8418L16-R17)
* Updated workflow build steps to pass the new `JAN_API_BASE_URL` as a build argument to Docker and as an environment variable for build steps. [[1]](diffhunk://#diff-434be3334aeac5262150bd855266f533eead8f50800bfb31adf914c85e77929bR65) [[2]](diffhunk://#diff-2b6f73da96a19539f308e72b753c57c4848dc60c8d359c113125d557659f8418R53)

**Dockerfile enhancements:**

* Added support for the new `JAN_API_BASE_URL` build argument and environment variable in the `Dockerfile`, ensuring it is available at build and runtime.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
