### PR TITLE
fix: restore default localhost on API Server start

### DIFF
--- a/web-app/src/hooks/useLocalApiServer.ts
+++ b/web-app/src/hooks/useLocalApiServer.ts
@@ -51,7 +51,7 @@ export const useLocalApiServer = create<LocalApiServerState>()(
         set({ defaultModelLocalApiServer: model }),
       lastServerModels: [],
       setLastServerModels: (models) => set({ lastServerModels: models }),
-      serverHost: '0.0.0.0',
+      serverHost: '127.0.0.1',
       setServerHost: (value) => set({ serverHost: value }),
       // Use port 0 (auto-assign) for mobile to avoid conflicts, 1337 for desktop
       serverPort: (typeof window !== 'undefined' && (window as { IS_ANDROID?: boolean }).IS_ANDROID) || (typeof window !== 'undefined' && (window as { IS_IOS?: boolean }).IS_IOS) ? 0 : 1337,


### PR DESCRIPTION
## Describe Your Changes

- Restore default localhost on API Server start on 127.0.0.1

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
