### PR TITLE
fix: disable auto fit setting by default

### DIFF
--- a/extensions/llamacpp-extension/settings.json
+++ b/extensions/llamacpp-extension/settings.json
@@ -54,7 +54,7 @@
     "description": "Whether to adjust unset arguments to fit in device memory ('on' or 'off'). (env: LLAMA_ARG_FIT)",
     "controllerType": "checkbox",
     "controllerProps": {
-      "value": true
+      "value": false
     }
   },
   {

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -134,14 +134,6 @@ export default class llamacpp_extension extends AIEngine {
 
     let settings = structuredClone(SETTINGS) // Clone to modify settings definition before registration
 
-    // Disable fit by default on macOS
-    if (IS_MAC) {
-      const fitSetting = settings.find((s: any) => s.key === 'fit')
-      if (fitSetting) {
-        fitSetting.controllerProps.value = false
-      }
-    }
-
     // This makes the settings (including the backend options and initial value) available to the Jan UI.
     this.registerSettings(settings)
 
@@ -1561,7 +1553,7 @@ export default class llamacpp_extension extends AIEngine {
     }
 
     // Migrate old env vars
-    if(typeof cfg.fit === 'string') cfg.fit = true
+    if (typeof cfg.fit === 'string') cfg.fit = true
 
     logger.info(
       'Calling Tauri command load_llama_model with config:',


### PR DESCRIPTION
## Summary
Disable `fit` feature in favor of #7609 

- Changed the default value of the `fit` (auto-fit) setting from `true` to `false` in `settings.json`
- Removed the macOS-specific override that disabled `fit` on Mac — `fit` is now disabled by default on all platforms
- Minor formatting fix in the `cfg.fit` migration check

## Motivation

Previously, `fit` was enabled by default on all platforms except macOS, which had a special code path to override it to `false`. This was inconsistent. Disabling it globally by default is the safer behavior: users who want auto-fitting can opt in explicitly.

## Test plan

- [ ] Build and launch the app; verify the **Auto Fit** checkbox in LlamaCPP engine settings is unchecked by default
- [ ] Load a model and confirm inference works normally without `fit` enabled
- [ ] Toggle `fit` on manually and confirm it applies correctly
- [ ] Verify no regression on macOS (previously it was already `false` there)