### PR TITLE
fix: update CLI help examples to use Jan model ID

### DIFF
--- a/src-tauri/src/bin/jan-cli.rs
+++ b/src-tauri/src/bin/jan-cli.rs
@@ -33,13 +33,13 @@ OpenAI-compatible API, then wires AI coding agent like Claude Code\n\
 directly to your own hardware — no cloud account, no usage fees, full privacy.\n\n\
 Models downloaded in the Jan desktop app are automatically available here.",
     after_help = "Examples:\n  \
-  jan launch claude                               # pick a model, then run Claude Code against it\n  \
-  jan launch claude --model qwen3.5-35b-a3b       # use a specific model\n  \
-  jan launch openclaw --model qwen3.5-35b-a3b     # wire openclaw to a local model\n  \
-  jan serve qwen3.5-35b-a3b                       # expose a model at localhost:6767/v1\n  \
-  jan serve qwen3.5-35b-a3b --fit                 # auto-fit context to available VRAM\n  \
-  jan serve qwen3.5-35b-a3b --detach              # run in the background\n  \
-  jan models list                                 # show all installed models",
+  jan launch claude                                      # pick a model, then run Claude Code against it\n  \
+  jan launch claude --model janhq/Jan-code-4b-gguf       # use a specific model\n  \
+  jan launch openclaw --model janhq/Jan-code-4b-gguf     # wire openclaw to a local model\n  \
+  jan serve janhq/Jan-code-4b-gguf                       # expose a model at localhost:6767/v1\n  \
+  jan serve janhq/Jan-code-4b-gguf --fit                 # auto-fit context to available VRAM\n  \
+  jan serve janhq/Jan-code-4b-gguf --detach              # run in the background\n  \
+  jan models list                                        # show all installed models",
     version
 )]
 struct Cli {


### PR DESCRIPTION
## Problem

CLI help examples used a generic placeholder model name instead of a real Jan model ID.

## Changes

- Replace `qwen3.5-35b-a3b` example model with `janhq/Jan-code-4b-gguf` across all CLI help strings

## Testing

- [ ] macOS tested
- [ ] Windows tested
- [ ] Linux tested