### PR TITLE
fix: add dir=auto for bidirectional text support

### DIFF
--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -1448,6 +1448,7 @@ const ChatInput = memo(function ChatInput({
               </div>
             )}
             <TextareaAutosize
+              dir="auto"
               ref={textareaRef}
               minRows={2}
               rows={1}

--- a/web-app/src/containers/MessageItem.tsx
+++ b/web-app/src/containers/MessageItem.tsx
@@ -173,7 +173,7 @@ export const MessageItem = memo(
                   </div>
                 )}
                 {displayText && (
-                  <div className="select-text whitespace-pre-wrap">
+                  <div dir="auto" className="select-text whitespace-pre-wrap">
                     {displayText}
                   </div>
                 )}

--- a/web-app/src/containers/RenderMarkdown.tsx
+++ b/web-app/src/containers/RenderMarkdown.tsx
@@ -93,6 +93,7 @@ function RenderMarkdownComponent({
   // Render the markdown content
   return (
     <div
+      dir="auto"
       className={cn(
         'markdown wrap-break-word select-text',
         isUser && 'is-user',

--- a/web-app/src/containers/dialogs/EditMessageDialog.tsx
+++ b/web-app/src/containers/dialogs/EditMessageDialog.tsx
@@ -153,6 +153,7 @@ export function EditMessageDialog({
             </div>
           )}
           <Textarea
+            dir="auto"
             ref={textareaRef}
             value={draft}
             onChange={(e) => setDraft(e.target.value)}


### PR DESCRIPTION
## Describe Your Changes

This PR provides basic RTL support by setting `dir="auto"` in the chat input, user messages, the markdown renderer, and the edit message dialog to enable automatic text direction detection.

While this change fixes the text ordering necessary for punctuation or bi-directional text, it also changes the message alignment for RTL languages. One may argue that this is not the optimal design.

The screenshots below show the original and updated behaviours, the latter matches the expected results.

<img width="1016" height="1009" alt="Screenshot from 2026-02-19 20-22-02" src="https://github.com/user-attachments/assets/acdce0cd-ed4c-41c5-b0dd-36b81ba948db" />
Original behaviour: Persian text in LTR format.

<img width="1016" height="1009" alt="Screenshot from 2026-02-19 20-21-33" src="https://github.com/user-attachments/assets/25b66eb8-6a59-404c-8757-676420d507e8" />
Updated behaviour: proper RTL.

English text continues to function as before, ensuring no regressions. For Persian, Arabic, and Hebrew, the implementation succeeds in most scenarios. However, its effectiveness in complex cases depends on the markdown renderer's implementation (see: https://github.com/vercel/streamdown/issues/311).

## Rationale

Compared to using the CSS property `unicode-bidi: plain-text`, which preserves alignment while correcting text flow, this is the approach suggested by the MDN documentation:

> Note: The auto value should be used for data with an unknown directionality, like data coming from user input or external data.

## Fixes Issues

- Closes #3020

## Self Checklist

- [X] Added relevant comments, especially in complex areas
- [X] Updated docs (for bug fixes / features)
- [X] Created issues for follow-up changes or refactoring needed
