### PR TITLE
ci: add condition for nightly external

### DIFF
--- a/.github/workflows/jan-tauri-build-nightly-external.yaml
+++ b/.github/workflows/jan-tauri-build-nightly-external.yaml
@@ -18,9 +18,11 @@ on:
 
 jobs:
   get-update-version:
+    if: github.event.pull_request.head.repo.full_name != github.repository
     uses: ./.github/workflows/template-get-update-version.yml
 
   build-macos:
+    if: github.event.pull_request.head.repo.full_name != github.repository
     uses: ./.github/workflows/template-tauri-build-macos-external.yml
     needs: [get-update-version]
     with:
@@ -29,6 +31,7 @@ jobs:
       channel: nightly
 
   build-windows-x64:
+    if: github.event.pull_request.head.repo.full_name != github.repository
     uses: ./.github/workflows/template-tauri-build-windows-x64-external.yml
     needs: [get-update-version]
     with:
@@ -37,6 +40,7 @@ jobs:
       channel: nightly
 
   build-linux-x64:
+    if: github.event.pull_request.head.repo.full_name != github.repository
     uses: ./.github/workflows/template-tauri-build-linux-x64-external.yml
     needs: [get-update-version]
     with:


### PR DESCRIPTION
## Describe Your Changes

This pull request updates the `.github/workflows/jan-tauri-build-nightly-external.yaml` workflow to ensure that certain jobs only run when the pull request originates from a fork (i.e., an external repository), not from the main repository itself. This helps prevent unnecessary or potentially unsafe builds from running on internal pull requests.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
