### PR TITLE
feat: implement fit settings in llamacpp extension and overhaul argument builder tests

### DIFF
--- a/extensions/llamacpp-extension/settings.json
+++ b/extensions/llamacpp-extension/settings.json
@@ -49,6 +49,44 @@
     }
   },
   {
+    "key": "fit",
+    "title": "Fit (auto-adjust to device memory)",
+    "description": "Whether to adjust unset arguments to fit in device memory ('on' or 'off'). (env: LLAMA_ARG_FIT)",
+    "controllerType": "dropdown",
+    "controllerProps": {
+      "value": "on",
+      "options": [
+        { "value": "on", "name": "On" },
+        { "value": "off", "name": "Off" }
+      ],
+      "recommended": "on"
+    }
+  },
+  {
+    "key": "fit_target",
+    "title": "Fit Target per Device (MiB)",
+    "description": "Target margin per device for fit, comma-separated list of MiB values. Single value is broadcast across all devices. (env: LLAMA_ARG_FIT_TARGET)",
+    "controllerType": "input",
+    "controllerProps": {
+      "value": "1024",
+      "placeholder": "1024 or MiB0,MiB1,...",
+      "type": "text",
+      "textAlign": "right"
+    }
+  },
+  {
+    "key": "fit_ctx",
+    "title": "Fit Minimum Context Size",
+    "description": "Minimum context size (tokens) that can be set by --fit option. (env: LLAMA_ARG_FIT_CTX)",
+    "controllerType": "input",
+    "controllerProps": {
+      "value": 4096,
+      "placeholder": "4096",
+      "type": "number",
+      "textAlign": "right"
+    }
+  },
+  {
     "key": "memory_util",
     "title": "Smart Memory utilization",
     "description": "Smart memory utilization mode for running local GGUF models",

--- a/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/index.ts
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/index.ts
@@ -39,6 +39,9 @@ export function normalizeLlamacppConfig(config: any): LlamacppConfig {
     timeout: asNumber(config.timeout, 600),
 
     llamacpp_env: asString(config.llamacpp_env),
+    fit: asString(config.fit),
+    fit_target: asString(config.fit_target),
+    fit_ctx: asString(config.fit_ctx),
     memory_util: asString(config.memory_util),
     chat_template: asString(config.chat_template),
 

--- a/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/types.ts
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/types.ts
@@ -33,6 +33,9 @@ export type LlamacppConfig = {
   auto_unload: boolean
   timeout: number
   llamacpp_env: string
+  fit: string
+  fit_target: string
+  fit_ctx: string
   memory_util: string
   chat_template: string
   n_gpu_layers: number

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/args.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/args.rs
@@ -7,7 +7,10 @@ pub struct LlamacppConfig {
     pub auto_unload: bool,
     pub timeout: i32,
     pub llamacpp_env: String,
-    pub memory_util: String,
+    pub fit: String,
+    pub fit_target: String,
+    pub fit_ctx: String,
+    pub memory_util: String, // TODO: Remove after fit implementation
     pub chat_template: String,
     pub n_gpu_layers: i32,
     pub offload_mmproj: bool,
@@ -124,6 +127,11 @@ impl ArgumentBuilder {
         } else {
             self.add_text_generation_args();
         }
+        // llama fit
+        // forks like ik is not supported
+        if !self.backend.starts_with("ik") {
+            self.add_fit_settings();
+        }
 
         self.args
     }
@@ -161,10 +169,11 @@ impl ArgumentBuilder {
     }
 
     fn add_gpu_layers(&mut self) {
-        let gpu_layers = if self.config.n_gpu_layers >= 0 {
+        let gpu_layers = if self.config.n_gpu_layers >= 0 && self.config.n_gpu_layers != 100 {
+            // 100 means load all layers
             self.config.n_gpu_layers
         } else {
-            100
+            -1
         };
         self.args.push("-ngl".to_string());
         self.args.push(gpu_layers.to_string());
@@ -183,12 +192,12 @@ impl ArgumentBuilder {
     }
 
     fn add_batch_settings(&mut self) {
-        if self.config.batch_size > 0 {
+        if self.config.batch_size > 0 && self.config.batch_size != 2048 {
             self.args.push("--batch-size".to_string());
             self.args.push(self.config.batch_size.to_string());
         }
 
-        if self.config.ubatch_size > 0 {
+        if self.config.ubatch_size > 0 && self.config.ubatch_size != 512 {
             self.args.push("--ubatch-size".to_string());
             self.args.push(self.config.ubatch_size.to_string());
         }
@@ -253,7 +262,8 @@ impl ArgumentBuilder {
     }
 
     fn add_text_generation_args(&mut self) {
-        if self.config.ctx_size > 0 {
+        if self.config.ctx_size > 0 && self.config.ctx_size != 8192 {
+            // set only when default values change
             self.args.push("--ctx-size".to_string());
             self.args.push(self.config.ctx_size.to_string());
         }
@@ -307,8 +317,30 @@ impl ArgumentBuilder {
             self.args.push(self.config.rope_freq_scale.to_string());
         }
     }
-}
 
+    fn add_fit_settings(&mut self) {
+        // Handle fit on/off
+        if self.config.fit == "off" {
+            self.args.push("--fit".to_string());
+            self.args.push("off".to_string());
+        } else if self.config.fit == "on" {
+            self.args.push("--fit".to_string());
+            self.args.push("on".to_string());
+        }
+        if self.config.fit == "on" {
+            if !self.config.fit_ctx.is_empty() && self.config.fit_ctx != "4096" {
+                self.args.push("--fit-ctx".to_string());
+                self.args.push(self.config.fit_ctx.clone());
+            }
+
+            if !self.config.fit_target.is_empty() && self.config.fit_target != "1024" {
+                self.args.push("--fit-target".to_string());
+                self.args.push(self.config.fit_target.clone());
+            }
+        }
+    }
+}
+// -- Tests
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -320,6 +352,9 @@ mod tests {
             auto_unload: false,
             timeout: 120,
             llamacpp_env: String::new(),
+            fit: String::new(),
+            fit_ctx: String::new(),
+            fit_target: String::new(),
             memory_util: String::new(),
             chat_template: String::new(),
             n_gpu_layers: 100,
@@ -352,31 +387,173 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_basic_argument_building() {
-        let mut config = default_config();
-        config.n_gpu_layers = 32;
-        config.threads = 4;
-        config.ctx_size = 2048;
+    fn assert_arg_pair(args: &[String], flag: &str, value: &str) {
+        let pos = args
+            .iter()
+            .position(|arg| arg == flag)
+            .unwrap_or_else(|| panic!("Flag '{}' not found in args: {:?}", flag, args));
+        assert_eq!(
+            args.get(pos + 1).unwrap(),
+            value,
+            "Expected '{}' after flag '{}', but got '{:?}'",
+            value,
+            flag,
+            args.get(pos + 1)
+        );
+    }
 
-        let builder = ArgumentBuilder::new(config, false).unwrap();
-        let args = builder.build("test-model", "/path/to/model", 8080, None);
+    fn assert_has_flag(args: &[String], flag: &str) {
+        assert!(
+            args.contains(&flag.to_string()),
+            "Flag '{}' not found in args: {:?}",
+            flag,
+            args
+        );
+    }
 
-        assert!(args.contains(&"--no-webui".to_string()));
-        assert!(args.contains(&"-m".to_string()));
-        assert!(args.contains(&"--port".to_string()));
-        assert!(args.contains(&"8080".to_string()));
+    fn assert_no_flag(args: &[String], flag: &str) {
+        assert!(
+            !args.contains(&flag.to_string()),
+            "Flag '{}' should not be present in args: {:?}",
+            flag,
+            args
+        );
     }
 
     #[test]
-    fn test_embedding_mode() {
+    fn test_basic_required_arguments() {
+        let config = default_config();
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test-model", "/path/to/model", 8080, None);
+
+        assert_has_flag(&args, "--no-webui");
+        assert_has_flag(&args, "--jinja");
+        assert_arg_pair(&args, "-m", "/path/to/model");
+        assert_arg_pair(&args, "-a", "test-model");
+        assert_arg_pair(&args, "--port", "8080");
+    }
+
+    #[test]
+    fn test_gpu_layers_default_100() {
+        let config = default_config();
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "-ngl", "-1");
+    }
+
+    #[test]
+    fn test_gpu_layers_custom_value() {
+        let mut config = default_config();
+        config.n_gpu_layers = 32;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "-ngl", "32");
+    }
+
+    #[test]
+    fn test_gpu_layers_negative_value() {
+        let mut config = default_config();
+        config.n_gpu_layers = -1;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "-ngl", "-1");
+    }
+
+    #[test]
+    fn test_embedding_mode_arguments() {
         let config = default_config();
         let builder = ArgumentBuilder::new(config, true).unwrap();
         let args = builder.build("embed-model", "/path/to/model", 8080, None);
 
-        assert!(args.contains(&"--embedding".to_string()));
-        assert!(args.contains(&"--pooling".to_string()));
-        assert!(args.contains(&"mean".to_string()));
+        assert_has_flag(&args, "--embedding");
+        assert_arg_pair(&args, "--pooling", "mean");
+    }
+
+    #[test]
+    fn test_text_generation_mode_no_embedding_flags() {
+        let config = default_config();
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--embedding");
+        assert_no_flag(&args, "--pooling");
+    }
+
+    #[test]
+    fn test_thread_settings() {
+        let mut config = default_config();
+        config.threads = 8;
+        config.threads_batch = 4;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--threads", "8");
+        assert_arg_pair(&args, "--threads-batch", "4");
+    }
+
+    #[test]
+    fn test_thread_settings_zero_not_added() {
+        let config = default_config();
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--threads");
+        assert_no_flag(&args, "--threads-batch");
+    }
+
+    #[test]
+    fn test_batch_settings_default_values_not_added() {
+        let mut config = default_config();
+        config.batch_size = 2048;
+        config.ubatch_size = 512;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--batch-size");
+        assert_no_flag(&args, "--ubatch-size");
+    }
+
+    #[test]
+    fn test_batch_settings_custom_values() {
+        let mut config = default_config();
+        config.batch_size = 1024;
+        config.ubatch_size = 256;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--batch-size", "1024");
+        assert_arg_pair(&args, "--ubatch-size", "256");
+    }
+
+    #[test]
+    fn test_ik_backend_no_webui_flag() {
+        let mut config = default_config();
+        config.version_backend = "v1.0/ik-backend".to_string();
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--no-webui");
+    }
+
+    #[test]
+    fn test_standard_backend_flash_attention() {
+        let mut config = default_config();
+        config.flash_attn = "on".to_string();
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--flash-attn", "on");
+        assert_no_flag(&args, "-fa");
     }
 
     #[test]
@@ -388,19 +565,442 @@ mod tests {
         let builder = ArgumentBuilder::new(config, false).unwrap();
         let args = builder.build("test", "/path", 8080, None);
 
-        assert!(args.contains(&"-fa".to_string()));
-        assert!(!args.contains(&"--flash-attn".to_string()));
+        assert_has_flag(&args, "-fa");
+        assert_no_flag(&args, "--flash-attn");
     }
 
     #[test]
-    fn test_empty_strings_not_added() {
+    fn test_flash_attention_auto_not_added() {
         let config = default_config();
         let builder = ArgumentBuilder::new(config, false).unwrap();
         let args = builder.build("test", "/path", 8080, None);
 
-        // Empty strings should not result in empty arguments
-        assert!(!args.contains(&"--device".to_string()));
-        assert!(!args.contains(&"--chat-template".to_string()));
-        assert!(!args.contains(&"--override-tensor".to_string()));
+        assert_no_flag(&args, "--flash-attn");
+    }
+
+    #[test]
+    fn test_cpu_moe_flags() {
+        let mut config = default_config();
+        config.cpu_moe = true;
+        config.n_cpu_moe = 4;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_has_flag(&args, "--cpu-moe");
+        assert_arg_pair(&args, "--n-cpu-moe", "4");
+    }
+
+    #[test]
+    fn test_cpu_moe_zero_not_added() {
+        let mut config = default_config();
+        config.cpu_moe = false;
+        config.n_cpu_moe = 0;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--cpu-moe");
+        assert_no_flag(&args, "--n-cpu-moe");
+    }
+
+    #[test]
+    fn test_mmproj_path_provided() {
+        let config = default_config();
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, Some("/path/to/mmproj".to_string()));
+
+        assert_arg_pair(&args, "--mmproj", "/path/to/mmproj");
+    }
+
+    #[test]
+    fn test_mmproj_path_empty_not_added() {
+        let config = default_config();
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, Some(String::new()));
+
+        assert_no_flag(&args, "--mmproj");
+    }
+
+    #[test]
+    fn test_chat_template() {
+        let mut config = default_config();
+        config.chat_template = "custom-template".to_string();
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--chat-template", "custom-template");
+    }
+
+    #[test]
+    fn test_empty_chat_template_not_added() {
+        let config = default_config();
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--chat-template");
+    }
+
+    #[test]
+    fn test_device_settings() {
+        let mut config = default_config();
+        config.device = "cuda:0".to_string();
+        config.split_mode = "row".to_string();
+        config.main_gpu = 1;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--device", "cuda:0");
+        assert_arg_pair(&args, "--split-mode", "row");
+        assert_arg_pair(&args, "--main-gpu", "1");
+    }
+
+    #[test]
+    fn test_split_mode_layer_default_not_added() {
+        let config = default_config();
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--split-mode");
+    }
+
+    #[test]
+    fn test_main_gpu_zero_not_added() {
+        let config = default_config();
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--main-gpu");
+    }
+
+    #[test]
+    fn test_boolean_flags_enabled() {
+        let mut config = default_config();
+        config.ctx_shift = true;
+        config.cont_batching = true;
+        config.no_mmap = true;
+        config.mlock = true;
+        config.no_kv_offload = true;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_has_flag(&args, "--context-shift");
+        assert_has_flag(&args, "--cont-batching");
+        assert_has_flag(&args, "--no-mmap");
+        assert_has_flag(&args, "--mlock");
+        assert_has_flag(&args, "--no-kv-offload");
+    }
+
+    #[test]
+    fn test_boolean_flags_disabled() {
+        let config = default_config();
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--context-shift");
+        assert_no_flag(&args, "--cont-batching");
+        assert_no_flag(&args, "--no-mmap");
+        assert_no_flag(&args, "--mlock");
+        assert_no_flag(&args, "--no-kv-offload");
+    }
+
+    #[test]
+    fn test_ctx_size_default_not_added() {
+        let mut config = default_config();
+        config.ctx_size = 8192;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--ctx-size");
+    }
+
+    #[test]
+    fn test_ctx_size_custom_value() {
+        let mut config = default_config();
+        config.ctx_size = 4096;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--ctx-size", "4096");
+    }
+
+    #[test]
+    fn test_n_predict() {
+        let mut config = default_config();
+        config.n_predict = 512;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--n-predict", "512");
+    }
+
+    #[test]
+    fn test_cache_type_k_default_not_added() {
+        let config = default_config();
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--cache-type-k");
+    }
+
+    #[test]
+    fn test_cache_type_k_custom_value() {
+        let mut config = default_config();
+        config.cache_type_k = "q8_0".to_string();
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--cache-type-k", "q8_0");
+    }
+
+    #[test]
+    fn test_cache_type_v_with_flash_attn() {
+        let mut config = default_config();
+        config.flash_attn = "on".to_string();
+        config.cache_type_v = "q8_0".to_string();
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--cache-type-v", "q8_0");
+    }
+
+    #[test]
+    fn test_cache_type_v_without_flash_attn_not_added() {
+        let mut config = default_config();
+        config.flash_attn = "off".to_string();
+        config.cache_type_v = "q8_0".to_string();
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--cache-type-v");
+    }
+
+    #[test]
+    fn test_cache_type_v_f16_not_added() {
+        let mut config = default_config();
+        config.flash_attn = "on".to_string();
+        config.cache_type_v = "f16".to_string();
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--cache-type-v");
+    }
+
+    #[test]
+    fn test_defrag_thold_default_not_added() {
+        let config = default_config();
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--defrag-thold");
+    }
+
+    #[test]
+    fn test_defrag_thold_custom_value() {
+        let mut config = default_config();
+        config.defrag_thold = 0.5;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--defrag-thold", "0.5");
+    }
+
+    #[test]
+    fn test_rope_scaling_none_not_added() {
+        let config = default_config();
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--rope-scaling");
+    }
+
+    #[test]
+    fn test_rope_scaling_custom_value() {
+        let mut config = default_config();
+        config.rope_scaling = "linear".to_string();
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--rope-scaling", "linear");
+    }
+
+    #[test]
+    fn test_rope_scale_default_not_added() {
+        let config = default_config();
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--rope-scale");
+    }
+
+    #[test]
+    fn test_rope_scale_custom_value() {
+        let mut config = default_config();
+        config.rope_scale = 2.0;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--rope-scale", "2");
+    }
+
+    #[test]
+    fn test_rope_freq_base_zero_not_added() {
+        let config = default_config();
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--rope-freq-base");
+    }
+
+    #[test]
+    fn test_rope_freq_base_custom_value() {
+        let mut config = default_config();
+        config.rope_freq_base = 10000.0;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--rope-freq-base", "10000");
+    }
+
+    #[test]
+    fn test_rope_freq_scale_default_not_added() {
+        let config = default_config();
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--rope-freq-scale");
+    }
+
+    #[test]
+    fn test_rope_freq_scale_custom_value() {
+        let mut config = default_config();
+        config.rope_freq_scale = 0.5;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--rope-freq-scale", "0.5");
+    }
+
+    #[test]
+    fn test_tensor_buffer_override() {
+        let mut config = default_config();
+        config.override_tensor_buffer_t = "f32".to_string();
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--override-tensor", "f32");
+    }
+
+    #[test]
+    fn test_fit_off() {
+        let mut config = default_config();
+        config.fit = "off".to_string();
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--fit", "off");
+        assert_no_flag(&args, "--fit-ctx");
+        assert_no_flag(&args, "--fit-target");
+    }
+
+    #[test]
+    fn test_fit_on_with_defaults() {
+        let mut config = default_config();
+        config.fit = "on".to_string();
+        config.fit_ctx = "4096".to_string();
+        config.fit_target = "1024".to_string();
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--fit", "on");
+        assert_no_flag(&args, "--fit-ctx");
+        assert_no_flag(&args, "--fit-target");
+    }
+
+    #[test]
+    fn test_fit_on_with_custom_values() {
+        let mut config = default_config();
+        config.fit = "on".to_string();
+        config.fit_ctx = "8192".to_string();
+        config.fit_target = "2048".to_string();
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--fit", "on");
+        assert_arg_pair(&args, "--fit-ctx", "8192");
+        assert_arg_pair(&args, "--fit-target", "2048");
+    }
+
+    #[test]
+    fn test_fit_not_added_for_ik_backend() {
+        let mut config = default_config();
+        config.version_backend = "v1.0/ik-backend".to_string();
+        config.fit = "on".to_string();
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--fit");
+        assert_no_flag(&args, "--fit-ctx");
+        assert_no_flag(&args, "--fit-target");
+    }
+
+    #[test]
+    fn test_invalid_version_backend_format() {
+        let mut config = default_config();
+        config.version_backend = "invalid-format".to_string();
+
+        let result = ArgumentBuilder::new(config, false);
+        assert!(result.is_err());
+        if let Err(e) = result {
+            assert_eq!(e, "Invalid version_backend format");
+        }
+    }
+
+    #[test]
+    fn test_complex_configuration() {
+        let mut config = default_config();
+        config.n_gpu_layers = 50;
+        config.threads = 16;
+        config.threads_batch = 8;
+        config.batch_size = 1024;
+        config.ctx_size = 4096;
+        config.flash_attn = "on".to_string();
+        config.cont_batching = true;
+        config.rope_scaling = "linear".to_string();
+        config.rope_scale = 2.0;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("complex-model", "/model/path", 9000, None);
+
+        assert_arg_pair(&args, "-ngl", "50");
+        assert_arg_pair(&args, "--threads", "16");
+        assert_arg_pair(&args, "--threads-batch", "8");
+        assert_arg_pair(&args, "--batch-size", "1024");
+        assert_arg_pair(&args, "--ctx-size", "4096");
+        assert_arg_pair(&args, "--flash-attn", "on");
+        assert_has_flag(&args, "--cont-batching");
+        assert_arg_pair(&args, "--rope-scaling", "linear");
+        assert_arg_pair(&args, "--rope-scale", "2");
+        assert_arg_pair(&args, "--port", "9000");
     }
 }


### PR DESCRIPTION
## Describe Your Changes

Introduces support for the `fit` parameter and its associated configurations (`fit_target`, `fit_ctx`) to allow automatic adjustment of arguments to device memory. This change spans the extension settings, guest-js types, and the Rust argument builder.

**Key changes:**

* **Settings & Types:** Added `fit`, `fit_target`, and `fit_ctx` to `settings.json` and synchronized these fields across the TypeScript definitions and the Rust `LlamacppConfig` struct.
* **Logic Updates:** * Implemented `add_fit_settings` in the `ArgumentBuilder` to handle `--fit`, `--fit-target`, and `--fit-ctx` flags.
* Modified `add_gpu_layers` to use `-1` as the default for loading all layers, while treating `100` as a manual override.
* Updated several argument methods (batch size, context size, etc.) to only append flags if the values differ from the defaults, reducing command-line clutter.
* Added a check to exclude `fit` settings when using the `ik` backend fork.

* **Testing:** Significantly expanded the Rust test suite. Replaced basic assertions with dedicated helper functions (`assert_arg_pair`, `assert_has_flag`, `assert_no_flag`) and added comprehensive test cases for various configurations, including GPU layers, embedding mode, and backend-specific behavior.

## Fixes Issues

- Closes #
- Closes #

## Future Tasks
 - Remove in house auto optimize feature - we rely on llamacpp now
 - Adjust UX

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
