### PR TITLE
fix: auto-approve internal RAG tools for embedded documents

### DIFF
--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -74,6 +74,7 @@ import { toast } from 'sonner'
 import { isPlatformTauri } from '@/lib/platform/utils'
 import { processAttachmentsForSend } from '@/lib/attachmentProcessing'
 import { useAttachmentIngestionPrompt } from '@/hooks/useAttachmentIngestionPrompt'
+import { useToolApproval } from '@/hooks/useToolApproval'
 import {
   NEW_THREAD_ATTACHMENT_KEY,
   useChatAttachments,
@@ -725,6 +726,11 @@ const ChatInput = memo(function ChatInput({
         }
 
         if (hasEmbeddedDocuments) {
+          const toolApproval = useToolApproval.getState()
+          const ragTools = useAppState.getState().ragToolNames
+          for (const toolName of ragTools) {
+            toolApproval.approveToolForThread(currentThreadId, toolName)
+          }
           useThreads.getState().updateThread(currentThreadId, {
             metadata: { hasDocuments: true },
           })

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -274,10 +274,12 @@ function ThreadDetail() {
           try {
             const toolName = toolCall.toolName
 
-            // Request approval if needed (unless auto-approve is enabled)
-            const approved = await useToolApproval
-              .getState()
-              .showApprovalModal(toolName, threadId, toolCall.input)
+            // Built-in RAG tools are internal and should not require approval.
+            const approved = ragToolNames.has(toolName)
+              ? true
+              : await useToolApproval
+                  .getState()
+                  .showApprovalModal(toolName, threadId, toolCall.input)
 
             if (!approved) {
               // User denied the tool call
@@ -525,6 +527,11 @@ function ThreadDetail() {
 
           // Update thread metadata if documents were embedded
           if (result.hasEmbeddedDocuments) {
+            const toolApproval = useToolApproval.getState()
+            const ragTools = useAppState.getState().ragToolNames
+            for (const toolName of ragTools) {
+              toolApproval.approveToolForThread(threadId, toolName)
+            }
             useThreads.getState().updateThread(threadId, {
               metadata: { hasDocuments: true },
             })


### PR DESCRIPTION
## Summary
- Skip tool approval modal for built-in internal RAG tools (`retrieve`, `list_attachments`, `get_chunks`) in thread tool-call flow.
- Auto-grant RAG tool permissions for a thread when documents are embedded successfully.
- Apply the same auto-grant behavior in both thread send flow and chat input attachment-processing flow.

## Fixes Issues

- Closes #7748

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
