### PR TITLE
fix: wrong cached model and provider first time create chat

### DIFF
--- a/web-app/src/hooks/use-chat.ts
+++ b/web-app/src/hooks/use-chat.ts
@@ -43,8 +43,6 @@ export function useChat(
   const updateStatus = useChatSessions((state) => state.updateStatus)
 
   // Get serviceHub and model metadata from app state
-  const languageModelId = useAppState((state) => state.languageModelId)
-  const languageModelProvider = useAppState((state) => state.languageModelProvider)
   const mcpToolNames = useAppState((state) => state.mcpToolNames)
   const ragToolNames = useAppState((state) => state.ragToolNames)
 
@@ -55,20 +53,13 @@ export function useChat(
   // Create transport immediately with modelId and provider
   if (!transportRef.current) {
     transportRef.current =
-      existingSessionTransport ?? new CustomChatTransport(languageModelId, languageModelProvider, systemMessage, sessionId)
+      existingSessionTransport ?? new CustomChatTransport(systemMessage, sessionId)
   } else if (
     existingSessionTransport &&
     transportRef.current !== existingSessionTransport
   ) {
     transportRef.current = existingSessionTransport
   }
-
-  // Update model metadata when it changes
-  useEffect(() => {
-    if (languageModelId && languageModelProvider && transportRef.current) {
-      transportRef.current.updateModelMetadata(languageModelId, languageModelProvider)
-    }
-  }, [languageModelId, languageModelProvider])
 
   useEffect(() => {
     if (transportRef.current) {
@@ -118,7 +109,7 @@ export function useChat(
       sessionTitle
     )
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionId, ensureSession, languageModelId, languageModelProvider])
+  }, [sessionId, ensureSession])
 
   useEffect(() => {
     if (sessionId && sessionTitle) {

--- a/web-app/src/hooks/useAppState.ts
+++ b/web-app/src/hooks/useAppState.ts
@@ -3,7 +3,6 @@ import { ThreadMessage } from '@janhq/core'
 import { MCPTool } from '@/types/completion'
 import { useAssistant } from './useAssistant'
 import { ChatCompletionMessageToolCall } from 'openai/resources'
-import type { LanguageModel } from 'ai'
 
 export type PromptProgress = {
   cache: number
@@ -32,9 +31,6 @@ type AppState = {
   errorMessage?: AppErrorMessage
   promptProgress?: PromptProgress
   activeModels: string[]
-  languageModel: LanguageModel | null
-  languageModelId?: string
-  languageModelProvider?: ProviderObject
   cancelToolCall?: () => void
   setServerStatus: (value: 'running' | 'stopped' | 'pending') => void
   updateStreamingContent: (content: ThreadMessage | undefined) => void
@@ -59,11 +55,6 @@ type AppState = {
   setErrorMessage: (error: AppErrorMessage | undefined) => void
   updatePromptProgress: (progress: PromptProgress | undefined) => void
   setActiveModels: (models: string[]) => void
-  setLanguageModel: (
-    model: LanguageModel | null,
-    modelId?: string,
-    provider?: ProviderObject
-  ) => void
 }
 
 export const useAppState = create<AppState>()((set) => ({
@@ -79,9 +70,6 @@ export const useAppState = create<AppState>()((set) => ({
   promptProgress: undefined,
   cancelToolCall: undefined,
   activeModels: [],
-  languageModel: null,
-  languageModelId: undefined,
-  languageModelProvider: undefined,
   updateStreamingContent: (content: ThreadMessage | undefined) => {
     const assistants = useAssistant.getState().assistants
     const currentAssistant = useAssistant.getState().currentAssistant
@@ -205,13 +193,6 @@ export const useAppState = create<AppState>()((set) => ({
   setActiveModels: (models: string[]) => {
     set(() => ({
       activeModels: models,
-    }))
-  },
-  setLanguageModel: (model, modelId, provider) => {
-    set(() => ({
-      languageModel: model,
-      languageModelId: modelId,
-      languageModelProvider: provider,
     }))
   },
 }))


### PR DESCRIPTION
## Describe Your Changes
This PR fixed an issue where the model and provider cached from a previous session caused the wrong session to load for a new chat.

This also simplifies state management, as it only needs to pull the latest value from the state when sending a message. There's no need to pass states around.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
