### PR TITLE
fix: disconnect channel and add spinner

### DIFF
--- a/src-tauri/src/core/openclaw/commands.rs
+++ b/src-tauri/src/core/openclaw/commands.rs
@@ -2423,33 +2423,23 @@ pub async fn telegram_get_config() -> Result<TelegramConfig, String> {
         }
     }
 
-    // If no local file, try to recover from openclaw.json (channel may have
-    // been configured in a different sandbox mode that didn't create this file)
+    // If no local file, try to recover from openclaw.json (read-only — never
+    // write back here; only explicit user actions should modify local files)
     if bot_token.is_empty() {
         if let Ok(main_config) = read_openclaw_config() {
             if let Some(tg) = main_config.get("channels").and_then(|c| c.get("telegram")) {
                 if let Some(token) = tg.get("botToken").and_then(|v| v.as_str()) {
                     if !token.is_empty() {
-                        log::info!("Recovered Telegram config from openclaw.json");
+                        log::info!("Recovered Telegram config from openclaw.json (in-memory only)");
                         bot_token = token.to_string();
-                        // We have a token but no local file — write one so future reads are fast
-                        let local_config = serde_json::json!({
-                            "enabled": tg.get("enabled").and_then(|v| v.as_bool()).unwrap_or(true),
-                            "bot_token": bot_token,
-                            "bot_username": serde_json::Value::Null,
-                            "connected": false,
-                        });
-                        let _ = std::fs::write(
-                            &telegram_config_path,
-                            serde_json::to_string_pretty(&local_config).unwrap(),
-                        );
                     }
                 }
             }
         }
     }
 
-    // If the gateway is running, verify actual channel status and reconcile
+    // If the gateway is running, check live channel status (read-only — report
+    // actual state but never persist it; only connect/disconnect actions write)
     if !bot_token.is_empty() && check_gateway_responding().await {
         let params = serde_json::json!({ "probe": true, "timeoutMs": 5000 });
         if let Ok(status) = gateway_request("channels.status", params).await {
@@ -2462,24 +2452,7 @@ pub async fn telegram_get_config() -> Result<TelegramConfig, String> {
                     .unwrap_or(false);
 
                 let live_connected = gw_configured && gw_running && gw_probe_ok;
-
-                // Update local file if live status differs
-                if live_connected != connected {
-                    log::info!(
-                        "Reconciling Telegram status: local={}, live={}",
-                        connected, live_connected
-                    );
-                    connected = live_connected;
-                    if let Ok(content) = std::fs::read_to_string(&telegram_config_path) {
-                        if let Ok(mut cfg) = serde_json::from_str::<serde_json::Value>(&content) {
-                            cfg["connected"] = serde_json::json!(connected);
-                            let _ = std::fs::write(
-                                &telegram_config_path,
-                                serde_json::to_string_pretty(&cfg).unwrap_or_default(),
-                            );
-                        }
-                    }
-                }
+                connected = live_connected;
             }
         }
     }
