### PR TITLE
fix: auto focus chat input for large screen

### DIFF
--- a/app/src/components/chat-input/index.tsx
+++ b/app/src/components/chat-input/index.tsx
@@ -23,6 +23,7 @@ import { useModels } from '@/stores/models-store'
 import { useConversations } from '@/stores/conversation-store'
 import { useCapabilities } from '@/stores/capabilities-store'
 import { useProjects } from '@/stores/projects-store'
+import { useIsMobile } from '@/hooks/use-mobile'
 import {
   FolderIcon,
   GlobeIcon,
@@ -65,6 +66,14 @@ const ChatInput = ({
   const browserConnectionState = useBrowserConnection(
     (state) => state.connectionState
   )
+  const isMobile = useIsMobile()
+
+  // Auto-focus on chat input when component mounts (desktop only)
+  useEffect(() => {
+    if (textareaRef.current && !isMobile) {
+      textareaRef.current.focus()
+    }
+  }, [isMobile])
 
   const selectedModel = useModels((state) => state.selectedModel)
   const modelDetail = useModels((state) => state.modelDetail)


### PR DESCRIPTION
## Describe Your Changes

-
This pull request introduces an improvement to the user experience in the `ChatInput` component by ensuring the chat input is automatically focused when the component mounts, but only on desktop devices. This change uses the new `useIsMobile` hook to detect mobile devices and conditionally apply the auto-focus behavior.

User experience improvements:

* Imported the `useIsMobile` hook and used it to detect if the user is on a mobile device, preventing auto-focus on mobile for better usability.
* Added a `useEffect` that auto-focuses the chat input (`textareaRef`) when the component mounts, but only if the user is not on a mobile device.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
