### PR TITLE
fix: wrong trouble shooting guide url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,7 +224,7 @@ docs: update installation instructions
 
 If things go sideways:
 
-1. **Check our [troubleshooting docs](https://www.jan.ai/docs/desktop/troubleshooting)**
+1. **Check our [troubleshooting docs](https://jan.ai/docs/desktop/troubleshooting)**
 2. **Clear everything and start fresh:** `make clean` then `make dev`
 3. **Copy your error logs and system specs**
 4. **Ask for help in our [Discord](https://discord.gg/FTk2MvZwJH)** `#🆘|jan-help` channel

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 </p>
 
 <p align="center">
-  <a href="https://www.jan.ai/docs/desktop">Getting Started</a>
+  <a href="https://jan.ai/docs/desktop">Getting Started</a>
   - <a href="https://discord.gg/Exe46xPMbK">Community</a>
   - <a href="https://jan.ai/changelog">Changelog</a>
   - <a href="https://github.com/janhq/jan/issues">Bug reports</a>
@@ -141,7 +141,7 @@ For detailed compatibility, check our [installation guides](https://jan.ai/docs/
 
 If things go sideways:
 
-1. Check our [troubleshooting docs](https://www.jan.ai/docs/desktop/troubleshooting)
+1. Check our [troubleshooting docs](https://jan.ai/docs/desktop/troubleshooting)
 2. Copy your error logs and system specs
 3. Ask for help in our [Discord](https://discord.gg/FTk2MvZwJH) `#🆘|jan-help` channel
 


### PR DESCRIPTION
## Describe Your Changes

This pull request makes a minor update to the troubleshooting documentation link in the `CONTRIBUTING.md` file, ensuring it points to the correct location.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
