### PR TITLE
fix: add back linux native top panel tauri

### DIFF
--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -13,12 +13,12 @@
         "zoomHotkeysEnabled": true,
         "center": true,
         "hiddenTitle": true,
-        "transparent": true,
+        "transparent": false,
         "trafficLightPosition": {
           "x": 20,
           "y": 32
         },
-        "decorations": false,
+        "decorations": true,
         "titleBarStyle": "Overlay",
         "windowEffects": {
           "effects": ["fullScreenUI", "mica", "tabbed", "blur", "acrylic"],

--- a/web-app/src/routes/__root.tsx
+++ b/web-app/src/routes/__root.tsx
@@ -55,8 +55,8 @@ const AppLayout = () => {
         <AnalyticProvider />
         <KeyboardShortcutsProvider />
         {/* Fake absolute panel top to enable window drag */}
-        {!IS_MACOS && <WindowControls />}
-        <div className="fixed w-full h-12 z-20 top-0" data-tauri-drag-region />
+        {IS_WINDOWS && <WindowControls />}
+        {!IS_LINUX && <div className="fixed w-full h-12 z-20 top-0" data-tauri-drag-region />}
         <DialogAppUpdater />
         <BackendUpdater />
         <LeftSidebar />


### PR DESCRIPTION
## Describe Your Changes

[src-tauri/tauri.linux.conf.json](vscode-webview://1hbs9r82ki16tfd6fdcclpb07aoj0ko2pfu3ehdeunnuhm2lim1m/src-tauri/tauri.linux.conf.json)

decorations: false → true — enables native window decorations so the WM handles the titlebar (fixes the broken menu bar/snapping issue on Linux WMs like Marco)
transparent: false — transparency is incompatible with native decorations and can cause rendering artifacts
[web-app/src/routes/__root.tsx](vscode-webview://1hbs9r82ki16tfd6fdcclpb07aoj0ko2pfu3ehdeunnuhm2lim1m/web-app/src/routes/__root.tsx:58-59)

{!IS_MACOS && <WindowControls />} → {IS_WINDOWS && <WindowControls />} — removes the custom minimize/maximize/close buttons on Linux (the native WM titlebar already provides them)
The data-tauri-drag-region div is also skipped on Linux — it's only needed for borderless windows; with native decorations the WM titlebar handles dragging

## Fixes Issues

https://github.com/janhq/jan/issues/7529

- Closes #7529 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
