### PR TITLE
fix: accept x-api-key header in place of custom header

### DIFF
--- a/src-tauri/src/core/server/tests.rs
+++ b/src-tauri/src/core/server/tests.rs
@@ -106,8 +106,198 @@ mod tests {
             "host",
             "origin",
             "user-agent",
+            "x-api-key",
         ];
         assert!(allowed_headers.contains(&"authorization"));
         assert!(allowed_headers.contains(&"content-type"));
+        assert!(allowed_headers.contains(&"x-api-key"));
+    }
+
+    // Tests for X-Api-Key header authentication support
+    // The proxy now accepts either Authorization: Bearer <token> or X-Api-Key: <token>
+
+    #[test]
+    fn test_bearer_token_extraction() {
+        let api_key = "test-secret-key";
+        let auth_header = "Bearer test-secret-key";
+
+        let auth_valid = auth_header
+            .strip_prefix("Bearer ")
+            .map(|token| token == api_key)
+            .unwrap_or(false);
+
+        assert!(auth_valid);
+    }
+
+    #[test]
+    fn test_bearer_token_extraction_invalid() {
+        let api_key = "test-secret-key";
+        let auth_header = "Bearer wrong-key";
+
+        let auth_valid = auth_header
+            .strip_prefix("Bearer ")
+            .map(|token| token == api_key)
+            .unwrap_or(false);
+
+        assert!(!auth_valid);
+    }
+
+    #[test]
+    fn test_bearer_token_extraction_missing_prefix() {
+        let api_key = "test-secret-key";
+        let auth_header = "test-secret-key"; // Missing "Bearer " prefix
+
+        let auth_valid = auth_header
+            .strip_prefix("Bearer ")
+            .map(|token| token == api_key)
+            .unwrap_or(false);
+
+        assert!(!auth_valid);
+    }
+
+    #[test]
+    fn test_x_api_key_validation() {
+        let api_key = "test-secret-key";
+        let x_api_key_header = "test-secret-key";
+
+        let api_key_valid = x_api_key_header == api_key;
+
+        assert!(api_key_valid);
+    }
+
+    #[test]
+    fn test_x_api_key_validation_invalid() {
+        let api_key = "test-secret-key";
+        let x_api_key_header = "wrong-key";
+
+        let api_key_valid = x_api_key_header == api_key;
+
+        assert!(!api_key_valid);
+    }
+
+    #[test]
+    fn test_auth_either_header_valid_bearer() {
+        let api_key = "test-secret-key";
+        let auth_header = Some("Bearer test-secret-key");
+        let x_api_key_header: Option<&str> = None;
+
+        let auth_valid = auth_header
+            .and_then(|auth_str| auth_str.strip_prefix("Bearer "))
+            .map(|token| token == api_key)
+            .unwrap_or(false);
+
+        let api_key_valid = x_api_key_header
+            .map(|key| key == api_key)
+            .unwrap_or(false);
+
+        assert!(auth_valid || api_key_valid);
+    }
+
+    #[test]
+    fn test_auth_either_header_valid_x_api_key() {
+        let api_key = "test-secret-key";
+        let auth_header: Option<&str> = None;
+        let x_api_key_header = Some("test-secret-key");
+
+        let auth_valid = auth_header
+            .and_then(|auth_str| auth_str.strip_prefix("Bearer "))
+            .map(|token| token == api_key)
+            .unwrap_or(false);
+
+        let api_key_valid = x_api_key_header
+            .map(|key| key == api_key)
+            .unwrap_or(false);
+
+        assert!(auth_valid || api_key_valid);
+    }
+
+    #[test]
+    fn test_auth_both_headers_missing() {
+        let api_key = "test-secret-key";
+        let auth_header: Option<&str> = None;
+        let x_api_key_header: Option<&str> = None;
+
+        let auth_valid = auth_header
+            .and_then(|auth_str| auth_str.strip_prefix("Bearer "))
+            .map(|token| token == api_key)
+            .unwrap_or(false);
+
+        let api_key_valid = x_api_key_header
+            .map(|key| key == api_key)
+            .unwrap_or(false);
+
+        assert!(!auth_valid && !api_key_valid);
+    }
+
+    #[test]
+    fn test_auth_both_headers_invalid() {
+        let api_key = "test-secret-key";
+        let auth_header = Some("Bearer wrong-key");
+        let x_api_key_header = Some("also-wrong-key");
+
+        let auth_valid = auth_header
+            .and_then(|auth_str| auth_str.strip_prefix("Bearer "))
+            .map(|token| token == api_key)
+            .unwrap_or(false);
+
+        let api_key_valid = x_api_key_header
+            .map(|key| key == api_key)
+            .unwrap_or(false);
+
+        assert!(!auth_valid && !api_key_valid);
+    }
+
+    #[test]
+    fn test_auth_both_headers_one_valid() {
+        let api_key = "test-secret-key";
+        // Bearer is wrong but X-Api-Key is correct
+        let auth_header = Some("Bearer wrong-key");
+        let x_api_key_header = Some("test-secret-key");
+
+        let auth_valid = auth_header
+            .and_then(|auth_str| auth_str.strip_prefix("Bearer "))
+            .map(|token| token == api_key)
+            .unwrap_or(false);
+
+        let api_key_valid = x_api_key_header
+            .map(|key| key == api_key)
+            .unwrap_or(false);
+
+        // Should pass if either is valid
+        assert!(auth_valid || api_key_valid);
+    }
+
+    #[test]
+    fn test_x_api_key_in_cors_allowed_headers() {
+        // Verify x-api-key is in the CORS allowed headers list used by the proxy
+        let allowed_headers = [
+            "accept",
+            "accept-language",
+            "authorization",
+            "cache-control",
+            "connection",
+            "content-type",
+            "dnt",
+            "host",
+            "if-modified-since",
+            "keep-alive",
+            "origin",
+            "user-agent",
+            "x-api-key",
+            "x-csrf-token",
+            "x-forwarded-for",
+            "x-forwarded-host",
+            "x-forwarded-proto",
+            "x-requested-with",
+            "x-stainless-arch",
+            "x-stainless-lang",
+            "x-stainless-os",
+            "x-stainless-package-version",
+            "x-stainless-retry-count",
+            "x-stainless-runtime",
+            "x-stainless-runtime-version",
+            "x-stainless-timeout",
+        ];
+        assert!(allowed_headers.contains(&"x-api-key"));
     }
 }


### PR DESCRIPTION
## Describe Your Changes
Add support for x-api-key header in API server. So that when connecting from Claude Code, users do not need to set a custom header for bearer token authorization.

- This change enables the API server to accept and validate API keys provided in the x-api-key
  header, aligning with standard API authentication practices. This improves security and
  flexibility by allowing integration with external services that use standard API key mechanisms.

<img width="912" height="744" alt="Screenshot 2026-01-27 at 20 15 54" src="https://github.com/user-attachments/assets/18bb8cfa-e743-41d9-a206-8344b8c7e02a" />


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
