### PR TITLE
fix: conversation update should make it go to the top

### DIFF
--- a/app/src/components/threads/thread-page-content.tsx
+++ b/app/src/components/threads/thread-page-content.tsx
@@ -63,6 +63,9 @@ export function ThreadPageContent({
   )
 
   const getUIMessages = useConversations((state) => state.getUIMessages)
+  const moveConversationToTop = useConversations(
+    (state) => state.moveConversationToTop
+  )
   const setActiveConversationId = useChatSessions(
     (state) => state.setActiveConversationId
   )
@@ -257,6 +260,10 @@ export function ThreadPageContent({
           text: message.text || 'Sent with attachments',
           files: message.files,
         })
+        // Move conversation to top when a new message is sent
+        if (conversationId && !isPrivateChat) {
+          moveConversationToTop(conversationId)
+        }
       } else if (status === 'streaming') {
         stop()
       } else {
@@ -268,7 +275,7 @@ export function ThreadPageContent({
         }
       }
     },
-    [sendMessage, sessionData, status, stop]
+    [sendMessage, sessionData, status, stop, conversationId, isPrivateChat, moveConversationToTop]
   )
 
   // Load conversation metadata (only for persistent conversations)
@@ -326,11 +333,15 @@ export function ThreadPageContent({
           text: message.text,
           files: message.files,
         })
+        // Move conversation to top when initial message is sent
+        if (conversationId && !isPrivateChat) {
+          moveConversationToTop(conversationId)
+        }
       } catch (error) {
         console.error('Failed to parse initial message:', error)
       }
     }
-  }, [conversationId, isPrivateChat, sendMessage, sessionData, setMessages])
+  }, [conversationId, isPrivateChat, sendMessage, sessionData, setMessages, moveConversationToTop])
 
   useEffect(() => {
     setActiveConversationId(conversationId)

--- a/app/src/stores/conversation-store.ts
+++ b/app/src/stores/conversation-store.ts
@@ -30,6 +30,7 @@ interface ConversationState {
   deleteConversation: (conversationId: string) => Promise<void>
   deleteAllConversations: () => Promise<void>
   clearConversations: () => void
+  moveConversationToTop: (conversationId: string) => void
   // Branch operations
   fetchBranches: (conversationId: string) => Promise<ConversationBranch[]>
   switchBranch: (conversationId: string, branchName: string) => Promise<void>
@@ -177,6 +178,28 @@ export const useConversations = create<ConversationState>((set, get) => ({
       activeBranch: 'MAIN',
     })
     fetchPromise = null
+  },
+
+  moveConversationToTop: (conversationId: string) => {
+    set((state) => {
+      const conversation = state.conversations.find(
+        (conv) => conv.id === conversationId
+      )
+      if (!conversation) return state
+
+      const updatedConversation = {
+        ...conversation,
+        updated_at: Date.now(),
+      }
+
+      const otherConversations = state.conversations.filter(
+        (conv) => conv.id !== conversationId
+      )
+
+      return {
+        conversations: [updatedConversation, ...otherConversations],
+      }
+    })
   },
 
   // Branch operations

--- a/app/src/types/conversation.d.ts
+++ b/app/src/types/conversation.d.ts
@@ -3,6 +3,7 @@ interface Conversation {
   object: string
   title: string
   created_at: number
+  updated_at: number
   project_id?: string
   active_branch?: string
   metadata: {


### PR DESCRIPTION
This pull request improves the user experience in conversation threads by ensuring that conversations move to the top of the list when a new message is sent or when an initial message is parsed. This behavior is implemented for non-private chats. The main changes include adding a new `moveConversationToTop` method to the conversation store and updating the thread page logic to use it.

Conversation ordering improvements:

* Added a new `moveConversationToTop` method to the `ConversationState` interface and implemented it in the conversation store to update a conversation's `updated_at` timestamp and move it to the top of the list. [[1]](diffhunk://#diff-ed3bd1744c0ebcef66a943bbc8ee2b2c6301f87678e089522cea57204c92672bR33) [[2]](diffhunk://#diff-ed3bd1744c0ebcef66a943bbc8ee2b2c6301f87678e089522cea57204c92672bR183-R204)
* Updated `ThreadPageContent` to call `moveConversationToTop` after sending a new message or parsing an initial message, ensuring the conversation is reordered in the UI for non-private chats. [[1]](diffhunk://#diff-f6d6101ceec942c677309a49c57ab9a59f51ed8d034111c3b9ac772db8c36a33R263-R266) [[2]](diffhunk://#diff-f6d6101ceec942c677309a49c57ab9a59f51ed8d034111c3b9ac772db8c36a33R336-R344)

Dependency management:

* Updated effect dependencies in `ThreadPageContent` to include `moveConversationToTop` and related variables, ensuring correct behavior when dependencies change. [[1]](diffhunk://#diff-f6d6101ceec942c677309a49c57ab9a59f51ed8d034111c3b9ac772db8c36a33L271-R278) [[2]](diffhunk://#diff-f6d6101ceec942c677309a49c57ab9a59f51ed8d034111c3b9ac772db8c36a33R336-R344)

State management:

* Added the `moveConversationToTop` selector to the `useConversations` hook in `ThreadPageContent` to access the new store method.