### PR TITLE
chore: update new ga

### DIFF
--- a/.github/workflows/jan-server-web-newui-ci-prod.yml
+++ b/.github/workflows/jan-server-web-newui-ci-prod.yml
@@ -15,8 +15,8 @@ jobs:
     env:
       JAN_BASE_URL: "https://api.jan.ai/v1"
       JAN_API_BASE_URL: "https://api.jan.ai/"
-      GA_MEASUREMENT_ID: "G-5HCJWQTZLD"
-      VITE_GA_ID: "G-5HCJWQTZLD"
+      GA_MEASUREMENT_ID: "G-5HCJWQTZLD" # will be deprecated along with web-app folder
+      VITE_GA_ID: "G-BWGTGCT2MC"
       VITE_AUTH_URL: "https://auth.jan.ai"
       VITE_AUTH_REALM: "jan"
       VITE_AUTH_CLIENT_ID: "jan-client"


### PR DESCRIPTION
## Describe Your Changes

This pull request updates the Google Analytics tracking ID for the new UI build in the production CI workflow. The change ensures that the new UI uses the correct analytics property while clarifying the deprecation status of the old ID.

Configuration update:

* Updated the `VITE_GA_ID` environment variable in `.github/workflows/jan-server-web-newui-ci-prod.yml` to use the new Google Analytics ID (`G-BWGTGCT2MC`) for the new UI, and added a note indicating that the old `GA_MEASUREMENT_ID` will be deprecated along with the legacy `web-app` folder.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
