### PR TITLE
docs: add community cards to desktop overview

### DIFF
--- a/docs/src/pages/docs/desktop/index.mdx
+++ b/docs/src/pages/docs/desktop/index.mdx
@@ -23,7 +23,7 @@ keywords:
 ---
 
 import { DocCard, DocCards } from '@/components/DocCard'
-import { Rocket, Package, Bot, Plug, Monitor, Globe, Server, Brain, Terminal, Layers } from 'lucide-react'
+import { Rocket, Package, Bot, Plug, Monitor, Globe, Server, Brain, Terminal, Layers, MessageCircle } from 'lucide-react'
 
 # Overview
 
@@ -49,6 +49,13 @@ Jan is an open-source replacement for Claude and ChatGPT. It comes with built-in
   <DocCard title="Jan Platform" href="https://jan.ai" icon={<Layers size={20} />}>The infrastructure layer for building AI products on top of Jan. (Coming Soon)</DocCard>
 </DocCards>
 
+
+## Community
+
+<DocCards>
+  <DocCard title="Discord" href="https://discord.gg/FTk2MvZwJH" icon={<MessageCircle size={20} />}>Join the Jan community — get help, share your setup, and talk local AI.</DocCard>
+  <DocCard title="Reddit" href="https://www.reddit.com/r/askjan/" icon={<MessageCircle size={20} />}>Ask questions, share setups, and discuss local AI on r/askjan.</DocCard>
+</DocCards>
 
 ## Principles
 


### PR DESCRIPTION
## Problem

The desktop overview page had no links to community resources for users to get help or discuss local AI.

## Changes

- Add a Community section with Discord and Reddit cards
- Import `MessageCircle` icon from lucide-react for the cards

## Testing

- [ ] Documentation updated