### PR TITLE
fix: disable preference while streaming

### DIFF
--- a/app/src/components/chat-input/index.tsx
+++ b/app/src/components/chat-input/index.tsx
@@ -282,6 +282,7 @@ const ChatInput = ({
                 deepResearchEnabled={deepResearchEnabled}
                 browserEnabled={browserEnabled}
                 reasoningEnabled={reasoningEnabled}
+                disablePreferences={status === 'streaming'}
                 toggleSearch={() => {
                   toggleSearch()
                   setBrowserEnabled(false)

--- a/app/src/components/chat-input/setting-chat-input.tsx
+++ b/app/src/components/chat-input/setting-chat-input.tsx
@@ -41,6 +41,7 @@ interface SettingChatInputProps {
   isSupportTools: boolean
   isSupportReasoningToggle: boolean
   isSupportDeepResearch: boolean
+  disablePreferences: boolean
   selectedTone?: ToneOption
   onToneChange?: (tone: ToneOption) => void
   children: React.ReactNode
@@ -68,6 +69,7 @@ export const SettingChatInput = ({
   isSupportDeepResearch,
   isSupportReasoningToggle,
   selectedTone = 'Friendly',
+  disablePreferences,
   onToneChange,
   children,
 }: SettingChatInputProps) => {
@@ -122,7 +124,11 @@ export const SettingChatInput = ({
             <div>
               <DropDrawerItem
                 onSelect={(e) => e.preventDefault()}
-                disabled={!isSupportReasoningToggle || deepResearchEnabled}
+                disabled={
+                  !isSupportReasoningToggle ||
+                  deepResearchEnabled ||
+                  disablePreferences
+                }
               >
                 <div className="flex gap-2 items-center justify-between w-full">
                   <div className="flex gap-2 items-center w-full">
@@ -130,7 +136,7 @@ export const SettingChatInput = ({
                     <span>Think</span>
                   </div>
                   <Switch
-                    disabled={!isSupportReasoningToggle}
+                    disabled={!isSupportReasoningToggle || disablePreferences}
                     checked={
                       !isSupportReasoningToggle || deepResearchEnabled
                         ? true
@@ -152,7 +158,10 @@ export const SettingChatInput = ({
           <Tooltip>
             <TooltipTrigger asChild>
               <div>
-                <DropDrawerItem onSelect={(e) => e.preventDefault()}>
+                <DropDrawerItem
+                  onSelect={(e) => e.preventDefault()}
+                  disabled={disablePreferences}
+                >
                   <div className="flex gap-2 items-center justify-between w-full">
                     <div className="flex gap-2 items-center w-full">
                       <ChromiumIcon />
@@ -161,6 +170,7 @@ export const SettingChatInput = ({
                     <Switch
                       checked={browserEnabled}
                       onCheckedChange={toggleBrowserAttempt}
+                      disabled={disablePreferences}
                     />
                   </div>
                 </DropDrawerItem>
@@ -173,7 +183,7 @@ export const SettingChatInput = ({
             <div>
               <DropDrawerItem
                 onSelect={(e) => e.preventDefault()}
-                disabled={!isSupportTools}
+                disabled={!isSupportTools || disablePreferences}
               >
                 <div className="flex gap-2 items-center justify-between w-full">
                   <div className="flex gap-2 items-center w-full">
@@ -183,7 +193,11 @@ export const SettingChatInput = ({
                   <Switch
                     checked={deepResearchEnabled ? true : searchEnabled}
                     onCheckedChange={toggleSearch}
-                    disabled={!isSupportTools || deepResearchEnabled}
+                    disabled={
+                      !isSupportTools ||
+                      deepResearchEnabled ||
+                      disablePreferences
+                    }
                   />
                 </div>
               </DropDrawerItem>
@@ -200,7 +214,7 @@ export const SettingChatInput = ({
             <div>
               <DropDrawerItem
                 onSelect={(e) => e.preventDefault()}
-                disabled={!isSupportDeepResearch}
+                disabled={!isSupportDeepResearch || disablePreferences}
               >
                 <div className="flex gap-2 items-center justify-between w-full">
                   <div className="flex gap-2 items-center w-full">
@@ -210,7 +224,7 @@ export const SettingChatInput = ({
                   <Switch
                     checked={deepResearchEnabled}
                     onCheckedChange={toggleDeepResearch}
-                    disabled={!isSupportDeepResearch}
+                    disabled={!isSupportDeepResearch || disablePreferences}
                   />
                 </div>
               </DropDrawerItem>


### PR DESCRIPTION
## Describe Your Changes

This pull request improves the user experience of the chat input settings by disabling preference toggles (such as browser, reasoning, and research options) while a chat is streaming. This prevents users from making changes that could interfere with an ongoing chat operation.

**Enhancements to chat input preference controls:**

* Added a new `disablePreferences` prop to `SettingChatInput` and passed it from `ChatInput`, which is set to `true` when the chat status is `'streaming'`. This disables all preference toggles during streaming. [[1]](diffhunk://#diff-5fb2bd329dff9a533f5a596910de88b35dca62a0fd0c7f93917c2914412fc8a4R44) [[2]](diffhunk://#diff-5fb2bd329dff9a533f5a596910de88b35dca62a0fd0c7f93917c2914412fc8a4R72) [[3]](diffhunk://#diff-92f24f6cb6e555cd8bf8ac1b29de6ed52d96d8df5119e93220d7325902fe1247R285)
* Updated all relevant `DropDrawerItem` and `Switch` components in `setting-chat-input.tsx` to respect the new `disablePreferences` prop, ensuring toggles for reasoning, browser, tools, and deep research are disabled as appropriate while streaming. [[1]](diffhunk://#diff-5fb2bd329dff9a533f5a596910de88b35dca62a0fd0c7f93917c2914412fc8a4L125-R139) [[2]](diffhunk://#diff-5fb2bd329dff9a533f5a596910de88b35dca62a0fd0c7f93917c2914412fc8a4L155-R164) [[3]](diffhunk://#diff-5fb2bd329dff9a533f5a596910de88b35dca62a0fd0c7f93917c2914412fc8a4R173) [[4]](diffhunk://#diff-5fb2bd329dff9a533f5a596910de88b35dca62a0fd0c7f93917c2914412fc8a4L176-R186) [[5]](diffhunk://#diff-5fb2bd329dff9a533f5a596910de88b35dca62a0fd0c7f93917c2914412fc8a4L186-R200) [[6]](diffhunk://#diff-5fb2bd329dff9a533f5a596910de88b35dca62a0fd0c7f93917c2914412fc8a4L203-R217) [[7]](diffhunk://#diff-5fb2bd329dff9a533f5a596910de88b35dca62a0fd0c7f93917c2914412fc8a4L213-R227)

## Fixes Issues

streaming
<img width="1626" height="1216" alt="Screenshot 2025-12-18 at 22 52 54" src="https://github.com/user-attachments/assets/70032555-b08d-41d2-addf-c52c21d713f2" />


finished
<img width="1564" height="824" alt="Screenshot 2025-12-18 at 22 53 22" src="https://github.com/user-attachments/assets/a623851b-4f08-4841-ae4c-61a59327b21f" />


- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
