### PR TITLE
fix: reasoning enabled for no-instruct support models

### DIFF
--- a/app/src/components/chat-input/setting-chat-input.tsx
+++ b/app/src/components/chat-input/setting-chat-input.tsx
@@ -128,7 +128,7 @@ export const SettingChatInput = ({
                   </div>
                   <Switch
                     disabled={!isSupportReasoningToggle}
-                    checked={deepResearchEnabled ? true :reasoningEnabled}
+                    checked={(!isSupportReasoningToggle || deepResearchEnabled) ? true :reasoningEnabled}
                     onCheckedChange={toggleInstruct}
                   />
                 </div>


### PR DESCRIPTION
## Describe Your Changes

- For non instruct model mapped models, should just enable think by default (UI)

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
