### PR TITLE
Revert: clear ANTHROPIC_ env on app exit #7628

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -499,13 +499,6 @@ pub fn run() {
                         }
                     }
 
-                    // Clean up Claude Code env vars from shell config on exit
-                    if let Err(e) = crate::core::system::commands::clear_claude_code_env() {
-                        log::warn!("Failed to clear Claude Code env vars: {}", e);
-                    } else {
-                        log::info!("Claude Code env vars cleaned up successfully");
-                    }
-
                     log::info!("App cleanup completed");
                 });
             });

--- a/web-app/src/routes/settings/local-api-server.tsx
+++ b/web-app/src/routes/settings/local-api-server.tsx
@@ -20,7 +20,6 @@ import { cn } from '@/lib/utils'
 import { ApiKeyInput } from '@/containers/ApiKeyInput'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
-import { invoke } from '@tauri-apps/api/core'
 import { LogViewer } from '@/components/LogViewer'
 import { ensureModelForServer } from '@/utils/ensureModelForServer'
 
@@ -194,24 +193,12 @@ function LocalAPIServerContent() {
       setServerStatus('pending')
       window.core?.api
         ?.stopServer()
-        .then(async () => {
+        .then(() => {
           setServerStatus('stopped')
-          // Clean up Claude Code env vars from shell config when server stops
-          try {
-            await invoke('clear_claude_code_env')
-          } catch (e) {
-            console.warn('Failed to clear Claude Code env vars:', e)
-          }
         })
-        .catch(async (error: unknown) => {
+        .catch((error: unknown) => {
           console.error('Error stopping server:', error)
           setServerStatus('stopped')
-          // Still try to clean up env vars even if stop had an error
-          try {
-            await invoke('clear_claude_code_env')
-          } catch (e) {
-            console.warn('Failed to clear Claude Code env vars:', e)
-          }
         })
     }
   }


### PR DESCRIPTION
## Problem

This reverts the behavior from the reverted PR #7628.

The app was clearing ANTHROPIC_* environment variables on exit, even when Claude Code integration was not enabled (no models configured). This causes:
- Unexpected permission prompts in secure environments
- Makes users suspicious of the app's behavior
- Affects other integrations that use ANTHROPIC_* variables

## Solution

Only clear Claude Code environment variables when the user has actually configured at least one Claude Code model (big, medium, or small).

## Changes

- Modified web-app/src/routes/settings/claude-code.tsx to check hasModels before calling clear_claude_code_env

## Related

- Reverts: https://github.com/janhq/jan/pull/7628
- See comment: https://github.com/janhq/jan/pull/7628#issuecomment-4044030883