### PR TITLE
fix: dynamically generate OpenAPI spec with actual server host and port

### DIFF
--- a/src-tauri/src/core/server/proxy.rs
+++ b/src-tauri/src/core/server/proxy.rs
@@ -20,6 +20,8 @@ pub struct ProxyConfig {
     pub prefix: String,
     pub proxy_api_key: String,
     pub trusted_hosts: Vec<Vec<String>>,
+    pub host: String,
+    pub port: u16,
 }
 
 /// Determines the final destination path based on the original request path
@@ -435,12 +437,37 @@ async fn proxy_request(
         }
 
         (hyper::Method::GET, "/openapi.json") => {
-            let body = include_str!("../../../static/openapi.json"); // relative to src-tauri/src/
-            return Ok(Response::builder()
-                .status(StatusCode::OK)
-                .header(hyper::header::CONTENT_TYPE, "application/json")
-                .body(Body::from(body))
-                .unwrap());
+            let static_body = include_str!("../../../static/openapi.json"); // relative to src-tauri/src/
+            // Parse the static OpenAPI JSON and update the server URL with actual host and port
+            match serde_json::from_str::<serde_json::Value>(static_body) {
+                Ok(mut openapi_spec) => {
+                    // Update the servers array with the actual host and port
+                    if let Some(servers) = openapi_spec.get_mut("servers").and_then(|s| s.as_array_mut()) {
+                        for server in servers {
+                            if let Some(server_obj) = server.as_object_mut() {
+                                if let Some(url) = server_obj.get_mut("url") {
+                                    let base_url = format!("http://{}:{}{}", config.host, config.port, config.prefix);
+                                    *url = serde_json::Value::String(base_url);
+                                }
+                            }
+                        }
+                    }
+                    let body = serde_json::to_string(&openapi_spec).unwrap_or_else(|_| static_body.to_string());
+                    return Ok(Response::builder()
+                        .status(StatusCode::OK)
+                        .header(hyper::header::CONTENT_TYPE, "application/json")
+                        .body(Body::from(body))
+                        .unwrap());
+                }
+                Err(_) => {
+                    // If parsing fails, return the static file as fallback
+                    return Ok(Response::builder()
+                        .status(StatusCode::OK)
+                        .header(hyper::header::CONTENT_TYPE, "application/json")
+                        .body(Body::from(static_body))
+                        .unwrap());
+                }
+            }
         }
 
         // DOCS route
@@ -706,6 +733,8 @@ pub async fn start_server(
         prefix,
         proxy_api_key,
         trusted_hosts,
+        host: host.clone(),
+        port,
     };
 
     let client = Client::builder()

--- a/src-tauri/src/core/server/tests.rs
+++ b/src-tauri/src/core/server/tests.rs
@@ -71,10 +71,14 @@ mod tests {
             prefix: "/v1".to_string(),
             proxy_api_key: "test-key".to_string(),
             trusted_hosts: vec![vec!["localhost".to_string()]],
+            host: "localhost".to_string(),
+            port: 1337,
         };
         assert_eq!(config.prefix, "/v1");
         assert_eq!(config.proxy_api_key, "test-key");
         assert_eq!(config.trusted_hosts.len(), 1);
+        assert_eq!(config.host, "localhost");
+        assert_eq!(config.port, 1337);
     }
 
     #[test]
@@ -83,10 +87,14 @@ mod tests {
             prefix: "".to_string(),
             proxy_api_key: "".to_string(),
             trusted_hosts: vec![],
+            host: "127.0.0.1".to_string(),
+            port: 8080,
         };
         assert_eq!(config.prefix, "");
         assert_eq!(config.proxy_api_key, "");
         assert_eq!(config.trusted_hosts.len(), 0);
+        assert_eq!(config.host, "127.0.0.1");
+        assert_eq!(config.port, 8080);
     }
 
     #[test]


### PR DESCRIPTION
Fixes #7337

The OpenAPI specification was using a hardcoded port (1337) in the servers array, which caused the API documentation page to show incorrect URLs when the server was running on a different port.

This change:
- Adds host and port fields to ProxyConfig
- Dynamically generates the OpenAPI JSON with the actual server host and port when serving /openapi.json
- Falls back to the static file if JSON parsing fails

## Testing

When the server runs on a non-default port (e.g., when Flatpak cannot bind to port 1337), the OpenAPI documentation now correctly shows the actual server URL instead of the hardcoded localhost:1337.