### PR TITLE
Feat/thinking instruct -  sample PR

### DIFF
--- a/app/src/components/chat-input/index.tsx
+++ b/app/src/components/chat-input/index.tsx
@@ -26,6 +26,7 @@ import { useProjects } from '@/stores/projects-store'
 import {
   FolderIcon,
   GlobeIcon,
+  BrainIcon,
   MegaphoneIcon,
   Settings2,
   X,
@@ -78,6 +79,11 @@ const ChatInput = ({
   const setDeepResearchEnabled = useCapabilities(
     (state) => state.setDeepResearchEnabled
   )
+  const thinkingEnabled = useCapabilities((state) => state.thinkingEnabled)
+  const toggleThinking = useCapabilities((state) => state.toggleThinking)
+  const setThinkingEnabled = useCapabilities(
+    (state) => state.setThinkingEnabled
+  )
 
   const setLastUsedModelId = useLastUsedModel(
     (state) => state.setLastUsedModelId
@@ -86,6 +92,7 @@ const ChatInput = ({
   const isSupportTools = modelDetail.supports_tools
   const isSupportReasoning = modelDetail.supports_reasoning
   const isSupportDeepResearch = isSupportTools && isSupportReasoning
+  const isSupportInstruct = modelDetail.supports_instruct
 
   // Auto-disable capabilities when model doesn't support them
   useEffect(() => {
@@ -110,6 +117,15 @@ const ChatInput = ({
     setDeepResearchEnabled,
     modelDetail.id,
   ])
+
+  useEffect(() => {
+    // Only run if we have a valid model loaded
+    if (!modelDetail.id) return
+
+    if (!isSupportInstruct && thinkingEnabled) {
+      setThinkingEnabled(false)
+    }
+  }, [isSupportInstruct, thinkingEnabled, setThinkingEnabled, modelDetail.id])
 
   const handleSubmit = (message: PromptInputMessage) => {
     const hasText = Boolean(message.text)
@@ -178,8 +194,8 @@ const ChatInput = ({
       className={cn(
         'w-full relative rounded-3xl p-[1.5px]',
         !initialConversation &&
-          status === 'streaming' &&
-          'overflow-hidden outline-0'
+        status === 'streaming' &&
+        'overflow-hidden outline-0'
       )}
     >
       <PromptInputProvider>
@@ -220,8 +236,11 @@ const ChatInput = ({
                 deepResearchEnabled={deepResearchEnabled}
                 toggleSearch={toggleSearch}
                 toggleDeepResearch={toggleDeepResearch}
+                thinkingEnabled={thinkingEnabled}
+                toggleThinking={toggleThinking}
                 isSupportTools={isSupportTools}
                 isSupportDeepResearch={isSupportDeepResearch}
+                isSupportInstruct={isSupportInstruct}
               >
                 <Button
                   className="rounded-full mx-1 size-8"
@@ -251,6 +270,18 @@ const ChatInput = ({
                   <MegaphoneIcon className="text-primary size-4 group-hover:hidden" />
                   <X className="text-primary size-4 hidden group-hover:block" />
                   <span className="text-primary">Deep Research</span>
+                </PromptInputButton>
+              )}
+
+              {thinkingEnabled && (
+                <PromptInputButton
+                  variant="outline"
+                  className="rounded-full group transition-all bg-primary/10 hover:bg-primary/10 border-0"
+                  onClick={toggleThinking}
+                >
+                  <BrainIcon className="text-primary size-4 group-hover:hidden" />
+                  <X className="text-primary size-4 hidden group-hover:block" />
+                  <span className="text-primary">Thinking</span>
                 </PromptInputButton>
               )}
               {selectedProjectId && !isPrivateChat && (

--- a/app/src/components/chat-input/setting-chat-input.tsx
+++ b/app/src/components/chat-input/setting-chat-input.tsx
@@ -14,6 +14,7 @@ import {
   Leaf,
   MegaphoneIcon,
   SmileIcon,
+  BrainIcon,
   type LucideIcon,
 } from 'lucide-react'
 import { Switch } from '@/components/ui/switch'
@@ -32,6 +33,9 @@ interface SettingChatInputProps {
   toggleDeepResearch: () => void
   isSupportTools: boolean
   isSupportDeepResearch: boolean
+  isSupportInstruct: boolean
+  thinkingEnabled: boolean
+  toggleThinking: () => void
   selectedTone?: ToneOption
   onToneChange?: (tone: ToneOption) => void
   children: React.ReactNode
@@ -50,6 +54,9 @@ export const SettingChatInput = ({
   toggleDeepResearch,
   isSupportTools,
   isSupportDeepResearch,
+  isSupportInstruct,
+  thinkingEnabled,
+  toggleThinking,
   selectedTone = 'Friendly',
   onToneChange,
   children,
@@ -139,6 +146,33 @@ export const SettingChatInput = ({
           {!isSupportDeepResearch && (
             <TooltipContent>
               <p>This model doesn't support deep research</p>
+            </TooltipContent>
+          )}
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div>
+              <DropDrawerItem
+                onSelect={(e) => e.preventDefault()}
+                disabled={!isSupportInstruct}
+              >
+                <div className="flex gap-2 items-center justify-between w-full">
+                  <div className="flex gap-2 items-center w-full">
+                    <BrainIcon />
+                    <span>Thinking</span>
+                  </div>
+                  <Switch
+                    checked={thinkingEnabled}
+                    onCheckedChange={toggleThinking}
+                    disabled={!isSupportInstruct}
+                  />
+                </div>
+              </DropDrawerItem>
+            </div>
+          </TooltipTrigger>
+          {!isSupportInstruct && (
+            <TooltipContent>
+              <p>This model doesn't support thinking</p>
             </TooltipContent>
           )}
         </Tooltip>

--- a/app/src/lib/api-client.ts
+++ b/app/src/lib/api-client.ts
@@ -147,9 +147,9 @@ export function createAuthenticatedFetch(customBody?: object): typeof fetch {
       ...init,
       body: customBody
         ? JSON.stringify({
-            ...customBody,
-            ...(init?.body ? JSON.parse(init.body.toString()) : {}),
-          })
+          ...customBody,
+          ...(init?.body ? JSON.parse(init.body.toString()) : {}),
+        })
         : init?.body,
       skipAuthRefresh: false,
     })
@@ -164,6 +164,7 @@ export function createAuthenticatedFetch(customBody?: object): typeof fetch {
 export function janProvider(
   conversationId?: string,
   deepResearch?: boolean,
+  thinking?: boolean,
   isPrivateChat?: boolean
 ): OpenAICompatibleProvider<string, string, string> {
   return createOpenAICompatible({
@@ -174,6 +175,7 @@ export function janProvider(
       ...(!isPrivateChat && { store: true }),
       ...(!isPrivateChat && { conversation: conversationId }),
       deep_research: deepResearch ?? false,
+      enable_thinking: thinking ?? false,
     }),
   })
 }

--- a/app/src/routes/projects/$projectId.tsx
+++ b/app/src/routes/projects/$projectId.tsx
@@ -44,6 +44,7 @@ import {
 import { ProjectConversations } from '@/components/projects/project-conversations'
 import { useConversations } from '@/stores/conversation-store'
 import { useLastUsedModel } from '@/stores/last-used-model-store'
+import { useCapabilities } from '@/stores/capabilities-store'
 
 function ProjectPageContent() {
   const navigate = useNavigate()
@@ -59,6 +60,10 @@ function ProjectPageContent() {
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
   const reasoningContainerRef = useRef<HTMLDivElement>(null)
   const allConversations = useConversations((state) => state.conversations)
+  const deepResearchEnabled = useCapabilities(
+    (state) => state.deepResearchEnabled
+  )
+  const thinkingEnabled = useCapabilities((state) => state.thinkingEnabled)
 
   const models = useModels((state) => state.models)
   const setSelectedModel = useModels((state) => state.setSelectedModel)
@@ -121,7 +126,7 @@ function ProjectPageContent() {
     }
   }
 
-  const provider = janProvider()
+  const provider = janProvider(undefined, deepResearchEnabled, thinkingEnabled)
 
   const { status, sendMessage } = useChat(provider(selectedModel?.id), {
     onFinish: () => {

--- a/app/src/routes/threads/$conversationId.tsx
+++ b/app/src/routes/threads/$conversationId.tsx
@@ -56,8 +56,13 @@ function ThreadPageContent() {
   const deepResearchEnabled = useCapabilities(
     (state) => state.deepResearchEnabled
   )
+  const thinkingEnabled = useCapabilities((state) => state.thinkingEnabled)
 
-  const provider = janProvider(conversationId, deepResearchEnabled)
+  const provider = janProvider(
+    conversationId,
+    deepResearchEnabled,
+    thinkingEnabled
+  )
 
   const getUIMessages = useConversations((state) => state.getUIMessages)
 
@@ -121,7 +126,7 @@ function ThreadPageContent() {
         text: message.text || 'Sent with attachments',
         files: message.files,
       })
-    } else if(status === 'streaming') {
+    } else if (status === 'streaming') {
       stop()
     }
   }

--- a/app/src/routes/threads/temporary.tsx
+++ b/app/src/routes/threads/temporary.tsx
@@ -52,9 +52,15 @@ function ThreadPageContent() {
   const deepResearchEnabled = useCapabilities(
     (state) => state.deepResearchEnabled
   )
+  const thinkingEnabled = useCapabilities((state) => state.thinkingEnabled)
   const isPrivateChat = usePrivateChat((state) => state.isPrivateChat)
 
-  const provider = janProvider(undefined, deepResearchEnabled, isPrivateChat)
+  const provider = janProvider(
+    undefined,
+    deepResearchEnabled,
+    thinkingEnabled,
+    isPrivateChat
+  )
 
   // const getUIMessages = useConversations((state) => state.getUIMessages)
 

--- a/app/src/stores/capabilities-store.ts
+++ b/app/src/stores/capabilities-store.ts
@@ -8,6 +8,9 @@ interface CapabilitiesState {
   setDeepResearchEnabled: (enabled: boolean) => void
   toggleSearch: () => void
   toggleDeepResearch: () => void
+  thinkingEnabled: boolean
+  setThinkingEnabled: (enabled: boolean) => void
+  toggleThinking: () => void
 }
 
 export const useCapabilities = create<CapabilitiesState>()(
@@ -22,6 +25,11 @@ export const useCapabilities = create<CapabilitiesState>()(
         set((state) => ({ searchEnabled: !state.searchEnabled })),
       toggleDeepResearch: () =>
         set((state) => ({ deepResearchEnabled: !state.deepResearchEnabled })),
+      thinkingEnabled: false,
+      setThinkingEnabled: (enabled: boolean) =>
+        set({ thinkingEnabled: enabled }),
+      toggleThinking: () =>
+        set((state) => ({ thinkingEnabled: !state.thinkingEnabled })),
     }),
     {
       name: 'capabilities-storage',

--- a/app/src/types/model.d.ts
+++ b/app/src/types/model.d.ts
@@ -64,6 +64,7 @@ interface ModelDetail {
   supports_reasoning: boolean
   supports_audio: boolean
   supports_video: boolean
+  supports_instruct: boolean
   created_at: number
   updated_at: number
 }

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -16,7 +16,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     define: {
-      JAN_API_BASE_URL: JSON.stringify(env.JAN_API_BASE_URL),
+      JAN_API_BASE_URL: JSON.stringify(env.JAN_API_BASE_URL || 'http://localhost:8000/'),
       VITE_GA_ID: JSON.stringify(env.VITE_GA_ID),
       VITE_AUTH_URL: JSON.stringify(
         env.VITE_AUTH_URL || 'https://auth-dev.jan.ai'

--- a/yarn.lock
+++ b/yarn.lock
@@ -25,16 +25,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ai-sdk/gateway@npm:2.0.19":
-  version: 2.0.19
-  resolution: "@ai-sdk/gateway@npm:2.0.19"
+"@ai-sdk/gateway@npm:2.0.21":
+  version: 2.0.21
+  resolution: "@ai-sdk/gateway@npm:2.0.21"
   dependencies:
     "@ai-sdk/provider": "npm:2.0.0"
-    "@ai-sdk/provider-utils": "npm:3.0.18"
+    "@ai-sdk/provider-utils": "npm:3.0.19"
     "@vercel/oidc": "npm:3.0.5"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/7c1e304404f55060659f32be10450c04ed1e3784d1fe04e992adc7ae0cfb843e41435d88783d1f11f5045bd0d5df26df8929202eeb3077d7747e1c2c263fb0cd
+  checksum: 10c0/776492f1e0b6d29d8503c940cd4c08fed96cbf65f22eaee683f15e59cb4d03e40b7b64f2790144f2bb22cb174f44d305bac957270ba65a5c3fd79a9826e4cfc8
   languageName: node
   linkType: hard
 
@@ -60,6 +60,19 @@ __metadata:
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
   checksum: 10c0/209c15b0dceef0ba95a7d3de544be0a417ad4a0bd5143496b3966a35fedf144156d93a42ff8c3d7db56781b9836bafc8c132c98978c49240e55bc1a36e18a67f
+  languageName: node
+  linkType: hard
+
+"@ai-sdk/provider-utils@npm:3.0.19":
+  version: 3.0.19
+  resolution: "@ai-sdk/provider-utils@npm:3.0.19"
+  dependencies:
+    "@ai-sdk/provider": "npm:2.0.0"
+    "@standard-schema/spec": "npm:^1.0.0"
+    eventsource-parser: "npm:^3.0.6"
+  peerDependencies:
+    zod: ^3.25.76 || ^4.1.8
+  checksum: 10c0/e4decb19264067fa1b1642e07d515d25d1509a1a9143f59ccc051e3ca413c9fb1d708e1052a70eaf329ca39ddf6152520cd833dbf8c95d9bf02bbeffae8ea363
   languageName: node
   linkType: hard
 
@@ -3720,6 +3733,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@gilbarbara/deep-equal@npm:^0.1.1":
+  version: 0.1.2
+  resolution: "@gilbarbara/deep-equal@npm:0.1.2"
+  checksum: 10c0/ef441034a34d3e3a2fdcdd473b1082c4e8a324682c8a35cea100d60b5341fecb7249ae043eecf2ea9bdf736a1fe582b294a347095c3d48a1d9d04d7d6e4ad16a
+  languageName: node
+  linkType: hard
+
+"@gilbarbara/deep-equal@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@gilbarbara/deep-equal@npm:0.3.1"
+  checksum: 10c0/009584aa912f13c59e98b35c3ebf99ff7fc7c5658d5394fd56d58570da61d68cbc6f7ec082ad2ef009ff72873cc1bd8b9b9fda9e39f7e6594fd643a915e0bc94
+  languageName: node
+  linkType: hard
+
 "@google/genai@npm:^1.10.0":
   version: 1.19.0
   resolution: "@google/genai@npm:1.19.0"
@@ -3732,6 +3759,15 @@ __metadata:
     "@modelcontextprotocol/sdk":
       optional: true
   checksum: 10c0/79b35c5717579779989dd9cba4b9a936ead6ff1b9e1b0cdde72210c8869f5192d261b5d9225b1f3cfdc62db9fcccac433f9211abff9a7e104aacecdf5bbe29c8
+  languageName: node
+  linkType: hard
+
+"@hono/node-server@npm:^1.19.7":
+  version: 1.19.7
+  resolution: "@hono/node-server@npm:1.19.7"
+  peerDependencies:
+    hono: ^4
+  checksum: 10c0/293818e02a9100122a9319fba7032a3bae86d5f98f55d1a0ff4843c2b729eb6b471978ea15e29f4fb680c6a0be23a6e5a2132f3790ab31e88fb0b6b6fcc6829e
   languageName: node
   linkType: hard
 
@@ -3878,6 +3914,7 @@ __metadata:
   resolution: "@jan/extensions-web@workspace:extensions-web"
   dependencies:
     "@janhq/core": "workspace:*"
+    "@janhq/mcp-web-client": "npm:@janhq/mcp-web-client@0.14.4"
     "@modelcontextprotocol/sdk": "npm:1.17.5"
     "@tabler/icons-react": "npm:^3.34.0"
     "@types/react": "npm:19.1.2"
@@ -3891,6 +3928,65 @@ __metadata:
     "@tabler/icons-react": "*"
     react: 19.0.0
     zustand: 5.0.3
+  languageName: unknown
+  linkType: soft
+
+"@janhq/app@workspace:app":
+  version: 0.0.0-use.local
+  resolution: "@janhq/app@workspace:app"
+  dependencies:
+    "@ai-sdk/openai-compatible": "npm:^1.0.28"
+    "@ai-sdk/react": "npm:^2.0.109"
+    "@eslint/js": "npm:^9.39.1"
+    "@hookform/resolvers": "npm:^5.2.2"
+    "@modelcontextprotocol/sdk": "npm:^1.24.3"
+    "@radix-ui/react-avatar": "npm:^1.1.11"
+    "@radix-ui/react-collapsible": "npm:^1.1.12"
+    "@radix-ui/react-dialog": "npm:^1.1.15"
+    "@radix-ui/react-dropdown-menu": "npm:^2.1.16"
+    "@radix-ui/react-hover-card": "npm:^1.1.15"
+    "@radix-ui/react-label": "npm:^2.1.8"
+    "@radix-ui/react-popover": "npm:^1.1.15"
+    "@radix-ui/react-select": "npm:^2.2.6"
+    "@radix-ui/react-separator": "npm:^1.1.8"
+    "@radix-ui/react-slot": "npm:^1.2.4"
+    "@radix-ui/react-switch": "npm:^1.2.6"
+    "@radix-ui/react-tooltip": "npm:^1.2.8"
+    "@radix-ui/react-use-controllable-state": "npm:^1.2.2"
+    "@tailwindcss/vite": "npm:^4.1.17"
+    "@tanstack/react-router": "npm:^1.140.0"
+    "@tanstack/router-plugin": "npm:^1.140.0"
+    "@types/node": "npm:^24.10.1"
+    "@types/react": "npm:^19.2.5"
+    "@types/react-dom": "npm:^19.2.3"
+    "@vitejs/plugin-react": "npm:^5.1.1"
+    ai: "npm:5.0.108"
+    class-variance-authority: "npm:^0.7.1"
+    clsx: "npm:^2.1.1"
+    cmdk: "npm:^1.1.1"
+    eslint: "npm:^9.39.1"
+    eslint-plugin-react-hooks: "npm:^7.0.1"
+    eslint-plugin-react-refresh: "npm:^0.4.24"
+    framer-motion: "npm:^12.23.25"
+    globals: "npm:^16.5.0"
+    lucide-react: "npm:^0.560.0"
+    motion: "npm:^12.23.26"
+    nanoid: "npm:^5.1.6"
+    react: "npm:^19.2.0"
+    react-dom: "npm:^19.2.0"
+    react-hook-form: "npm:^7.68.0"
+    shiki: "npm:^3.19.0"
+    streamdown: "npm:^1.6.10"
+    tailwind-merge: "npm:^3.4.0"
+    tailwindcss: "npm:^4.1.17"
+    tw-animate-css: "npm:^1.4.0"
+    typescript: "npm:~5.9.3"
+    typescript-eslint: "npm:^8.46.4"
+    use-stick-to-bottom: "npm:^1.1.1"
+    vaul: "npm:^1.1.2"
+    vite: "npm:rolldown-vite@7.2.5"
+    zod: "npm:^4.1.13"
+    zustand: "npm:^5.0.9"
   languageName: unknown
   linkType: soft
 
@@ -3921,6 +4017,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@janhq/mcp-web-client@npm:@janhq/mcp-web-client@0.14.4":
+  version: 0.14.4
+  resolution: "@janhq/mcp-web-client@npm:0.14.4"
+  dependencies:
+    zod: "npm:^3.24.1"
+    zod-to-json-schema: "npm:^3.24.1"
+  checksum: 10c0/3ff32260ee9517adb297d0d396aaa9106a2ed6d7d26faa614f83c81b7c6e53cb61f29c9b6599ed55e94445a6900cb94b9ac8d6cbd66d393933e39dd1d88aa494
+  languageName: node
+  linkType: hard
+
 "@janhq/web-app@workspace:web-app":
   version: 0.0.0-use.local
   resolution: "@janhq/web-app@workspace:web-app"
@@ -3933,16 +4039,19 @@ __metadata:
     "@janhq/core": "workspace:*"
     "@radix-ui/react-accordion": "npm:1.2.11"
     "@radix-ui/react-avatar": "npm:1.1.10"
+    "@radix-ui/react-collapsible": "npm:^1.1.12"
     "@radix-ui/react-dialog": "npm:1.1.15"
     "@radix-ui/react-dropdown-menu": "npm:2.1.16"
     "@radix-ui/react-hover-card": "npm:1.1.14"
     "@radix-ui/react-popover": "npm:1.1.14"
     "@radix-ui/react-progress": "npm:1.1.4"
     "@radix-ui/react-radio-group": "npm:1.3.8"
+    "@radix-ui/react-separator": "npm:^1.1.8"
     "@radix-ui/react-slider": "npm:1.3.2"
-    "@radix-ui/react-slot": "npm:1.2.0"
+    "@radix-ui/react-slot": "npm:^1.2.4"
     "@radix-ui/react-switch": "npm:1.2.2"
-    "@radix-ui/react-tooltip": "npm:1.2.4"
+    "@radix-ui/react-tooltip": "npm:^1.2.8"
+    "@radix-ui/react-use-controllable-state": "npm:^1.2.2"
     "@tabler/icons-react": "npm:3.34.0"
     "@tailwindcss/vite": "npm:4.1.4"
     "@tanstack/react-router": "npm:^1.121.34"
@@ -3972,6 +4081,7 @@ __metadata:
     "@uiw/react-textarea-code-editor": "npm:3.1.1"
     "@vitejs/plugin-react": "npm:4.4.1"
     "@vitest/coverage-v8": "npm:3.2.4"
+    ai: "npm:^5.0.108"
     class-variance-authority: "npm:0.7.1"
     clsx: "npm:2.1.1"
     culori: "npm:4.0.1"
@@ -3992,14 +4102,15 @@ __metadata:
     katex: "npm:0.16.22"
     lodash.clonedeep: "npm:4.5.0"
     lodash.debounce: "npm:4.0.8"
-    lucide-react: "npm:0.536.0"
-    motion: "npm:12.18.1"
+    lucide-react: "npm:^0.556.0"
+    motion: "npm:^12.23.25"
     next-themes: "npm:0.4.6"
     posthog-js: "npm:1.255.1"
     react: "npm:19.0.0"
     react-colorful: "npm:5.6.1"
     react-dom: "npm:19.0.0"
     react-i18next: "npm:15.5.1"
+    react-joyride: "npm:2.9.3"
     react-markdown: "npm:10.1.0"
     react-resizable-panels: "npm:3.0.5"
     react-syntax-highlighter: "npm:15.6.1"
@@ -4013,6 +4124,7 @@ __metadata:
     remark-math: "npm:6.0.0"
     serve: "npm:14.2.5"
     sonner: "npm:2.0.5"
+    streamdown: "npm:^1.6.10"
     tailwind-merge: "npm:3.3.1"
     tailwindcss: "npm:4.1.4"
     token.js: "npm:token.js-fork@0.7.31"
@@ -4165,6 +4277,38 @@ __metadata:
     zod: "npm:^3.23.8"
     zod-to-json-schema: "npm:^3.24.1"
   checksum: 10c0/182b92b5e7c07da428fd23c6de22021c4f9a91f799c02a8ef15def07e4f9361d0fc22303548658fec2a700623535fd44a9dc4d010fb5d803a8f80e3c6c64a45e
+  languageName: node
+  linkType: hard
+
+"@modelcontextprotocol/sdk@npm:^1.24.3":
+  version: 1.25.0
+  resolution: "@modelcontextprotocol/sdk@npm:1.25.0"
+  dependencies:
+    "@hono/node-server": "npm:^1.19.7"
+    ajv: "npm:^8.17.1"
+    ajv-formats: "npm:^3.0.1"
+    content-type: "npm:^1.0.5"
+    cors: "npm:^2.8.5"
+    cross-spawn: "npm:^7.0.5"
+    eventsource: "npm:^3.0.2"
+    eventsource-parser: "npm:^3.0.0"
+    express: "npm:^5.0.1"
+    express-rate-limit: "npm:^7.5.0"
+    jose: "npm:^6.1.1"
+    json-schema-typed: "npm:^8.0.2"
+    pkce-challenge: "npm:^5.0.0"
+    raw-body: "npm:^3.0.0"
+    zod: "npm:^3.25 || ^4.0"
+    zod-to-json-schema: "npm:^3.25.0"
+  peerDependencies:
+    "@cfworker/json-schema": ^4.1.1
+    zod: ^3.25 || ^4.0
+  peerDependenciesMeta:
+    "@cfworker/json-schema":
+      optional: true
+    zod:
+      optional: false
+  checksum: 10c0/70c6b1654464957af3cd3b3ec71a526e8dcd114d609c5a987673c0844d27fd439be6fbbcfe6d16f22d6c4e1fe5354937ba9549d7fe05f80fcabcdae20c252b46
   languageName: node
   linkType: hard
 
@@ -4602,25 +4746,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-arrow@npm:1.1.4":
-  version: 1.1.4
-  resolution: "@radix-ui/react-arrow@npm:1.1.4"
-  dependencies:
-    "@radix-ui/react-primitive": "npm:2.1.0"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/ce93c35e6c85661d9ba90d235164dcbe9a1bd477dd9096763526c71348378d959f3642a017eb32fb4e72952043fddd8e100b17c67d5552250d60c8fc11551323
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-arrow@npm:1.1.7":
   version: 1.1.7
   resolution: "@radix-ui/react-arrow@npm:1.1.7"
@@ -4912,29 +5037,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-dismissable-layer@npm:1.1.7":
-  version: 1.1.7
-  resolution: "@radix-ui/react-dismissable-layer@npm:1.1.7"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.2"
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-primitive": "npm:2.1.0"
-    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
-    "@radix-ui/react-use-escape-keydown": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/bb93b821ab1e24da86f4a4e74e251d9bc53c021a8a2cb4be5273af6cfe94fcd95807058a789b74bd5ca256bcb8be6dfaec3a0768f8323009dd2b2a9161964d7a
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-dropdown-menu@npm:2.1.16, @radix-ui/react-dropdown-menu@npm:^2.1.16":
   version: 2.1.16
   resolution: "@radix-ui/react-dropdown-menu@npm:2.1.16"
@@ -5197,34 +5299,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-popper@npm:1.2.4":
-  version: 1.2.4
-  resolution: "@radix-ui/react-popper@npm:1.2.4"
-  dependencies:
-    "@floating-ui/react-dom": "npm:^2.0.0"
-    "@radix-ui/react-arrow": "npm:1.1.4"
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-primitive": "npm:2.1.0"
-    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
-    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
-    "@radix-ui/react-use-rect": "npm:1.1.1"
-    "@radix-ui/react-use-size": "npm:1.1.1"
-    "@radix-ui/rect": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/3c0b1dac6f3e25700604424c11f0e3a29aacb430f4cf5ed78ea3acb059481c7dc6907fbb9538f068415583c03b2ba7ebb2a270e5dfd156421e4112b42ae70168
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-popper@npm:1.2.7":
   version: 1.2.7
   resolution: "@radix-ui/react-popper@npm:1.2.7"
@@ -5278,26 +5352,6 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10c0/48e3f13eac3b8c13aca8ded37d74db17e1bb294da8d69f142ab6b8719a06c3f90051668bed64520bf9f3abdd77b382ce7ce209d056bb56137cecc949b69b421c
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-portal@npm:1.1.6":
-  version: 1.1.6
-  resolution: "@radix-ui/react-portal@npm:1.1.6"
-  dependencies:
-    "@radix-ui/react-primitive": "npm:2.1.0"
-    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/46bc998794848289665fc5a31c14827a56406bc5ad104fc1ba829cc52506b38989301fe5405e3960d4ac504f5176549cf5ef42e80a5e3844ce53148b4f86f31b
   languageName: node
   linkType: hard
 
@@ -5675,36 +5729,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@radix-ui/react-tooltip@npm:1.2.4":
-  version: 1.2.4
-  resolution: "@radix-ui/react-tooltip@npm:1.2.4"
-  dependencies:
-    "@radix-ui/primitive": "npm:1.1.2"
-    "@radix-ui/react-compose-refs": "npm:1.1.2"
-    "@radix-ui/react-context": "npm:1.1.2"
-    "@radix-ui/react-dismissable-layer": "npm:1.1.7"
-    "@radix-ui/react-id": "npm:1.1.1"
-    "@radix-ui/react-popper": "npm:1.2.4"
-    "@radix-ui/react-portal": "npm:1.1.6"
-    "@radix-ui/react-presence": "npm:1.1.4"
-    "@radix-ui/react-primitive": "npm:2.1.0"
-    "@radix-ui/react-slot": "npm:1.2.0"
-    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
-    "@radix-ui/react-visually-hidden": "npm:1.2.0"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/da07e538f26a309edac954bf6bd04835209e96ec79c6812cebd656f94513b4b6667501a610aeb85f3858310be2d6c4acb3a279857bafd2578be36f30962ebee6
-  languageName: node
-  linkType: hard
-
 "@radix-ui/react-tooltip@npm:^1.2.8":
   version: 1.2.8
   resolution: "@radix-ui/react-tooltip@npm:1.2.8"
@@ -5862,25 +5886,6 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10c0/851d09a816f44282e0e9e2147b1b571410174cc048703a50c4fa54d672de994fd1dfff1da9d480ecfd12c77ae8f48d74f01adaf668f074156b8cd0043c6c21d8
-  languageName: node
-  linkType: hard
-
-"@radix-ui/react-visually-hidden@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@radix-ui/react-visually-hidden@npm:1.2.0"
-  dependencies:
-    "@radix-ui/react-primitive": "npm:2.1.0"
-  peerDependencies:
-    "@types/react": "*"
-    "@types/react-dom": "*"
-    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/58d9dc7b39078b3da609e51d0cb0f5fa80b547ba94f8794d20616e34d5c1724b8908d6cc253797f78983eed7e29d04a092e4810161658c0d890389743cdd34c1
   languageName: node
   linkType: hard
 
@@ -6517,6 +6522,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@shikijs/core@npm:3.20.0":
+  version: 3.20.0
+  resolution: "@shikijs/core@npm:3.20.0"
+  dependencies:
+    "@shikijs/types": "npm:3.20.0"
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+    "@types/hast": "npm:^3.0.4"
+    hast-util-to-html: "npm:^9.0.5"
+  checksum: 10c0/3df490754e631bf71723aec921de623d0e464c868bccafda89cdb1f061b968ee56385f5709d7401213773dc0c36d9650db436492bd2fa13eac4cf50255f12d26
+  languageName: node
+  linkType: hard
+
 "@shikijs/engine-javascript@npm:3.19.0":
   version: 3.19.0
   resolution: "@shikijs/engine-javascript@npm:3.19.0"
@@ -6525,6 +6542,17 @@ __metadata:
     "@shikijs/vscode-textmate": "npm:^10.0.2"
     oniguruma-to-es: "npm:^4.3.4"
   checksum: 10c0/f468b49ecea35a82178e2667e6ee97429a100b659fbefbfa22e0407ba088a6c698535964a4bc16770e3a8043a4b42b9e2fc17ef3590373b06a2429308b92adcb
+  languageName: node
+  linkType: hard
+
+"@shikijs/engine-javascript@npm:3.20.0":
+  version: 3.20.0
+  resolution: "@shikijs/engine-javascript@npm:3.20.0"
+  dependencies:
+    "@shikijs/types": "npm:3.20.0"
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+    oniguruma-to-es: "npm:^4.3.4"
+  checksum: 10c0/52ee46eba86bd0e4f5ca9520736a17e5a052830685edb319d77a2929ca30bcd176353212b9978d680109fd93d7e13c9ad5b039b69223d817a6331fc9f88389f2
   languageName: node
   linkType: hard
 
@@ -6538,12 +6566,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@shikijs/engine-oniguruma@npm:3.20.0":
+  version: 3.20.0
+  resolution: "@shikijs/engine-oniguruma@npm:3.20.0"
+  dependencies:
+    "@shikijs/types": "npm:3.20.0"
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+  checksum: 10c0/4a5a8f316a8482e799cd836c8e3f8ba83274b3631b2d66ec82ad839b0ee1dd3df50a08480f791d59f22e42bf6b707032f043a9f651445efc04e59b7ec9e669c9
+  languageName: node
+  linkType: hard
+
 "@shikijs/langs@npm:3.19.0":
   version: 3.19.0
   resolution: "@shikijs/langs@npm:3.19.0"
   dependencies:
     "@shikijs/types": "npm:3.19.0"
   checksum: 10c0/a7e69ed7c1cea2ccf412a149bd9c4327b6d9314b03271f9782b1703d61949e9787a05d1265f8590c8aa3641657709661c719d105100e70b35a6490c443ceac19
+  languageName: node
+  linkType: hard
+
+"@shikijs/langs@npm:3.20.0":
+  version: 3.20.0
+  resolution: "@shikijs/langs@npm:3.20.0"
+  dependencies:
+    "@shikijs/types": "npm:3.20.0"
+  checksum: 10c0/6830460025d0df4c527ffeacf0a78cd4331ffde1cfcd1e8028aa9814be8a4cea84367dd938528a9b55de72b163c58ad3576915ea08c3d0a29ef1dc80e120116c
   languageName: node
   linkType: hard
 
@@ -6556,6 +6603,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@shikijs/themes@npm:3.20.0":
+  version: 3.20.0
+  resolution: "@shikijs/themes@npm:3.20.0"
+  dependencies:
+    "@shikijs/types": "npm:3.20.0"
+  checksum: 10c0/d6fc059c51c3c0694e026cc1f80eed927d9b91adaeda0fb3fd5725eabc6d066aaf022919def435245446ae91e3da541ed6d88d875cf59a35bfbabb6920efb6da
+  languageName: node
+  linkType: hard
+
 "@shikijs/types@npm:3.19.0":
   version: 3.19.0
   resolution: "@shikijs/types@npm:3.19.0"
@@ -6563,6 +6619,16 @@ __metadata:
     "@shikijs/vscode-textmate": "npm:^10.0.2"
     "@types/hast": "npm:^3.0.4"
   checksum: 10c0/fc6509e282c257e4b614d5da3e1e99c7d2e6d4fef6ade3afa668b30dee6763035ad98fadace14f97021cdb371a70eed5ae46cde87f7794fe95e098d6d8a46a3f
+  languageName: node
+  linkType: hard
+
+"@shikijs/types@npm:3.20.0":
+  version: 3.20.0
+  resolution: "@shikijs/types@npm:3.20.0"
+  dependencies:
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+    "@types/hast": "npm:^3.0.4"
+  checksum: 10c0/7faea130362a6cdf3d66fcb47d6b609a8e0209e76ba86688f56a65411b6ae400a37414cd1a3a2fe1ee3fe39f18e274585d3972129c7e79244aaa0c15bc8f1c21
   languageName: node
   linkType: hard
 
@@ -10137,17 +10203,31 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ai@npm:^5.0.109":
-  version: 5.0.110
-  resolution: "ai@npm:5.0.110"
+"ai@npm:^5.0.108":
+  version: 5.0.113
+  resolution: "ai@npm:5.0.113"
   dependencies:
-    "@ai-sdk/gateway": "npm:2.0.19"
+    "@ai-sdk/gateway": "npm:2.0.21"
     "@ai-sdk/provider": "npm:2.0.0"
-    "@ai-sdk/provider-utils": "npm:3.0.18"
+    "@ai-sdk/provider-utils": "npm:3.0.19"
     "@opentelemetry/api": "npm:1.9.0"
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/7fca58424ea2dc577fd7b35a971a31c4247104b17646db4d26b7ba09b271b22e3e7096183240536158f8297428eb937af98e36a78af5539d0a2e1243b98617ee
+  checksum: 10c0/07c4b89f919322cccb636c0689c77fc90d9791b91acf4094b908b82fbd60b886daac86ad761cc354727bc06ca710b0f89e4526e261344216566f559d5d87d7bc
+  languageName: node
+  linkType: hard
+
+"ajv-formats@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "ajv-formats@npm:3.0.1"
+  dependencies:
+    ajv: "npm:^8.0.0"
+  peerDependencies:
+    ajv: ^8.0.0
+  peerDependenciesMeta:
+    ajv:
+      optional: true
+  checksum: 10c0/168d6bca1ea9f163b41c8147bae537e67bd963357a5488a1eaf3abe8baa8eec806d4e45f15b10767e6020679315c7e1e5e6803088dfb84efa2b4e9353b83dd0a
   languageName: node
   linkType: hard
 
@@ -10175,7 +10255,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ajv@npm:^8.6.0":
+"ajv@npm:^8.0.0, ajv@npm:^8.17.1, ajv@npm:^8.6.0":
   version: 8.17.1
   resolution: "ajv@npm:8.17.1"
   dependencies:
@@ -10266,63 +10346,6 @@ __metadata:
   checksum: 10c0/57b06ae984bc32a0d22592c87384cd88fe4511b1dd7581497831c56d41939c8a001b28e7b853e1450f2bf61992dfcaa8ae2d0d161a0a90c4fb631ef07098fbac
   languageName: node
   linkType: hard
-
-"app@workspace:app":
-  version: 0.0.0-use.local
-  resolution: "app@workspace:app"
-  dependencies:
-    "@ai-sdk/openai-compatible": "npm:^1.0.28"
-    "@ai-sdk/react": "npm:^2.0.109"
-    "@eslint/js": "npm:^9.39.1"
-    "@hookform/resolvers": "npm:^5.2.2"
-    "@radix-ui/react-avatar": "npm:^1.1.11"
-    "@radix-ui/react-collapsible": "npm:^1.1.12"
-    "@radix-ui/react-dialog": "npm:^1.1.15"
-    "@radix-ui/react-dropdown-menu": "npm:^2.1.16"
-    "@radix-ui/react-hover-card": "npm:^1.1.15"
-    "@radix-ui/react-label": "npm:^2.1.8"
-    "@radix-ui/react-popover": "npm:^1.1.15"
-    "@radix-ui/react-select": "npm:^2.2.6"
-    "@radix-ui/react-separator": "npm:^1.1.8"
-    "@radix-ui/react-slot": "npm:^1.2.4"
-    "@radix-ui/react-switch": "npm:^1.2.6"
-    "@radix-ui/react-tooltip": "npm:^1.2.8"
-    "@radix-ui/react-use-controllable-state": "npm:^1.2.2"
-    "@tailwindcss/vite": "npm:^4.1.17"
-    "@tanstack/react-router": "npm:^1.140.0"
-    "@tanstack/router-plugin": "npm:^1.140.0"
-    "@types/node": "npm:^24.10.1"
-    "@types/react": "npm:^19.2.5"
-    "@types/react-dom": "npm:^19.2.3"
-    "@vitejs/plugin-react": "npm:^5.1.1"
-    ai: "npm:^5.0.109"
-    class-variance-authority: "npm:^0.7.1"
-    clsx: "npm:^2.1.1"
-    cmdk: "npm:^1.1.1"
-    eslint: "npm:^9.39.1"
-    eslint-plugin-react-hooks: "npm:^7.0.1"
-    eslint-plugin-react-refresh: "npm:^0.4.24"
-    framer-motion: "npm:^12.23.25"
-    globals: "npm:^16.5.0"
-    lucide-react: "npm:^0.559.0"
-    motion: "npm:^12.23.26"
-    nanoid: "npm:^5.1.6"
-    react: "npm:^19.2.0"
-    react-dom: "npm:^19.2.0"
-    react-hook-form: "npm:^7.68.0"
-    streamdown: "npm:^1.6.10"
-    tailwind-merge: "npm:^3.4.0"
-    tailwindcss: "npm:^4.1.17"
-    tw-animate-css: "npm:^1.4.0"
-    typescript: "npm:~5.9.3"
-    typescript-eslint: "npm:^8.46.4"
-    use-stick-to-bottom: "npm:^1.1.1"
-    vaul: "npm:^1.1.2"
-    vite: "npm:rolldown-vite@7.2.5"
-    zod: "npm:^4.1.13"
-    zustand: "npm:^5.0.9"
-  languageName: unknown
-  linkType: soft
 
 "append-transform@npm:^1.0.0":
   version: 1.0.0
@@ -12477,6 +12500,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"deep-diff@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "deep-diff@npm:1.0.2"
+  checksum: 10c0/cc3e315ba95963eba4bbb79ed88d0a37d80ba19bd3b0039b79d2ad0e19e48b0e15c692b49bcd617bbe0dcc7358d40464c993889313dd8bf806bb25978b12375d
+  languageName: node
+  linkType: hard
+
 "deep-eql@npm:^5.0.1":
   version: 5.0.2
   resolution: "deep-eql@npm:5.0.2"
@@ -12498,7 +12528,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"deepmerge@npm:^4.2.2":
+"deepmerge@npm:^4.2.2, deepmerge@npm:^4.3.1":
   version: 4.3.1
   resolution: "deepmerge@npm:4.3.1"
   checksum: 10c0/e53481aaf1aa2c4082b5342be6b6d8ad9dfe387bc92ce197a66dea08bd4265904a087e75e464f14d1347cf2ac8afe1e4c16b266e0561cc5df29382d3c5f80044
@@ -14208,28 +14238,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"framer-motion@npm:^12.18.1":
-  version: 12.18.1
-  resolution: "framer-motion@npm:12.18.1"
-  dependencies:
-    motion-dom: "npm:^12.18.1"
-    motion-utils: "npm:^12.18.1"
-    tslib: "npm:^2.4.0"
-  peerDependencies:
-    "@emotion/is-prop-valid": "*"
-    react: ^18.0.0 || ^19.0.0
-    react-dom: ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@emotion/is-prop-valid":
-      optional: true
-    react:
-      optional: true
-    react-dom:
-      optional: true
-  checksum: 10c0/13aa6030fb619a482cb7d3fdb375a2ced54adcc11d23abf7e42b9dc8a40bc47d32fb3492dbb450e75c465c8469da72db21376719316d945829700f663af18c20
-  languageName: node
-  linkType: hard
-
 "framer-motion@npm:^12.23.25":
   version: 12.23.25
   resolution: "framer-motion@npm:12.23.25"
@@ -15868,6 +15876,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-lite@npm:^0.8.2":
+  version: 0.8.2
+  resolution: "is-lite@npm:0.8.2"
+  checksum: 10c0/ed4b99d47ff12d0bf9730994cec8bcdee20bf46d68810f55e9e041797c76da664ab6d48a9ed2e7fb3aa52843a48ac4a083561a2235311a046551542504d995fd
+  languageName: node
+  linkType: hard
+
+"is-lite@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "is-lite@npm:1.2.1"
+  checksum: 10c0/53acb0f6329f0aba96fef4d883d42f3d9aabf2c42baba45821407d14b1782b9c6bea42c3eef72b37788be1acc95d6cf2df8a6b8424cb9f6eb12c08d5a7d81288
+  languageName: node
+  linkType: hard
+
 "is-map@npm:^2.0.3":
   version: 2.0.3
   resolution: "is-map@npm:2.0.3"
@@ -16398,6 +16420,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jose@npm:^6.1.1":
+  version: 6.1.3
+  resolution: "jose@npm:6.1.3"
+  checksum: 10c0/b9577b4a7a5e84131011c23823db9f5951eae3ba796771a6a2401ae5dd50daf71104febc8ded9c38146aa5ebe94a92ac09c725e699e613ef26949b9f5a8bc30f
+  languageName: node
+  linkType: hard
+
 "js-base64@npm:3.7.2":
   version: 3.7.2
   resolution: "js-base64@npm:3.7.2"
@@ -16541,6 +16570,13 @@ __metadata:
   version: 1.0.0
   resolution: "json-schema-traverse@npm:1.0.0"
   checksum: 10c0/71e30015d7f3d6dc1c316d6298047c8ef98a06d31ad064919976583eb61e1018a60a0067338f0f79cabc00d84af3fcc489bd48ce8a46ea165d9541ba17fb30c6
+  languageName: node
+  linkType: hard
+
+"json-schema-typed@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "json-schema-typed@npm:8.0.2"
+  checksum: 10c0/89f5e2fb1495483b705c027203c07277ee6bf2665165ad25a9cb55de5af7f72570326d13d32565180781e4083ad5c9688102f222baed7b353c2f39c1e02b0428
   languageName: node
   linkType: hard
 
@@ -17125,15 +17161,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lucide-react@npm:0.536.0":
-  version: 0.536.0
-  resolution: "lucide-react@npm:0.536.0"
-  peerDependencies:
-    react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10c0/643d6960630c5e8678c8140ccb60710b019a385c847f4ad089b2598ae3321f80ddc7f73c2b3a648576674c3e475a6effa2fc58665da9c07e568a010e677cab42
-  languageName: node
-  linkType: hard
-
 "lucide-react@npm:^0.542.0":
   version: 0.542.0
   resolution: "lucide-react@npm:0.542.0"
@@ -17143,12 +17170,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lucide-react@npm:^0.559.0":
-  version: 0.559.0
-  resolution: "lucide-react@npm:0.559.0"
+"lucide-react@npm:^0.556.0":
+  version: 0.556.0
+  resolution: "lucide-react@npm:0.556.0"
   peerDependencies:
     react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
-  checksum: 10c0/0fcab0197949cda2873770c29a8374ca237133555b9ae8cb3987892681b10511728f2ee558eeb09a05cfbe9bef824e2382be7c7d68facacb243e082ad2d6643d
+  checksum: 10c0/5c73bd317b2cd7d220082d1cc6f78c864819652be87a84c976f2b08aae0bf257b0f066f86f5d84c2cb838ba8fbd2fb1d2b9d84fbe025d9c6cb97dbf1cdbf6bbc
+  languageName: node
+  linkType: hard
+
+"lucide-react@npm:^0.560.0":
+  version: 0.560.0
+  resolution: "lucide-react@npm:0.560.0"
+  peerDependencies:
+    react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10c0/1dc1fb09a91816ed4211a6f000903c18763ebf8c1cede0aac00433f068e50e548e9c36e56e99fec68f40df4c808ff7ae0f5c375a9c8d312e2bace6157128136e
   languageName: node
   linkType: hard
 
@@ -18392,15 +18428,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"motion-dom@npm:^12.18.1":
-  version: 12.18.1
-  resolution: "motion-dom@npm:12.18.1"
-  dependencies:
-    motion-utils: "npm:^12.18.1"
-  checksum: 10c0/33914f174fc8ff27e65b579d70cb6ae2af320eb3f85d12a29c05fe046dd5966844844fbac59b9e7e98f8a325e7529666173fca7fe5e4a3aff59b9bd1eb1b3266
-  languageName: node
-  linkType: hard
-
 "motion-dom@npm:^12.23.12":
   version: 12.23.12
   resolution: "motion-dom@npm:12.23.12"
@@ -18419,13 +18446,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"motion-utils@npm:^12.18.1":
-  version: 12.18.1
-  resolution: "motion-utils@npm:12.18.1"
-  checksum: 10c0/703702d9a82db223f4b0e0437e7c00b9e3f347bf7bffb20b0b7ad171d937db823b2420dbd8bf0764def885ba6c8aac659cc3595bcd8ecd56b5e63a990a1fae07
-  languageName: node
-  linkType: hard
-
 "motion-utils@npm:^12.23.6":
   version: 12.23.6
   resolution: "motion-utils@npm:12.23.6"
@@ -18433,28 +18453,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"motion@npm:12.18.1":
-  version: 12.18.1
-  resolution: "motion@npm:12.18.1"
-  dependencies:
-    framer-motion: "npm:^12.18.1"
-    tslib: "npm:^2.4.0"
-  peerDependencies:
-    "@emotion/is-prop-valid": "*"
-    react: ^18.0.0 || ^19.0.0
-    react-dom: ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@emotion/is-prop-valid":
-      optional: true
-    react:
-      optional: true
-    react-dom:
-      optional: true
-  checksum: 10c0/f90c533af3c7636ac28b819ea192b971650e672033808942eacc0bf2a7ba5e802d164763948f71faf374e07de6a069e902fe7f3cec1bc3f66064c516c3385e7b
-  languageName: node
-  linkType: hard
-
-"motion@npm:^12.23.26":
+"motion@npm:^12.23.25, motion@npm:^12.23.26":
   version: 12.23.26
   resolution: "motion@npm:12.23.26"
   dependencies:
@@ -19556,6 +19555,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"popper.js@npm:^1.16.0":
+  version: 1.16.1
+  resolution: "popper.js@npm:1.16.1"
+  checksum: 10c0/1c1a826f757edb5b8c2049dfd7a9febf6ae1e9d0e51342fc715b49a0c1020fced250d26484619883651e097c5764bbcacd2f31496e3646027f079dd83e072681
+  languageName: node
+  linkType: hard
+
 "posix-character-classes@npm:^0.1.0":
   version: 0.1.1
   resolution: "posix-character-classes@npm:0.1.1"
@@ -19757,7 +19763,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.7.2":
+"prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -19979,6 +19985,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-floater@npm:^0.7.9":
+  version: 0.7.9
+  resolution: "react-floater@npm:0.7.9"
+  dependencies:
+    deepmerge: "npm:^4.3.1"
+    is-lite: "npm:^0.8.2"
+    popper.js: "npm:^1.16.0"
+    prop-types: "npm:^15.8.1"
+    tree-changes: "npm:^0.9.1"
+  peerDependencies:
+    react: 15 - 18
+    react-dom: 15 - 18
+  checksum: 10c0/3fa58e968a405fb95a004897ed19c87b4991e52ebd45d837b8577eb9175ddc1dfab223bb653a0fa73ffc22fc2b2a30f2d07e924f41f41a040299793e4d2decd4
+  languageName: node
+  linkType: hard
+
 "react-hook-form@npm:^7.68.0":
   version: 7.68.0
   resolution: "react-hook-form@npm:7.68.0"
@@ -20009,6 +20031,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-innertext@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "react-innertext@npm:1.1.5"
+  peerDependencies:
+    "@types/react": ">=0.0.0 <=99"
+    react: ">=0.0.0 <=99"
+  checksum: 10c0/45335918ac83334133a9fa0df4ce109e0d4a45d54b783a8eaec88811b36dd5c3bbb5d9a6af2da1eed518a6f325a6ffae4be7bd30878596e0ec1760b231a8e0ee
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^16.13.1":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
@@ -20020,6 +20052,28 @@ __metadata:
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 10c0/2bdb6b93fbb1820b024b496042cce405c57e2f85e777c9aabd55f9b26d145408f9f74f5934676ffdc46f3dcff656d78413a6e43968e7b3f92eea35b3052e9053
+  languageName: node
+  linkType: hard
+
+"react-joyride@npm:2.9.3":
+  version: 2.9.3
+  resolution: "react-joyride@npm:2.9.3"
+  dependencies:
+    "@gilbarbara/deep-equal": "npm:^0.3.1"
+    deep-diff: "npm:^1.0.2"
+    deepmerge: "npm:^4.3.1"
+    is-lite: "npm:^1.2.1"
+    react-floater: "npm:^0.7.9"
+    react-innertext: "npm:^1.1.5"
+    react-is: "npm:^16.13.1"
+    scroll: "npm:^3.0.1"
+    scrollparent: "npm:^2.1.0"
+    tree-changes: "npm:^0.11.2"
+    type-fest: "npm:^4.27.0"
+  peerDependencies:
+    react: 15 - 18
+    react-dom: 15 - 18
+  checksum: 10c0/8045ef1cc14e1d48aebf46f9ecff43c1aecb6eacf3310f533844c5bf7b4d6390cdbed5f43424bb4d19c6a3351ca8d150d0a0e0c5c5e99138b70d52830276d554
   languageName: node
   linkType: hard
 
@@ -21319,6 +21373,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"scroll@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "scroll@npm:3.0.1"
+  checksum: 10c0/5b0c98089be0edb43444c7604a4866a0a4c457ac6c3c559b23b9c19e48bb9f977a5876bfeba8e567740b70c05dab75a01cef1a935faf47fdb6a505b538b413ed
+  languageName: node
+  linkType: hard
+
+"scrollparent@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "scrollparent@npm:2.1.0"
+  checksum: 10c0/b377ec5a461f6ed8021f0c3c6b0c76317341c33838f047e91387cdfe0ba4c28aa2a3855240458f9bcf1e18e6c8718540075eb1215fc094496300114f295b2e6b
+  languageName: node
+  linkType: hard
+
 "semver@npm:^5.6.0":
   version: 5.7.2
   resolution: "semver@npm:5.7.2"
@@ -21566,6 +21634,22 @@ __metadata:
     "@shikijs/vscode-textmate": "npm:^10.0.2"
     "@types/hast": "npm:^3.0.4"
   checksum: 10c0/ecba45e17ae19fab868435e3ce1f3e1d5d37e77ce41910c1e33454a97377f13c93cf92dfb91d9e9d9a713217a66ac433827bb933b38146de0d683be2f2f890e2
+  languageName: node
+  linkType: hard
+
+"shiki@npm:^3.19.0":
+  version: 3.20.0
+  resolution: "shiki@npm:3.20.0"
+  dependencies:
+    "@shikijs/core": "npm:3.20.0"
+    "@shikijs/engine-javascript": "npm:3.20.0"
+    "@shikijs/engine-oniguruma": "npm:3.20.0"
+    "@shikijs/langs": "npm:3.20.0"
+    "@shikijs/themes": "npm:3.20.0"
+    "@shikijs/types": "npm:3.20.0"
+    "@shikijs/vscode-textmate": "npm:^10.0.2"
+    "@types/hast": "npm:^3.0.4"
+  checksum: 10c0/e7f0a8e6b8748b1d25cccc186e5cd32cbc8b272c08b4b554a3328c95714ee564d5525747d5ceb52c1ee766ec25cb7a5fa1de748edeb6508a57be15433de1564f
   languageName: node
   linkType: hard
 
@@ -22736,6 +22820,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tree-changes@npm:^0.11.2":
+  version: 0.11.3
+  resolution: "tree-changes@npm:0.11.3"
+  dependencies:
+    "@gilbarbara/deep-equal": "npm:^0.3.1"
+    is-lite: "npm:^1.2.1"
+  checksum: 10c0/4479a54fb1589a0963a29e17959a6d13c5f60f962032bf23e84111b34d367d0abb56c6c17c5511a95aade7274b25eacccb651d1d88c6606151e6fdcd2e185feb
+  languageName: node
+  linkType: hard
+
+"tree-changes@npm:^0.9.1":
+  version: 0.9.3
+  resolution: "tree-changes@npm:0.9.3"
+  dependencies:
+    "@gilbarbara/deep-equal": "npm:^0.1.1"
+    is-lite: "npm:^0.8.2"
+  checksum: 10c0/e7a38ed3c22ed1195a78e800a8f08a01d44cd8f4abac421b2be6ae34f991dfbd60ce4235be4e002882f3debef95b8e0f7e027b3b758325e9b4bda905c34d3d8f
+  languageName: node
+  linkType: hard
+
 "treeverse@npm:^3.0.0":
   version: 3.0.0
   resolution: "treeverse@npm:3.0.0"
@@ -22889,6 +22993,13 @@ __metadata:
   version: 2.19.0
   resolution: "type-fest@npm:2.19.0"
   checksum: 10c0/a5a7ecf2e654251613218c215c7493574594951c08e52ab9881c9df6a6da0aeca7528c213c622bc374b4e0cb5c443aa3ab758da4e3c959783ce884c3194e12cb
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^4.27.0":
+  version: 4.41.0
+  resolution: "type-fest@npm:4.41.0"
+  checksum: 10c0/f5ca697797ed5e88d33ac8f1fec21921839871f808dc59345c9cf67345bfb958ce41bd821165dbf3ae591cedec2bf6fe8882098dfdd8dc54320b859711a2c1e4
   languageName: node
   linkType: hard
 
@@ -24614,6 +24725,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"zod-to-json-schema@npm:^3.25.0":
+  version: 3.25.0
+  resolution: "zod-to-json-schema@npm:3.25.0"
+  peerDependencies:
+    zod: ^3.25 || ^4
+  checksum: 10c0/2d2cf6ca49752bf3dc5fb37bc8f275eddbbc4020e7958d9c198ea88cd197a5f527459118188a0081b889da6a6474d64c4134cd60951fa70178c125138761c680
+  languageName: node
+  linkType: hard
+
 "zod-validation-error@npm:^3.5.0 || ^4.0.0":
   version: 4.0.2
   resolution: "zod-validation-error@npm:4.0.2"
@@ -24623,7 +24743,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zod@npm:^3.23.8":
+"zod@npm:^3.23.8, zod@npm:^3.24.1":
   version: 3.25.76
   resolution: "zod@npm:3.25.76"
   checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
@@ -24634,6 +24754,13 @@ __metadata:
   version: 3.24.3
   resolution: "zod@npm:3.24.3"
   checksum: 10c0/ab0369810968d0329a1a141e9418e01e5c9c2a4905cbb7cb7f5a131d6e9487596e1400e21eeff24c4a8ee28dacfa5bd6103893765c055b7a98c2006a5a4fc68d
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.25 || ^4.0":
+  version: 4.2.1
+  resolution: "zod@npm:4.2.1"
+  checksum: 10c0/ecb5219bddf76a42d092a843fb98ad4cb78f1e1077082772b03ef032ee5cbc80790a4051836b962d26fb4af854323bc784d628bd1b8d9898149eba7af21c5560
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Instruct Model Backup - Client Migration Guide

> **Feature**: When a model supports instruct backup, clients can pass `enable_thinking=false` in `/chat/completions` to use a faster, cheaper instruct model instead of the main reasoning model.

---

## 📋 Overview

### What Changed

The backend now supports an optional `enable_thinking` parameter in chat completion requests. When set to `false`, the request will be routed to a pre-configured instruct model instead of the main thinking/reasoning model.

### Use Cases

1. **Cost Optimization**: Use cheaper instruct models for simple queries
2. **Speed**: Faster responses when deep reasoning isn't needed
3. **User Preference**: Let users toggle between thinking and instruct modes

---

## 🔌 API Changes

### New Request Parameter

| Field | Type | Default | Description |
|-------|------|---------|-------------|
| `enable_thinking` | `boolean` | `true` | When `false`, uses the configured instruct model backup |

### Request Example

```json
POST /v1/chat/completions
Content-Type: application/json
Authorization: Bearer <token>

{
  "model": "jan/jan-v2-30",
  "enable_thinking": false,
  "messages": [
    {"role": "user", "content": "What is 2+2?"}
  ]
}
```

### Behavior Matrix

| `enable_thinking` | Instruct Model Configured | Model Used |
|-------------------|---------------------------|------------|
| `true` (default)  | Yes                       | Main model (reasoning) |
| `true` (default)  | No                        | Main model |
| `false`           | Yes                       | **Instruct model** |
| `false`           | No                        | Main model (fallback) |

---

## 🖥️ Client Implementation

### TypeScript/JavaScript

```typescript
interface ChatCompletionRequest {
  model: string;
  messages: ChatMessage[];
  stream?: boolean;
  temperature?: number;
  max_tokens?: number;
  // NEW: Toggle thinking mode
  enable_thinking?: boolean;
}

// Example: Use instruct model for simple queries
async function chatCompletion(messages: ChatMessage[], useThinking: boolean = true) {
  const response = await fetch('/v1/chat/completions', {
    method: 'POST',
    headers: {
      'Content-Type': 'application/json',
      'Authorization': `Bearer ${token}`,
    },
    body: JSON.stringify({
      model: 'jan/jan-v2-30',
      messages,
      enable_thinking: useThinking,
    }),
  });
  return response.json();
}

// Quick mode (instruct)
await chatCompletion([{ role: 'user', content: 'Hello' }], false);

// Deep thinking mode (default)
await chatCompletion([{ role: 'user', content: 'Explain quantum physics' }], true);
```


---

## 📝 Changelog

### v1.x.x (Current Release)

- Added `enable_thinking` parameter to `/v1/chat/completions`
- Added `supports_instruct` capability flag on model catalogs
- Added `instruct_model_id` configuration on provider models
- Admin UI: Added "Instruct Model Backup" dropdown in provider model edit
- Admin UI: Added "Supports Instruct Backup" checkbox in catalog edit
