### PR TITLE
feat: Add LLM API (llmapi.ai) as predefined provider

### DIFF
--- a/web-app/src/constants/providers.ts
+++ b/web-app/src/constants/providers.ts
@@ -351,4 +351,38 @@ export const predefinedProviders = [
       },
     ],
   },
+  {
+    active: true,
+    api_key: '',
+    base_url: 'https://api.llmapi.ai/v1',
+    explore_models_url: 'https://llmapi.ai',
+    provider: 'llmapi',
+    settings: [
+      {
+        key: 'api-key',
+        title: 'API Key',
+        description:
+          'The LLM API uses API keys for authentication. Visit [llmapi.ai](https://llmapi.ai) to retrieve your API key.',
+        controller_type: 'input',
+        controller_props: {
+          placeholder: 'Insert API Key',
+          value: '',
+          type: 'password',
+          input_actions: ['unobscure', 'copy'],
+        },
+      },
+      {
+        key: 'base-url',
+        title: 'Base URL',
+        description:
+          'The base OpenAI-compatible endpoint to use. See the [LLM API documentation](https://llmapi.ai) for more information.',
+        controller_type: 'input',
+        controller_props: {
+          placeholder: 'https://api.llmapi.ai/v1',
+          value: 'https://api.llmapi.ai/v1',
+        },
+      },
+    ],
+    models: [],
+  },
 ]


### PR DESCRIPTION
## Summary
- Adds [LLM API](https://llmapi.ai) (llmapi.ai) as a predefined OpenAI-compatible provider
- LLM API is a unified API gateway providing access to 120+ models across OpenAI, Anthropic, Google, xAI, Alibaba, Moonshot, and more
- Base URL: `https://api.llmapi.ai/v1`, standard Bearer token authentication

## Changes
- Added provider entry to `predefinedProviders` array in `web-app/src/constants/providers.ts`
- Includes API key and base URL settings configuration

## Test plan
- [ ] Verify provider appears in the provider list UI
- [ ] Add an LLM API key and confirm models are fetched
- [ ] Send a chat message and verify response streaming works

🤖 Generated with [Claude Code](https://claude.com/claude-code)