### PR TITLE
fix: let users scroll and read thinking content during streaming without being interrupted

### DIFF
--- a/web-app/src/components/ai-elements/reasoning.tsx
+++ b/web-app/src/components/ai-elements/reasoning.tsx
@@ -14,7 +14,6 @@ import {
   useContext,
   useEffect,
   useMemo,
-  useRef,
   useState,
 } from 'react'
 import { Streamdown } from 'streamdown'
@@ -69,7 +68,6 @@ export const Reasoning = memo(
     })
 
     const [startTime, setStartTime] = useState<number | null>(null)
-    const wasStreamingRef = useRef(isStreaming)
 
     // Track duration when streaming starts and ends
     useEffect(() => {
@@ -82,15 +80,6 @@ export const Reasoning = memo(
         setStartTime(null)
       }
     }, [isStreaming, startTime, setDuration])
-
-    // Auto-close when streaming ends (only when transitioning from streaming to not streaming)
-    useEffect(() => {
-      if (wasStreamingRef.current && !isStreaming) {
-        // Streaming just ended, auto-close
-        setIsOpen(false)
-      }
-      wasStreamingRef.current = isStreaming
-    }, [isStreaming, setIsOpen])
 
     const handleOpenChange = (newOpen: boolean) => {
       setIsOpen(newOpen)

--- a/web-app/src/containers/MessageItem.tsx
+++ b/web-app/src/containers/MessageItem.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/components/ai-elements/tool'
 import { CopyButton } from './CopyButton'
 import { useModelProvider } from '@/hooks/useModelProvider'
-import { IconRefresh, IconPaperclip } from '@tabler/icons-react'
+import { IconRefresh, IconPaperclip, IconArrowDown } from '@tabler/icons-react'
 import { EditMessageDialog } from '@/containers/dialogs/EditMessageDialog'
 import { DeleteMessageDialog } from '@/containers/dialogs/DeleteMessageDialog'
 import TokenSpeedIndicator from '@/containers/TokenSpeedIndicator'
@@ -43,6 +43,9 @@ export type MessageItemProps = {
   isLastMessage: boolean
   status: ChatStatus
   reasoningContainerRef?: React.RefObject<HTMLDivElement | null>
+  isReasoningAtBottom?: boolean
+  onReasoningScroll?: () => void
+  onReasoningScrollToBottom?: () => void
   onRegenerate?: (messageId: string) => void
   onEdit?: (messageId: string, newText: string) => void
   onDelete?: (messageId: string) => void
@@ -60,6 +63,9 @@ export const MessageItem = memo(
     isAnimating,
     hideActions,
     reasoningContainerRef,
+    isReasoningAtBottom,
+    onReasoningScroll,
+    onReasoningScrollToBottom,
     onRegenerate,
     onEdit,
     onDelete,
@@ -277,15 +283,27 @@ export const MessageItem = memo(
             )}
             <div
               ref={isStreaming ? reasoningContainerRef : null}
+              onScroll={isStreaming ? onReasoningScroll : undefined}
               className={twMerge(
                 'w-full overflow-auto relative',
                 isStreaming
-                  ? 'max-h-32 opacity-70 mt-2 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden'
+                  ? 'max-h-64 opacity-70 mt-2 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden'
                   : 'h-auto opacity-100'
               )}
             >
               <ReasoningContent>{part.text}</ReasoningContent>
             </div>
+            {isStreaming && !isReasoningAtBottom && (
+              <Button
+                className="absolute bottom-2 left-[50%] translate-x-[-50%] rounded-full size-7 z-10"
+                onClick={onReasoningScrollToBottom}
+                size="icon"
+                type="button"
+                variant="outline"
+              >
+                <IconArrowDown className="size-3" />
+              </Button>
+            )}
           </div>
         </Reasoning>
       )

--- a/web-app/src/hooks/__tests__/useAutoScroll.test.ts
+++ b/web-app/src/hooks/__tests__/useAutoScroll.test.ts
@@ -1,0 +1,233 @@
+import { renderHook, act } from '@testing-library/react'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useAutoScroll } from '../useAutoScroll'
+
+describe('useAutoScroll', () => {
+  let container: HTMLDivElement
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    // jsdom doesn't compute layout, so we stub the scroll properties
+    Object.defineProperty(container, 'scrollHeight', {
+      value: 500,
+      writable: true,
+      configurable: true,
+    })
+    Object.defineProperty(container, 'clientHeight', {
+      value: 200,
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  it('should return all expected properties', () => {
+    const { result } = renderHook(() => useAutoScroll())
+
+    expect(result.current.containerRef).toBeDefined()
+    expect(result.current.isAtBottom).toBe(true)
+    expect(typeof result.current.handleScroll).toBe('function')
+    expect(typeof result.current.scrollToBottom).toBe('function')
+    expect(typeof result.current.forceScrollToBottom).toBe('function')
+    expect(typeof result.current.reset).toBe('function')
+  })
+
+  it('should auto-scroll to bottom by default (stuck state)', () => {
+    const { result } = renderHook(() => useAutoScroll())
+
+    Object.defineProperty(result.current.containerRef, 'current', {
+      value: container,
+      writable: true,
+    })
+
+    act(() => {
+      result.current.scrollToBottom()
+    })
+
+    expect(container.scrollTop).toBe(500)
+    expect(result.current.isAtBottom).toBe(true)
+  })
+
+  it('should NOT auto-scroll when user has scrolled away from the bottom', () => {
+    const { result } = renderHook(() => useAutoScroll())
+
+    Object.defineProperty(result.current.containerRef, 'current', {
+      value: container,
+      writable: true,
+    })
+
+    // Simulate user scrolling to somewhere in the middle (not at bottom)
+    // scrollHeight=500, clientHeight=200, scrollTop=100 => distFromBottom=200
+    container.scrollTop = 100
+
+    act(() => {
+      result.current.handleScroll()
+    })
+
+    expect(result.current.isAtBottom).toBe(false)
+
+    container.scrollTop = 100
+
+    act(() => {
+      result.current.scrollToBottom()
+    })
+
+    // Should remain at 100, not jump to 500
+    expect(container.scrollTop).toBe(100)
+  })
+
+  it('should resume auto-scroll when user scrolls back to bottom', () => {
+    const { result } = renderHook(() => useAutoScroll())
+
+    Object.defineProperty(result.current.containerRef, 'current', {
+      value: container,
+      writable: true,
+    })
+
+    // User scrolls away
+    container.scrollTop = 100
+    act(() => {
+      result.current.handleScroll()
+    })
+    expect(result.current.isAtBottom).toBe(false)
+
+    // User scrolls back to bottom (scrollHeight - scrollTop - clientHeight <= 20)
+    container.scrollTop = 290 // 500 - 290 - 200 = 10, which is <= 20
+    act(() => {
+      result.current.handleScroll()
+    })
+    expect(result.current.isAtBottom).toBe(true)
+
+    act(() => {
+      result.current.scrollToBottom()
+    })
+
+    expect(container.scrollTop).toBe(500)
+  })
+
+  it('should re-enable auto-scroll on reset()', () => {
+    const { result } = renderHook(() => useAutoScroll())
+
+    Object.defineProperty(result.current.containerRef, 'current', {
+      value: container,
+      writable: true,
+    })
+
+    // User scrolls away
+    container.scrollTop = 50
+    act(() => {
+      result.current.handleScroll()
+    })
+    expect(result.current.isAtBottom).toBe(false)
+
+    // Verify auto-scroll is paused
+    container.scrollTop = 50
+    act(() => {
+      result.current.scrollToBottom()
+    })
+    expect(container.scrollTop).toBe(50)
+
+    // Reset (as if a new streaming session started)
+    act(() => {
+      result.current.reset()
+    })
+    expect(result.current.isAtBottom).toBe(true)
+
+    act(() => {
+      result.current.scrollToBottom()
+    })
+
+    expect(container.scrollTop).toBe(500)
+  })
+
+  it('should treat positions within the threshold as "at bottom"', () => {
+    const { result } = renderHook(() => useAutoScroll())
+
+    Object.defineProperty(result.current.containerRef, 'current', {
+      value: container,
+      writable: true,
+    })
+
+    // Position within the 20px threshold: 500 - 285 - 200 = 15, <= 20
+    container.scrollTop = 285
+    act(() => {
+      result.current.handleScroll()
+    })
+
+    expect(result.current.isAtBottom).toBe(true)
+
+    act(() => {
+      result.current.scrollToBottom()
+    })
+
+    expect(container.scrollTop).toBe(500)
+  })
+
+  it('should treat positions just beyond the threshold as "scrolled away"', () => {
+    const { result } = renderHook(() => useAutoScroll())
+
+    Object.defineProperty(result.current.containerRef, 'current', {
+      value: container,
+      writable: true,
+    })
+
+    // Position just beyond threshold: 500 - 279 - 200 = 21, > 20
+    container.scrollTop = 279
+    act(() => {
+      result.current.handleScroll()
+    })
+
+    expect(result.current.isAtBottom).toBe(false)
+
+    container.scrollTop = 279
+    act(() => {
+      result.current.scrollToBottom()
+    })
+
+    // Should NOT auto-scroll
+    expect(container.scrollTop).toBe(279)
+  })
+
+  it('should force-scroll to bottom regardless of stuck state', () => {
+    const { result } = renderHook(() => useAutoScroll())
+
+    Object.defineProperty(result.current.containerRef, 'current', {
+      value: container,
+      writable: true,
+    })
+
+    // User scrolls away
+    container.scrollTop = 100
+    act(() => {
+      result.current.handleScroll()
+    })
+    expect(result.current.isAtBottom).toBe(false)
+
+    // Normal scrollToBottom should be a no-op
+    container.scrollTop = 100
+    act(() => {
+      result.current.scrollToBottom()
+    })
+    expect(container.scrollTop).toBe(100)
+
+    // forceScrollToBottom ignores stuck state
+    act(() => {
+      result.current.forceScrollToBottom()
+    })
+    expect(container.scrollTop).toBe(500)
+    expect(result.current.isAtBottom).toBe(true)
+  })
+
+  it('should be a no-op when containerRef has no element', () => {
+    const { result } = renderHook(() => useAutoScroll())
+
+    // containerRef.current is null by default — nothing should throw
+    expect(() => {
+      act(() => {
+        result.current.handleScroll()
+        result.current.scrollToBottom()
+        result.current.forceScrollToBottom()
+        result.current.reset()
+      })
+    }).not.toThrow()
+  })
+})

--- a/web-app/src/hooks/useAutoScroll.ts
+++ b/web-app/src/hooks/useAutoScroll.ts
@@ -1,0 +1,55 @@
+import { useRef, useCallback, useState } from 'react'
+
+// How close to the bottom (in px) counts as "at the bottom"
+const BOTTOM_THRESHOLD = 20
+
+/**
+ * Auto-scrolls a container to bottom as content streams in, but pauses
+ * when the user scrolls up to read. Resumes once they scroll back down.
+ */
+export function useAutoScroll() {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const isStuckRef = useRef(true)
+  const [isAtBottom, setIsAtBottom] = useState(true)
+
+  // Update stuck state whenever the user (or programmatic) scrolls
+  const handleScroll = useCallback(() => {
+    const el = containerRef.current
+    if (!el) return
+    const stuck =
+      el.scrollHeight - el.scrollTop - el.clientHeight <= BOTTOM_THRESHOLD
+    isStuckRef.current = stuck
+    setIsAtBottom(stuck)
+  }, [])
+
+  // Scroll to bottom only when the user hasn't scrolled away
+  const scrollToBottom = useCallback(() => {
+    if (isStuckRef.current && containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight
+    }
+  }, [])
+
+  // Force-scroll to bottom regardless of stuck state (for the button)
+  const forceScrollToBottom = useCallback(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight
+    }
+    isStuckRef.current = true
+    setIsAtBottom(true)
+  }, [])
+
+  // Re-enable auto-scroll (e.g. when a new streaming session begins)
+  const reset = useCallback(() => {
+    isStuckRef.current = true
+    setIsAtBottom(true)
+  }, [])
+
+  return {
+    containerRef,
+    isAtBottom,
+    handleScroll,
+    scrollToBottom,
+    forceScrollToBottom,
+    reset,
+  }
+}

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -54,6 +54,7 @@ import { ExtensionManager } from '@/lib/extension'
 import { Shimmer } from '@/components/ai-elements/shimmer'
 import { useAgentMode } from '@/hooks/useAgentMode'
 import { generateThreadTitle } from '@/lib/thread-title-summarizer'
