### PR TITLE
fix: default minimum 32k for models starting with local api server

### DIFF
--- a/web-app/src/routes/settings/local-api-server.tsx
+++ b/web-app/src/routes/settings/local-api-server.tsx
@@ -238,7 +238,7 @@ function LocalAPIServerContent() {
                     }
                     return m
                   }
-                ),
+                ) as Model[],
               }
             }
 


### PR DESCRIPTION
## Describe Your Changes

- Fix model hosted by local api server should have at least 32k ctx_len

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
