### PR TITLE
ci: add path trigger condition

### DIFF
--- a/.github/workflows/jan-server-web-newui-ci-prod.yml
+++ b/.github/workflows/jan-server-web-newui-ci-prod.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - prod-web
+    paths:
+    - "app/**"
+    - ".github/workflows/jan-server-web-newui-ci-prod.yml"
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
## Describe Your Changes

This pull request updates the GitHub Actions workflow trigger to only run the CI/CD pipeline for the `prod-web` branch when changes are made to the application code or the workflow file itself.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
