### PR TITLE
fix: stop streaming tool call

### DIFF
--- a/app/src/services/mcp-service.ts
+++ b/app/src/services/mcp-service.ts
@@ -205,7 +205,11 @@ class MCPService {
    */
   async callTool(
     payload: CallToolPayload,
-    metadata?: { conversationId?: string; toolCallId?: string }
+    metadata?: {
+      conversationId?: string
+      toolCallId?: string
+      signal?: AbortSignal
+    }
   ): Promise<MCPToolCallResult> {
     try {
       await this.ensureInitialized()
@@ -251,12 +255,22 @@ class MCPService {
       console.log(
         `Routing tool call "${payload.toolName}" to client: ${targetClientKey}`
       )
+
+      // Check if already aborted before calling
+      if (metadata?.signal?.aborted) {
+        return createErrorResult('Tool call was cancelled')
+      }
+
       return await targetClient
         .callTool(payload, metadata)
         .then(async (toolResult) => {
           console.log(
-            `Tool "${payload.toolName}" executed successfully on client: ${targetClientKey}`
+            `Tool "${payload.toolName}" executed successfully on client: ${targetClientKey}`,
+            toolResult
           )
+          if (toolResult.error) {
+            return createErrorResult(toolResult.error)
+          }
 
           // Process content to upload images and convert to Jan media URLs
           const processedContent = await Promise.all(

--- a/app/src/types/mcp.d.ts
+++ b/app/src/types/mcp.d.ts
@@ -29,12 +29,12 @@ interface CallToolPayload {
 }
 
 interface ToolCallClient {
-  async getTools(): Promise<MCPTool[]> 
+  async getTools(): Promise<MCPTool[]>
   async callTool(
     payload: CallToolPayload,
-    metadata?: { conversationId?: string; toolCallId?: string }
+    metadata?: { conversationId?: string; toolCallId?: string; signal?: AbortSignal }
   ): Promise<MCPToolCallResult>
   async disconnect(): Promise<void>
   async refreshTools(): Promise<void>
-  async isHealthy(): Promise<boolean> 
+  async isHealthy(): Promise<boolean>
 }


### PR DESCRIPTION
## Describe Your Changes

This PR is to allow users to stop tool-call mid-stream. It basically passes abort controller down to registered MCP clients. As soon as the user stops a message (actually stream ended and tool call is executing), it will send a signal to cancel.

It works with 2 registered clients: StreamableHttpMCP and BrowserClient.

There is a new function (followUpMessage) to check if tool calls are aborted or not before passing messages down to `lastAssistantMessageIsCompleteWithToolCalls` (agentic flow)

[885546bc-cdc3-48e6-9e64-5b31331be714.webm](https://github.com/user-attachments/assets/b045ffc7-bcb0-4560-a3d9-b893d3c22901)


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
