### PR TITLE
fix: disable fit does not work well - llama.cpp somehow use max ctx-size

### DIFF
--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/args.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/args.rs
@@ -705,17 +705,6 @@ mod tests {
     }
 
     #[test]
-    fn test_ctx_size_default_not_added() {
-        let mut config = default_config();
-        config.ctx_size = 8192;
-
-        let builder = ArgumentBuilder::new(config, false).unwrap();
-        let args = builder.build("test", "/path", 8080, None);
-
-        assert_no_flag(&args, "--ctx-size");
-    }
-
-    #[test]
     fn test_ctx_size_custom_value() {
         let mut config = default_config();
         config.ctx_size = 4096;


### PR DESCRIPTION
## Describe Your Changes

Somehow llama.cpp with fit disabled not load full ctx-size which is weird. So now it's better to send ctx-size everytime.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
