### PR TITLE
fix: disable --fit for mac

### DIFF
--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -125,6 +125,14 @@ export default class llamacpp_extension extends AIEngine {
 
     let settings = structuredClone(SETTINGS) // Clone to modify settings definition before registration
 
+    // Disable fit by default on macOS
+    if (IS_MAC) {
+      const fitSetting = settings.find((s: any) => s.key === 'fit')
+      if (fitSetting) {
+        fitSetting.controllerProps.value = false
+      }
+    }
+
     // This makes the settings (including the backend options and initial value) available to the Jan UI.
     this.registerSettings(settings)
 


### PR DESCRIPTION
## Describe Your Changes

- --fit option is not stable for unified memory devices, it's better to just disable by default (same as model planner)

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
