### PR TITLE
chore: temporary disable regenerate action

### DIFF
--- a/app/src/components/threads/thread-page-content.tsx
+++ b/app/src/components/threads/thread-page-content.tsx
@@ -33,7 +33,7 @@ import {
   ToolInput,
   ToolOutput,
 } from '@/components/ai-elements/tool'
-import { RefreshCcwIcon, CopyIcon, Loader, CheckIcon } from 'lucide-react'
+import { CopyIcon, Loader, CheckIcon } from 'lucide-react'
 import { lastAssistantMessageIsCompleteWithToolCalls } from 'ai'
 import { useModels } from '@/stores/models-store'
 import { useEffect, useRef, useState } from 'react'
@@ -78,7 +78,7 @@ export function ThreadPageContent({
     messages,
     status,
     sendMessage,
-    regenerate,
+    // regenerate,
     setMessages,
     addToolOutput,
     stop,
@@ -271,12 +271,12 @@ export function ThreadPageContent({
                                         <CopyIcon className="text-muted-foreground size-3" />
                                       )}
                                     </MessageAction>
-                                    <MessageAction
+                                    {/* <MessageAction
                                       onClick={() => regenerate()}
                                       label="Retry"
                                     >
                                       <RefreshCcwIcon className="text-muted-foreground size-3" />
-                                    </MessageAction>
+                                    </MessageAction> */}
                                     {/* Temporary hide till we have function */}
                                     {/* <MessageAction label="Like">
                                       <ThumbsUpIcon className="text-muted-foreground size-3" />


### PR DESCRIPTION
## Describe Your Changes

This pull request makes minor UI changes to the `ThreadPageContent` component, primarily removing the "Retry" message action and cleaning up unused imports.

- **UI Cleanup:**
  * The "Retry" (`regenerate`) message action and its associated icon (`RefreshCcwIcon`) have been commented out or removed from the UI, temporarily hiding this functionality until further notice. [[1]](diffhunk://#diff-f6d6101ceec942c677309a49c57ab9a59f51ed8d034111c3b9ac772db8c36a33L81-R81) [[2]](diffhunk://#diff-f6d6101ceec942c677309a49c57ab9a59f51ed8d034111c3b9ac772db8c36a33L274-R279)

- **Code Cleanup:**
  * The unused `RefreshCcwIcon` import has been removed from the component.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
