### PR TITLE
fix: autofocus chat input

### DIFF
--- a/app/src/components/chat-input/index.tsx
+++ b/app/src/components/chat-input/index.tsx
@@ -80,6 +80,14 @@ const ChatInput = ({
     }
   }, [isMobile])
 
+  // Auto-focus when assistant finishes responding (desktop only)
+  useEffect(() => {
+    // Focus when status changes from 'streaming' to idle (assistant finished)
+    if (status !== 'streaming' && textareaRef.current && !isMobile) {
+      textareaRef.current.focus()
+    }
+  }, [status, isMobile])
+
   const selectedModel = useModels((state) => state.selectedModel)
   const modelDetail = useModels((state) => state.modelDetail)
 
@@ -234,8 +242,14 @@ const ChatInput = ({
     const controller = usePromptInputController()
 
     useEffect(() => {
+      // Reset input and attachments when conversationId changes
       controller.textInput.clear()
       controller.attachments.clear()
+
+      // Restore focus after clearing (desktop only)
+      if (textareaRef.current && !isMobile) {
+        textareaRef.current.focus()
+      }
     }, [])
 
     return null


### PR DESCRIPTION
## Describe Your Changes

This pull request improves the user experience of the chat input component by ensuring the input field is automatically focused in key scenarios, making it more efficient for users to continue interacting with the chat, especially on desktop devices.

**Focus management improvements:**

* The chat input (`textareaRef`) is now automatically focused when the assistant finishes responding, provided the user is on a desktop device. This allows users to immediately start typing their next message without manually clicking the input.
* When the conversation ID changes (such as when starting a new conversation), the input and attachments are cleared, and the chat input is auto-focused on desktop, ensuring a smooth transition for the user.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
