### PR TITLE
fix: sorting provider name

### DIFF
--- a/web-app/src/containers/DropdownModelProvider.tsx
+++ b/web-app/src/containers/DropdownModelProvider.tsx
@@ -267,13 +267,15 @@ const DropdownModelProvider = memo(function DropdownModelProvider({
         if (modelItem.embedding) return
 
         // Skip models that require API key but don't have one (except llamacpp)
+        // For custom providers, allow if they have at least one model loaded
+        const isPredefined = predefinedProviders.some((e) =>
+          e.provider.includes(provider.provider)
+        )
         if (
           provider &&
-          predefinedProviders.some((e) =>
-            e.provider.includes(provider.provider)
-          ) &&
           provider.provider !== 'llamacpp' &&
-          !provider.api_key?.length
+          !provider.api_key?.length &&
+          (isPredefined || provider.models.length === 0)
         )
           return
 
@@ -338,7 +340,7 @@ const DropdownModelProvider = memo(function DropdownModelProvider({
 
     if (!searchValue) {
       // When not searching, show all active providers (even without models)
-      // Sort: local first, then providers with API keys, then others, alphabetically
+      // Sort: local first, then providers with API keys or custom with models, then others, alphabetically
       const activeProviders = providers
         .filter((p) => p.active)
         .sort((a, b) => {
@@ -348,11 +350,22 @@ const DropdownModelProvider = memo(function DropdownModelProvider({
           if (aIsLocal && !bIsLocal) return -1
           if (!aIsLocal && bIsLocal) return 1
 
-          const aHasApiKey = (a.api_key?.length ?? 0) > 0
-          const bHasApiKey = (b.api_key?.length ?? 0) > 0
-          // Providers with API keys filled second
-          if (aHasApiKey && !bHasApiKey) return -1
-          if (!aHasApiKey && bHasApiKey) return 1
+          // Custom providers without API key but with models should be treated like "have API key"
+          const aIsPredefined = predefinedProviders.some((e) =>
+            e.provider.includes(a.provider)
+          )
+          const bIsPredefined = predefinedProviders.some((e) =>
+            e.provider.includes(b.provider)
+          )
+          const aHasApiKeyOrCustomModel =
+            (a.api_key?.length ?? 0) > 0 ||
+            (!aIsPredefined && a.models.length > 0)
+          const bHasApiKeyOrCustomModel =
+            (b.api_key?.length ?? 0) > 0 ||
+            (!bIsPredefined && b.models.length > 0)
+          // Providers with API keys or custom with models filled second
+          if (aHasApiKeyOrCustomModel && !bHasApiKeyOrCustomModel) return -1
+          if (!aHasApiKeyOrCustomModel && bHasApiKeyOrCustomModel) return 1
 
           // Sort remaining by provider name
           return a.provider.localeCompare(b.provider)


### PR DESCRIPTION
## Describe Your Changes

 Sort model providers in the dropdown with a more intuitive ordering: local providers first, then providers with configured API keys, then others alphabetically. 
  
## Changes

  Modified web-app/src/containers/DropdownModelProvider.tsx:
  - Sort active providers in the dropdown with priority order:
    a. Local providers (llamacpp, mlx) - for faster local inference
    b. Providers with API keys configured - for easy access to configured remote providers

## Fixes Issues

<img width="2624" height="1826" alt="Screenshot 2026-02-13 at 13 49 51" src="https://github.com/user-attachments/assets/4b98fb32-d98d-405c-9332-f8b181b14892" />


- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
