### PR TITLE
fix: display message timestamps in local timezone

### DIFF
--- a/web-app/src/utils/formatDate.ts
+++ b/web-app/src/utils/formatDate.ts
@@ -15,10 +15,9 @@ export const formatDate = (
   }
 
   if (includeTime) {
-    // Time mode: short month + time, fixed UTC for stable output in tests
+    // Time mode: short month + time, using local timezone
     return new Date(date).toLocaleString('en-US', {
       ...base,
-      timeZone: 'UTC',
       month: 'short',
       hour: 'numeric',
       minute: 'numeric',
@@ -26,10 +25,9 @@ export const formatDate = (
     })
   }
 
-  // Date-only mode: long month, no timezone adjustment
+  // Date-only mode: long month, using local timezone
   return new Date(date).toLocaleDateString('en-US', {
     ...base,
-    timeZone: 'UTC',
     month: 'long',
   })
 }


### PR DESCRIPTION
## Describe Your Changes

formatDate had timeZone: 'UTC' hardcoded in both the time and date-only formatting paths
This caused message timestamps to always show in UTC regardless of the user's local timezone (e.g. showing 8:30 AM when the local time was 15:31)
Removed the UTC override so timestamps now reflect the user's local timezone

## Fixes Issues


<img width="2700" height="1768" alt="Screenshot 2026-04-01 at 15 41 05" src="https://github.com/user-attachments/assets/ba1b7a9a-1cb7-4a6e-a60e-2483945b0922" />


- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
