### PR TITLE
feat: clarify that models are stored in appdata too

### DIFF
--- a/web-app/src/locales/en/settings.json
+++ b/web-app/src/locales/en/settings.json
@@ -47,7 +47,7 @@
   "appVersion": "App Version",
   "dataFolder": {
     "appData": "App Data",
-    "appDataDesc": "Default location for messages and other user data.",
+    "appDataDesc": "Location for messages, downloaded models and other data.",
     "appLogs": "App Logs",
     "appLogsDesc": "View detailed logs of the App."
   },


### PR DESCRIPTION
## Describe Your Changes

The app data settings description said "default location", but when the path is changed, it is no longer default, right? I am not sure what "messages" are, but I was specifically looking to configure an alternative location for models, because they take a lot of space. So I left "messages" in the description and added "downloaded models" there.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
