### PR TITLE
fix(security): guard archive extraction paths

### DIFF
--- a/scripts/archive-extract-guard.mjs
+++ b/scripts/archive-extract-guard.mjs
@@ -1,0 +1,47 @@
+import path from 'path'
+
+function buildUnsafePathError(archiveType, entryPath) {
+  return new Error(`Unsafe ${archiveType} entry path: ${entryPath}`)
+}
+
+export function assertSafeArchivePath(entryPath, targetDir, archiveType) {
+  const rawPath = typeof entryPath === 'string' ? entryPath : ''
+  const sourcePath = rawPath.replaceAll('\\', '/')
+  const normalizedPath = path.posix.normalize(sourcePath)
+  const hasWindowsDrive = /^[a-zA-Z]:\//.test(sourcePath)
+
+  if (
+    !rawPath ||
+    sourcePath.startsWith('/') ||
+    hasWindowsDrive ||
+    normalizedPath === '..' ||
+    normalizedPath.startsWith('../')
+  ) {
+    throw buildUnsafePathError(archiveType, entryPath)
+  }
+
+  const targetRoot = path.resolve(targetDir)
+  const destinationPath = path.resolve(targetRoot, normalizedPath)
+  if (destinationPath !== targetRoot && !destinationPath.startsWith(`${targetRoot}${path.sep}`)) {
+    throw buildUnsafePathError(archiveType, entryPath)
+  }
+}
+
+export function isZipSymlink(entry) {
+  const mode = (Number(entry?.externalFileAttributes || 0) >>> 16) & 0o170000
+  return mode === 0o120000
+}
+
+export function assertSafeZipEntry(entry, targetDir) {
+  assertSafeArchivePath(entry.path, targetDir, '.zip')
+  if (isZipSymlink(entry)) {
+    throw new Error(`Unsafe .zip entry type: ${entry.path}`)
+  }
+}
+
+export function assertSafeTarEntry(entryPath, entry, targetDir) {
+  assertSafeArchivePath(entryPath, targetDir, '.tar.gz')
+  if (entry && (entry.type === 'SymbolicLink' || entry.type === 'Link')) {
+    throw new Error(`Unsafe .tar.gz entry type: ${entryPath}`)
+  }
+}

--- a/scripts/archive-extract-guard.test.mjs
+++ b/scripts/archive-extract-guard.test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { assertSafeArchivePath } from './archive-extract-guard.mjs'
+
+test('rejects unsafe archive entry paths', () => {
+  assert.throws(() => assertSafeArchivePath('../escape.txt', 'scripts/dist', '.zip'), /Unsafe \.zip entry path/)
+  assert.throws(() => assertSafeArchivePath('nested/../../escape.txt', 'scripts/dist', '.tar.gz'), /Unsafe \.tar\.gz entry path/)
+  assert.throws(() => assertSafeArchivePath('/etc/passwd', 'scripts/dist', '.zip'), /Unsafe \.zip entry path/)
+  assert.throws(
+    () => assertSafeArchivePath('C:/Windows/System32/drivers/etc/hosts', 'scripts/dist', '.zip'),
+    /Unsafe \.zip entry path/
+  )
+  assert.throws(() => assertSafeArchivePath('..\\escape.txt', 'scripts/dist', '.zip'), /Unsafe \.zip entry path/)
+  assert.doesNotThrow(() => assertSafeArchivePath('nested/file.txt', 'scripts/dist', '.zip'))
+})


### PR DESCRIPTION
## Summary
Harden archive extraction used by the binary downloader to prevent path traversal and link-based escape writes.

## Security Changes
- Validates each archive entry path before extraction.
- Rejects absolute paths, `..` traversal segments, and Windows drive-prefixed paths.
- Rejects symlink entries in `.zip` archives.
- Rejects `SymbolicLink` and `Link` entries in `.tar.gz` archives.
- Enables `preservePaths: false` for tar extraction.

## Scope
- `scripts/download-bin.mjs`: applies guard checks before and during extraction.
- `scripts/archive-extract-guard.mjs`: centralized path and entry-type validation helpers.
- `scripts/archive-extract-guard.test.mjs`: focused test ensuring unsafe paths are rejected.

## Result
This reduces risk of archive extraction writing files outside the intended destination directory (Zip Slip / tar path traversal classes).
