### PR TITLE
ci: temporarily disable portable artifact on windows

### DIFF
--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -258,12 +258,12 @@ jobs:
           path: |
             ./src-tauri/target/release/bundle/msi/*.msi
 
-      - name: Upload Portable Artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: jan-windows-portable-${{ inputs.new_version }}
-          path: |
-            ./src-tauri/target/release/Jan*.exe
+      # - name: Upload Portable Artifact
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: jan-windows-portable-${{ inputs.new_version }}
+      #     path: |
+      #       ./src-tauri/target/release/Jan*.exe
 
       ## Set output filename for windows
       - name: Set output filename for windows
@@ -329,13 +329,13 @@ jobs:
           asset_name: ${{ steps.metadata.outputs.FILE_NAME }}
           asset_content_type: application/octet-stream
 
-      - name: Upload portable exe to release (github)
-        if: inputs.public_provider == 'github'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ inputs.upload_url }}
-          asset_path: ./src-tauri/target/release/${{ steps.metadata.outputs.PORTABLE_FILE_NAME }}
-          asset_name: ${{ steps.metadata.outputs.PORTABLE_FILE_NAME }}
-          asset_content_type: application/octet-stream
+      # - name: Upload portable exe to release (github)
+      #   if: inputs.public_provider == 'github'
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   uses: actions/upload-release-asset@v1.0.1
+      #   with:
+      #     upload_url: ${{ inputs.upload_url }}
+      #     asset_path: ./src-tauri/target/release/${{ steps.metadata.outputs.PORTABLE_FILE_NAME }}
+      #     asset_name: ${{ steps.metadata.outputs.PORTABLE_FILE_NAME }}
+      #     asset_content_type: application/octet-stream


### PR DESCRIPTION
## Describe Your Changes

This pull request makes adjustments to the Windows build workflow by commenting out steps related to uploading the portable `.exe` artifact. This means the workflow will no longer upload the portable executable as part of its build and release process.

Changes to artifact upload steps:

* Commented out the step that uploads the portable `.exe` artifact using `actions/upload-artifact@v4` in `.github/workflows/template-tauri-build-windows-x64.yml`.
* Commented out the step that uploads the portable `.exe` to the GitHub release using `actions/upload-release-asset@v1.0.1` in `.github/workflows/template-tauri-build-windows-x64.yml`.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
