### PR TITLE
chore: disable auto updater for flatpak build

### DIFF
--- a/web-app/src/hooks/useAppUpdater.ts
+++ b/web-app/src/hooks/useAppUpdater.ts
@@ -52,16 +52,11 @@ export const useAppUpdater = () => {
 
   const checkForUpdate = useCallback(
     async (resetRemindMeLater = false) => {
-      if (AUTO_UPDATER_DISABLED) {
-        console.log('Auto updater is disabled')
-        return
-      }
-
       console.log('Checking for updates...')
 
       try {
         // Reset remindMeLater if requested (e.g., when called from settings)
-        if (resetRemindMeLater) {
+        if (resetRemindMeLater && !AUTO_UPDATER_DISABLED) {
           const newState = {
             remindMeLater: false,
           }
@@ -78,6 +73,11 @@ export const useAppUpdater = () => {
           const update = await getServiceHub().updater().check()
 
           if (update) {
+            if (AUTO_UPDATER_DISABLED) {
+              console.log('Auto updater is disabled')
+              return null
+            }
+
             const newState = {
               isUpdateAvailable: true,
               remindMeLater: false,

--- a/web-app/src/providers/DataProvider.tsx
+++ b/web-app/src/providers/DataProvider.tsx
@@ -99,7 +99,7 @@ export function DataProvider() {
     // Only check for updates if the auto updater is not disabled
     // App might be distributed via other package managers
     // or methods that handle updates differently
-    if (AUTO_UPDATER_DISABLED || isDev()) {
+    if (isDev()) {
       return
     }
 


### PR DESCRIPTION
This pull request updates the logic for checking application updates to ensure that the auto updater is only disabled where necessary, and streamlines how the `AUTO_UPDATER_DISABLED` flag is handled. The changes clarify when update checks and state resets should occur, improving consistency and reducing unnecessary early returns.

**Auto updater logic improvements:**

* In `useAppUpdater.ts`, removed the early return when `AUTO_UPDATER_DISABLED` is set, so the updater logic can still execute certain code paths.
* Now, the `remindMeLater` state is only reset if `resetRemindMeLater` is true and the auto updater is not disabled, preventing unnecessary state changes when updates are managed externally.
* When an update is detected, the updater now checks if `AUTO_UPDATER_DISABLED` is set before proceeding, logging a message and returning `null` if auto updates are disabled.

**Provider update check conditions:**

* In `DataProvider.tsx`, update checks are now only skipped in development mode, regardless of the `AUTO_UPDATER_DISABLED` flag, allowing for more flexible distribution scenarios.