### PR TITLE
chore: collapse sidebar when click history chat

### DIFF
--- a/app/src/components/sidebar/nav-chat.tsx
+++ b/app/src/components/sidebar/nav-chat.tsx
@@ -34,7 +34,7 @@ import { Input } from '@/components/ui/input'
 import { useConversations } from '@/stores/conversation-store'
 
 export function NavChats() {
-  const { isMobile } = useSidebar()
+  const { isMobile, setOpenMobile } = useSidebar()
   const navigate = useNavigate()
   const params = useParams({ strict: false }) as { conversationId?: string }
   const allConversations = useConversations((state) => state.conversations)
@@ -173,6 +173,11 @@ export function NavChats() {
                   to="/threads/$conversationId"
                   params={{ conversationId: item.id }}
                   title={item.title}
+                  onClick={() => {
+                    if (isMobile) {
+                      setOpenMobile(false)
+                    }
+                  }}
                 >
                   <span>{item.title}</span>
                 </Link>


### PR DESCRIPTION
## Describe Your Changes

This pull request updates the sidebar chat navigation to improve the mobile experience. The most important changes are:

**Mobile sidebar behavior:**

* The `NavChats` component now imports and uses the `setOpenMobile` function from `useSidebar`, allowing it to programmatically close the sidebar on mobile devices.
* When a chat link is clicked on mobile (`isMobile` is true), the sidebar will automatically close by calling `setOpenMobile(false)`.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
