### PR TITLE
ci: move config yarn makefile to ci

### DIFF
--- a/.github/workflows/jan-linter-and-test.yml
+++ b/.github/workflows/jan-linter-and-test.yml
@@ -88,6 +88,13 @@ jobs:
           rm -rf ~/jan
           make clean
 
+      - name: Config Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@4.5.3 --activate
+          yarn --version
+          yarn config set -H enableImmutableInstalls false
+
       - name: Linter and test
         run: |
           make test
@@ -124,6 +131,13 @@ jobs:
               Write-Output "Folder does not exist."
           }
           make clean
+
+      - name: Config Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@4.5.3 --activate
+          yarn --version
+          yarn config set -H enableImmutableInstalls false
 
       - name: Linter and test
         shell: powershell
@@ -165,6 +179,13 @@ jobs:
         run: |
           Invoke-WebRequest -Uri 'https://go.microsoft.com/fwlink/p/?LinkId=2124703' -OutFile 'setup.exe'
           Start-Process -FilePath setup.exe -Verb RunAs -Wait
+
+      - name: Config Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@4.5.3 --activate
+          yarn --version
+          yarn config set -H enableImmutableInstalls false
 
       - name: Linter and test
         shell: powershell
@@ -209,6 +230,13 @@ jobs:
           rm -rf ~/jan
           make clean
 
+      - name: Config Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@4.5.3 --activate
+          yarn --version
+          yarn config set -H enableImmutableInstalls false
+
       - name: Linter and test
         run: |
           export DISPLAY=$(w -h | awk 'NR==1 {print $2}')
@@ -242,6 +270,13 @@ jobs:
         run: |
           rm -rf ~/jan
           make clean
+
+      - name: Config Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@4.5.3 --activate
+          yarn --version
+          yarn config set -H enableImmutableInstalls false
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/template-tauri-build-linux-x64-external.yml
+++ b/.github/workflows/template-tauri-build-linux-x64-external.yml
@@ -121,6 +121,13 @@ jobs:
             .github/scripts/rename-workspace.sh ./package.json ${{ inputs.channel }}
           fi
 
+      - name: Config Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@4.5.3 --activate
+          yarn --version
+          yarn config set -H enableImmutableInstalls false
+
       - name: Build app
         run: |
           make build

--- a/.github/workflows/template-tauri-build-linux-x64-flatpak.yml
+++ b/.github/workflows/template-tauri-build-linux-x64-flatpak.yml
@@ -151,6 +151,14 @@ jobs:
             .github/scripts/rename-workspace.sh ./package.json ${{ inputs.channel }}
             cat ./package.json
           fi
+
+      - name: Config Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@4.5.3 --activate
+          yarn --version
+          yarn config set -H enableImmutableInstalls false
+
       - name: Build app
         run: |
           make build

--- a/.github/workflows/template-tauri-build-linux-x64.yml
+++ b/.github/workflows/template-tauri-build-linux-x64.yml
@@ -172,6 +172,14 @@ jobs:
             .github/scripts/rename-workspace.sh ./package.json ${{ inputs.channel }}
             cat ./package.json
           fi
+
+      - name: Config Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@4.5.3 --activate
+          yarn --version
+          yarn config set -H enableImmutableInstalls false
+
       - name: Build app
         run: |
           make build

--- a/.github/workflows/template-tauri-build-macos-external.yml
+++ b/.github/workflows/template-tauri-build-macos-external.yml
@@ -93,6 +93,13 @@ jobs:
             .github/scripts/rename-workspace.sh ./package.json ${{ inputs.channel }}
           fi
 
+      - name: Config Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@4.5.3 --activate
+          yarn --version
+          yarn config set -H enableImmutableInstalls false
+
       - name: Build app
         run: |
           make build

--- a/.github/workflows/template-tauri-build-macos.yml
+++ b/.github/workflows/template-tauri-build-macos.yml
@@ -169,6 +169,13 @@ jobs:
           p12-file-base64: ${{ secrets.CODE_SIGN_P12_BASE64 }}
           p12-password: ${{ secrets.CODE_SIGN_P12_PASSWORD }}
 
+      - name: Config Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@4.5.3 --activate
+          yarn --version
+          yarn config set -H enableImmutableInstalls false
+
       - name: Build app
         run: |
           make build

--- a/.github/workflows/template-tauri-build-windows-x64-external.yml
+++ b/.github/workflows/template-tauri-build-windows-x64-external.yml
@@ -147,6 +147,14 @@ jobs:
           fi
           echo "---------nsis.template---------"
           cat ./src-tauri/tauri.bundle.windows.nsis.template
+
+      - name: Config Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@4.5.3 --activate
+          yarn --version
+          yarn config set -H enableImmutableInstalls false
+
       - name: Build app
         shell: bash
         run: |

--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -216,6 +216,13 @@ jobs:
         run: |
           dotnet tool install --global --version 6.0.0 AzureSignTool
 
+      - name: Config Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@4.5.3 --activate
+          yarn --version
+          yarn config set -H enableImmutableInstalls false
+
       - name: Build app
         shell: bash
         run: |

--- a/Makefile
+++ b/Makefile
@@ -10,16 +10,8 @@ REPORT_PORTAL_DESCRIPTION ?= "Jan App report"
 all:
 	@echo "Specify a target to run"
 
-# Config yarn version
-
-config-yarn:
-	corepack enable
-	corepack prepare yarn@4.5.3 --activate
-	yarn --version
-	yarn config set -H enableImmutableInstalls false
-
 # Installs yarn dependencies and builds core and extensions
-install-and-build: config-yarn
+install-and-build:
 ifeq ($(OS),Windows_NT)
 	echo "skip"
 else ifeq ($(shell uname -s),Linux)
@@ -63,7 +55,7 @@ dev: install-and-build
 	yarn dev
 
 # Web application targets
-install-web-app: config-yarn
+install-web-app:
 	yarn install
 
 dev-web-app: install-web-app


### PR DESCRIPTION
## Describe Your Changes

This pull request standardizes the Yarn configuration process across all CI build workflows by moving the Yarn setup steps directly into each GitHub Actions workflow file, instead of relying on a separate Makefile target. This ensures that the correct Yarn version and configuration are consistently applied in all build environments.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
