### PR TITLE
fix: Display embedding models in settings with visual distinction

### DIFF
--- a/web-app/src/containers/Capabilities.tsx
+++ b/web-app/src/containers/Capabilities.tsx
@@ -30,6 +30,9 @@ const Capabilities = ({ capabilities }: CapabilitiesProps) => {
       {filteredCapabilities.map((capability: string, capIndex: number) => {
         let icon = null
 
+        // Embedding models get special treatment with a distinct visual style
+        const isEmbedding = capability === 'embeddings'
+
         if (capability === 'vision') {
           icon = <IconEye className="size-4" />
         } else if (capability === 'tools') {
@@ -44,24 +47,29 @@ const Capabilities = ({ capabilities }: CapabilitiesProps) => {
           icon = null
         }
 
+        // Special badge style for embedding models
+        const badgeClass = isEmbedding
+          ? 'flex items-center gap-1 px-1.5 h-5 bg-amber-500/10 border border-amber-500/20 rounded text-amber-600 dark:text-amber-400 justify-center last:mr-1 hover:bg-amber-500/20 transition-all text-[10px] font-medium'
+          : 'flex items-center gap-1 size-5 bg-main-view-fg/5 rounded text-main-view-fg/50 justify-center last:mr-1 hover:text-main-view-fg transition-all'
+
         return (
           <Fragment key={`capability-${capIndex}`}>
             {icon && (
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <span
-                      className="flex items-center gap-1 size-5 bg-main-view-fg/5 rounded text-main-view-fg/50 justify-center last:mr-1 hover:text-main-view-fg transition-all"
-                      title={capability}
-                    >
+                    <span className={badgeClass} title={capability}>
                       {icon}
+                      {isEmbedding && <span>Embedding</span>}
                     </span>
                   </TooltipTrigger>
                   <TooltipContent>
                     <p>
                       {capability === 'web_search'
                         ? 'Web Search'
-                        : capability}
+                        : capability === 'embeddings'
+                          ? 'Embedding Model (for RAG/vectors, not chat)'
+                          : capability}
                     </p>
                   </TooltipContent>
                 </Tooltip>

--- a/web-app/src/containers/DropdownModelProvider.tsx
+++ b/web-app/src/containers/DropdownModelProvider.tsx
@@ -262,6 +262,9 @@ const DropdownModelProvider = ({
       if (!provider.active) return
 
       provider.models.forEach((modelItem) => {
+        // Skip embedding models - they can't be used for chat
+        if (modelItem.embedding) return
+
         // Skip models that require API key but don't have one (except llamacpp)
         if (
           provider &&

--- a/web-app/src/services/providers/tauri.ts
+++ b/web-app/src/services/providers/tauri.ts
@@ -47,7 +47,7 @@ export class TauriProvidersService extends DefaultProvidersService {
 
       const runtimeProviders: ModelProvider[] = []
       for (const [providerName, value] of EngineManager.instance().engines) {
-        const models = await value.list().then(list => list.filter(e => !e.embedding)) ?? []
+        const models = await value.list() ?? [] 
         const provider: ModelProvider = {
           active: false,
           persist: true,
@@ -88,12 +88,18 @@ export class TauriProvidersService extends DefaultProvidersService {
                 }
               }
 
+              // Add embeddings capability for embedding models
+              if (model.embedding && !capabilities.includes(ModelCapabilities.EMBEDDINGS)) {
+                capabilities = [...capabilities, ModelCapabilities.EMBEDDINGS]
+              }
+
               return {
                 id: model.id,
                 model: model.id,
                 name: model.name,
                 description: model.description,
                 capabilities,
+                embedding: model.embedding, // Preserve embedding flag for filtering in UI
                 provider: providerName,
                 settings: Object.values(modelSettings).reduce(
                   (acc, setting) => {

--- a/web-app/src/types/modelProviders.d.ts
+++ b/web-app/src/types/modelProviders.d.ts
@@ -34,6 +34,8 @@ type Model = {
   format?: string
   capabilities?: string[]
   settings?: Record<string, ProviderSetting>
+  /** Whether this model is an embedding model (e.g., BERT-based) */
+  embedding?: boolean
 }
 
 /**


### PR DESCRIPTION
## Describe Changes
- Show embedding models in Settings → Model Providers → Llama.cpp (previously hidden)
- Add distinctive amber "Embedding" badge to identify embedding models
- Filter embedding models from chat model dropdown (they can't be used for chat)
- Add tooltip: "Embedding Model (for RAG/vectors, not chat)"

<img width="1174" height="869" alt="1" src="https://github.com/user-attachments/assets/4e7841fe-f677-44fc-bdee-24c97123b9ea" />


## Problem
Embedding models (e.g., all-MiniLM-L6-v2, bge-small-en) were imported successfully but not visible in the UI. When users tried to import again, they got "model already exists" error, causing confusion.

## Fixes Issues
- Closes #7357 

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
