### PR TITLE
fix: left panel full height

### DIFF
--- a/web-app/src/containers/LeftPanel.tsx
+++ b/web-app/src/containers/LeftPanel.tsx
@@ -267,7 +267,7 @@ const LeftPanel = () => {
           </div>
         }
 
-        <div className={cn("flex flex-col gap-y-1 overflow-hidden mt-0", !IS_MACOS ? "h-[calc(100%-42px)]!" : "h-full")}>
+        <div className={cn("flex flex-col gap-y-1 overflow-hidden mt-0", IS_MACOS ? "h-[calc(100%-42px)]!" : "h-full")}>
           <div className="space-y-1 py-1">
             {/* Search button */}
             <button


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a small but important fix to the layout logic in the `LeftPanel` component. The change corrects the conditional height assignment so that the panel height is set appropriately depending on whether the user is on macOS or another platform.

* Fixed the conditional logic for setting the height of the main container in the `LeftPanel` component, ensuring the correct height is applied for macOS and non-macOS users.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
