### PR TITLE
fix: thumb default interface accent color based on theme color

### DIFF
--- a/web-app/src/containers/AccentColorPicker.tsx
+++ b/web-app/src/containers/AccentColorPicker.tsx
@@ -17,7 +17,7 @@ export function AccentColorPicker() {
             title={color.name}
             onClick={() => setAccentColor(color.value)}
             className={cn(
-              'size-5 rounded-full border border-secondary transition-all duration-200 cursor-pointer hover:scale-110',
+              'size-5 rounded-full border-2 border-secondary transition-all duration-200 cursor-pointer hover:scale-110',
               isSelected &&
                 'ring-2 ring-offset-2 ring-primary border-none'
             )}


### PR DESCRIPTION
## Describe Your Changes

<img width="2624" height="1826" alt="Screenshot 2026-02-10 at 14 31 16" src="https://github.com/user-attachments/assets/30f4e334-91af-432c-a957-fffcb45d2eda" />
<img width="2624" height="1826" alt="Screenshot 2026-02-10 at 14 31 13" src="https://github.com/user-attachments/assets/ee6ee3ed-4b4e-4760-ad15-08959cc0c13e" />

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
