### PR TITLE
fix: navigation back from detail hub page

### DIFF
--- a/web-app/src/routes/hub/$modelId.tsx
+++ b/web-app/src/routes/hub/$modelId.tsx
@@ -250,12 +250,13 @@ function HubModelDetailContent() {
   return (
     <div className="flex flex-col h-svh w-full">
       <HeaderPage>
-        <div className="flex items-center gap-2 w-full relative z-20">
+        <div className="flex items-center gap-2 w-full">
           <Button
             onClick={() => navigate({ to: route.hub.index })}
             aria-label="Go back"
             variant="ghost"
             size="sm"
+            className='relative z-20'
           >
             <IconArrowLeft size={18} className="text-muted-foreground" />
             <span className="text-foreground">Back to Hub</span>


### PR DESCRIPTION
## Describe Your Changes

can't navigate back.
<img width="1312" height="912" alt="Screenshot 2026-02-27 at 21 44 12" src="https://github.com/user-attachments/assets/2f309207-c0a7-4c71-a3af-47d9d33166e3" />

## Fixes Issues

<img width="2624" height="1824" alt="Screenshot 2026-02-27 at 21 46 49" src="https://github.com/user-attachments/assets/70349ec3-8f21-43bf-b525-c295d8eafaa0" />


- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
