### PR TITLE
chore: reset attachment and input value when switch conv

### DIFF
--- a/app/src/components/chat-input/index.tsx
+++ b/app/src/components/chat-input/index.tsx
@@ -16,6 +16,7 @@ import {
   PromptInputSubmit,
   PromptInputTextarea,
   PromptInputTools,
+  usePromptInputController,
 } from '@/components/ai-elements/prompt-input'
 
 import { useRef, useEffect, useState } from 'react'
@@ -228,6 +229,18 @@ const ChatInput = ({
     }
   }
 
+  // Component to handle resetting input when conversation changes
+  const InputResetHandler = () => {
+    const controller = usePromptInputController()
+
+    useEffect(() => {
+      controller.textInput.clear()
+      controller.attachments.clear()
+    }, [])
+
+    return null
+  }
+
   return (
     <div
       className={cn(
@@ -243,6 +256,7 @@ const ChatInput = ({
         accept="image/jpeg,image/jpg,image/png"
         onError={handleError}
       >
+        <InputResetHandler />
         <PromptInput
           accept="image/jpeg,image/jpg,image/png"
           globalDrop


### PR DESCRIPTION
## Describe Your Changes

This pull request adds a mechanism to reset the chat input fields when the conversation changes in the `ChatInput` component. The main change is the introduction of an `InputResetHandler` component that leverages a new controller hook to clear the text input and attachments on mount.

**Input Reset Functionality:**

* Added the `usePromptInputController` hook to the imports from `@/components/ai-elements/prompt-input` to enable programmatic control of the prompt input fields.
* Introduced the `InputResetHandler` component within `ChatInput`, which uses the controller to clear both the text input and attachments when the component mounts, ensuring the input is reset with each new conversation.
* Rendered the `InputResetHandler` inside the `PromptInputSubmit` component tree so that the input and attachments are reset appropriately when the chat context changes.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
