### PR TITLE
fix: regression - model download - users could not download with HF_TOKEN

### DIFF
--- a/web-app/src/containers/ModelDownloadAction.tsx
+++ b/web-app/src/containers/ModelDownloadAction.tsx
@@ -10,7 +10,6 @@ import { CatalogModel } from '@/services/models/types'
 import { IconDownload } from '@tabler/icons-react'
 import { useNavigate } from '@tanstack/react-router'
 import { useCallback, useMemo } from 'react'
-import { toast } from 'sonner'
 
 export const ModelDownloadAction = ({
   variant,
@@ -56,76 +55,6 @@ export const ModelDownloadAction = ({
   )
 
   const handleDownloadModel = useCallback(async () => {
-    const preflight = await serviceHub
-      .models()
-      .preflightArtifactAccess(variant.path, huggingfaceToken)
-
-    const repoPage = `https://huggingface.co/${model.model_name}`
-
-    if (!preflight.ok) {
-      if (preflight.reason === 'AUTH_REQUIRED') {
-        toast.error('Hugging Face token required', {
-          description:
-            'This model requires a Hugging Face access token. Add your token in Settings and retry.',
-          action: {
-            label: 'Open Settings',
-            onClick: () =>
-              navigate({
-                to: route.settings.general,
-                params: {},
-              }),
-          },
-        })
-        return
-      }
-
-      if (preflight.reason === 'LICENSE_NOT_ACCEPTED') {
-        toast.error('Accept model license on Hugging Face', {
-          description:
-            'You must accept the model’s license on its Hugging Face page before downloading.',
-          action: {
-            label: 'Open model page',
-            onClick: () => window.open(repoPage, '_blank'),
-          },
-        })
-        return
-      }
-
-      if (preflight.reason === 'RATE_LIMITED') {
-        toast.error('Rate limited by Hugging Face', {
-          description:
-            'You have been rate-limited. Adding a token can increase rate limits. Please try again later.',
-          action: {
-            label: 'Open Settings',
-            onClick: () =>
-              navigate({
-                to: route.settings.general,
-                params: {},
-              }),
-          },
-        })
-        return
-      }
-
-      if (preflight.reason === 'NOT_FOUND') {
-        toast.error('Model file not found', {
-          description:
-            'The requested model could not be found. Please verify the model URL',
-          action: {
-            label: 'Open model page',
-            onClick: () => window.open(repoPage, '_blank'),
-          },
-        })
-        return
-      }
-
-      toast.error('Unable to start download', {
-        description:
-          'Jan encountered an issue. Please check your connection and try again.',
-      })
-      return
-    }
-
     addLocalDownloadingModel(variant.model_id)
     serviceHub
       .models()

--- a/web-app/src/services/models/default.ts
+++ b/web-app/src/services/models/default.ts
@@ -24,7 +24,6 @@ import type {
   ModelValidationResult,
   ModelPlan,
 } from './types'
-import { PreflightResult } from './types'
 
 // TODO: Replace this with the actual provider later
 const defaultProvider = 'llamacpp'
@@ -103,37 +102,6 @@ export class DefaultModelsService implements ModelsService {
     } catch (error) {
       console.error('Error fetching HuggingFace repository:', error)
       return null
-    }
-  }
-
-  async preflightArtifactAccess(
-    url: string,
-    hfToken?: string
-  ): Promise<PreflightResult> {
-    try {
-      const resp = await fetch(url, {
-        method: 'HEAD',
-        headers: hfToken
-          ? {
-              Authorization: `Bearer ${hfToken}`,
-            }
-          : {},
-      })
-
-      if (resp.ok) {
-        return { ok: true, status: resp.status }
-      }
-
-      const status = resp.status
-      if (status === 401) return { ok: false, status, reason: 'AUTH_REQUIRED' }
-      if (status === 403)
-        return { ok: false, status, reason: 'LICENSE_NOT_ACCEPTED' }
-      if (status === 404) return { ok: false, status, reason: 'NOT_FOUND' }
-      if (status === 429) return { ok: false, status, reason: 'RATE_LIMITED' }
-      return { ok: false, status, reason: 'UNKNOWN' }
-    } catch (e) {
-      console.warn('Preflight artifact access failed:', e)
-      return { ok: false, reason: 'NETWORK' }
     }
   }
 

--- a/web-app/src/services/models/types.ts
+++ b/web-app/src/services/models/types.ts
@@ -98,12 +98,6 @@ export type PreflightReason =
   | 'NETWORK'
   | 'UNKNOWN'
 
-export interface PreflightResult {
-  ok: boolean
-  status?: number
-  reason?: PreflightReason
-}
-
 export interface ModelsService {
   getModel(modelId: string): Promise<modelInfo | undefined>
   fetchModels(): Promise<modelInfo[]>
@@ -113,10 +107,6 @@ export interface ModelsService {
     hfToken?: string
   ): Promise<HuggingFaceRepo | null>
   convertHfRepoToCatalogModel(repo: HuggingFaceRepo): CatalogModel
-  preflightArtifactAccess(
-    url: string,
-    hfToken?: string
-  ): Promise<PreflightResult>
   updateModel(modelId: string, model: Partial<CoreModel>): Promise<void>
   pullModel(
     id: string,


### PR DESCRIPTION
## Describe Your Changes

#6892 causes regression where users could not download any models using custom HF token. All preflight requests are blocked and returned 401 even with a proper bearer token header.. There is no need to do preflight check as model downloader will return proper error message from server.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