@@ -2681,54 +2654,30 @@ pub async fn telegram_approve_pairing(code: String) -> Result<(), String> {
 pub async fn telegram_disconnect() -> Result<(), String> {
     log::info!("Disconnecting Telegram channel");
 
-    // 1. Disable the channel in the gateway so the bot stops responding
-    if is_docker_container_running().await {
-        // Docker mode: set enabled=false in openclaw.json directly
-        if let Ok(mut config) = read_openclaw_config() {
-            if let Some(tg) = config.get_mut("channels")
-                .and_then(|c| c.get_mut("telegram"))
-            {
-                tg["enabled"] = serde_json::json!(false);
-                let _ = write_openclaw_config(&config);
-            }
+    // 1. Remove channel from openclaw.json — gateway hot-reloads on file change
+    if let Ok(mut config) = read_openclaw_config() {
+        if let Some(channels) = config.get_mut("channels").and_then(|c| c.as_object_mut()) {
+            channels.remove("telegram");
+            write_openclaw_config(&config)
+                .map_err(|e| format!("Failed to update config: {}", e))?;
+            log::info!("Telegram channel removed from openclaw.json (hot-reload will stop bot)");
         }
-    } else {
-        // Direct process mode: use CLI to disable
-        let _ = openclaw_command(&["config", "set", "channels.telegram.enabled", "false"]).await
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-            .await;
     }
 
-    // 2. Restart gateway so it picks up the disabled state and stops the bot
-    if check_gateway_responding().await {
-        log::info!("Restarting gateway to stop Telegram bot");
-        let _ = restart_gateway_cli().await;
-        // Don't need to wait for ready — we're tearing down, not setting up
-    }
-
-    // 3. Update local config file (keep credentials for easy reconnection)
+    // 2. Delete local config file
     let config_dir = get_openclaw_config_dir()?;
     let telegram_config_path = config_dir.join("telegram.json");
-
     if telegram_config_path.exists() {
-        let config_json = std::fs::read_to_string(&telegram_config_path)
-            .map_err(|e| format!("Failed to read Telegram config: {}", e))?;
-
-        let mut settings: serde_json::Value = serde_json::from_str(&config_json)
-            .map_err(|e| format!("Failed to parse Telegram config: {}", e))?;
-
-        settings["enabled"] = serde_json::json!(false);
-        settings["connected"] = serde_json::json!(false);
-        settings["paired_users"] = serde_json::json!(0);
-        // Keep bot_token and bot_username for easy reconnection
-
-        std::fs::write(&telegram_config_path, serde_json::to_string_pretty(&settings).unwrap())
-            .map_err(|e| format!("Failed to save Telegram config: {}", e))?;
+        let _ = std::fs::remove_file(&telegram_config_path);
     }
 
-    log::info!("Telegram channel disconnected — bot will stop responding");
+    // Also clean up pairing file
+    let pairing_path = config_dir.join("telegram-pairing.json");
+    if pairing_path.exists() {
+        let _ = std::fs::remove_file(&pairing_path);
+    }
+
+    log::info!("Telegram channel fully disconnected and credentials removed");
     Ok(())
 }
 
@@ -3578,81 +3527,35 @@ pub async fn whatsapp_get_config() -> Result<WhatsAppConfig, String> {
         }
     }
 
-    // If no meaningful local data, try to recover from openclaw.json (channel
-    // may have been configured in a different sandbox mode)
+    // If no meaningful local data, check openclaw.json (read-only — never write
+    // back here; only explicit user actions should modify local files)
     if !has_local_data {
         if let Ok(main_config) = read_openclaw_config() {
             if let Some(wa) = main_config.get("channels").and_then(|c| c.get("whatsapp")) {
                 let enabled = wa.get("enabled").and_then(|v| v.as_bool()).unwrap_or(false);
                 if enabled {
-                    log::info!("Recovered WhatsApp channel enabled from openclaw.json");
-                    // WhatsApp doesn't store credentials in openclaw.json (unlike Telegram's botToken).
-                    // The channel being enabled means it was set up — write a minimal local file
-                    // so future reads are fast, with connected=false until gateway probe confirms.
-                    let local_config = serde_json::json!({
-                        "account_id": "default",
-                        "session_path": "",
-                        "connected": false,
-                        "phone_number": serde_json::Value::Null,
-                        "contacts_count": 0,
-                    });
-                    let _ = std::fs::write(
-                        &config_path,
-                        serde_json::to_string_pretty(&local_config).unwrap(),
-                    );
+                    log::info!("WhatsApp channel enabled in openclaw.json (in-memory only)");
                 }
             }
         }
     }
 
-    // If the gateway is running, verify actual channel status and reconcile
+    // If the gateway is running, check live channel status (read-only — report
+    // actual state but never persist it; only connect/disconnect actions write)
     if check_gateway_responding().await {
         let params = serde_json::json!({ "probe": true, "timeoutMs": 5000 });
         if let Ok(status) = gateway_request("channels.status", params).await {
             if let Some(whatsapp) = status.get("channels").and_then(|c| c.get("whatsapp")) {
+                let gw_running = whatsapp.get("running")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
                 let gw_linked = whatsapp.get("linked")
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
-                let gw_connected = whatsapp.get("connected")
-                    .and_then(|v| v.as_bool())
-                    .unwrap_or(false);
 
-                // WhatsApp is truly connected when it's linked (authenticated with phone)
-                let live_connected = gw_linked || gw_connected;
-
-                // Update local file if live status differs
-                if live_connected != connected {
-                    log::info!(
-                        "Reconciling WhatsApp status: local={}, live={} (linked={}, connected={})",
-                        connected, live_connected, gw_linked, gw_connected
-                    );
-                    connected = live_connected;
-                    // Persist reconciled state
-                    if config_path.exists() {
-                        if let Ok(content) = std::fs::read_to_string(&config_path) {
-                            if let Ok(mut cfg) = serde_json::from_str::<serde_json::Value>(&content) {
-                                cfg["connected"] = serde_json::json!(connected);
-                                let _ = std::fs::write(
-                                    &config_path,
-                                    serde_json::to_string_pretty(&cfg).unwrap_or_default(),
-                                );
-                            }
-                        }
-                    } else {
-                        // No local file yet but gateway says connected — write one
-                        let local_config = serde_json::json!({
-                            "account_id": account_id,
-                            "session_path": session_path,
-                            "connected": connected,
-                            "phone_number": phone_number,
-                            "contacts_count": contacts_count,
-                        });
-                        let _ = std::fs::write(
-                            &config_path,
-                            serde_json::to_string_pretty(&local_config).unwrap(),
-                        );
-                    }
-                }
+                // linked=true just means session auth exists (credentials kept after disconnect).
+                // The channel is only truly active when the gateway is running it.
+                connected = gw_running && gw_linked;
             }
         }
     }
@@ -3703,54 +3606,30 @@ pub async fn whatsapp_get_contacts() -> Result<Vec<String>, String> {
 pub async fn whatsapp_disconnect() -> Result<(), String> {
     log::info!("Disconnecting WhatsApp channel");
 
-    // 1. Disable the channel in the gateway so WhatsApp stops responding
-    if is_docker_container_running().await {
-        // Docker mode: set enabled=false in openclaw.json directly
-        if let Ok(mut config) = read_openclaw_config() {
-            if let Some(wa) = config.get_mut("channels")
-                .and_then(|c| c.get_mut("whatsapp"))
-            {
-                wa["enabled"] = serde_json::json!(false);
-                let _ = write_openclaw_config(&config);
-            }
+    // 1. Remove channel from openclaw.json — gateway hot-reloads on file change
+    if let Ok(mut config) = read_openclaw_config() {
+        if let Some(channels) = config.get_mut("channels").and_then(|c| c.as_object_mut()) {
+            channels.remove("whatsapp");
+            write_openclaw_config(&config)
+                .map_err(|e| format!("Failed to update config: {}", e))?;
+            log::info!("WhatsApp channel removed from openclaw.json (hot-reload will stop bot)");
         }
-    } else {
-        // Direct process mode: use CLI to disable
-        let _ = openclaw_command(&["config", "set", "channels.whatsapp.enabled", "false"]).await
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-            .await;
     }
 
-    // 2. Restart gateway so it picks up the disabled state
-    if check_gateway_responding().await {
-        log::info!("Restarting gateway to stop WhatsApp channel");
-        let _ = restart_gateway_cli().await;
-    }
-
-    // 3. Update local config file (keep session data for easy reconnection)
+    // 2. Delete local config file
     let config_path = get_whatsapp_config_path()?;
-
     if config_path.exists() {
-        let config_json = std::fs::read_to_string(&config_path)
-            .map_err(|e| format!("Failed to read WhatsApp config: {}", e))?;
-
-        let mut settings: serde_json::Value = serde_json::from_str(&config_json)
-            .map_err(|e| format!("Failed to parse WhatsApp config: {}", e))?;
-
-        settings["connected"] = serde_json::json!(false);
-        settings["phone_number"] = serde_json::json!(null);
-        settings["contacts_count"] = serde_json::json!(0);
-        // Keep account_id and session_path for easy reconnection —
-        // the WhatsApp session may still be valid, allowing reconnect
-        // without QR re-scan.
-
-        std::fs::write(&config_path, serde_json::to_string_pretty(&settings).unwrap())
-            .map_err(|e| format!("Failed to save WhatsApp config: {}", e))?;
+        let _ = std::fs::remove_file(&config_path);
     }
 
-    log::info!("WhatsApp channel disconnected — bot will stop responding");
+    // 3. Delete WhatsApp auth/session directory
+    let config_dir = get_openclaw_config_dir()?;
+    let auth_dir = config_dir.join("whatsapp_auth");
+    if auth_dir.exists() {
+        let _ = std::fs::remove_dir_all(&auth_dir);
+    }
+
+    log::info!("WhatsApp channel fully disconnected and credentials removed");
     Ok(())
 }
 

--- a/web-app/src/containers/ChannelCard.tsx
+++ b/web-app/src/containers/ChannelCard.tsx
@@ -5,6 +5,7 @@ import {
   IconBrandWhatsapp,
   IconSettings,
   IconTrash,
+  IconLoader2,
 } from '@tabler/icons-react'
 import { cn } from '@/lib/utils'
 import type { ChannelType, ChannelConfig, TelegramConfig, WhatsAppConfig } from '@/types/openclaw'
@@ -17,6 +18,7 @@ interface ChannelCardProps {
   onSettings: () => void
   onDisconnect: () => void
   OCIsInstalled: boolean
+  isDisconnecting?: boolean
 }
 
 export function ChannelCard({
@@ -25,6 +27,7 @@ export function ChannelCard({
   onSettings,
   onDisconnect,
   OCIsInstalled,
+  isDisconnecting = false,
 }: ChannelCardProps) {
   const { t } = useTranslation()
 
@@ -105,13 +108,15 @@ export function ChannelCard({
         </div>
 
         <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm" onClick={onSettings}>
-            <IconSettings />
-            {t('settings:remoteAccess.settings')}
-          </Button>
+          {!isConnected && (
+            <Button variant="outline" size="sm" onClick={onSettings}>
+              <IconSettings />
+              {t('settings:remoteAccess.settings')}
+            </Button>
+          )}
           {isConnected && (
-            <Button variant="ghost" size="sm" onClick={onDisconnect}>
-              <IconTrash />
+            <Button variant="ghost" size="sm" onClick={onDisconnect} disabled={isDisconnecting}>
+              {isDisconnecting ? <IconLoader2 className="animate-spin" /> : <IconTrash />}
             </Button>
           )}
         </div>

--- a/web-app/src/routes/settings/remote-access.tsx
+++ b/web-app/src/routes/settings/remote-access.tsx
@@ -48,6 +48,7 @@ function RemoteAccess() {
   const [status, setStatus] = useState<OpenClawStatus | null>(null)
   const [isStarting, setIsStarting] = useState(false)
   const [isStopping, setIsStopping] = useState(false)
+  const [disconnectingChannel, setDisconnectingChannel] = useState<ChannelType | null>(null)
   const [isTelegramWizardOpen, setIsTelegramWizardOpen] = useState(false)
   const [isWhatsAppWizardOpen, setIsWhatsAppWizardOpen] = useState(false)
 const [isTailscaleDialogOpen, setIsTailscaleDialogOpen] = useState(false)
@@ -194,6 +195,7 @@ const [isTailscaleDialogOpen, setIsTailscaleDialogOpen] = useState(false)
   }
 
   const handleDisconnectChannel = async (channel: ChannelType) => {
+    setDisconnectingChannel(channel)
     try {
       switch (channel) {
         case 'telegram':
@@ -210,6 +212,8 @@ const [isTailscaleDialogOpen, setIsTailscaleDialogOpen] = useState(false)
       )
     } catch {
       toast.error(t('settings:remoteAccess.disconnectError'))
+    } finally {
+      setDisconnectingChannel(null)
     }
   }
 
@@ -337,14 +341,16 @@ const isRunning = status?.running ?? false
                           ? t('settings:remoteAccess.dockerSandbox')
                           : t('settings:remoteAccess.directProcess')}
                       </span>
-                      <Button
-                        variant="ghost"
-                        size="icon-sm"
-                        onClick={() => setIsLogsDialogOpen(true)}
-                        title={t('settings:viewLogs')}
-                      >
-                        <IconFileText className="h-4 w-4" />
-                      </Button>
+                      {status.isolation_tier === 'full_container' && (
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          onClick={() => setIsLogsDialogOpen(true)}
+                          title={t('settings:viewLogs')}
+                        >
+                          <IconFileText className="h-4 w-4" />
+                        </Button>
+                      )}
                     </div>
                   }
                 />
@@ -368,6 +374,7 @@ const isRunning = status?.running ?? false
                   onSettings={() => handleAddChannel('telegram')}
                   onDisconnect={() => handleDisconnectChannel('telegram')}
                   OCIsInstalled={isInstalled}
+                  isDisconnecting={disconnectingChannel === 'telegram'}
                 />
                 <ChannelCard
                   type="whatsapp"
@@ -375,6 +382,7 @@ const isRunning = status?.running ?? false
                   onSettings={() => handleAddChannel('whatsapp')}
                   onDisconnect={() => handleDisconnectChannel('whatsapp')}
                   OCIsInstalled={isInstalled}
+                  isDisconnecting={disconnectingChannel === 'whatsapp'}
                 />
               </div>
             </Card>


### PR DESCRIPTION
## Describe Your Changes

### Current state

- Delete channel connection works, but once returns to the openclaw, we probe the gateway to check its status immediately.
- Probing gateway will definitely restart any previous channel config and mark them as running again. This cannot be overwritten because the configs lies within the session. But deleting the whole session is overkill

### Fix
- Delete the whole config of disconnecting channel.
- Leave the session - pair device auth untouched
- Probe the gateway will not mistakenly reactivate the gateway and its channels connection
- Add spinner during the deletion to indicate the gateway reload status

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed