### PR TITLE
feat: allow reading image from shared thread

### DIFF
--- a/app/src/lib/utils.ts
+++ b/app/src/lib/utils.ts
@@ -83,15 +83,9 @@ export const convertToUIMessages = (items: ConversationItem[]): UIMessage[] => {
           }
 
           let imageUrl: string | undefined = undefined
-          if (contentType === 'file') {
-            if (content.image?.url) {
-              imageUrl = content.image.url
-            } else if (content.file_ref?.url) {
-              imageUrl = content.file_ref.url
-            } else if (content.file_ref?.file_id) {
-              const mimeType = content.file_ref.mime_type || 'image/jpeg'
-              imageUrl = `data:${mimeType};base64,${content.file_ref.file_id}`
-            }
+          if (contentType === 'file' && content.image) {
+            // Use presigned URL if available, otherwise construct from file_id
+            imageUrl = content.image.url
           }
 
           return [

--- a/app/src/types/conversation.d.ts
+++ b/app/src/types/conversation.d.ts
@@ -82,20 +82,15 @@ interface ConversationItemContent {
   text?: string & { text?: string }
   input_text?: string
   reasoning_text?: string
-  image?: { url: string }
+  image?: {
+    url?: string    // Direct URL or presigned URL for public shares
+    file_id?: string // Media ID (jan_xxx) for internal reference
+  }
   tool_calls?: Array<ToolCall>
 
   // Tool result fields
   mcp_call?: string | unknown
   tool_result?: string | unknown
-
-  // Share snapshot format for files/images (file_ref instead of image.url)
-  file_ref?: {
-    file_id: string
-    mime_type?: string
-    name?: string
-    url?: string // Presigned URL from server (for public access)
-  }
 }
 
 // Branch types


### PR DESCRIPTION
## Describe Your Changes

- Check shared file_url to display image in shared conversation
- Only show image if shared thread allow to include image

<img width="1300" height="1150" alt="Screenshot 2025-12-25 at 3 04 30 PM" src="https://github.com/user-attachments/assets/802a4be6-b935-4f29-83c5-fb47e6df587a" />


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
