### PR TITLE
chore: show back the instruction to require nodejs

### DIFF
--- a/web-app/src/locales/en/settings.json
+++ b/web-app/src/locales/en/settings.json
@@ -335,6 +335,7 @@
     "start": "Start",
     "noLocalModelAvailable": "A local model is required to enable OpenClaw. Download a model first.",
     "noModelAvailable": "A model is required to enable OpenClaw. Download a local model or configure a remote provider with an API key.",
+    "nodejsPrerequisite": "Node.js (v22 or later) is required to run OpenClaw. Please ensure it is installed before enabling.",
     "stop": "Stop",
     "startError": "Couldn't start Remote Access. Please try again.",
     "stopError": "Couldn't stop Remote Access. Please try again.",

--- a/web-app/src/routes/settings/remote-access.tsx
+++ b/web-app/src/routes/settings/remote-access.tsx
@@ -332,6 +332,12 @@ function RemoteAccess() {
                 description={!isRunning && !hasAnyModel ? t('settings:remoteAccess.noModelAvailable') : undefined}
               />
 
+              {!isRunning && (
+                <p className="text-sm text-muted-foreground px-1">
+                  {t('settings:remoteAccess.nodejsPrerequisite')}
+                </p>
+              )}
+
               {isRunning && status?.sandbox_type && (
                 <CardItem
                   title={t('settings:remoteAccess.runtimeMode')}


### PR DESCRIPTION
## Describe Your Changes

- Show back the instruction to require nodejs installed in order to integrate with openclaw successfully.
- One of the challenge is where openclaw install the gateway (non-Window), it will install to OS service, which has hardcoded node runtime.
- Requesting users to have nodejs is a safer solution

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
