### PR TITLE
fix: wrong display shortcut create project

### DIFF
--- a/web-app/src/components/left-sidebar/NavMain.tsx
+++ b/web-app/src/components/left-sidebar/NavMain.tsx
@@ -42,6 +42,7 @@ import { useAgentMode } from '@/hooks/useAgentMode'
 import { TEMPORARY_CHAT_ID } from '@/constants/chat'
 import { useAppState } from '@/hooks/useAppState'
 import { isOpenClawRunning } from '@/utils/openclaw'
+import { PlatformShortcuts, ShortcutAction } from '@/lib/shortcuts'
 
 type AnimatedIconHandle =
   | SearchIconHandle
@@ -81,7 +82,7 @@ const getNavMainItems = (
         <Kbd className="bg-transparent size-3">
           <PlatformMetaKey />
         </Kbd>
-        <Kbd className="bg-transparent size-3">N</Kbd>
+        <Kbd className="bg-transparent size-3 uppercase">{PlatformShortcuts[ShortcutAction.NEW_CHAT].key}</Kbd>
       </KbdGroup>
     ),
   },
@@ -94,7 +95,7 @@ const getNavMainItems = (
         <Kbd className="bg-transparent size-3">
           <PlatformMetaKey />
         </Kbd>
-        <Kbd className="bg-transparent size-3">M</Kbd>
+        <Kbd className="bg-transparent size-3 uppercase">{PlatformShortcuts[ShortcutAction.NEW_AGENT_CHAT].key}</Kbd>
       </KbdGroup>
     ),
   },
@@ -107,7 +108,7 @@ const getNavMainItems = (
         <Kbd className="bg-transparent size-3">
           <PlatformMetaKey />
         </Kbd>
-        <Kbd className="bg-transparent size-3">L</Kbd>
+        <Kbd className="bg-transparent size-3 uppercase">{PlatformShortcuts[ShortcutAction.NEW_PROJECT].key}</Kbd>
       </KbdGroup>
     ),
   },
@@ -120,7 +121,7 @@ const getNavMainItems = (
         <Kbd className="bg-transparent size-3">
           <PlatformMetaKey />
         </Kbd>
-        <Kbd className="bg-transparent size-3">K</Kbd>
+        <Kbd className="bg-transparent size-3 uppercase">{PlatformShortcuts[ShortcutAction.SEARCH].key} </Kbd>
       </KbdGroup>
     ),
   },


### PR DESCRIPTION
## Describe Your Changes

Issue
Wrong key shortcut for create project, UI show `L` it should be `P` 

<img width="1350" height="884" alt="Screenshot 2026-03-17 at 23 29 46" src="https://github.com/user-attachments/assets/c8bbe4c0-3db5-475b-9c75-52d9c74e16d9" />


## Fixes Issues
Keys now stay in sync with `const.ts` automatically — no more drift between the registered shortcut and what's shown in the UI

<img width="2700" height="1768" alt="Screenshot 2026-03-17 at 23 28 06" src="https://github.com/user-attachments/assets/7a2ab322-e12a-4636-9017-00bd742c3fa3" />


- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
