### PR TITLE
fix: should show OpenClaw Folder only when it's enabled

### DIFF
--- a/web-app/src/routes/settings/remote-access.tsx
+++ b/web-app/src/routes/settings/remote-access.tsx
@@ -333,7 +333,7 @@ const isRunning = status?.running ?? false
                 </div>
               )}
 
-              <CardItem
+              {isRunning && (<CardItem
                 title={t('settings:remoteAccess.openclawFolder')}
                 description={t('settings:remoteAccess.openclawFolderDesc')}
                 actions={
@@ -350,6 +350,7 @@ const isRunning = status?.running ?? false
                   </Button>
                 }
               />
+              )}
 
               {isRunning && (
                 <CardItem


### PR DESCRIPTION
## Describe Your Changes

- Show Open OpenClaw Folder shortcut only when it's enabled

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
