### PR TITLE
docs: add Windows data folder relocation troubleshooting section

### DIFF
--- a/docs/src/pages/docs/desktop/troubleshooting.mdx
+++ b/docs/src/pages/docs/desktop/troubleshooting.mdx
@@ -142,6 +142,36 @@ Following these steps, you can cleanly uninstall and reinstall Jan, ensuring a s
   Before reinstalling Jan, ensure it's completely removed from all shared spaces if installed on multiple user accounts on your device.
 </Callout>
 
+## Cannot Relocate Data Folder on Windows
+
+If you are unable to change the data folder location through Jan's interface on Windows, you can manually update it by editing the settings file:
+
+1. Fully **quit Jan** (right-click the system tray icon → Quit)
+
+2. Open File Explorer and navigate to:
+   ```
+   C:\Users\[username]\AppData\Roaming\Jan\
+   ```
+
+3. Open `settings.json` with a text editor (e.g. Notepad)
+
+4. Find the `"data_folder"` field and update its value to your desired path, for example:
+   ```json
+   {
+     "data_folder": "D:\\Jan"
+   }
+   ```
+
+5. Optionally, **copy your data** from the old folder to the new folder to preserve your models, chat history, and settings
+
+6. **Save** the file and **restart Jan**
+
+Jan will now use the new data folder location.
+
+<Callout type="info">
+  Use double backslashes (`\\`) for path separators in the JSON file, e.g. `"D:\\Jan\\data"`.
+</Callout>
+
 ## Troubleshooting NVIDIA GPU
 To resolve issues when Jan does not utilize the NVIDIA GPU on Windows and Linux systems.
 


### PR DESCRIPTION
## Summary

- Adds a new troubleshooting section for users who cannot relocate the data folder on Windows through Jan's UI
- Guides users to manually edit `C:\Users\[username]\AppData\Roaming\Jan\settings.json` and update the `data_folder` field
- Mentions copying data from the old folder to the new one before restarting

## Test plan

- [ ] Verify the new section renders correctly in the docs
- [ ] Confirm the JSON example and file path are accurate on Windows