### PR TITLE
feat: settings to auto increase ctx_len

### DIFF
--- a/web-app/src/containers/ModelSetting.tsx
+++ b/web-app/src/containers/ModelSetting.tsx
@@ -126,6 +126,17 @@ export function ModelSetting({
 
         <div className="px-4 space-y-8 pb-4">
           {Object.entries(model.settings || {})
+          .reduce<[string, unknown][]>((acc, entry) => {
+            if (entry[0] === 'auto_increase_ctx_len') return acc
+            if (entry[0] === 'ctx_len') {
+              const autoIncrease = Object.entries(model.settings || {}).find(
+                ([k]) => k === 'auto_increase_ctx_len'
+              )
+              if (autoIncrease) acc.push(autoIncrease)
+            }
+            acc.push(entry)
+            return acc
+          }, [])
           .filter(([key]) => {
             // MLX models only support context size setting
             if (provider.provider === 'mlx') {

--- a/web-app/src/hooks/useModelProvider.ts
+++ b/web-app/src/hooks/useModelProvider.ts
@@ -501,9 +501,28 @@ export const useModelProvider = create<ModelProviderState>()(
             (provider) => provider.provider !== 'cohere'
           )
         }
+
+        if (version <= 10 && state?.providers) {
+          state.providers.forEach((provider) => {
+            if (provider.models && provider.provider === 'llamacpp') {
+              provider.models.forEach((model) => {
+                if (!model.settings) model.settings = {}
+
+                if (!model.settings.auto_increase_ctx_len) {
+                  model.settings.auto_increase_ctx_len = {
+                    ...modelSettings.auto_increase_ctx_len,
+                    controller_props: {
+                      ...modelSettings.auto_increase_ctx_len.controller_props,
+                    },
+                  }
+                }
+              })
+            }
+          })
+        }
         return state
       },
-      version: 10,
+      version: 11,
     }
   )
 )

--- a/web-app/src/lib/predefined.ts
+++ b/web-app/src/lib/predefined.ts
@@ -1,4 +1,14 @@
 export const modelSettings = {
+  auto_increase_ctx_len: {
+    key: 'auto_increase_ctx_len',
+    title: 'Auto Increase Context Size',
+    description:
+      'Automatically increase context size when the model runs out of context mid-conversation.',
+    controller_type: 'checkbox',
+    controller_props: {
+      value: true,
+    },
+  },
   ctx_len: {
     key: 'ctx_len',
     title: 'Context Size',

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -149,6 +149,7 @@ function ThreadDetail() {
   const [pendingContinueMessage, setPendingContinueMessage] =
     useState<UIMessage | null>(null)
   const [isAutoIncreasingContext, setIsAutoIncreasingContext] = useState(false)
+  const [contextLimitError, setContextLimitError] = useState<Error | null>(null)
 
   // Refs so onFinish (captured in closure) always calls the latest callbacks
   const handleContextSizeIncreaseRef = useRef<(() => void) | null>(null)
@@ -181,16 +182,36 @@ function ThreadDetail() {
       // from where it stopped. The stream wrapper injects it as the first text-delta
       // of the new message, so the user sees the partial text immediately.
       if (!isAbort && finishReason === 'length') {
-        const partialText = message.parts
-          .filter((p) => p.type === 'text')
-          .map((p) => (p as { type: 'text'; text: string }).text)
-          .join('')
-        if (partialText) {
-          setContinueFromContentRef.current?.(partialText)
-          // Keep the partial message visible while the model reloads
-          setPendingContinueMessage(message)
+        const selectedModelState = useModelProvider.getState().selectedModel
+        const usage = msgMeta?.usage as
+          | { inputTokens?: number; outputTokens?: number }
+          | undefined
+        const totalTokens =
+          (usage?.inputTokens ?? 0) + (usage?.outputTokens ?? 0)
+        const ctxLen =
+          (selectedModelState?.settings?.ctx_len?.controller_props
+            ?.value as number) ?? 32768
+        const isContextLimit = totalTokens >= ctxLen * 0.9
+
+        if (isContextLimit) {
+          const autoIncrease =
+            selectedModelState?.settings?.auto_increase_ctx_len
+              ?.controller_props?.value ?? true
+          if (autoIncrease) {
+            const partialText = message.parts
+              .filter((p) => p.type === 'text')
+              .map((p) => (p as { type: 'text'; text: string }).text)
+              .join('')
+            if (partialText) {
+              setContinueFromContentRef.current?.(partialText)
+              // Keep the partial message visible while the model reloads
+              setPendingContinueMessage(message)
+            }
+            handleContextSizeIncreaseRef.current?.()
+          } else {
+            setContextLimitError(new Error(OUT_OF_CONTEXT_SIZE))
+          }
         }
-        handleContextSizeIncreaseRef.current?.()
         return
       }
 
@@ -748,13 +769,17 @@ function ThreadDetail() {
 
     const model = provider.models[modelIndex]
 
-    // Increase context length by 50%
+    // Increase context length in steps: <8192 -> 8192 -> 32768 -> x1.5
     const currentCtxLen =
-      (model.settings?.ctx_len?.controller_props?.value as number) ?? 32768
-    const newCtxLen =
-      currentCtxLen < 32768
-        ? 32768
-        : Math.round(Math.max(32768, currentCtxLen) * 1.5)
+      (model.settings?.ctx_len?.controller_props?.value as number) ?? 8192
+    let newCtxLen: number
+    if (currentCtxLen < 8192) {
+      newCtxLen = 8192
+    } else if (currentCtxLen < 32768) {
+      newCtxLen = 32768
+    } else {
+      newCtxLen = Math.round(currentCtxLen * 1.5)
+    }
 
     const updatedModel = {
       ...model,
@@ -800,6 +825,10 @@ function ThreadDetail() {
   )
   useEffect(() => {
     if (!error || agentModeActive) return
+    const autoIncrease =
+      selectedModel?.settings?.auto_increase_ctx_len?.controller_props?.value ??
+      true
+    if (!autoIncrease) return
     const isContextError =
       (error.message?.toLowerCase().includes('context') &&
         (error.message?.toLowerCase().includes('size') ||
@@ -813,6 +842,9 @@ function ThreadDetail() {
   }, [error]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
+    if (status === 'streaming' || status === 'submitted') {
+      setContextLimitError(null)
+    }
     if (isAutoIncreasingContext && (status === 'streaming' || status === 'error')) {
       setIsAutoIncreasingContext(false)
     }
@@ -882,7 +914,7 @@ function ThreadDetail() {
                   {status === CHAT_STATUS.SUBMITTED && <PromptProgress />}
                 </div>
               )}
-              {error && !isAutoIncreasingContext && (
+              {(error || contextLimitError) && !isAutoIncreasingContext && (
                 <div className="px-4 py-3 mx-4 my-2 rounded-lg border border-destructive/10 bg-destructive/10">
                   <div className="flex items-start gap-3">
                     <IconAlertCircle className="size-5 text-destructive shrink-0 mt-0.5" />
@@ -895,14 +927,14 @@ function ThreadDetail() {
                           className="text-sm text-muted-foreground table-cell align-middle"
                           style={{ wordWrap: 'break-word' }}
                         >
-                          {error.message}
+                          {(error ?? contextLimitError)?.message}
                         </span>
                       </div>
-                      {(error.message?.toLowerCase().includes('context') &&
-                        (error.message?.toLowerCase().includes('size') ||
-                          error.message?.toLowerCase().includes('length') ||
-                          error.message?.toLowerCase().includes('limit'))) ||
-                      error.message === OUT_OF_CONTEXT_SIZE ? (
+                      {((error ?? contextLimitError)?.message?.toLowerCase().includes('context') &&
+                        ((error ?? contextLimitError)?.message?.toLowerCase().includes('size') ||
+                          (error ?? contextLimitError)?.message?.toLowerCase().includes('length') ||
+                          (error ?? contextLimitError)?.message?.toLowerCase().includes('limit'))) ||
+                      (error ?? contextLimitError)?.message === OUT_OF_CONTEXT_SIZE ? (
                         <Button
                           variant="outline"
                           size="sm"


### PR DESCRIPTION
## Describe Your Changes

<img width="800" height="600" alt="Screenshot 2026-03-18 at 8 58 12 PM" src="https://github.com/user-attachments/assets/a5b9acc9-60b6-4fef-8288-217ffdaee17e" />


- Add a settings to auto increase ctx_len
- Jump step from < 8192 -> 8192 -> 32768 -> x1.5 prev ctx_len
- Show similar error on OOC during mid-generating
- Distinct OOC vs n_predict (max_output_tokens) when hitting signal `finishReason === 'length' `

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
