### PR TITLE
Create fedora rpms build artifacts for release

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "jan",
+  "productName": "Jan",
   "version": "0.6.599",
   "identifier": "jan.ai.app",
   "build": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "Jan",
+  "productName": "jan",
   "version": "0.6.599",
   "identifier": "jan.ai.app",
   "build": {

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,6 +1,6 @@
 {
   "bundle": {
-    "targets": ["deb", "appimage"],
+    "targets": ["rpm", "deb", "appimage"],
     "resources": ["resources/pre-install/**/*", "resources/LICENSE"],
     "externalBin": ["resources/bin/uv"],
     "linux": {
@@ -12,6 +12,9 @@
         "files": {
           "usr/bin/bun": "resources/bin/bun"
         }
+      },
+      "rpm": {
+        "files": {}
       }
     }
   }


### PR DESCRIPTION
## Describe Your Changes

This change creates rpm build artifacts for Fedora and related distros. 

## Why rpm  ?
This was briefly raised at https://github.com/janhq/jan/issues/6115 (I was absent there, just found this project a couple of hours back) but that was closed as providing flatpak as an alternative. However flatpak's sandbox and portals actually get in the way when trying to manage various custom llamas and models, while a native rpm is able to work very easily with the existing model and runtime libraries on a system.

Example:

In `~/.var/app/ai.jan.Jan/data/Jan/data/llamacpp/models/some-model.gguf/model.yml` you might have 

 ```
 mmproj_path: /run/user/1000/doc/992d4590/mmproj-model-f16.gguf 
 model_path: /run/user/1000/doc/ea87324/model.gguf 
 ```

Those entries are very opaque, leading to a poor experience. Plus those `/run/user/1000/doc/<id>/` entries are ephemeral mount points created by the xdg-document-portal service, so they are on their own lifecycle.

All said and done, the native deb or rpm application run is great for power users on Linux.

## Other considerations

I kept the commit to have the binary called `jan` as opposed to `Jan` by default as a separate commit to allow easy picking. I personally think a `Jan` binary is weird on linux but so you guys can decide :) !
