### PR TITLE
fix: hide browse on mobile only

### DIFF
--- a/app/src/components/chat-input/setting-chat-input.tsx
+++ b/app/src/components/chat-input/setting-chat-input.tsx
@@ -25,6 +25,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip'
 import { isExtensionAvailable } from '@janhq/mcp-web-client'
+import { useIsMobileDevice } from '@/hooks/use-is-mobile-device'
 
 type ToneOption = 'Friendly' | 'Concise' | 'Professional'
 
@@ -70,6 +71,8 @@ export const SettingChatInput = ({
   onToneChange,
   children,
 }: SettingChatInputProps) => {
+  const isMobileDevice = useIsMobileDevice()
+
   const toggleBrowserAttempt = async () => {
     const browserUseAvailable = await isExtensionAvailable(EXTENSION_ID)
     if ((browserUseAvailable && !browserEnabled) || browserEnabled) {
@@ -128,7 +131,11 @@ export const SettingChatInput = ({
                   </div>
                   <Switch
                     disabled={!isSupportReasoningToggle}
-                    checked={(!isSupportReasoningToggle || deepResearchEnabled) ? true :reasoningEnabled}
+                    checked={
+                      !isSupportReasoningToggle || deepResearchEnabled
+                        ? true
+                        : reasoningEnabled
+                    }
                     onCheckedChange={toggleInstruct}
                   />
                 </div>
@@ -141,24 +148,26 @@ export const SettingChatInput = ({
             </TooltipContent>
           )}
         </Tooltip>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div>
-              <DropDrawerItem onSelect={(e) => e.preventDefault()}>
-                <div className="flex gap-2 items-center justify-between w-full">
-                  <div className="flex gap-2 items-center w-full">
-                    <ChromiumIcon />
-                    <span>Browse</span>
+        {!isMobileDevice && (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <div>
+                <DropDrawerItem onSelect={(e) => e.preventDefault()}>
+                  <div className="flex gap-2 items-center justify-between w-full">
+                    <div className="flex gap-2 items-center w-full">
+                      <ChromiumIcon />
+                      <span>Browse</span>
+                    </div>
+                    <Switch
+                      checked={browserEnabled}
+                      onCheckedChange={toggleBrowserAttempt}
+                    />
                   </div>
-                  <Switch
-                    checked={browserEnabled}
-                    onCheckedChange={toggleBrowserAttempt}
-                  />
-                </div>
-              </DropDrawerItem>
-            </div>
-          </TooltipTrigger>
-        </Tooltip>
+                </DropDrawerItem>
+              </div>
+            </TooltipTrigger>
+          </Tooltip>
+        )}
         <Tooltip>
           <TooltipTrigger asChild>
             <div>

--- a/app/src/hooks/use-is-mobile-device.ts
+++ b/app/src/hooks/use-is-mobile-device.ts
@@ -1,0 +1,22 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import * as React from 'react'
+
+export function useIsMobileDevice() {
+  const [isMobileDevice, setIsMobileDevice] = React.useState<boolean>(false)
+
+  React.useEffect(() => {
+    const checkMobileDevice = () => {
+      const userAgent =
+        navigator.userAgent || navigator.vendor || (window as any).opera
+
+      // Check for mobile devices in user agent
+      const mobileRegex =
+        /android|webos|iphone|ipad|ipod|blackberry|iemobile|opera mini/i
+      return mobileRegex.test(userAgent.toLowerCase())
+    }
+
+    setIsMobileDevice(checkMobileDevice())
+  }, [])
+
+  return isMobileDevice
+}


### PR DESCRIPTION
## Describe Your Changes

This pull request adds mobile device detection to the chat input component and uses it to conditionally render certain UI elements. The main goal is to improve the user experience on mobile devices by hiding specific controls that are not suitable for smaller screens.

**Mobile device detection and conditional UI rendering:**

* Added a new hook, `useIsMobileDevice`, in `app/src/hooks/use-is-mobile-device.ts` to detect if the user is on a mobile device using the user agent string.
* Imported and used the `useIsMobileDevice` hook in `setting-chat-input.tsx` to determine device type. [[1]](diffhunk://#diff-5fb2bd329dff9a533f5a596910de88b35dca62a0fd0c7f93917c2914412fc8a4R28) [[2]](diffhunk://#diff-5fb2bd329dff9a533f5a596910de88b35dca62a0fd0c7f93917c2914412fc8a4R74-R75)
* Updated the chat input UI to conditionally render certain `Tooltip` elements only when not on a mobile device, improving mobile usability. [[1]](diffhunk://#diff-5fb2bd329dff9a533f5a596910de88b35dca62a0fd0c7f93917c2914412fc8a4R151) [[2]](diffhunk://#diff-5fb2bd329dff9a533f5a596910de88b35dca62a0fd0c7f93917c2914412fc8a4R170)

**Minor logic improvements:**

* Refactored the logic for the `checked` prop of the `Switch` component for better readability.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
