### PR TITLE
fix: searchbox auto zoom on mobile

### DIFF
--- a/app/src/components/ui/command.tsx
+++ b/app/src/components/ui/command.tsx
@@ -73,7 +73,7 @@ function CommandInput({
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          'placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm! outline-hidden disabled:cursor-not-allowed disabled:opacity-50',
+          'placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-base outline-hidden disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
           className
         )}
         {...props}


### PR DESCRIPTION
## Describe Your Changes

This pull request makes a minor adjustment to the `CommandInput` component, specifically updating the input's text size for better consistency across different screen sizes.

- UI update:
  * Changed the input's text size from always small (`text-sm!`) to use a base size (`text-base`) by default and revert to small (`text-sm`) on medium screens and up, improving responsive design in `command.tsx`.
  
Mobile browsers (especially Safari on iOS) automatically zoom into input fields when the font size is less than 16px. This is a built-in accessibility feature to make small text readable. The solution: The CommandInput should use the same responsive text sizing pattern as the regular Input component. Change text-sm! to text-base md:text-sm to prevent mobile zoom while keeping the smaller font on desktop.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
