### PR TITLE
feat: add highlight on dragabble area and also add cursor change

### DIFF
--- a/web-app/src/routes/__root.tsx
+++ b/web-app/src/routes/__root.tsx
@@ -15,7 +15,6 @@ import { useAnalytic } from '@/hooks/useAnalytic'
 import { PromptAnalytic } from '@/containers/analytics/PromptAnalytic'
 import { useJanModelPrompt } from '@/hooks/useJanModelPrompt'
 import { PromptJanModel } from '@/containers/PromptJanModel'
-import { useLatestJanModel } from '@/hooks/useLatestJanModel'
 import { AnalyticProvider } from '@/providers/AnalyticProvider'
 import { useLeftPanel } from '@/hooks/useLeftPanel'
 import ToolApproval from '@/containers/dialogs/ToolApproval'
@@ -45,13 +44,6 @@ const AppLayout = () => {
     width: sidebarWidth,
     setLeftPanelWidth,
   } = useLeftPanel()
-  const fetchLatestJanModel = useLatestJanModel(
-    (state) => state.fetchLatestJanModel
-  )
-
-  useEffect(() => {
-    fetchLatestJanModel()
-  }, [fetchLatestJanModel])
 
   return (
     <div className="bg-neutral-50 dark:bg-background size-full relative">
@@ -67,7 +59,7 @@ const AppLayout = () => {
         {IS_WINDOWS && <WindowControls />}
         {IS_TAURI && (
           <div
-            className="fixed w-full h-12 z-20 top-0 cursor-grab active:cursor-grabbing hover:bg-primary/10 transition-colors duration-150"
+            className="fixed w-full h-12 z-20 top-0 cursor-grab active:cursor-grabbing"
             title="Drag window"
             aria-label="Window drag area"
             {...(IS_LINUX


### PR DESCRIPTION
## Describe Your Changes

- Added a consistent top window drag strip for desktop (Linux, macOS, Windows) with a fixed height.
- This change only appears when you hover on drag area.
- Improved drag-area discoverability by adding hover highlight and drag cursor feedback (`cursor-grab` / `cursor-grabbing`) so users can clearly see where they can drag the window.
- Unified cross-platform drag behavior:
  - Linux uses `startDragging()` on mouse down for reliable dragging.
  - macOS/Windows use `data-tauri-drag-region`.

## Fixes Issues

- Closes #7546

## Self Checklist

- [x] Added relevant comments, especially in complex areas
- [x] Updated docs (for bug fixes / features)
- [x] Created issues for follow-up changes or refactoring needed

## Before and After Evidence
Before:
<img width="1350" height="900" alt="screenshot_2" src="https://github.com/user-attachments/assets/7a11227e-b193-4447-aeb8-2746051e6bb4" />
After:
Linux:
<img width="1374" height="867" alt="Screenshot_1" src="https://github.com/user-attachments/assets/6e57e5e6-586c-411f-b3b5-8cc096287305" />

MacOS:
<img width="1200" height="765" alt="macos-screenshot" src="https://github.com/user-attachments/assets/c52e820d-05b8-45f9-8801-d3e2ff70bbe8" />


