### PR TITLE
fix: bump router plugin to fix vite crash

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -102,7 +102,7 @@
   },
   "devDependencies": {
     "@eslint/js": "8.57.0",
-    "@tanstack/router-plugin": "1.117.0",
+    "@tanstack/router-plugin": "1.121.34",
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "6.8.0",
     "@testing-library/react": "16.3.0",


### PR DESCRIPTION
## Describe Your Changes

- vite router older version is causing crash on details settings screen

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
