### PR TITLE
fix: leftpanel toggle on windows

### DIFF
--- a/web-app/src/containers/LeftPanel.tsx
+++ b/web-app/src/containers/LeftPanel.tsx
@@ -223,7 +223,7 @@ const LeftPanel = () => {
       <aside
         ref={panelRef}
         className={cn(
-          'text-left-panel-fg overflow-hidden',
+          'text-left-panel-fg overflow-hidden relative',
           // Resizable context: full height and width, no margins
           isResizableContext && 'h-full w-full',
           // Small screen context: fixed positioning and styling
@@ -239,21 +239,33 @@ const LeftPanel = () => {
             : 'w-0 absolute -top-100 -left-100 visibility-hidden'
         )}
       >
-        <div className="relative h-10">
-          <button
-            className={cn(
-              'absolute top-1/2 -translate-y-1/2 z-20 right-0',
-              (IS_MACOS && isSmallScreen) || (IS_MACOS && !open)
-                ? 'pl-20 right-auto'
-                : ''
-            )}
-            onClick={() => setLeftPanel(!open)}
-          >
-            <div className="size-6 cursor-pointer flex items-center justify-center rounded hover:bg-left-panel-fg/10 transition-all duration-200 ease-in-out data-[state=open]:bg-left-panel-fg/10">
-              <IconLayoutSidebar size={18} className="text-left-panel-fg" />
-            </div>
-          </button>
-        </div>
+        {IS_MACOS ? 
+          <div className="relative h-10">
+            <button
+              className={cn(
+                'absolute top-1/2 -translate-y-1/2 z-20 right-0',
+                (isSmallScreen) || (!open)
+                  ? 'pl-20 right-auto'
+                  : ''
+              )}
+              onClick={() => setLeftPanel(!open)}
+            >
+              <div className="size-6 cursor-pointer flex items-center justify-center rounded hover:bg-left-panel-fg/10 transition-all duration-200 ease-in-out data-[state=open]:bg-left-panel-fg/10">
+                <IconLayoutSidebar size={18} className="text-left-panel-fg" />
+              </div>
+            </button>
+          </div> 
+          : 
+          <div className="absolute right-0 z-40 top-1.5">
+            <button
+              onClick={() => setLeftPanel(!open)}
+            >
+              <div className="size-6 cursor-pointer flex items-center justify-center rounded hover:bg-left-panel-fg/10 transition-all duration-200 ease-in-out data-[state=open]:bg-left-panel-fg/10">
+                <IconLayoutSidebar size={18} className="text-left-panel-fg" />
+              </div>
+            </button>
+          </div>
+        }
 
         <div className="flex flex-col gap-y-1 overflow-hidden mt-0 !h-[calc(100%-42px)]">
           <div className="space-y-1 py-1">


### PR DESCRIPTION
## Describe Your Changes

This pull request updates the `LeftPanel` component in `web-app/src/containers/LeftPanel.tsx` to improve platform-specific UI behavior and button placement. The most notable changes are the conditional rendering of sidebar toggle buttons based on the user's operating system and adjustments to layout styling for better positioning.

**Platform-specific UI improvements:**

* The sidebar toggle button is now rendered differently for macOS users (`IS_MACOS`) versus other platforms, ensuring a more native experience for each. [[1]](diffhunk://#diff-8fe9510686bc63c447d596c9015da8053ef7172d644ed42f7daa12a2a794a706R242-R247) [[2]](diffhunk://#diff-8fe9510686bc63c447d596c9015da8053ef7172d644ed42f7daa12a2a794a706R258-R268)

**Layout and styling adjustments:**

* Added the `relative` class to the sidebar container to support absolute positioning of child elements, improving overall layout control.
* Refined conditional class logic for the toggle button, simplifying checks and ensuring correct placement and styling on small screens and when the panel is closed.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
