### PR TITLE
fix: main navigation should close sidebar

### DIFF
--- a/app/src/components/sidebar/nav-main.tsx
+++ b/app/src/components/sidebar/nav-main.tsx
@@ -6,6 +6,7 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  useSidebar,
 } from '@/components/ui/sidebar'
 import { Link, useRouter } from '@tanstack/react-router'
 
@@ -54,6 +55,8 @@ export function NavMain() {
     },
   ]
 
+  const { isMobile, setOpenMobile } = useSidebar()
+
   return (
     <SidebarMenu>
       {navMain.map((item) => (
@@ -61,7 +64,12 @@ export function NavMain() {
           <SidebarMenuButton
             asChild={!item.onClick}
             isActive={item.isActive}
-            onClick={item.onClick}
+            onClick={() => {
+              item.onClick?.()
+              if (isMobile) {
+                setOpenMobile(false)
+              }
+            }}
           >
             {item.onClick ? (
               <>


### PR DESCRIPTION
## Describe Your Changes

This pull request updates the `NavMain` sidebar navigation to improve its behavior on mobile devices. The main change is that when a navigation item is clicked on mobile, the sidebar will automatically close, providing a better user experience.

**Mobile sidebar improvements:**

* Imported the `useSidebar` hook into `nav-main.tsx` to access mobile state and sidebar controls.
* Updated the `onClick` handler for sidebar menu buttons: after executing any custom click logic, it now closes the sidebar if the user is on a mobile device by calling `setOpenMobile(false)`.

## Fixes Issues

- Closes # 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
