### PR TITLE
fix: lower support version openclaw

### DIFF
--- a/src-tauri/src/core/openclaw/constants.rs
+++ b/src-tauri/src/core/openclaw/constants.rs
@@ -3,7 +3,7 @@ pub const OPENCLAW_PACKAGE_NAME: &str = "openclaw";
 
 /// Pinned OpenClaw version (npm semver and Docker image tag)
 /// This ensures config compatibility across installs.
-pub const OPENCLAW_VERSION: &str = "2026.3.8";
+pub const OPENCLAW_VERSION: &str = "2026.3.2";
 
 /// Default OpenClaw gateway port
 pub const DEFAULT_OPENCLAW_PORT: u16 = 18789;


### PR DESCRIPTION
## Describe Your Changes

- Lower the openclaw version support back to tested and stable 2026.3.2

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
