### PR TITLE
fix: remove footer

### DIFF
--- a/app/src/components/settings/settings-dialog.tsx
+++ b/app/src/components/settings/settings-dialog.tsx
@@ -8,20 +8,8 @@ import {
 } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
 import { GeneralSettings } from '@/components/settings/general-settings'
-// import { AppsConnectorSettings } from '@/components/settings/apps-connectors-settings'
-// import { PrivacySettings } from '@/components/settings/privacy-settings'
-import {
-  // LockKeyhole,
-  Settings2,
-  Globe,
-  type LucideIcon,
-  BugIcon,
-  BookOpen,
-  LeafIcon,
-} from 'lucide-react'
-import { Separator } from '@/components/ui/separator'
-import { GitHub } from '@/components/ui/svgs/github'
-import { Discord } from '@/components/ui/svgs/discord'
+import { Settings2, type LucideIcon, LeafIcon } from 'lucide-react'
+
 import { PersonalizationSettings } from './personalization-setting'
 
 interface SettingsDialogProps {
@@ -83,66 +71,6 @@ export function SettingsDialog({
     }
   }
 
-  const renderSettingFooter = () => {
-    return (
-      <>
-        <Separator className="my-4" />
-        <p className="text-xs">
-          Jan is built with ❤️ by the Menlo Research team. Special thanks to our
-          open-source dependencies and our amazing community.
-        </p>
-        <Separator className="my-4" />
-        <div className="flex items-center gap-6">
-          <a
-            href="https://github.com/janhq/jan/issues/new"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2"
-          >
-            <BugIcon className="text-muted-foreground size-4" />
-            <span className="font-medium text-xs">Report Issue</span>
-          </a>
-          <a
-            href="https://jan.ai/docs"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-2"
-          >
-            <BookOpen className="text-muted-foreground size-4" />
-            <span className="font-medium text-xs">Docs</span>
-          </a>
-        </div>
-        <Separator className="my-4" />
-        <div className="flex items-center gap-2">
-          <a
-            href="https://jan.ai"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="size-8 items-center flex justify-center rounded-full bg-muted"
-          >
-            <Globe className="text-muted-foreground size-4" />
-          </a>
-          <a
-            href="https://discord.com/invite/FTk2MvZwJH"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="size-8 items-center flex justify-center rounded-full bg-muted"
-          >
-            <Discord className="fill-muted-foreground size-4" />
-          </a>
-          <a
-            href="https://github.com/janhq/jan"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="size-8 items-center flex justify-center rounded-full bg-muted"
-          >
-            <GitHub className="fill-muted-foreground size-4" />
-          </a>
-        </div>
-      </>
-    )
-  }
-
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
       <DialogContent
@@ -174,9 +102,6 @@ export function SettingsDialog({
                 </button>
               ))}
             </nav>
-            <div className="text-muted-foreground hidden lg:block">
-              {renderSettingFooter()}
-            </div>
           </div>
 
           {/* Content */}


### PR DESCRIPTION
## Describe Your Changes

This pull request simplifies the `SettingsDialog` component by removing the custom footer that included links to documentation, issue reporting, and social/community resources. It also cleans up related imports that are no longer needed.

Main changes:

**UI Cleanup and Simplification:**
* Removed the `renderSettingFooter` function, which previously rendered links to documentation, issue reporting, and community resources at the bottom of the settings dialog.
* Removed the section that rendered this footer in the settings dialog layout.

**Code and Import Cleanup:**
* Removed unused imports for icons and components (`BugIcon`, `BookOpen`, `Globe`, `Discord`, `GitHub`, and `Separator`) that were only used in the deleted footer.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
