### PR TITLE
fix: add pointer cursor to tool header when hovering

### DIFF
--- a/web-app/src/components/ai-elements/tool.tsx
+++ b/web-app/src/components/ai-elements/tool.tsx
@@ -108,7 +108,7 @@ export const ToolHeader = memo(
     return (
       <CollapsibleTrigger
         className={cn(
-          'flex w-full items-center gap-2 text-muted-foreground text-sm transition-colors capitalize',
+          'cursor-pointer flex w-full items-center gap-2 text-muted-foreground text-sm transition-colors capitalize', !isOpen && 'hover:bg-secondary',
           className
         )}
       >


### PR DESCRIPTION
## Describe Your Changes
If the response contains information about tool calling, the tool header only contains a chevron icon. It doesn't have common UI styling for toggle elements like cursor or change in background color.

I've added `cursor: pointer` and a contrasting background color to the CollapsibleTrigger element to make it more obvious that it is clickable/toggle-able.

## Fixes Issues

- Closes #7113 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
