### PR TITLE
fix: resolve runtime on window upon gateway restart

### DIFF
--- a/src-tauri/src/core/openclaw/commands.rs
+++ b/src-tauri/src/core/openclaw/commands.rs
@@ -42,6 +42,63 @@ async fn is_docker_container_running() -> bool {
         .unwrap_or(false)
 }
 
+/// Returns the BUN_INSTALL directory (`~/.jan/.bunx`), creating it if needed.
+fn get_bunx_dir() -> Option<std::path::PathBuf> {
+    let dir = dirs::home_dir()?.join(".jan").join(".bunx");
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        log::warn!("Failed to create BUN_INSTALL dir {:?}: {}", dir, e);
+    }
+    Some(dir)
+}
+
+/// Build a command for openclaw. On Unix, uses bun as explicit interpreter
+/// to bypass shebang resolution. On Windows, runs openclaw.exe directly.
+fn build_openclaw_command(args: &[&str]) -> tokio::process::Command {
+    let bunx_dir = get_bunx_dir();
+
+    let installed_bin = bunx_dir.as_ref().map(|d| {
+        if cfg!(target_os = "windows") {
+            d.join("bin").join("openclaw.exe")
+        } else {
+            d.join("bin").join("openclaw")
+        }
+    });
+
+    let mut cmd = if installed_bin.as_ref().map(|p| p.exists()).unwrap_or(false) {
+        log::info!("Running openclaw from installed path: {:?}", installed_bin);
+        tokio::process::Command::new(installed_bin.unwrap())
+    } else if let Some(bun) = super::resolve_bundled_bun() {
+        log::info!("openclaw not installed yet, falling back to bun x");
+        let mut c = tokio::process::Command::new(bun);
+        c.arg("x");
+        c.arg("openclaw");
+        c
+    } else {
+        tokio::process::Command::new("openclaw")
+    };
+
+    cmd.args(args)
+        // .current_dir(config_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    if let Some(dir) = bunx_dir {
+        cmd.env("BUN_INSTALL", dir);
+    }
+
+    if let Some(new_path) = super::build_augmented_path() {
+        cmd.env("PATH", new_path);
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x08000000);
+    }
+
+    cmd
+}
+
 /// Build a `Command` for openclaw: docker exec when container is running,
 /// otherwise direct process with bun interpreter (Unix) or native exe (Windows).
 async fn openclaw_command(args: &[&str]) -> Command {
@@ -59,41 +116,7 @@ async fn openclaw_command(args: &[&str]) -> Command {
         hide_window(&mut cmd);
         cmd
     } else {
-        let _ = super::ensure_bun_node_shim();
-
-        let openclaw_path = super::get_openclaw_bin_path().ok();
-        let use_installed_binary = openclaw_path
-            .as_ref()
-            .map(|p| p.exists())
-            .unwrap_or(false);
-        let bun_path = super::resolve_bundled_bun();
-        let use_bun_interpreter = !cfg!(target_os = "windows")
-            && use_installed_binary
-            && bun_path.is_some();
-
-        let mut cmd = if use_bun_interpreter {
-            let mut c = Command::new(bun_path.unwrap());
-            c.arg(openclaw_path.unwrap());
-            if let Some(new_path) = super::build_augmented_path() {
-                c.env("PATH", new_path);
-            }
-            c.args(args);
-            c
-        } else if use_installed_binary {
-            let mut c = Command::new(openclaw_path.unwrap());
-            if let Some(new_path) = super::build_augmented_path() {
-                c.env("PATH", new_path);
-            }
-            c.args(args);
-            c
-        } else {
-            let mut c = Command::new("openclaw");
-            if let Some(new_path) = super::build_augmented_path() {
-                c.env("PATH", new_path);
-            }
-            c.args(args);
-            c
-        };
+        let mut cmd = build_openclaw_command(args);
         hide_window(&mut cmd);
         cmd
     }


### PR DESCRIPTION
## Describe Your Changes

- Remove the gateway install step during the restart gateway flow
- Resolve runtime on window upon gateway restart

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
