### PR TITLE
fix: Fix auto-increase context size bugs

### DIFF
--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -64,7 +64,6 @@ import {
 import { getSystemUsage, getSystemInfo } from '@janhq/tauri-plugin-hardware-api'
 
 // Error message constant - matches web-app/src/utils/error.ts
-const OUT_OF_CONTEXT_SIZE = 'the request exceeds the available context size.'
 
 /**
  * Override the default app.log function to use Jan's logging system.
@@ -1830,12 +1829,6 @@ export default class llamacpp_extension extends AIEngine {
             const data = JSON.parse(jsonStr)
             const chunk = data as chatCompletionChunk
 
-            // Check for out-of-context error conditions
-            if (chunk.choices?.[0]?.finish_reason === 'length') {
-              // finish_reason 'length' indicates context limit was hit
-              throw new Error(OUT_OF_CONTEXT_SIZE)
-            }
-
             yield chunk
           } catch (e) {
             logger.error('Error parsing JSON from stream or server error:', e)
@@ -1922,12 +1915,6 @@ export default class llamacpp_extension extends AIEngine {
     }
 
     const completionResponse = (await response.json()) as chatCompletion
-
-    // Check for out-of-context error conditions
-    if (completionResponse.choices?.[0]?.finish_reason === 'length') {
-      // finish_reason 'length' indicates context limit was hit
-      throw new Error(OUT_OF_CONTEXT_SIZE)
-    }
 
     return completionResponse
   }

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -148,7 +148,9 @@ function ThreadDetail() {
   // context-limit hit, so the user sees it instead of a blank gap.
   const [pendingContinueMessage, setPendingContinueMessage] =
     useState<UIMessage | null>(null)
-  const [isAutoIncreasingContext, setIsAutoIncreasingContext] = useState(false)
+  const [autoIncreaseAttempts, setAutoIncreaseAttempts] = useState(0)
+  const MAX_AUTO_INCREASE_ATTEMPTS = 3
+  const isAutoIncreasingContext = autoIncreaseAttempts > 0 && autoIncreaseAttempts < MAX_AUTO_INCREASE_ATTEMPTS
   const [contextLimitError, setContextLimitError] = useState<Error | null>(null)
 
   // Refs so onFinish (captured in closure) always calls the latest callbacks
@@ -772,6 +774,9 @@ function ThreadDetail() {
     // Increase context length in steps: <8192 -> 8192 -> 32768 -> x1.5
     const currentCtxLen =
       (model.settings?.ctx_len?.controller_props?.value as number) ?? 8192
+    const maxCtxLen =
+      (model.settings?.ctx_len?.controller_props?.max as number) || 131072
+
     let newCtxLen: number
     if (currentCtxLen < 8192) {
       newCtxLen = 8192
@@ -779,6 +784,12 @@ function ThreadDetail() {
       newCtxLen = 32768
     } else {
       newCtxLen = Math.round(currentCtxLen * 1.5)
+    }
+
+    newCtxLen = Math.min(newCtxLen, maxCtxLen)
+    if (newCtxLen <= currentCtxLen) {
+      setContextLimitError(new Error(OUT_OF_CONTEXT_SIZE))
+      return
     }
 
     const updatedModel = {
@@ -825,6 +836,7 @@ function ThreadDetail() {
   )
   useEffect(() => {
     if (!error || agentModeActive) return
+    if (autoIncreaseAttempts >= MAX_AUTO_INCREASE_ATTEMPTS) return
     const autoIncrease =
       selectedModel?.settings?.auto_increase_ctx_len?.controller_props?.value ??
       true
@@ -836,7 +848,7 @@ function ThreadDetail() {
           error.message?.toLowerCase().includes('limit'))) ||
       error.message === OUT_OF_CONTEXT_SIZE
     if (isContextError) {
-      setIsAutoIncreasingContext(true)
+      setAutoIncreaseAttempts((prev) => prev + 1)
       handleContextSizeIncrease()
     }
   }, [error]) // eslint-disable-line react-hooks/exhaustive-deps
@@ -845,8 +857,8 @@ function ThreadDetail() {
     if (status === 'streaming' || status === 'submitted') {
       setContextLimitError(null)
     }
-    if (isAutoIncreasingContext && (status === 'streaming' || status === 'error')) {
-      setIsAutoIncreasingContext(false)
+    if (status === 'streaming' && autoIncreaseAttempts > 0) {
+      setAutoIncreaseAttempts(0)
     }
     if (status === 'error' && pendingContinueMessage) {
       setPendingContinueMessage(null)

--- a/web-app/src/types/modelProviders.d.ts
+++ b/web-app/src/types/modelProviders.d.ts
@@ -8,6 +8,9 @@ type ControllerProps = {
   options?: Array<{ value: number | string; name: string }>
   input_actions?: string[]
   recommended?: string
+  min?: number
+  max?: number
+  step?: number
 }
 
 /**


### PR DESCRIPTION
## Describe Your Changes

### Problem
The auto-increase context size feature had several bugs that could cause unbounded ctx_len growth, unnecessary model reloads, and poor error handling:

1. `finish_reason: "length"` from llama.cpp was unconditionally treated as out-of-context error, even when caused by `n_predict` limit — triggering false auto-increases
2. The error useEffect had no re-trigger guard, allowing infinite error→increase→error loops
3. No cap on `newCtxLen` — the x1.5 multiplier could grow unbounded (32k → 49k → 74k → ...)

### Changes

- Removed `throw Error` on `finish_reason === 'length'` — let it flow through to the frontend `onFinish` handler which correctly checks `totalTokens >= ctx_len` before deciding to auto-increase
- Added `maxCtxLen` cap with bail-out when at ceiling
- Replaced `isAutoIncreasingContext` boolean with attempt counter (max 3) to prevent runaway loops
- Counter resets only on successful streaming, not on error

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
