### PR TITLE
fix: resolve link api-reference page

### DIFF
--- a/docs/src/components/FooterMenu/index.tsx
+++ b/docs/src/components/FooterMenu/index.tsx
@@ -31,7 +31,7 @@ const FOOTER_MENUS: FooterMenu[] = [
       { name: 'Blog', href: '/blog' },
       { name: 'Docs', href: '/docs' },
       { name: 'Changelog', href: '/changelog' },
-      { name: 'API Reference', href: '/api-reference' },
+      { name: 'API Reference', href: '/docs/desktop/api-server' },
       { name: 'Jan Exam', href: '/', comingSoon: true },
     ],
   },


### PR DESCRIPTION
## Describe Your Changes
Fixed broken "API Reference" link in the website footer.

## Problem
The footer's "API Reference" link pointed to `/api-reference`, which returns a 404 error. This has been reported by users navigating from the jan.ai homepage.

## Solution
Updated the link to point to `/docs/desktop/api-server`, which is the actual location of the Local API Server documentation.

## Changes
`docs/src/components/FooterMenu/index.tsx`: Changed href from` /api-reference` to `/docs/desktop/api-server`

## Fixes Issues
- Closes #7382

## Self Checklist
- [X] Added relevant comments, esp in complex areas
- [X] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
