### PR TITLE
fix: cli install method on Window

### DIFF
--- a/src-tauri/src/core/system/commands.rs
+++ b/src-tauri/src/core/system/commands.rs
@@ -444,8 +444,9 @@ pub fn install_jan_cli_sync<R: Runtime>(
     #[cfg(windows)]
     {
         if bundled.exists() {
-            std::fs::rename(&bundled, &dest)
-                .map_err(|e| format!("Failed to rename jan-cli.exe to jan.exe: {}", e))?;
+            if let Err(e) = std::fs::rename(&bundled, &dest) {
+                log::warn!("Could not rename jan-cli.exe to jan.exe: {}", e);
+            }
         }
         add_to_path_windows(&resource_bin_dir)?;
         return Ok(CliInstallStatus {


### PR DESCRIPTION
## Describe Your Changes

#### Change the mech to install/uninstall cli on window
- Rename instead of copy jan-cli.exe to jan.exe to keep simple cli `jan launch` command
- Env PATH point to `<jan_program_path>/resources/bin` on window
- No copy to parent folder to avoid the duplication of file name Jan.exe vs jan.exe which could be case insensitive on shell

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
