### PR TITLE
fix: visibility toolbar state window on local api server

### DIFF
--- a/web-app/src/routes/settings/local-api-server.tsx
+++ b/web-app/src/routes/settings/local-api-server.tsx
@@ -390,7 +390,7 @@ function LocalAPIServerContent() {
   return (
     <div className="flex flex-col h-svh w-full">
       <HeaderPage>
-        <div className="flex items-center justify-between w-full mr-2 pr-4">
+        <div className={cn("flex items-center justify-between w-full mr-2 pr-3", !IS_MACOS && "pr-30")}>
           <span className="font-medium text-base font-studio">
             {t('common:settings')}
           </span>


### PR DESCRIPTION
## Describe Your Changes

This pull request makes a minor UI adjustment to the `LocalAPIServerContent` component. The change modifies the right padding of a container div to improve layout consistency, especially for non-macOS platforms.

- UI/layout update:
  * In `local-api-server.tsx`, updated the container div's class to conditionally apply a larger right padding (`pr-30`) when not running on macOS, replacing the previous fixed padding (`pr-4`).

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
