### PR TITLE
fix: fork shared conversation should update the left panel

### DIFF
--- a/app/src/components/share/share-page-content.tsx
+++ b/app/src/components/share/share-page-content.tsx
@@ -17,7 +17,6 @@ import { convertToUIMessages } from '@/lib/utils'
 import { useModels } from '@/stores/models-store'
 import { useNavigate } from '@tanstack/react-router'
 import { toast } from 'sonner'
-import { conversationService } from '@/services/conversation-service'
 import { useConversations } from '@/stores/conversation-store'
 
 interface SharePageContentProps {


### PR DESCRIPTION
## Describe Your Changes

- This PR fixes an issue where user forked a shared conversation does not see new item in the left panel. 

Root cause: 
- It uses create conversation service to create a new convo where it should use convo hook where the panel reload trigger already there.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
