### PR TITLE
fix: state server running when save config claude code

### DIFF
--- a/web-app/src/routes/settings/claude-code.tsx
+++ b/web-app/src/routes/settings/claude-code.tsx
@@ -135,16 +135,23 @@ function ClaudeCodeIntegration() {
         }
       }
 
-      const actualPort = await window.core?.api?.startServer({
-        host: serverHost,
-        port: serverPort,
-        prefix: apiPrefix,
-        apiKey,
-        trustedHosts,
-        isCorsEnabled: corsEnabled,
-        isVerboseEnabled: verboseLogs,
-        proxyTimeout: proxyTimeout,
-      })
+      let actualPort: number | undefined
+      try {
+        actualPort = await window.core?.api?.startServer({
+          host: serverHost,
+          port: serverPort,
+          prefix: apiPrefix,
+          apiKey,
+          trustedHosts,
+          isCorsEnabled: corsEnabled,
+          isVerboseEnabled: verboseLogs,
+          proxyTimeout: proxyTimeout,
+        })
+      } catch (startErr) {
+        const msg =
+          startErr instanceof Error ? startErr.message : String(startErr)
+        if (!msg.includes('already running')) throw startErr
+      }
 
       if (actualPort && actualPort !== serverPort) {
         setServerPort(actualPort)


### PR DESCRIPTION
## Describe Your Changes

fix: handle "server already running" error gracefully in Claude Code launch

When clicking "Save & Enable" on the Claude Code settings page, if the frontend state was stale (serverStatus = 'stopped') while the backend server was already running, the startServer call would throw "Server is already running" and show an error toast — even though everything was actually fine.

Changes:

Catch "already running" errors from startServer and treat them as success instead of propagating to the error handler
Frontend state is still synced to 'running' afterwards


## Fixes Issues

<img width="1362" height="516" alt="Screenshot 2026-03-07 at 22 54 27" src="https://github.com/user-attachments/assets/b2b38be4-c661-4e03-b795-71114feb1f22" />

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
