### PR TITLE
fix: openclaw direct run does not have dashboard bundled

### DIFF
--- a/src-tauri/src/core/openclaw/constants.rs
+++ b/src-tauri/src/core/openclaw/constants.rs
@@ -3,7 +3,7 @@ pub const OPENCLAW_PACKAGE_NAME: &str = "openclaw";
 
 /// Pinned OpenClaw version (npm semver and Docker image tag)
 /// This ensures config compatibility across installs.
-pub const OPENCLAW_VERSION: &str = "2026.3.2";
+pub const OPENCLAW_VERSION: &str = "2026.3.8";
 
 /// Default OpenClaw gateway port
 pub const DEFAULT_OPENCLAW_PORT: u16 = 18789;

--- a/src-tauri/src/core/openclaw/sandbox_direct.rs
+++ b/src-tauri/src/core/openclaw/sandbox_direct.rs
@@ -22,7 +22,7 @@ async fn install_openclaw_globally() -> Result<(), String> {
     log::info!("Installing openclaw globally into {:?}", bunx_dir);
 
     let mut cmd = tokio::process::Command::new(&bun_path);
-    cmd.args(["add", "-g", "openclaw"])
+    cmd.args(["add", "-g", &format!("openclaw@{}", super::constants::OPENCLAW_VERSION)])
         .env("BUN_INSTALL", &bunx_dir)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());


### PR DESCRIPTION
## Describe Your Changes
This PR fixes an issue where direct run OpenClaw might not have dashboard bundled

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
