### PR TITLE
chore: enhance state focus search dialog

### DIFF
--- a/app/src/components/ui/command.tsx
+++ b/app/src/components/ui/command.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { Command as CommandPrimitive } from 'cmdk'
 import { SearchIcon } from 'lucide-react'
-
+import { useIsMobile } from '@/hooks/use-mobile'
 import { cn } from '@/lib/utils'
 import {
   Dialog,
@@ -40,6 +40,7 @@ function CommandDialog({
   className?: string
   showCloseButton?: boolean
 }) {
+  const isMobile = useIsMobile()
   return (
     <Dialog {...props}>
       <DialogHeader className="sr-only">
@@ -47,6 +48,7 @@ function CommandDialog({
         <DialogDescription>{description}</DialogDescription>
       </DialogHeader>
       <DialogContent
+        onOpenAutoFocus={(e) => (isMobile ? e.preventDefault() : undefined)}
         className={cn('overflow-hidden p-0', className)}
         showCloseButton={showCloseButton}
       >
@@ -71,7 +73,7 @@ function CommandInput({
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          'placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+          'placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm! outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
           className
         )}
         {...props}


### PR DESCRIPTION
## Describe Your Changes

This pull request makes several improvements to the `CommandDialog` and `CommandInput` components in `command.tsx`, primarily to enhance mobile usability and address minor styling issues. The most significant change is the addition of mobile-specific behavior to prevent unwanted autofocus when opening dialogs on mobile devices.

Enhancements for mobile support:

* Added the `useIsMobile` hook to determine if the user is on a mobile device and prevent autofocus in `DialogContent` when opening the dialog on mobile, improving user experience on smaller screens. [[1]](diffhunk://#diff-c75cf3681592d87638fa74b782db5c81d2b55d44f99049100d375a814616b5fcL4-R4) [[2]](diffhunk://#diff-c75cf3681592d87638fa74b782db5c81d2b55d44f99049100d375a814616b5fcR43-R51)

Styling fix:

* Updated the class name for the `CommandPrimitive.Input` element to include a missing exclamation mark (`text-sm!`), likely to ensure correct styling precedence.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
