### PR TITLE
fix: model capability toggles resetting after restart in edit model settings

### DIFF
--- a/web-app/src/hooks/__tests__/useModelProvider.test.ts
+++ b/web-app/src/hooks/__tests__/useModelProvider.test.ts
@@ -129,6 +129,58 @@ describe('useModelProvider - displayName functionality', () => {
     expect(provider?.models[0].displayName).toBe('My Custom Model')
   })
 
+  it('should preserve user-configured capabilities when merging setProviders refresh', () => {
+    const { result } = renderHook(() => useModelProvider())
+
+    act(() => {
+      useModelProvider.setState({
+        providers: [
+          {
+            provider: 'llamacpp',
+            active: true,
+            models: [
+              {
+                id: 'test-model.gguf',
+                capabilities: ['completion'],
+                _userConfiguredCapabilities: true,
+              },
+            ],
+            settings: [],
+          },
+        ] as any,
+        selectedProvider: 'llamacpp',
+        selectedModel: null,
+        deletedModels: [],
+      })
+    })
+
+    const freshProviders = [
+      {
+        provider: 'llamacpp',
+        active: true,
+        persist: true,
+        models: [
+          {
+            id: 'test-model.gguf',
+            capabilities: ['completion', 'vision', 'tools'],
+          },
+        ],
+        settings: [],
+      },
+    ] as any
+
+    act(() => {
+      result.current.setProviders(freshProviders)
+    })
+
+    const provider = result.current.getProviderByName('llamacpp')
+    expect(provider?.models[0].capabilities).toEqual(['completion'])
+    expect(
+      (provider?.models[0] as { _userConfiguredCapabilities?: boolean })
+        ._userConfiguredCapabilities
+    ).toBe(true)
+  })
+
   it('should provide basic functionality without breaking existing behavior', () => {
     const { result } = renderHook(() => useModelProvider())
 

--- a/web-app/src/hooks/useModelProvider.ts
+++ b/web-app/src/hooks/useModelProvider.ts
@@ -100,17 +100,32 @@ export const useModelProvider = create<ModelProviderState>()(
                       .join(getServiceHub().path().sep()) === model.id
                 )?.settings || model.settings
               const existingModel = models.find((m) => m.id === model.id)
-              const mergedCapabilities = [
-                ...(model.capabilities || []),
-                ...(existingModel?.capabilities || []).filter(
-                  (cap) => !(model.capabilities || []).includes(cap)
-                ),
-              ]
+              const userConfiguredCapabilities =
+                (
+                  existingModel as Model & {
+                    _userConfiguredCapabilities?: boolean
+                  }
+                )?._userConfiguredCapabilities === true
+
+              // When the user set tools/vision in Edit Model, honor that list on every
+              // refresh from the engine; otherwise fresh engine data would re-add defaults.
+              const mergedCapabilities = userConfiguredCapabilities
+                ? [...(existingModel?.capabilities || [])]
+                : [
+                    ...(model.capabilities || []),
+                    ...(existingModel?.capabilities || []).filter(
+                      (cap) => !(model.capabilities || []).includes(cap)
+                    ),
+                  ]
               return {
                 ...model,
                 settings: settings,
-                capabilities: mergedCapabilities.length > 0 ? mergedCapabilities : undefined,
+                capabilities:
+                  mergedCapabilities.length > 0 ? mergedCapabilities : undefined,
                 displayName: existingModel?.displayName || model.displayName,
+                ...(userConfiguredCapabilities
+                  ? { _userConfiguredCapabilities: true as const }
+                  : {}),
               }
             })
 


### PR DESCRIPTION
## Describe Your Changes
- Fixed llama.cpp model tools and vision toggles in Edit model resetting after restart.
- In useModelProvider, when merging refreshed provider data from the engine with persisted state, we now treat models with _userConfiguredCapabilities === true as authoritative: their saved capabilities array is kept instead of being merged with the engine’s defaults (which re-added vision/tools from mmproj and tool-support checks).
- Re-applied _userConfiguredCapabilities: true on the merged model so the flag survives each refresh.
- Added a unit test in useModelProvider.test.ts that simulates a fresh provider list with vision/tools while persisted state has only completion and asserts the user-configured list is preserved.

## Fixes Issues

- Closes #7818 

## Self Checklist

Added relevant comments, esp in complex areas
(short comment above the merge branch explaining why user-configured capabilities win)

Updated docs (for bug fixes / features)
(not required — behavior matches user expectation; no user-facing doc change)

Created issues for follow-up changes or refactoring needed
