### PR TITLE
fix: disabled chat input while streaming

### DIFF
--- a/app/src/components/chat-input/index.tsx
+++ b/app/src/components/chat-input/index.tsx
@@ -256,7 +256,10 @@ const ChatInput = ({
             {(attachment) => <PromptInputAttachment data={attachment} />}
           </PromptInputAttachments>
           <PromptInputBody>
-            <PromptInputTextarea ref={textareaRef} />
+            <PromptInputTextarea
+              ref={textareaRef}
+              disabled={status === 'streaming'}
+            />
           </PromptInputBody>
           <PromptInputFooter>
             <PromptInputTools>


### PR DESCRIPTION
## Describe Your Changes

This pull request makes a minor update to the `ChatInput` component to improve user experience during streaming. The change ensures that the text area is disabled while a streaming operation is in progress, preventing user input during that time.

- User experience improvement:
  * [`app/src/components/chat-input/index.tsx`](diffhunk://#diff-92f24f6cb6e555cd8bf8ac1b29de6ed52d96d8df5119e93220d7325902fe1247L259-R262): Disabled the `PromptInputTextarea` when the `status` is set to `'streaming'` to prevent user input during streaming.

<img width="1658" height="1564" alt="Screenshot 2025-12-19 at 09 48 03" src="https://github.com/user-attachments/assets/76c763ac-c737-41b3-a37a-321b44831b58" />

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
