### PR TITLE
fix: add redirect from /guides to /docs

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -119,6 +119,8 @@
 /docs/desktop/mac                               /docs/desktop/install/mac 302
 /handbook/open-superintelligence                /handbook/why/open-superintelligence 302
 
+/guides                                          /docs 302
+/guides/*                                        /docs/:splat 302
 /guides/integrations/continue/                  /docs/desktop/server-examples/continue-dev 302
 /continue-dev                                   /docs/desktop/server-examples/continue-dev 302
 /integrations                                   /docs/desktop/server-examples/continue-dev 302


### PR DESCRIPTION
## Problem

Visiting `/guides` or any `/guides/*` path returns a 404 instead of routing to the docs.

## Changes

- Add catch-all redirect from `/guides` to `/docs`
- Add splat redirect so `/guides/<path>` maps to `/docs/<path>`

## Testing

- [ ] macOS tested