+import { useAutoScroll } from '@/hooks/useAutoScroll'
 
 const CHAT_STATUS = {
   STREAMING: 'streaming',
@@ -470,16 +471,27 @@ function ThreadDetail() {
     disabledTools, // Re-run when tools are enabled/disabled
   ])
 
-  // Ref for reasoning container auto-scroll
-  const reasoningContainerRef = useRef<HTMLDivElement>(null)
+  // Auto-scroll the reasoning container during streaming, pausing when the user scrolls up
+  const {
+    containerRef: reasoningContainerRef,
+    isAtBottom: isReasoningAtBottom,
+    handleScroll: handleReasoningScroll,
+    scrollToBottom: scrollReasoningToBottom,
+    forceScrollToBottom: forceScrollReasoningToBottom,
+    reset: resetReasoningScroll,
+  } = useAutoScroll()
 
-  // Auto-scroll reasoning container to bottom during streaming
   useEffect(() => {
-    if (status === 'streaming' && reasoningContainerRef.current) {
-      reasoningContainerRef.current.scrollTop =
-        reasoningContainerRef.current.scrollHeight
+    if (status === 'streaming') {
+      resetReasoningScroll()
     }
-  }, [status, chatMessages])
+  }, [status, resetReasoningScroll])
+
+  useEffect(() => {
+    if (status === 'streaming') {
+      scrollReasoningToBottom()
+    }
+  }, [status, chatMessages, scrollReasoningToBottom])
 
   useEffect(() => {
     setCurrentThreadId(threadId)
@@ -966,6 +978,9 @@ function ThreadDetail() {
                     isLastMessage={isLastMessage}
                     status={status}
                     reasoningContainerRef={reasoningContainerRef}
+                    isReasoningAtBottom={isReasoningAtBottom}
+                    onReasoningScroll={handleReasoningScroll}
+                    onReasoningScrollToBottom={forceScrollReasoningToBottom}
                     onRegenerate={handleRegenerate}
                     onEdit={handleEditMessage}
                     onDelete={handleDeleteMessage}
@@ -982,6 +997,9 @@ function ThreadDetail() {
                   isLastMessage={true}
                   status={status}
                   reasoningContainerRef={reasoningContainerRef}
+                  isReasoningAtBottom={isReasoningAtBottom}
+                  onReasoningScroll={handleReasoningScroll}
+                  onReasoningScrollToBottom={forceScrollReasoningToBottom}
                   onRegenerate={handleRegenerate}
                   onEdit={handleEditMessage}
                   onDelete={handleDeleteMessage}


### PR DESCRIPTION
## Describe Your Changes

The thinking/reasoning area auto-scroll was forcing users to the bottom on every token, making it impossible to read thinking content during generation. 

Changes:
- Added `useAutoScroll` hook that tracks whether the user is near the bottom, and only auto-scrolls when they are
- Added a small scroll-to-bottom button inside the thinking area so users can jump back to the latest content
- Stopped auto-collapsing the thinking panel when streaming ends, so users can keep reading
- Increased thinking container height from 128px to 256px for better readability

## Fixes Issues

- Closes #7445

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
