### PR TITLE
feat: Enable proxy to llama.cpp for Anthropic Messages API support.

### DIFF
--- a/src-tauri/src/core/server/mod.rs
+++ b/src-tauri/src/core/server/mod.rs
@@ -1,2 +1,4 @@
 pub mod commands;
 pub mod proxy;
+#[cfg(test)]
+pub mod tests;

--- a/src-tauri/src/core/server/tests.rs
+++ b/src-tauri/src/core/server/tests.rs
@@ -1,0 +1,113 @@
+#[cfg(test)]
+mod tests {
+    use crate::core::server::proxy;
+
+    #[test]
+    fn test_get_destination_path_basic() {
+        let result = proxy::get_destination_path("/v1/messages", "/v1");
+        assert_eq!(result, "/messages");
+    }
+
+    #[test]
+    fn test_get_destination_path_with_subpath() {
+        let result = proxy::get_destination_path("/v1/messages/threads/123", "/v1");
+        assert_eq!(result, "/messages/threads/123");
+    }
+
+    #[test]
+    fn test_get_destination_path_no_prefix() {
+        let result = proxy::get_destination_path("/messages", "");
+        assert_eq!(result, "/messages");
+    }
+
+    #[test]
+    fn test_get_destination_path_different_prefix() {
+        let result = proxy::get_destination_path("/api/v1/messages", "/api/v1");
+        assert_eq!(result, "/messages");
+    }
+
+    #[test]
+    fn test_get_destination_path_empty_prefix() {
+        let result = proxy::get_destination_path("/messages", "/v1");
+        assert_eq!(result, "/messages");
+    }
+
+    #[test]
+    fn test_messages_in_cors_whitelist() {
+        let whitelisted_paths = ["/", "/openapi.json", "/favicon.ico", "/messages"];
+        assert!(whitelisted_paths.contains(&"/messages"));
+    }
+
+    #[test]
+    fn test_messages_in_main_whitelist() {
+        let whitelisted_paths = [
+            "/",
+            "/openapi.json",
+            "/favicon.ico",
+            "/docs/swagger-ui.css",
+            "/docs/swagger-ui-bundle.js",
+            "/docs/swagger-ui-standalone-preset.js",
+            "/messages",
+        ];
+        assert!(whitelisted_paths.contains(&"/messages"));
+    }
+
+    #[test]
+    fn test_messages_subpath_not_in_exact_whitelist() {
+        let whitelisted_paths = [
+            "/",
+            "/openapi.json",
+            "/favicon.ico",
+            "/messages",
+        ];
+        // Only exact match
+        assert!(!whitelisted_paths.contains(&"/messages/threads"));
+        assert!(!whitelisted_paths.contains(&"/messages/api"));
+    }
+
+    #[test]
+    fn test_proxy_config_creation() {
+        let config = proxy::ProxyConfig {
+            prefix: "/v1".to_string(),
+            proxy_api_key: "test-key".to_string(),
+            trusted_hosts: vec![vec!["localhost".to_string()]],
+        };
+        assert_eq!(config.prefix, "/v1");
+        assert_eq!(config.proxy_api_key, "test-key");
+        assert_eq!(config.trusted_hosts.len(), 1);
+    }
+
+    #[test]
+    fn test_proxy_config_default() {
+        let config = proxy::ProxyConfig {
+            prefix: "".to_string(),
+            proxy_api_key: "".to_string(),
+            trusted_hosts: vec![],
+        };
+        assert_eq!(config.prefix, "");
+        assert_eq!(config.proxy_api_key, "");
+        assert_eq!(config.trusted_hosts.len(), 0);
+    }
+
+    #[test]
+    fn test_allowed_methods() {
+        let allowed_methods = ["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"];
+        assert!(allowed_methods.contains(&"POST"));
+        assert!(allowed_methods.contains(&"GET"));
+        assert!(allowed_methods.contains(&"OPTIONS"));
+    }
+
+    #[test]
+    fn test_allowed_headers() {
+        let allowed_headers = [
+            "accept",
+            "authorization",
+            "content-type",
+            "host",
+            "origin",
+            "user-agent",
+        ];
+        assert!(allowed_headers.contains(&"authorization"));
+        assert!(allowed_headers.contains(&"content-type"));
+    }
+}


### PR DESCRIPTION
## Describe Your Changes

This PR is to update the Local API Server proxy to enable Llama.cpp Anthropic Messages API support. Thanks to Llama.cpp
with this PR support https://github.com/ggml-org/llama.cpp/pull/17570.

Anthropic Messages API Reference: https://platform.claude.com/docs/en/api/messages

Small bug fix, previously it does not fully OAI compatible for completion endpoint since it forwards to /completions not v1/completions.

Note: Anthropic API Key header is not supported yet through this PR, so there is a minor tweak needed to have bearer token in the env setting (https://github.com/anthropics/claude-code/issues/1859)
Example env.
```
export ANTHROPIC_BASE_URL=http://127.0.0.1:1337
export ANTHROPIC_AUTH_TOKEN="Authorization: Bearer 1234"
// This header will be skipped in the next update since it should send x-api-key header
export ANTHROPIC_CUSTOM_HEADERS="Authorization: Bearer 1234"
export ANTHROPIC_DEFAULT_SONNET_MODEL=janhq/Jan-v3-4b-base-instruct-Q4_K_XL
export ANTHROPIC_DEFAULT_OPUS_MODEL=janhq/Jan-v3-4b-base-instruct-Q4_K_XL
export ANTHROPIC_DEFAULT_HAIKU_MODEL=janhq/Jan-v3-4b-base-instruct-Q4_K_XL
```

### Screenshots
<img width="822" height="811" alt="Screenshot 2026-01-24 at 21 15 55" src="https://github.com/user-attachments/assets/a2b89883-9488-48d5-bcd9-eddfa11d6fd5" />
<img width="818" height="808" alt="Screenshot 2026-01-24 at 21 10 49" src="https://github.com/user-attachments/assets/d2653ae2-8951-4e1a-9724-7fbf8b8a5136" />

### Action Items:
- Update docs

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
