### PR TITLE
fix: should not allow user to send message while streaming

### DIFF
--- a/app/src/components/threads/thread-page-content.tsx
+++ b/app/src/components/threads/thread-page-content.tsx
@@ -127,7 +127,7 @@ export function ThreadPageContent({
   })
 
   const handleSubmit = (message?: PromptInputMessage) => {
-    if (message) {
+    if (message && status !== 'streaming' && !tools.current.length) {
       tools.current = []
       sendMessage({
         text: message.text || 'Sent with attachments',


### PR DESCRIPTION
## Describe Your Changes

This pull request makes a small but important update to the message submission logic in the `ThreadPageContent` component. Now, messages can only be submitted if the system is not currently streaming and there are no active tools in use. This helps prevent overlapping actions and ensures a smoother user experience.

- Improved message submission logic:
  * Updated the `handleSubmit` function in `thread-page-content.tsx` to only allow message submission when not streaming and no tools are active.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
