### PR TITLE
Add VITE_GA_ID env on prod deployment

### DIFF
--- a/.github/workflows/jan-server-web-newui-ci-prod.yml
+++ b/.github/workflows/jan-server-web-newui-ci-prod.yml
@@ -16,6 +16,7 @@ jobs:
       JAN_BASE_URL: "https://api.jan.ai/v1"
       JAN_API_BASE_URL: "https://api.jan.ai/"
       GA_MEASUREMENT_ID: "G-5HCJWQTZLD"
+      VITE_GA_ID: "G-5HCJWQTZLD"
       VITE_AUTH_URL: "https://auth.jan.ai"
       VITE_AUTH_REALM: "jan"
       VITE_AUTH_CLIENT_ID: "jan-client"
@@ -57,6 +58,7 @@ jobs:
           VITE_AUTH_REALM: ${{ env.VITE_AUTH_REALM }} 
           VITE_AUTH_CLIENT_ID: ${{ env.VITE_AUTH_CLIENT_ID }}
           VITE_OAUTH_REDIRECT_URI: ${{ env.VITE_OAUTH_REDIRECT_URI }}
+          VITE_GA_ID: ${{ env.VITE_GA_ID }}
 
       - name: Publish to Cloudflare Pages Production
         uses: cloudflare/pages-action@v1


### PR DESCRIPTION
## Describe Your Changes

This pull request adds support for the `VITE_GA_ID` environment variable in the production CI workflow for the Jan server web new UI. This ensures that the Google Analytics ID is available during the build and deployment process.

**CI/CD workflow improvements:**

* Added `VITE_GA_ID` with the correct Google Analytics ID to the environment variables in `.github/workflows/jan-server-web-newui-ci-prod.yml` to ensure it's available during CI builds.
* Updated the build step to pass `VITE_GA_ID` from the environment to the build context, so it is included in the deployed application.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
