### PR TITLE
fix: resend message on stop

### DIFF
--- a/app/src/components/threads/thread-page-content.tsx
+++ b/app/src/components/threads/thread-page-content.tsx
@@ -112,7 +112,7 @@ export function ThreadPageContent({
     experimental_throttle: 50,
     sessionId: chatSessionId,
     sessionTitle: conversationTitle || undefined,
-    onFinish: ({ message }) => {
+    onFinish: ({ message, isAbort }) => {
       // Note: These values are captured at Chat creation time, which is correct
       // because onFinish fires for the Chat that started the stream, not the current conversation
       initialMessageSentRef.current = false
@@ -125,6 +125,7 @@ export function ThreadPageContent({
       // Check whether this is a valid message otherwise continue
       const needFollowUp =
         !hadToolCalls &&
+        !isAbort &&
         message?.parts.some((e) => e.type === 'reasoning') &&
         !message?.parts.some((e) => e.type === 'text' && e.text.length > 0)
       // After finishing a message, check if we need to resubmit for tool calls


### PR DESCRIPTION
## Describe Your Changes

- This PR fixes an issue where app sends message automatically when user stop at reasoning stage

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
