### PR TITLE
fix: line break user message

### DIFF
--- a/app/src/components/threads/thread-page-content.tsx
+++ b/app/src/components/threads/thread-page-content.tsx
@@ -245,8 +245,18 @@ export function ThreadPageContent({
                                   'mt-0!'
                               )}
                             >
-                              <MessageContent className="leading-relaxed">
-                                <MessageResponse>{part.text}</MessageResponse>
+                              <MessageContent
+                                className={cn(
+                                  'leading-relaxed',
+                                  message.role === 'user' &&
+                                    'whitespace-pre-wrap'
+                                )}
+                              >
+                                {message.role === 'user' ? (
+                                  part.text
+                                ) : (
+                                  <MessageResponse>{part.text}</MessageResponse>
+                                )}
                               </MessageContent>
                               {message.role === 'assistant' &&
                                 isLastMessage &&


### PR DESCRIPTION
## Describe Your Changes

This pull request makes a small but meaningful improvement to the rendering of user messages in the `ThreadPageContent` component. Now, user messages will preserve line breaks and whitespace formatting for better readability, while assistant messages remain unchanged.

- User message formatting:
  * In `thread-page-content.tsx`, user messages are now rendered with the `whitespace-pre-wrap` style, ensuring that line breaks and extra spaces are preserved in the UI.

## Fixes Issues

<img width="588" height="438" alt="Screenshot 2025-12-18 at 21 34 28" src="https://github.com/user-attachments/assets/a4ec192a-1da5-4dad-9429-4fd0fa5725bb" />
<img width="954" height="402" alt="Screenshot 2025-12-18 at 21 34 25" src="https://github.com/user-attachments/assets/267b4290-232b-45f7-8c03-c467216dad8f" />


- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
