### PR TITLE
feat: add Tensorix as predefined AI provider

### DIFF
--- a/web-app/src/constants/models.ts
+++ b/web-app/src/constants/models.ts
@@ -118,6 +118,15 @@ export const providerModels = {
     supportsToolCalls: true,
     supportsN: true,
   },
+  tensorix: {
+    models: true,
+    supportsCompletion: true,
+    supportsStreaming: true,
+    supportsJSON: true,
+    supportsImages: true,
+    supportsToolCalls: true,
+    supportsN: true,
+  },
   'openai-compatible': {
     models: true,
     supportsCompletion: true,

--- a/web-app/src/constants/providers.ts
+++ b/web-app/src/constants/providers.ts
@@ -385,4 +385,63 @@ export const predefinedProviders = [
       },
     ],
   },
+  {
+    active: true,
+    api_key: '',
+    base_url: 'https://api.tensorix.ai/v1',
+    explore_models_url: 'https://tensorix.ai/models',
+    provider: 'tensorix',
+    settings: [
+      {
+        key: 'api-key',
+        title: 'API Key',
+        description:
+          "The Tensorix API uses API keys for authentication. Visit your [Dashboard](https://app.tensorix.ai) to retrieve the API key you'll use in your requests.",
+        controller_type: 'input',
+        controller_props: {
+          placeholder: 'Insert API Key',
+          value: '',
+          type: 'password',
+          input_actions: ['unobscure', 'copy'],
+        },
+      },
+      {
+        key: 'base-url',
+        title: 'Base URL',
+        description:
+          'The base endpoint to use. See the [Tensorix documentation](https://docs.tensorix.ai) for more information.',
+        controller_type: 'input',
+        controller_props: {
+          placeholder: 'https://api.tensorix.ai/v1',
+          value: 'https://api.tensorix.ai/v1',
+        },
+      },
+    ],
+    models: [
+      {
+        id: 'deepseek/deepseek-chat-v3.1',
+        name: 'DeepSeek V3.1',
+        version: '1.0',
+        description:
+          'Hybrid reasoning model with strong performance for tool use, code generation, and complex reasoning.',
+        capabilities: ['completion', 'tools'],
+      },
+      {
+        id: 'deepseek/deepseek-r1-0528',
+        name: 'DeepSeek R1 0528',
+        version: '1.0',
+        description:
+          'Advanced reasoning model with chain-of-thought for improved accuracy.',
+        capabilities: ['completion'],
+      },
+      {
+        id: 'z-ai/glm-5',
+        name: 'GLM 5',
+        version: '1.0',
+        description:
+          'Latest generation GLM model with strong coding, reasoning, and multi-step task capabilities.',
+        capabilities: ['completion', 'tools'],
+      },
+    ],
+  },
 ]


### PR DESCRIPTION
## Summary

Hey! This adds [Tensorix](https://tensorix.ai) as a new built-in provider in Jan. Tensorix is an OpenAI-compatible API service with competitive pricing on popular open-source models — thought it'd be a handy option for users alongside the existing providers.

## Changes

**`web-app/src/constants/providers.ts`**
- Added Tensorix to `predefinedProviders` with:
  - Base URL: `https://api.tensorix.ai/v1`
  - API key + base URL settings (same pattern as other providers)
  - 3 pre-configured models: DeepSeek V3.1, DeepSeek R1 0528, GLM 5
  - Explore models URL pointing to tensorix.ai/models

**`web-app/src/constants/models.ts`**
- Added `tensorix` entry to `providerModels` with full capability flags (completion, streaming, JSON, images, tool calls)

## Why no other files needed

- **model-factory.ts**: The `default` case already routes unknown providers to `createOpenAICompatibleModel`, so Tensorix works out of the box
- **utils.ts**: `getProviderTitle` default case capitalizes first letter → "Tensorix" ✓; `getProviderLogo` returns `undefined` which is fine (shows default icon)
- **ai-model.ts**: Uses generic `createOpenAICompatible` for all non-special providers

Follows the same patterns used by OpenRouter, Groq, and the other predefined providers. Let me know if you'd like any adjustments!