### PR TITLE
fix: thinking render with long content

### DIFF
--- a/web-app/src/components/ai-elements/reasoning.tsx
+++ b/web-app/src/components/ai-elements/reasoning.tsx
@@ -13,6 +13,7 @@ import {
   memo,
   useContext,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react'
@@ -95,10 +96,18 @@ export const Reasoning = memo(
       setIsOpen(newOpen)
     }
 
+    const contextValue = useMemo(
+      () => ({
+        isStreaming,
+        isOpen,
+        setIsOpen,
+        duration,
+      }),
+      [isStreaming, isOpen, duration]
+    )
+
     return (
-      <ReasoningContext.Provider
-        value={{ isStreaming, isOpen, setIsOpen, duration }}
-      >
+      <ReasoningContext.Provider value={contextValue}>
         <Collapsible
           className={cn('not-prose mb-4', className)}
           onOpenChange={handleOpenChange}


### PR DESCRIPTION
## Describe Your Changes

Issue, when thinking is to long sometime its make app freeze, we try memorize the value to avoid rerender

<img width="861" height="370" alt="Screenshot 2026-02-13 at 14 22 59" src="https://github.com/user-attachments/assets/61110509-cecf-40ae-8a06-6429d09fb3ef" />


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
