### PR TITLE
fix: issue descendant element

### DIFF
--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -163,6 +163,9 @@ const ChatInput = memo(function ChatInput({
   const [hasMmproj, setHasMmproj] = useState(false)
   const [showVisionModelPrompt, setShowVisionModelPrompt] = useState(false)
   const activeModels = useAppState(useShallow((state) => state.activeModels))
+
+  // Check if selected model is currently loaded/active
+  const isModelActive = selectedModel?.id ? activeModels.includes(selectedModel.id) : false
   const [selectedAssistant, setSelectedAssistant] = useState<Assistant | undefined>()
 
   // Jan Browser Extension hook
@@ -1843,6 +1846,7 @@ const ChatInput = memo(function ChatInput({
       )}
 
       {selectedProvider === 'llamacpp' &&
+        isModelActive &&
         !tokenCounterCompact &&
         !initialMessage &&
         (threadMessages?.length > 0 || prompt.trim().length > 0) && (

--- a/web-app/src/containers/SettingsMenu.tsx
+++ b/web-app/src/containers/SettingsMenu.tsx
@@ -15,7 +15,7 @@ import ProvidersAvatar from '@/containers/ProvidersAvatar'
 
 const SettingsMenu = () => {
   const { t } = useTranslation()
-  const [expandedProviders, setExpandedProviders] = useState(true)
+  const [expandedProviders, setExpandedProviders] = useState(false)
   const matches = useMatches()
   const navigate = useNavigate()
 

--- a/web-app/src/containers/__tests__/SettingsMenu.test.tsx
+++ b/web-app/src/containers/__tests__/SettingsMenu.test.tsx
@@ -107,25 +107,25 @@ describe('SettingsMenu', () => {
   it('shows expanded providers by default', () => {
     render(<SettingsMenu />)
 
-    // Providers should be expanded by default (expandedProviders starts as true)
-    expect(screen.getByTestId('provider-avatar-openai')).toBeInTheDocument()
-    expect(screen.getByTestId('provider-avatar-llama.cpp')).toBeInTheDocument()
+    // Providers are NOT expanded by default (expandedProviders starts as false)
+    // They only expand when the chevron is clicked or when on a provider route
+    expect(screen.queryByTestId('provider-avatar-openai')).not.toBeInTheDocument()
   })
 
   it('collapses providers submenu when chevron is clicked', async () => {
     const user = userEvent.setup()
     render(<SettingsMenu />)
 
-    // Providers should be visible initially
-    expect(screen.getByTestId('provider-avatar-openai')).toBeInTheDocument()
+    // Providers are NOT visible initially (collapsed by default)
+    expect(screen.queryByTestId('provider-avatar-openai')).not.toBeInTheDocument()
 
-    // Click the chevron to collapse
+    // Click the chevron to expand
     const chevronButtons = screen.getAllByRole('button')
     const chevron = chevronButtons[0]
     await user.click(chevron)
 
-    // After clicking, providers should be hidden
-    expect(screen.queryByTestId('provider-avatar-openai')).not.toBeInTheDocument()
+    // After clicking, providers should be visible
+    expect(screen.getByTestId('provider-avatar-openai')).toBeInTheDocument()
   })
 
   it('auto-expands providers when on provider route', () => {
@@ -161,7 +161,11 @@ describe('SettingsMenu', () => {
     const user = userEvent.setup()
     render(<SettingsMenu />)
 
-    // Providers are expanded by default, so click on a provider directly
+    // Providers are collapsed by default, first click chevron to expand
+    const chevronButtons = screen.getAllByRole('button')
+    await user.click(chevronButtons[0])
+
+    // Now click on a provider
     const openaiProvider = screen
       .getByTestId('provider-avatar-openai')
       .closest('div[class*="cursor-pointer"]')
@@ -189,7 +193,8 @@ describe('SettingsMenu', () => {
     expect(llamaCpp?.className).toContain('hidden')
   })
 
-  it('filters out inactive providers from submenu', () => {
+  it('filters out inactive providers from submenu', async () => {
+    const user = userEvent.setup()
     vi.mocked(useModelProvider).mockReturnValue({
       providers: [
         {
@@ -206,6 +211,10 @@ describe('SettingsMenu', () => {
     })
 
     render(<SettingsMenu />)
+
+    // Providers are collapsed by default, click chevron to expand
+    const chevronButtons = screen.getAllByRole('button')
+    await user.click(chevronButtons[0])
 
     expect(screen.getByTestId('provider-avatar-openai')).toBeInTheDocument()
     expect(

--- a/web-app/src/containers/dynamicControllerSetting/DropdownControl.tsx
+++ b/web-app/src/containers/dynamicControllerSetting/DropdownControl.tsx
@@ -27,7 +27,7 @@ export function DropdownControl({
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger >
+      <DropdownMenuTrigger asChild>
         <Button variant="outline" size="sm" className="w-full justify-between">
           {isSelected}
           <ChevronsUpDown className="size-4 shrink-0 text-muted-foreground ml-2" />


### PR DESCRIPTION
## Describe Your Changes

This pull request primarily updates the behavior of the providers submenu in the `SettingsMenu` to be collapsed by default, adjusts related tests, and adds a conditional check for active models in the chat input. It also includes a small UI fix for a dropdown control.

**SettingsMenu submenu behavior and related tests:**

* Changed the default state of the `expandedProviders` variable in `SettingsMenu` to `false`, so providers are now collapsed by default.
* Updated tests in `SettingsMenu.test.tsx` to reflect the new default collapsed state, including adjusting expectations and user interactions to expand the submenu before accessing providers. [[1]](diffhunk://#diff-7ad3ce01f27350618852840b164025218f8fd0dbe4ca571e8c4cad0bb889918fL110-R128) [[2]](diffhunk://#diff-7ad3ce01f27350618852840b164025218f8fd0dbe4ca571e8c4cad0bb889918fL164-R168) [[3]](diffhunk://#diff-7ad3ce01f27350618852840b164025218f8fd0dbe4ca571e8c4cad0bb889918fL192-R197) [[4]](diffhunk://#diff-7ad3ce01f27350618852840b164025218f8fd0dbe4ca571e8c4cad0bb889918fR215-R218)

**Chat input model activity check:**

* Added an `isModelActive` check in `ChatInput.tsx` to ensure that certain UI elements are only shown if the selected model is currently active. [[1]](diffhunk://#diff-e6927577dd0c5d682ae3ac9367b9a6b7df9f76df4cf35c5a05779e539749f417R166-R168) [[2]](diffhunk://#diff-e6927577dd0c5d682ae3ac9367b9a6b7df9f76df4cf35c5a05779e539749f417R1849)

**UI component fix:**

* Updated `DropdownControl.tsx` to use `asChild` for the `DropdownMenuTrigger`, improving component composition and button rendering.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
