### PR TITLE
fix: CSRF error replace session into local storage

### DIFF
--- a/app/src/lib/oauth.ts
+++ b/app/src/lib/oauth.ts
@@ -59,40 +59,40 @@ export function generateState(): string {
 }
 
 /**
- * Store OAuth flow data in sessionStorage
+ * Store OAuth flow data in localStorage (for PWA/home screen compatibility)
  */
 export function storeOAuthState(data: {
   state: string
   codeVerifier: string
   redirectUrl?: string
 }) {
-  sessionStorage.setItem('oauth_state', data.state)
-  sessionStorage.setItem('oauth_code_verifier', data.codeVerifier)
+  localStorage.setItem('oauth_state', data.state)
+  localStorage.setItem('oauth_code_verifier', data.codeVerifier)
   if (data.redirectUrl) {
-    sessionStorage.setItem('oauth_redirect_url', data.redirectUrl)
+    localStorage.setItem('oauth_redirect_url', data.redirectUrl)
   }
 }
 
 /**
- * Retrieve and validate OAuth state from sessionStorage
+ * Retrieve and validate OAuth state from localStorage (for PWA/home screen compatibility)
  */
 export function retrieveOAuthState(state: string): {
   codeVerifier: string
   redirectUrl?: string
 } | null {
-  const storedState = sessionStorage.getItem('oauth_state')
-  const codeVerifier = sessionStorage.getItem('oauth_code_verifier')
+  const storedState = localStorage.getItem('oauth_state')
+  const codeVerifier = localStorage.getItem('oauth_code_verifier')
 
   if (!storedState || !codeVerifier || storedState !== state) {
     return null
   }
 
-  const redirectUrl = sessionStorage.getItem('oauth_redirect_url') || undefined
+  const redirectUrl = localStorage.getItem('oauth_redirect_url') || undefined
 
   // Clean up
-  sessionStorage.removeItem('oauth_state')
-  sessionStorage.removeItem('oauth_code_verifier')
-  sessionStorage.removeItem('oauth_redirect_url')
+  localStorage.removeItem('oauth_state')
+  localStorage.removeItem('oauth_code_verifier')
+  localStorage.removeItem('oauth_redirect_url')
 
   return { codeVerifier, redirectUrl }
 }


### PR DESCRIPTION
## Describe Your Changes

This pull request updates the OAuth state management logic to use `localStorage` instead of `sessionStorage`. This change ensures compatibility with Progressive Web Apps (PWA) and home screen usage, where `sessionStorage` may not persist as expected.

OAuth flow storage improvements:

* Changed storage of OAuth state, code verifier, and redirect URL from `sessionStorage` to `localStorage` in the `storeOAuthState` and `retrieveOAuthState` functions to support PWA/home screen scenarios.


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
