### PR TITLE
feat: allow retrieving last typed message by pressing up arrow key

### DIFF
--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -124,6 +124,8 @@ const ChatInput = memo(function ChatInput({
   const setActiveModels = useAppState((state) => state.setActiveModels)
   const prompt = usePrompt((state) => state.prompt)
   const setPrompt = usePrompt((state) => state.setPrompt)
+  const addToHistory = usePrompt((state) => state.addToHistory)
+  const navigateHistory = usePrompt((state) => state.navigateHistory)
   const currentThreadId = useThreads((state) => state.currentThreadId)
   const currentThread = useThreads((state) => state.getCurrentThread())
   const updateCurrentThreadAssistant = useThreads(
@@ -372,6 +374,7 @@ const ChatInput = memo(function ChatInput({
     }
 
     setMessage('')
+    addToHistory(prompt)
 
     // Use onSubmit prop if available (AI SDK), otherwise create thread and navigate
     if (onSubmit) {
@@ -1649,6 +1652,27 @@ const ChatInput = memo(function ChatInput({
                     handleSendMessage(prompt)
                   }
                   // When Shift+Enter is pressed, a new line is added (default behavior)
+                }
+                // Navigate prompt history with Up/Down arrow keys
+                if (e.key === 'ArrowUp' && !isComposing) {
+                  const textarea = e.currentTarget
+                  const cursorAtStart =
+                    textarea.selectionStart === 0 &&
+                    textarea.selectionEnd === 0
+                  if (cursorAtStart || !prompt) {
+                    e.preventDefault()
+                    navigateHistory('up')
+                  }
+                }
+                if (e.key === 'ArrowDown' && !isComposing) {
+                  const textarea = e.currentTarget
+                  const cursorAtEnd =
+                    textarea.selectionStart === prompt.length &&
+                    textarea.selectionEnd === prompt.length
+                  if (cursorAtEnd) {
+                    e.preventDefault()
+                    navigateHistory('down')
+                  }
                 }
               }}
               onPaste={handlePaste}

--- a/web-app/src/hooks/__tests__/usePrompt.test.ts
+++ b/web-app/src/hooks/__tests__/usePrompt.test.ts
@@ -1,101 +1,93 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { act, renderHook } from '@testing-library/react'
 import { usePrompt } from '../usePrompt'
 
 describe('usePrompt', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    act(() => {
+      usePrompt.setState({ prompt: '', promptHistory: [], historyIndex: -1, draftPrompt: '' })
+    })
   })
 
-  it('should initialize with empty prompt', () => {
+  it('should set and clear prompt', () => {
     const { result } = renderHook(() => usePrompt())
-    
-    expect(result.current.prompt).toBe('')
-    expect(typeof result.current.setPrompt).toBe('function')
-  })
 
-  it('should update prompt', () => {
-    const { result } = renderHook(() => usePrompt())
-    
-    act(() => {
-      result.current.setPrompt('Hello, world!')
-    })
-    
-    expect(result.current.prompt).toBe('Hello, world!')
-  })
+    act(() => result.current.setPrompt('Hello'))
+    expect(result.current.prompt).toBe('Hello')
 
-  it('should clear prompt', () => {
-    const { result } = renderHook(() => usePrompt())
-    
-    act(() => {
-      result.current.setPrompt('Some text')
-    })
-    
-    expect(result.current.prompt).toBe('Some text')
-    
-    act(() => {
-      result.current.setPrompt('')
-    })
-    
+    act(() => result.current.resetPrompt())
     expect(result.current.prompt).toBe('')
   })
 
-  it('should handle multiple prompt updates', () => {
-    const { result } = renderHook(() => usePrompt())
-    
-    act(() => {
-      result.current.setPrompt('First')
-    })
-    
-    expect(result.current.prompt).toBe('First')
-    
-    act(() => {
-      result.current.setPrompt('Second')
-    })
-    
-    expect(result.current.prompt).toBe('Second')
-    
-    act(() => {
-      result.current.setPrompt('Third')
-    })
-    
-    expect(result.current.prompt).toBe('Third')
-  })
+  describe('prompt history', () => {
+    it('should add entries, skip empty/duplicates, and cap at 100', () => {
+      const { result } = renderHook(() => usePrompt())
 
-  it('should handle special characters in prompt', () => {
-    const { result } = renderHook(() => usePrompt())
-    
-    const specialText = 'Hello! @#$%^&*()_+{}|:"<>?[]\\;\',./'
-    
-    act(() => {
-      result.current.setPrompt(specialText)
-    })
-    
-    expect(result.current.prompt).toBe(specialText)
-  })
+      act(() => {
+        result.current.addToHistory('')
+        result.current.addToHistory('   ')
+        result.current.addToHistory('first')
+        result.current.addToHistory('first') // duplicate
+        result.current.addToHistory('second')
+      })
 
-  it('should handle multiline prompts', () => {
-    const { result } = renderHook(() => usePrompt())
-    
-    const multilineText = 'Line 1\nLine 2\nLine 3'
-    
-    act(() => {
-      result.current.setPrompt(multilineText)
-    })
-    
-    expect(result.current.prompt).toBe(multilineText)
-  })
+      expect(result.current.promptHistory).toEqual(['second', 'first'])
 
-  it('should handle very long prompts', () => {
-    const { result } = renderHook(() => usePrompt())
-    
-    const longText = 'A'.repeat(10000)
-    
-    act(() => {
-      result.current.setPrompt(longText)
+      act(() => {
+        for (let i = 0; i < 110; i++) result.current.addToHistory(`msg ${i}`)
+      })
+      expect(result.current.promptHistory.length).toBe(100)
     })
-    
-    expect(result.current.prompt).toBe(longText)
-    expect(result.current.prompt.length).toBe(10000)
+
+    it('should navigate up/down and restore draft', () => {
+      const { result } = renderHook(() => usePrompt())
+
+      act(() => {
+        result.current.addToHistory('first')
+        result.current.addToHistory('second')
+        result.current.setPrompt('my draft')
+      })
+
+      // Up through history
+      act(() => result.current.navigateHistory('up'))
+      expect(result.current.prompt).toBe('second')
+
+      act(() => result.current.navigateHistory('up'))
+      expect(result.current.prompt).toBe('first')
+
+      // Can't go past oldest
+      act(() => result.current.navigateHistory('up'))
+      expect(result.current.prompt).toBe('first')
+
+      // Down restores
+      act(() => result.current.navigateHistory('down'))
+      expect(result.current.prompt).toBe('second')
+
+      act(() => result.current.navigateHistory('down'))
+      expect(result.current.prompt).toBe('my draft')
+      expect(result.current.historyIndex).toBe(-1)
+    })
+
+    it('should do nothing on empty history or no active browsing', () => {
+      const { result } = renderHook(() => usePrompt())
+
+      act(() => result.current.setPrompt('text'))
+      act(() => result.current.navigateHistory('up'))
+      expect(result.current.prompt).toBe('text')
+
+      act(() => result.current.navigateHistory('down'))
+      expect(result.current.prompt).toBe('text')
+    })
+
+    it('should reset history index when user types', () => {
+      const { result } = renderHook(() => usePrompt())
+
+      act(() => result.current.addToHistory('old'))
+      act(() => result.current.navigateHistory('up'))
+      expect(result.current.historyIndex).toBe(0)
+
+      act(() => result.current.setPrompt('typing'))
+      expect(result.current.historyIndex).toBe(-1)
+    })
   })
 })

--- a/web-app/src/hooks/usePrompt.ts
+++ b/web-app/src/hooks/usePrompt.ts
@@ -1,13 +1,81 @@
 import { create } from 'zustand'
 
+const MAX_HISTORY_SIZE = 100
+
 type PromptStoreState = {
   prompt: string
   setPrompt: (value: string) => void
   resetPrompt: () => void
+
+  // Prompt history for up/down arrow navigation
+  promptHistory: string[]
+  historyIndex: number
+  draftPrompt: string
+  addToHistory: (value: string) => void
+  navigateHistory: (direction: 'up' | 'down') => void
+  resetHistoryNavigation: () => void
 }
 
-export const usePrompt = create<PromptStoreState>((set) => ({
+export const usePrompt = create<PromptStoreState>((set, get) => ({
   prompt: '',
-  setPrompt: (value) => set({ prompt: value }),
+  setPrompt: (value) => {
+    set({ prompt: value })
+    // Reset history navigation when user types manually
+    if (get().historyIndex !== -1) {
+      set({ historyIndex: -1 })
+    }
+  },
   resetPrompt: () => set({ prompt: '' }),
+
+  // History state
+  promptHistory: [],
+  historyIndex: -1,
+  draftPrompt: '',
+
+  addToHistory: (value) => {
+    const trimmed = value.trim()
+    if (!trimmed) return
+    const { promptHistory } = get()
+    // Avoid consecutive duplicates
+    if (promptHistory.length > 0 && promptHistory[0] === trimmed) return
+    set({
+      promptHistory: [trimmed, ...promptHistory].slice(0, MAX_HISTORY_SIZE),
+      historyIndex: -1,
+    })
+  },
+
+  navigateHistory: (direction) => {
+    const { promptHistory, historyIndex, prompt, draftPrompt } = get()
+    if (promptHistory.length === 0) return
+
+    if (direction === 'up') {
+      const nextIndex = historyIndex + 1
+      if (nextIndex >= promptHistory.length) return
+      // Save current input as draft when first entering history
+      const newDraft = historyIndex === -1 ? prompt : draftPrompt
+      set({
+        historyIndex: nextIndex,
+        draftPrompt: newDraft,
+        prompt: promptHistory[nextIndex],
+      })
+    } else {
+      // direction === 'down'
+      if (historyIndex <= -1) return
+      const nextIndex = historyIndex - 1
+      if (nextIndex === -1) {
+        // Restore draft
+        set({
+          historyIndex: -1,
+          prompt: draftPrompt,
+        })
+      } else {
+        set({
+          historyIndex: nextIndex,
+          prompt: promptHistory[nextIndex],
+        })
+      }
+    }
+  },
+
+  resetHistoryNavigation: () => set({ historyIndex: -1, draftPrompt: '' }),
 }))


### PR DESCRIPTION
## Summary
- Add prompt history navigation using Up/Down arrow keys in the chat input
- When the input is empty or cursor is at position 0, pressing Up cycles through previously sent messages
- Pressing Down navigates forward through history, restoring the user's draft when reaching the end
- History stores up to 100 entries, skips duplicates and empty prompts

Closes #5580

## Screenshots
[Screencast from 2026-03-31 21-17-35.webm](https://github.com/user-attachments/assets/a6ce1278-0618-4eeb-8d85-887dbd34a0d3)


## Test plan
- [x] Unit tests pass: 8/8 (usePrompt: 5, ChatInput: 3)
- [x] Press Up arrow in empty input - shows last sent message
- [x] Press Up again - shows older messages
- [x] Press Down - navigates forward, restores empty input at the end
- [x] Type a draft, press Up, then Down - draft is preserved
- [x] Multi-line input with cursor in the middle - Up/Down moves cursor normally (no history)