### PR TITLE
feat: new option to remove a convo away from project

### DIFF
--- a/app/src/components/projects/project-conversations.tsx
+++ b/app/src/components/projects/project-conversations.tsx
@@ -228,9 +228,12 @@ export function ProjectConversations({ projectId }: ProjectConversationsProps) {
                   onClick={() => handleRemoveFromProject(conversation.id)}
                 >
                   <div className="flex gap-2 items-center">
-                    <FolderX className="size-4 text-muted-foreground" />
-                    <span>
-                      Remove from {currentProject?.name || 'Project'}
+                    <FolderX className="size-4 text-muted-foreground flex-shrink-0" />
+                    <span className="truncate">
+                      Remove from{' '}
+                      {(currentProject?.name || 'Project').length > 8
+                        ? `${(currentProject?.name || 'Project').slice(0, 8)}...`
+                        : currentProject?.name || 'Project'}
                     </span>
                   </div>
                 </DropDrawerItem>


### PR DESCRIPTION
## Describe Your Changes

- Add another option for conversation within a project in the projects/ view to allow remove the conversation away from the current project
- Removed thread is restored to normal thread and appear in sidebar


https://github.com/user-attachments/assets/278a880b-a2b2-4afb-9116-36b3013c9c3f



## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
