### PR TITLE
docs: update CLI and agents docs for v0.7.8

### DIFF
--- a/docs/src/pages/docs/desktop/agents.mdx
+++ b/docs/src/pages/docs/desktop/agents.mdx
@@ -14,12 +14,12 @@ keywords:
   ]
 ---
 
-import { Steps, Callout } from 'nextra/components'
+import { Callout, Steps } from 'nextra/components'
 
 # Agents
 
-<Callout type="warning">
-  This feature is not available in the current stable release. It will be available in **Jan 0.7.8**, estimated release **March 10, 2026**.
+<Callout type="info">
+Available since **Jan 0.7.8** (March 2026).
 </Callout>
 
 Jan supports autonomous AI agents that run entirely on your own hardware — no cloud required.

--- a/docs/src/pages/docs/desktop/cli.mdx
+++ b/docs/src/pages/docs/desktop/cli.mdx
@@ -20,6 +20,10 @@ import { Callout, Tabs } from 'nextra/components'
 
 # Jan CLI
 
+<Callout type="info">
+Available since **Jan 0.7.8** (March 2026).
+</Callout>
+
 The `jan` CLI lets you serve local AI models and launch autonomous agents from your terminal — no cloud account, no usage fees, full privacy.
 
 ```
@@ -66,6 +70,8 @@ Jan CLI is installed automatically when you launch the Jan desktop app for the f
 The CLI binary is installed at `~/.local/bin/jan` on macOS/Linux. Make sure this path is in your `$PATH` to use the `jan` command from any terminal.
 </Callout>
 
+The Jan desktop app helps you manage inference backends (LlamaCPP, MLX) and models — or use the CLI to manage them. Both share the same data folder, so models installed via either interface are available to both.
+
 ## Quick Start
 
 Getting started takes a single command:
@@ -90,7 +96,7 @@ jan serve [MODEL_ID] [OPTIONS]
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `MODEL_ID` | Model ID to load (omit to pick interactively) | — |
+| `MODEL_ID` | Model ID to load (omit to pick interactively). Can be a local model ID or a HuggingFace repo ID (e.g., `unsloth/Qwen3.5-9B-GGUF`) | — |
 | `--port` | Port to listen on (0 = random free port) | `6767` |
 | `--n-gpu-layers` | GPU layers to offload (-1 = all, 0 = CPU only) | `-1` |
 | `--ctx-size` | Context window size in tokens | `32768` |
@@ -122,7 +128,26 @@ jan serve qwen3.5-35b-a3b             # serve a specific model
 jan serve qwen3.5-35b-a3b --fit       # auto-fit context to available VRAM
 jan serve qwen3.5-35b-a3b --detach    # run in background
 jan serve qwen3.5-35b-a3b --port 8080 # serve on a custom port
+jan serve unsloth/Qwen3.5-9B-GGUF     # download and serve a HuggingFace model
 ```
+
+<Callout type="info">
+When using a HuggingFace repo ID (e.g., `unsloth/Qwen3.5-9B-GGUF`), if the model isn't downloaded yet, Jan will automatically download it from HuggingFace.
+</Callout>
+
+#### LlamaCPP Server Arguments
+
+You can pass additional arguments to the underlying LlamaCPP server using environment variables with the `LLAMA_ARG_` prefix:
+
+```bash
+export LLAMA_ARG_HOST=0.0.0.0          # bind to specific host
+export LLAMA_ARG_N_GPU_LAYERS=32       # set GPU layers
+export LLAMA_ARG_CTX_SIZE=8192         # set context size
+export LLAMA_ARG_THREADS=8             # set CPU threads
+jan serve qwen3.5-35b-a3b
+```
+
+Any LlamaCPP server flag can be passed this way — just prefix the flag name with `LLAMA_ARG_`.
 
 ---
 

--- a/docs/src/pages/docs/desktop/index.mdx
+++ b/docs/src/pages/docs/desktop/index.mdx
@@ -22,10 +22,15 @@ keywords:
   ]
 ---
 
+import { Callout } from 'nextra/components'
 import { DocCard, DocCards } from '@/components/DocCard'
 import { Rocket, Package, Bot, Plug, Monitor, Globe, Server, Brain, Terminal, Layers, MessageCircle } from 'lucide-react'
 
 # Overview
+
+<Callout type="info">
+**Jan 0.7.8 is now live!** — Agents, CLI, and more. [See the full changelog.](/changelog/2026-03-11-jan-openclaw-cli-context)
+</Callout>
 
 Jan is an open-source replacement for Claude and ChatGPT. It comes with built-in foundation models and an application ecosystem that runs entirely on your hardware — keeping your data private and giving you full ownership over your AI.
 


### PR DESCRIPTION
## Problem

Documentation needed updates to reflect the Jan 0.7.8 release: CLI and Agents pages were missing availability notes, and CLI docs needed improvements for HuggingFace model support and LlamaCPP server arguments.

## Changes

- Add \"Available since Jan 0.7.8\" note to CLI and Agents pages
- Add info callout on Overview page linking to changelog for v0.7.8
- Document HuggingFace repo ID support for `jan serve` command
- Add section on LlamaCPP server arguments via `LLAMA_ARG_` environment variables
- Add note explaining desktop app and CLI share the same data folder

## Testing

- [ ] Documentation builds successfully