### PR TITLE
fix: remove delete all conv

### DIFF
--- a/app/src/components/sidebar/nav-chat.tsx
+++ b/app/src/components/sidebar/nav-chat.tsx
@@ -46,7 +46,6 @@ export function NavChats() {
     (state) => state.updateConversation
   )
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
-  const [deleteAllDialogOpen, setDeleteAllDialogOpen] = useState(false)
   const [renameDialogOpen, setRenameDialogOpen] = useState(false)
   const [itemToDelete, setItemToDelete] = useState<Conversation | null>(null)
   const [itemToRename, setItemToRename] = useState<Conversation | null>(null)
@@ -79,24 +78,6 @@ export function NavChats() {
       }
     } catch (error) {
       console.error('Failed to delete conversation:', error)
-    }
-  }
-
-  const handleDeleteAllClick = () => {
-    setDeleteAllDialogOpen(true)
-  }
-
-  const handleConfirmDeleteAll = async () => {
-    try {
-      // Delete all conversations
-      await Promise.all(
-        conversations.map((conversation) => deleteConversation(conversation.id))
-      )
-      setDeleteAllDialogOpen(false)
-      // Redirect to home after deleting all
-      navigate({ to: '/' })
-    } catch (error) {
-      console.error('Failed to delete all conversations:', error)
     }
   }
 
@@ -139,28 +120,6 @@ export function NavChats() {
       <SidebarGroup className="group-data-[collapsible=icon]:hidden">
         <SidebarGroupLabel className="text-muted-foreground  flex w-full items-center justify-between pr-0">
           Chats
-          <DropDrawer>
-            <DropDrawerTrigger asChild>
-              <Button variant="ghost" className="size-5 mr-0.5">
-                <MoreHorizontal className="text-muted-foreground" />
-              </Button>
-            </DropDrawerTrigger>
-            <DropDrawerContent
-              className="md:w-40"
-              side={isMobile ? 'bottom' : 'right'}
-              align={isMobile ? 'end' : 'start'}
-            >
-              <DropDrawerItem
-                variant="destructive"
-                onClick={handleDeleteAllClick}
-              >
-                <div className="flex gap-2 items-center justify-center">
-                  <Trash2 className="text-destructive" />
-                  <span>Delete All</span>
-                </div>
-              </DropDrawerItem>
-            </DropDrawerContent>
-          </DropDrawer>
         </SidebarGroupLabel>
         <SidebarMenu>
           {conversations.map((item) => (
@@ -248,35 +207,6 @@ export function NavChats() {
               className="rounded-full"
             >
               Delete
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      <Dialog open={deleteAllDialogOpen} onOpenChange={setDeleteAllDialogOpen}>
-        <DialogContent className="md:max-w-[500px]" showCloseButton={false}>
-          <DialogHeader>
-            <DialogTitle>Delete All Chats</DialogTitle>
-            <DialogDescription>
-              Are you sure you want to delete all{' '}
-              <span className="font-semibold">
-                {conversations.length} chats
-              </span>
-              ? This action cannot be undone.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button variant="outline" className="rounded-full">
-                Cancel
-              </Button>
-            </DialogClose>
-            <Button
-              variant="destructive"
-              onClick={handleConfirmDeleteAll}
-              className="rounded-full"
-            >
-              Delete All
             </Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## Describe Your Changes

This pull request simplifies the `NavChats` component by removing the "Delete All Chats" functionality from the sidebar. The related state, handlers, UI elements, and dialog have all been deleted, resulting in a cleaner and less cluttered user interface.

Removed "Delete All Chats" feature:

* Removed the `deleteAllDialogOpen` state, the `handleDeleteAllClick` and `handleConfirmDeleteAll` handlers, and all related logic from the `NavChats` component. [[1]](diffhunk://#diff-00e5476d48b7227a493682c9d94f9bfcf3a0d1ddc71e37769a7d785f73307291L49) [[2]](diffhunk://#diff-00e5476d48b7227a493682c9d94f9bfcf3a0d1ddc71e37769a7d785f73307291L85-L102)
* Deleted the "Delete All" option from the sidebar menu, including the associated button and dropdown UI.
* Removed the confirmation dialog for deleting all chats, along with its content and footer actions.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
