### PR TITLE
fix: mlx provider only show for MacOs

### DIFF
--- a/web-app/src/containers/SettingsMenu.tsx
+++ b/web-app/src/containers/SettingsMenu.tsx
@@ -52,6 +52,7 @@ const SettingsMenu = () => {
   // On web: exclude llamacpp provider as it's not available
   const activeProviders = providers.filter((provider) => {
     if (!provider.active) return false
+    if (!IS_MACOS && provider.provider === 'mlx') return false
 
     return true
   })

--- a/web-app/src/routes/settings/providers/index.tsx
+++ b/web-app/src/routes/settings/providers/index.tsx
@@ -89,7 +89,7 @@ function ModelProviders() {
                 </div>
               }
             >
-              {providers.map((provider, index) => (
+              {providers.filter((provider) => IS_MACOS || provider.provider !== 'mlx').map((provider, index) => (
                 <CardItem
                   key={index}
                   title={


### PR DESCRIPTION
## Describe Your Changes

This pull request makes a small update to the settings UI to ensure that the `mlx` provider is only shown on macOS. The change filters out the `mlx` provider from both the settings menu and the model providers list for non-macOS users.

* UI filtering: In `SettingsMenu.tsx`, the `mlx` provider is excluded from the active providers list if the user is not on macOS.
* UI filtering: In `providers/index.tsx`, the model providers list only includes the `mlx` provider for macOS users.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
