### PR TITLE
feat: add API key fallbacks with automatic rotation

### DIFF
--- a/src-tauri/src/core/server/proxy.rs
+++ b/src-tauri/src/core/server/proxy.rs
@@ -19,6 +19,13 @@ use crate::core::{
     state::{ProviderConfig, ServerHandle, SharedMcpServers},
 };
 
+fn http_status_indicates_api_key_retry(status: StatusCode) -> bool {
+    matches!(
+        status,
+        StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN | StatusCode::TOO_MANY_REQUESTS
+    )
+}
+
 /// Transform Anthropic /messages API body to OpenAI /chat/completions body
 fn transform_anthropic_to_openai(body: &serde_json::Value) -> Option<serde_json::Value> {
     let model = body.get("model")?.as_str()?;
@@ -542,7 +549,7 @@ async fn resolve_upstream_for_model(
     provider_configs: Arc<Mutex<HashMap<String, ProviderConfig>>>,
     sessions: Arc<Mutex<HashMap<i32, LLamaBackendSession>>>,
     mlx_sessions: Arc<Mutex<HashMap<i32, MlxBackendSession>>>,
-) -> Result<(String, Option<String>), String> {
+) -> Result<(String, Vec<String>), String> {
     let destination_path = "/chat/completions";
 
     // Prefer remote provider if model is registered there.
@@ -570,7 +577,7 @@ async fn resolve_upstream_for_model(
                 .clone()
                 .ok_or_else(|| format!("Missing base_url for provider '{provider}'"))?;
             let url = format!("{}{}", api_url, destination_path);
-            return Ok((url, provider_cfg.api_key.clone()));
+            return Ok((url, provider_cfg.bearer_key_chain()));
         }
     }
 
@@ -580,7 +587,7 @@ async fn resolve_upstream_for_model(
         let target_port = session.info.port;
         return Ok((
             format!("http://127.0.0.1:{target_port}/v1{destination_path}"),
-            Some(session.info.api_key.clone()),
+            vec![session.info.api_key.clone()],
         ));
     }
     drop(sessions_guard);
@@ -590,7 +597,7 @@ async fn resolve_upstream_for_model(
         let target_port = info.info.port;
         return Ok((
             format!("http://127.0.0.1:{target_port}/v1{destination_path}"),
-            Some(info.info.api_key.clone()),
+            vec![info.info.api_key.clone()],
         ));
     }
 
@@ -737,33 +744,53 @@ async fn execute_mcp_tool_calls(
 async fn call_openai_chat_completions(
     client: &Client,
     upstream_url: &str,
-    api_key: &Option<String>,
+    api_keys: &[String],
     body: &serde_json::Value,
 ) -> Result<serde_json::Value, String> {
-    let mut req = client
-        .post(upstream_url)
-        .header("Content-Type", "application/json")
-        .header("Accept-Encoding", "identity");
+    let attempts: Vec<Option<&str>> = if api_keys.is_empty() {
+        vec![None]
+    } else {
+        api_keys.iter().map(|s| Some(s.as_str())).collect()
+    };
 
-    if let Some(key) = api_key {
-        req = req.header("Authorization", format!("Bearer {key}"));
+    let mut last_err = String::new();
+    for (i, key_ref) in attempts.iter().enumerate() {
+        let mut req = client
+            .post(upstream_url)
+            .header("Content-Type", "application/json")
+            .header("Accept-Encoding", "identity");
+
+        if let Some(key) = key_ref {
+            req = req.header("Authorization", format!("Bearer {key}"));
+        }
+
+        let resp = req
+            .body(body.to_string())
+            .send()
+            .await
+            .map_err(|e| format!("Upstream request failed: {e}"))?;
+
+        let status = resp.status();
+        let text = resp.text().await.map_err(|e| e.to_string())?;
+
+        if status.is_success() {
+            return serde_json::from_str::<serde_json::Value>(&text).map_err(|e| {
+                format!("Failed to parse upstream JSON: {e}. Body: {text}")
+            });
+        }
+
+        last_err = format!("Upstream returned HTTP {status}: {text}");
+        if http_status_indicates_api_key_retry(status) && i + 1 < attempts.len() {
+            log::warn!(
+                "OpenAI completion: HTTP {status} with API key index {i}, trying next key"
+            );
+            continue;
+        }
+
+        return Err(last_err);
     }
 
-    let resp = req
-        .body(body.to_string())
-        .send()
-        .await
-        .map_err(|e| format!("Upstream request failed: {e}"))?;
-
-    let status = resp.status();
-    let text = resp.text().await.map_err(|e| e.to_string())?;
-
-    if !status.is_success() {
-        return Err(format!("Upstream returned HTTP {status}: {text}"));
-    }
-
-    serde_json::from_str::<serde_json::Value>(&text)
-        .map_err(|e| format!("Failed to parse upstream JSON: {e}. Body: {text}"))
+    Err(last_err)
 }
 
 async fn run_server_side_openai_orchestration(
@@ -821,7 +848,7 @@ async fn run_server_side_openai_orchestration(
     let (openai_tools, tool_to_server) =
         collect_mcp_openai_tools(&mcp_servers, &mcp_settings).await?;
 
-    let (upstream_url, session_api_key) = resolve_upstream_for_model(
+    let (upstream_url, session_api_keys) = resolve_upstream_for_model(
         &model_id,
         provider_configs.clone(),
         sessions.clone(),
@@ -860,7 +887,7 @@ async fn run_server_side_openai_orchestration(
         let completion = call_openai_chat_completions(
             client,
             &upstream_url,
-            &session_api_key,
+            &session_api_keys,
             &request_value,
         )
         .await?;
@@ -1186,7 +1213,7 @@ async fn proxy_request(
     let destination_path = get_destination_path(original_path, &config.prefix);
 
     // Initialize variables that will be set in the match
-    let mut session_api_key: Option<String> = None;
+    let mut session_api_keys: Vec<String> = Vec::new();
     #[allow(unused_assignments)]
     let mut buffered_body: Option<Bytes> = None;
     let mut target_base_url: Option<String> = None;
@@ -1317,7 +1344,7 @@ async fn proxy_request(
                                 target_base_url = provider_cfg.base_url.clone().map(|url| {
                                     format!("{}{}", url.trim_end_matches('/'), "/messages")
                                 });
-                                session_api_key = provider_cfg.api_key.clone();
+                                session_api_keys = provider_cfg.bearer_key_chain();
                             }
                         } else {
                             // No remote provider, try local sessions
@@ -1336,12 +1363,12 @@ async fn proxy_request(
 
                             if let Some(session) = llama_session {
                                 let target_port = session.info.port;
-                                session_api_key = Some(session.info.api_key.clone());
+                                session_api_keys = vec![session.info.api_key.clone()];
                                 target_base_url =
                                     Some(format!("http://127.0.0.1:{}/v1/messages", target_port));
                             } else if let Some(info) = mlx_session_info {
                                 let target_port = info.port;
-                                session_api_key = Some(info.api_key.clone());
+                                session_api_keys = vec![info.api_key.clone()];
                                 target_base_url =
                                     Some(format!("http://127.0.0.1:{}/v1/messages", target_port));
                             } else {
@@ -1576,7 +1603,7 @@ async fn proxy_request(
                     }
                 };
 
-            let (upstream_url, session_api_key) = match resolve_upstream_for_model(
+            let (upstream_url, session_api_keys) = match resolve_upstream_for_model(
                 &model_id,
                 provider_configs.clone(),
                 sessions.clone(),
@@ -1628,7 +1655,7 @@ async fn proxy_request(
                 let completion = match call_openai_chat_completions(
                     &client,
                     &upstream_url,
-                    &session_api_key,
+                    &session_api_keys,
                     &request_value,
                 )
                 .await
@@ -1854,11 +1881,7 @@ async fn proxy_request(
                                 } else {
                                     target_base_url = None;
                                 }
-                                if let Some(api_key_value) = provider_cfg.api_key.clone() {
-                                    session_api_key = Some(api_key_value);
-                                } else {
-                                    session_api_key = None;
-                                }
+                                session_api_keys = provider_cfg.bearer_key_chain();
                             } else {
                                 log::error!("Provider config not found for '{provider}'");
                             }
@@ -1913,14 +1936,14 @@ async fn proxy_request(
 
                             if let Some(session) = llama_session {
                                 let target_port = session.info.port;
-                                session_api_key = Some(session.info.api_key.clone());
+                                session_api_keys = vec![session.info.api_key.clone()];
                                 log::debug!("Found llama.cpp session for model_id {model_id}");
                                 target_base_url = Some(format!(
                                     "http://127.0.0.1:{target_port}/v1{destination_path}"
                                 ));
                             } else if let Some(info) = mlx_session {
                                 let target_port = info.port;
-                                session_api_key = Some(info.api_key.clone());
+                                session_api_keys = vec![info.api_key.clone()];
                                 log::debug!("Found MLX session for model_id {model_id}");
                                 target_base_url = Some(format!(
                                     "http://127.0.0.1:{target_port}/v1{destination_path}"
@@ -2220,47 +2243,63 @@ async fn proxy_request(
         "Proxying request to model server at base URL {upstream_url}, path: {destination_path}"
     );
 
-    let mut outbound_req = client.request(method.clone(), upstream_url);
-
-    for (name, value) in headers.iter() {
-        if name != hyper::header::HOST && name != hyper::header::AUTHORIZATION {
-            outbound_req = outbound_req.header(name, value);
+    let body_bytes_for_proxy = match buffered_body.clone() {
+        Some(b) => b,
+        None => {
+            log::error!("Internal logic error: Request reached proxy stage without a buffered body.");
+            let mut error_response = Response::builder().status(StatusCode::INTERNAL_SERVER_ERROR);
+            error_response = add_cors_headers_with_host_and_origin(
+                error_response,
+                &host_header,
+                &origin_header,
+                &config.trusted_hosts,
+            );
+            return Ok(error_response
+                .body(Body::from("Internal server error: unhandled request path"))
+                .unwrap());
         }
-    }
+    };
 
-    let session_api_key_for_req = session_api_key.clone();
-    let buffered_body_for_req = buffered_body.clone();
-
-    if let Some(key) = session_api_key_for_req {
-        outbound_req = outbound_req.header("Authorization", format!("Bearer {key}"));
+    let key_attempts: Vec<Option<String>> = if session_api_keys.is_empty() {
+        vec![None]
     } else {
-        log::debug!("No session API key available for this request");
-    }
-
-    let outbound_req_with_body = if let Some(bytes) = buffered_body_for_req {
-        outbound_req.body(bytes)
-    } else {
-        log::error!("Internal logic error: Request reached proxy stage without a buffered body.");
-        let mut error_response = Response::builder().status(StatusCode::INTERNAL_SERVER_ERROR);
-        error_response = add_cors_headers_with_host_and_origin(
-            error_response,
-            &host_header,
-            &origin_header,
-            &config.trusted_hosts,
-        );
-        return Ok(error_response
-            .body(Body::from("Internal server error: unhandled request path"))
-            .unwrap());
+        session_api_keys.iter().cloned().map(Some).collect()
     };
 
     // For Anthropic /messages, we need to track if we should transform the response
     let destination_path = path.clone();
 
-    match outbound_req_with_body.send().await {
+    for (key_idx, key_opt) in key_attempts.iter().enumerate() {
+        let mut outbound_req = client.request(method.clone(), upstream_url.clone());
+
+        for (name, value) in headers.iter() {
+            if name != hyper::header::HOST && name != hyper::header::AUTHORIZATION {
+                outbound_req = outbound_req.header(name, value);
+            }
+        }
+
+        if let Some(key) = key_opt {
+            outbound_req = outbound_req.header("Authorization", format!("Bearer {key}"));
+        } else {
+            log::debug!("No session API key for this attempt");
+        }
+
+        let outbound_req_with_body = outbound_req.body(body_bytes_for_proxy.clone());
+
+        match outbound_req_with_body.send().await {
         Ok(response) => {
             let status = response.status();
 
             let is_error = !status.is_success();
+
+            if is_error
+                && http_status_indicates_api_key_retry(status)
+                && key_idx + 1 < key_attempts.len()
+            {
+                let _ = response.text().await;
+                log::warn!("Upstream {status} for API key index {key_idx}, trying next key");
+                continue;
+            }
 
             // For Anthropic /messages requests with errors, try /chat/completions
             if is_error && is_anthropic_messages {
@@ -2278,8 +2317,8 @@ async fn proxy_request(
                         .trim_end_matches('/')
                         .to_string()
                 });
-                let fallback_api_key = session_api_key.clone();
-                let fallback_body = buffered_body.clone();
+                let fallback_api_key = key_opt.clone();
+                let fallback_body = Some(body_bytes_for_proxy.clone());
 
                 // Transform body to OpenAI format for fallback
                 if let Some((url, openai_body)) = fallback_url.zip(fallback_body).and_then(|(url, body)| {
@@ -2451,7 +2490,7 @@ async fn proxy_request(
                 log::debug!("Streaming complete to client");
             });
 
-            Ok(builder.body(body).unwrap())
+            return Ok(builder.body(body).unwrap());
         }
         Err(e) => {
             let error_msg = format!("Proxy request to model failed: {e}");
@@ -2463,9 +2502,22 @@ async fn proxy_request(
                 &origin_header,
                 &config.trusted_hosts,
             );
-            Ok(error_response.body(Body::from(error_msg)).unwrap())
+            return Ok(error_response.body(Body::from(error_msg)).unwrap());
         }
     }
+    }
+
+    log::error!("Internal error: proxy key loop exited without a response");
+    let mut error_response = Response::builder().status(StatusCode::INTERNAL_SERVER_ERROR);
+    error_response = add_cors_headers_with_host_and_origin(
+        error_response,
+        &host_header,
+        &origin_header,
+        &config.trusted_hosts,
+    );
+    Ok(error_response
+        .body(Body::from("Internal proxy error"))
+        .unwrap())
 }
 
 fn add_cors_headers_with_host_and_origin(

--- a/src-tauri/src/core/server/remote_provider_commands.rs
+++ b/src-tauri/src/core/server/remote_provider_commands.rs
@@ -15,9 +15,32 @@ pub struct ProviderCustomHeader {
 pub struct RegisterProviderRequest {
     pub provider: String,
     pub api_key: Option<String>,
+    /// Additional keys (after `api_key`) when the upstream returns 401, 403, or 429.
+    #[serde(default)]
+    pub api_keys: Vec<String>,
     pub base_url: Option<String>,
     pub custom_headers: Vec<ProviderCustomHeader>,
     pub models: Vec<String>,
+}
+
+fn merge_register_api_keys(api_key: Option<String>, api_keys: Vec<String>) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut push_unique = |s: String| {
+        let t = s.trim().to_string();
+        if t.is_empty() {
+            return;
+        }
+        if !out.iter().any(|x| x == &t) {
+            out.push(t);
+        }
+    };
+    if let Some(k) = api_key {
+        push_unique(k);
+    }
+    for k in api_keys {
+        push_unique(k);
+    }
+    out
 }
 
 /// Register a remote provider configuration
@@ -29,9 +52,13 @@ pub async fn register_provider_config(
     let provider_configs = state.provider_configs.clone();
     let mut configs = provider_configs.lock().await;
 
+    let key_chain = merge_register_api_keys(request.api_key.clone(), request.api_keys.clone());
+    let api_key = key_chain.first().cloned();
+
     let config = ProviderConfig {
         provider: request.provider.clone(),
-        api_key: request.api_key,
+        api_key,
+        api_keys: key_chain,
         base_url: request.base_url,
         custom_headers: request
             .custom_headers

--- a/src-tauri/src/core/state.rs
+++ b/src-tauri/src/core/state.rs
@@ -16,10 +16,23 @@ pub type ServerHandle =
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct ProviderConfig {
     pub provider: String,
+    /// First key (mirrors `api_keys[0]` when populated); kept for backward compatibility.
     pub api_key: Option<String>,
+    /// Ordered keys for Bearer auth: proxy tries each on 401/403/429.
+    #[serde(default)]
+    pub api_keys: Vec<String>,
     pub base_url: Option<String>,
     pub custom_headers: Vec<ProviderCustomHeader>,
     pub models: Vec<String>,
+}
+
+impl ProviderConfig {
+    pub fn bearer_key_chain(&self) -> Vec<String> {
+        if !self.api_keys.is_empty() {
+            return self.api_keys.clone();
+        }
+        self.api_key.clone().into_iter().collect()
+    }
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]

--- a/web-app/src/containers/DropdownModelProvider.tsx
+++ b/web-app/src/containers/DropdownModelProvider.tsx
@@ -21,6 +21,7 @@ import { localStorageKey } from '@/constants/localStorage'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { useFavoriteModel } from '@/hooks/useFavoriteModel'
 import { predefinedProviders } from '@/constants/providers'
+import { providerHasRemoteApiKeys } from '@/lib/provider-api-keys'
 import { useServiceHub } from '@/hooks/useServiceHub'
 import { getLastUsedModel } from '@/utils/getModelToStart'
 import { ChevronsUpDown } from 'lucide-react'
@@ -276,7 +277,7 @@ const DropdownModelProvider = memo(function DropdownModelProvider({
         if (
           provider &&
           provider.provider !== 'llamacpp' &&
-          !provider.api_key?.length &&
+          !providerHasRemoteApiKeys(provider) &&
           (isPredefined || provider.models.length === 0)
         )
           return
@@ -360,10 +361,10 @@ const DropdownModelProvider = memo(function DropdownModelProvider({
             e.provider.includes(b.provider)
           )
           const aHasApiKeyOrCustomModel =
-            (a.api_key?.length ?? 0) > 0 ||
+            providerHasRemoteApiKeys(a) ||
             (!aIsPredefined && a.models.length > 0)
           const bHasApiKeyOrCustomModel =
-            (b.api_key?.length ?? 0) > 0 ||
+            providerHasRemoteApiKeys(b) ||
             (!bIsPredefined && b.models.length > 0)
           // Providers with API keys or custom with models filled second
           if (aHasApiKeyOrCustomModel && !bHasApiKeyOrCustomModel) return -1

--- a/web-app/src/hooks/useJanModelPrompt.ts
+++ b/web-app/src/hooks/useJanModelPrompt.ts
@@ -5,6 +5,7 @@ import { useModelProvider } from './useModelProvider'
 import { useDownloadStore } from './useDownloadStore'
 import { useLatestJanModel } from './useLatestJanModel'
 import { predefinedProviders } from '@/constants/providers'
+import { providerHasRemoteApiKeys } from '@/lib/provider-api-keys'
 
 export type JanModelPromptDismissedState = {
   dismissedModelName: string | null
@@ -57,7 +58,7 @@ export const useJanModelPrompt = () => {
       return provider.models.length > 0
     }
     return (
-      provider.api_key?.length ||
+      providerHasRemoteApiKeys(provider) ||
       (provider.provider === 'llamacpp' && provider.models.length) ||
       (provider.provider === 'jan' && provider.models.length)
     )

--- a/web-app/src/hooks/useModelProvider.ts
+++ b/web-app/src/hooks/useModelProvider.ts
@@ -147,6 +147,9 @@ export const useModelProvider = create<ModelProviderState>()(
                 }
               }),
               api_key: existingProvider?.api_key || provider.api_key,
+              api_key_fallbacks:
+                existingProvider?.api_key_fallbacks ??
+                provider.api_key_fallbacks,
               base_url: existingProvider?.base_url || provider.base_url,
               active: existingProvider ? existingProvider?.active : true,
             }

--- a/web-app/src/lib/model-factory.ts
+++ b/web-app/src/lib/model-factory.ts
@@ -58,6 +58,7 @@ import { invoke } from '@tauri-apps/api/core'
 import { SessionInfo } from '@janhq/core'
 import { fetch as httpFetch } from '@tauri-apps/plugin-http'
 import { isPlatformTauri } from '@/lib/platform/utils'
+import { providerRemoteApiKeyChain } from '@/lib/provider-api-keys'
 
 /**
  * Llama.cpp timings structure from the response
@@ -157,6 +158,42 @@ function createCustomFetch(
     }
 
     return baseFetch(input, init)
+  }
+}
+
+type ApiKeyHeaderMode = 'authorization-bearer' | 'x-api-key'
+
+/** Retries with the next key when the upstream returns 401, 403, or 429. */
+function createApiKeyRotatingFetch(
+  baseFetch: typeof globalThis.fetch,
+  apiKeys: string[],
+  parameters: Record<string, unknown>,
+  headerMode: ApiKeyHeaderMode
+): typeof globalThis.fetch {
+  const inner = createCustomFetch(baseFetch, parameters)
+  if (apiKeys.length <= 1) {
+    return inner
+  }
+  return async (
+    input: RequestInfo | URL,
+    init?: RequestInit
+  ): Promise<Response> => {
+    for (let i = 0; i < apiKeys.length; i++) {
+      const key = apiKeys[i]!
+      const nextHeaders = new Headers(init?.headers as HeadersInit | undefined)
+      if (headerMode === 'authorization-bearer') {
+        nextHeaders.set('Authorization', `Bearer ${key}`)
+      } else {
+        nextHeaders.set('x-api-key', key)
+      }
+      const res = await inner(input, { ...init, headers: nextHeaders })
+      if ([401, 403, 429].includes(res.status) && i < apiKeys.length - 1) {
+        res.body?.cancel().catch(() => {})
+        continue
+      }
+      return res
+    }
+    throw new Error('API key rotation exhausted')
   }
 }
 
@@ -289,10 +326,10 @@ export class ModelFactory {
         return this.createFoundationModelsModel(modelId, provider, parameters)
 
       case 'anthropic':
-        return this.createAnthropicModel(modelId, provider)
+        return this.createAnthropicModel(modelId, provider, parameters)
 
       case 'openai':
-        return this.createOpenAIModel(modelId, provider)
+        return this.createOpenAIModel(modelId, provider, parameters)
       case 'google':
       case 'gemini':
       case 'azure':
@@ -308,7 +345,7 @@ export class ModelFactory {
         return this.createOpenAICompatibleModel(modelId, provider)
 
       case 'xai':
-        return this.createXaiModel(modelId, provider)
+        return this.createXaiModel(modelId, provider, parameters)
 
       default:
         return this.createOpenAICompatibleModel(modelId, provider, parameters)
@@ -557,11 +594,22 @@ export class ModelFactory {
       })
     }
 
+    const keyChain = providerRemoteApiKeyChain(provider)
+    const fetchImpl =
+      keyChain.length > 1
+        ? createApiKeyRotatingFetch(
+            getRuntimeFetch(),
+            keyChain,
+            parameters,
+            'x-api-key'
+          )
+        : createCustomFetch(getRuntimeFetch(), parameters)
+
     const anthropic = createAnthropic({
-      apiKey: provider.api_key,
+      apiKey: keyChain[0] ?? provider.api_key ?? '',
       baseURL: provider.base_url,
       headers: Object.keys(headers).length > 0 ? headers : undefined,
-      fetch: createCustomFetch(getRuntimeFetch(), parameters),
+      fetch: fetchImpl,
     })
 
     return anthropic(modelId)
@@ -584,11 +632,22 @@ export class ModelFactory {
       })
     }
 
+    const keyChain = providerRemoteApiKeyChain(provider)
+    const fetchImpl =
+      keyChain.length > 1
+        ? createApiKeyRotatingFetch(
+            getRuntimeFetch(),
+            keyChain,
+            parameters,
+            'authorization-bearer'
+          )
+        : createCustomFetch(getRuntimeFetch(), parameters)
+
     const openai = createOpenAI({
-      apiKey: provider.api_key,
+      apiKey: keyChain[0] ?? provider.api_key ?? '',
       baseURL: provider.base_url,
       headers: Object.keys(headers).length > 0 ? headers : undefined,
-      fetch: createCustomFetch(getRuntimeFetch(), parameters),
+      fetch: fetchImpl,
     })
 
     return openai(modelId)
@@ -611,11 +670,22 @@ export class ModelFactory {
       })
     }
 
+    const keyChain = providerRemoteApiKeyChain(provider)
+    const fetchImpl =
+      keyChain.length > 1
+        ? createApiKeyRotatingFetch(
+            getRuntimeFetch(),
+            keyChain,
+            parameters,
+            'authorization-bearer'
+          )
+        : createCustomFetch(getRuntimeFetch(), parameters)
+
     const xai = createXai({
-      apiKey: provider.api_key,
+      apiKey: keyChain[0] ?? provider.api_key ?? '',
       baseURL: provider.base_url,
       headers: Object.keys(headers).length > 0 ? headers : undefined,
-      fetch: createCustomFetch(getRuntimeFetch(), parameters),
+      fetch: fetchImpl,
     })
 
     return xai(modelId)
@@ -638,17 +708,27 @@ export class ModelFactory {
       })
     }
 
-    // Add authorization header if api_key is present
-    if (provider.api_key) {
-      headers['Authorization'] = `Bearer ${provider.api_key}`
+    const keyChain = providerRemoteApiKeyChain(provider)
+    if (keyChain.length === 1) {
+      headers['Authorization'] = `Bearer ${keyChain[0]}`
     }
+
+    const fetchImpl =
+      keyChain.length > 1
+        ? createApiKeyRotatingFetch(
+            getRuntimeFetch(),
+            keyChain,
+            parameters,
+            'authorization-bearer'
+          )
+        : createCustomFetch(getRuntimeFetch(), parameters)
 
     const openAICompatible = createOpenAICompatible({
       name: provider.provider,
       baseURL: provider.base_url || 'https://api.openai.com/v1',
       headers,
       includeUsage: true,
-      fetch: createCustomFetch(getRuntimeFetch(), parameters),
+      fetch: fetchImpl,
     })
 
     return openAICompatible.languageModel(modelId)

--- a/web-app/src/lib/provider-api-keys.ts
+++ b/web-app/src/lib/provider-api-keys.ts
@@ -1,0 +1,26 @@
+/**
+ * Ordered API keys for a remote provider: primary `api_key` first, then `api_key_fallbacks`.
+ */
+export function providerRemoteApiKeyChain(provider: {
+  api_key?: string
+  api_key_fallbacks?: string[]
+}): string[] {
+  const primary = provider.api_key?.trim()
+  const fallbacks = (provider.api_key_fallbacks ?? [])
+    .map((k) => String(k).trim())
+    .filter((k) => k.length > 0)
+  const ordered = [...(primary ? [primary] : []), ...fallbacks]
+  const seen = new Set<string>()
+  return ordered.filter((k) => {
+    if (seen.has(k)) return false
+    seen.add(k)
+    return true
+  })
+}
+
+export function providerHasRemoteApiKeys(provider: {
+  api_key?: string
+  api_key_fallbacks?: string[]
+}): boolean {
+  return providerRemoteApiKeyChain(provider).length > 0
+}

--- a/web-app/src/locales/en/providers.json
+++ b/web-app/src/locales/en/providers.json
@@ -61,7 +61,7 @@
   "enterNameForProvider": "Enter name for provider",
   "apiKeys": {
     "title": "API keys",
-    "description": "Enter your primary API key. Optionally add fallback keys in Advanced; Jan retries the next key on 401/403/429.",
+    "description": "Enter your API key. You can add extra keys in Advanced, and Jan will try the next one automatically if a key fails.",
     "placeholder": "sk-…\nsk-…",
     "primaryPlaceholder": "Enter primary API key",
     "keyPlaceholder": "Enter API key",

--- a/web-app/src/locales/en/providers.json
+++ b/web-app/src/locales/en/providers.json
@@ -64,11 +64,15 @@
     "description": "Enter your primary API key. Optionally add fallback keys in Advanced; Jan retries the next key on 401/403/429.",
     "placeholder": "sk-…\nsk-…",
     "primaryPlaceholder": "Enter primary API key",
+    "keyPlaceholder": "Enter API key",
+    "primaryBadge": "Primary",
     "test": "Test keys",
     "testing": "Testing...",
     "testHint": "Checks /models with each key and shows per-key status.",
     "advanced": "Advanced",
     "hideAdvanced": "Hide advanced",
-    "oneKeyHint": "Optional fallback keys are configured in Advanced."
+    "oneKeyHint": "Optional fallback keys are configured in Advanced.",
+    "addKey": "Add key",
+    "removeKey": "Remove key"
   }
 }

--- a/web-app/src/locales/en/providers.json
+++ b/web-app/src/locales/en/providers.json
@@ -58,5 +58,10 @@
   },
   "addProvider": "Add Provider",
   "addOpenAIProvider": "Add OpenAI Provider",
-  "enterNameForProvider": "Enter name for provider"
+  "enterNameForProvider": "Enter name for provider",
+  "apiKeyFallbacks": {
+    "title": "Fallback API keys",
+    "description": "Optional extra keys, one per line. If the provider returns 401, 403, or rate limits (429), Jan tries the next key automatically (in order: main API key first, then these lines).",
+    "placeholder": "sk-…\nsk-…"
+  }
 }

--- a/web-app/src/locales/en/providers.json
+++ b/web-app/src/locales/en/providers.json
@@ -61,10 +61,14 @@
   "enterNameForProvider": "Enter name for provider",
   "apiKeys": {
     "title": "API keys",
-    "description": "One key per line. The first line is the primary key. If the provider returns 401, 403, or 429, Jan automatically tries the next key.",
+    "description": "Enter your primary API key. Optionally add fallback keys in Advanced; Jan retries the next key on 401/403/429.",
     "placeholder": "sk-…\nsk-…",
+    "primaryPlaceholder": "Enter primary API key",
     "test": "Test keys",
     "testing": "Testing...",
-    "testHint": "Checks /models with each key and shows per-key status."
+    "testHint": "Checks /models with each key and shows per-key status.",
+    "advanced": "Advanced",
+    "hideAdvanced": "Hide advanced",
+    "oneKeyHint": "Optional fallback keys are configured in Advanced."
   }
 }

--- a/web-app/src/locales/en/providers.json
+++ b/web-app/src/locales/en/providers.json
@@ -1,5 +1,5 @@
 {
-  "refreshModelsError": "Provider must have base URL and API key configured to fetch models.",
+  "refreshModelsError": "Provider must have base URL and at least one API key configured to fetch models.",
   "refreshModelsSuccess": "Added {{count}} new model(s) from {{provider}}.",
   "noNewModels": "No new models found. All available models are already added.",
   "refreshModelsFailed": "Failed to fetch models from {{provider}}. Please check your API key and base URL.",
@@ -59,9 +59,12 @@
   "addProvider": "Add Provider",
   "addOpenAIProvider": "Add OpenAI Provider",
   "enterNameForProvider": "Enter name for provider",
-  "apiKeyFallbacks": {
-    "title": "Fallback API keys",
-    "description": "Optional extra keys, one per line. If the provider returns 401, 403, or rate limits (429), Jan tries the next key automatically (in order: main API key first, then these lines).",
-    "placeholder": "sk-…\nsk-…"
+  "apiKeys": {
+    "title": "API keys",
+    "description": "One key per line. The first line is the primary key. If the provider returns 401, 403, or 429, Jan automatically tries the next key.",
+    "placeholder": "sk-…\nsk-…",
+    "test": "Test keys",
+    "testing": "Testing...",
+    "testHint": "Checks /models with each key and shows per-key status."
   }
 }

--- a/web-app/src/providers/DataProvider.tsx
+++ b/web-app/src/providers/DataProvider.tsx
@@ -14,6 +14,7 @@ import { AppEvent, events } from '@janhq/core'
 import { SystemEvent } from '@/types/events'
 import { isDev } from '@/lib/utils'
 import { invoke } from '@tauri-apps/api/core'
+import { providerHasRemoteApiKeys, providerRemoteApiKeyChain } from '@/lib/provider-api-keys'
 
 type ProviderCustomHeader = {
   header: string
@@ -23,6 +24,7 @@ type ProviderCustomHeader = {
 type RegisterProviderRequest = {
   provider: string
   api_key?: string
+  api_keys?: string[]
   base_url?: string
   custom_headers: ProviderCustomHeader[]
   models: string[]
@@ -32,15 +34,16 @@ async function registerRemoteProvider(provider: ModelProvider) {
   // Skip llamacpp - those are local models
   if (provider.provider === 'llamacpp') return
 
-  // Skip providers without API key (they can't make requests)
-  if (!provider.api_key) {
+  const chain = providerRemoteApiKeyChain(provider)
+  if (chain.length === 0) {
     console.log(`Provider ${provider.provider} has no API key, skipping registration`)
     return
   }
 
   const request: RegisterProviderRequest = {
     provider: provider.provider,
-    api_key: provider.api_key,
+    api_key: chain[0],
+    api_keys: chain.slice(1),
     base_url: provider.base_url,
     custom_headers: (provider.custom_header || []).map((h) => ({
       header: h.header,
@@ -66,7 +69,11 @@ const syncRemoteProviders = () => {
   const currentActive = new Set<string>()
 
   providers.forEach((provider) => {
-    if (provider.active && provider.provider !== 'llamacpp' && provider.api_key) {
+    if (
+      provider.active &&
+      provider.provider !== 'llamacpp' &&
+      providerHasRemoteApiKeys(provider)
+    ) {
       registerRemoteProvider(provider)
       currentActive.add(provider.provider)
     }

--- a/web-app/src/routes/index.tsx
+++ b/web-app/src/routes/index.tsx
@@ -10,6 +10,7 @@ import { useModelProvider } from '@/hooks/useModelProvider'
 import SetupScreen from '@/containers/SetupScreen'
 import { route } from '@/constants/routes'
 import { predefinedProviders } from '@/constants/providers'
+import { providerHasRemoteApiKeys } from '@/lib/provider-api-keys'
 
 type ThreadModel = {
   id: string
@@ -57,7 +58,7 @@ function Index() {
 
     // Predefined providers need either API key or models (for llamacpp/jan)
     return (
-      provider.api_key?.length ||
+      providerHasRemoteApiKeys(provider) ||
       (provider.provider === 'llamacpp' && provider.models.length) ||
       (provider.provider === 'jan' && provider.models.length)
     )

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -20,6 +20,7 @@ import DeleteProvider from '@/containers/dialogs/DeleteProvider'
 import { useServiceHub } from '@/hooks/useServiceHub'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
+import { Textarea } from '@/components/ui/textarea'
 import {
   IconFolderPlus,
   IconLoader,
@@ -36,6 +37,7 @@ import { basenameNoExt } from '@/lib/utils'
 import { useAppState } from '@/hooks/useAppState'
 import { useShallow } from 'zustand/shallow'
 import { DialogAddModel } from '@/containers/dialogs/AddModel'
+import { providerHasRemoteApiKeys } from '@/lib/provider-api-keys'
 
 // as route.threadsDetail
 export const Route = createFileRoute('/settings/providers/$providerName')({
@@ -60,6 +62,7 @@ function ProviderDetail() {
   const [isCheckingBackendUpdate, setIsCheckingBackendUpdate] = useState(false)
   const [isInstallingBackend, setIsInstallingBackend] = useState(false)
   const [importingModel, setImportingModel] = useState<string | null>(null)
+  const [fallbackKeysDraft, setFallbackKeysDraft] = useState('')
   const { checkForUpdate: checkForBackendUpdate, installBackend } =
     useBackendUpdater()
   const { providerName } = useParams({ from: Route.id })
@@ -174,6 +177,15 @@ function ProviderDetail() {
     }
   }, [importingModel])
 
+  useEffect(() => {
+    if (!provider) return
+    if (provider.provider === 'llamacpp' || provider.provider === 'mlx') return
+    setFallbackKeysDraft((provider.api_key_fallbacks ?? []).join('\n'))
+  }, [
+    providerName,
+    JSON.stringify(provider?.api_key_fallbacks ?? []),
+  ])
+
   // Auto-refresh provider settings to get updated backend configuration
   const refreshSettings = useCallback(async () => {
     if (!provider) return
@@ -200,7 +212,7 @@ function ProviderDetail() {
   // This ensures all screens receive the event intermediately
 
   const handleRefreshModels = async () => {
-    if (!provider || !provider.base_url) {
+    if (!provider || !provider.base_url || !providerHasRemoteApiKeys(provider)) {
       toast.error(t('providers:models'), {
         description: t('providers:refreshModelsError'),
       })
@@ -599,6 +611,43 @@ function ProviderDetail() {
                 <DeleteProvider provider={provider} />
               </Card>
 
+              {provider &&
+                provider.provider !== 'llamacpp' &&
+                provider.provider !== 'mlx' && (
+                  <Card>
+                    <div className="space-y-2">
+                      <div className="space-y-1">
+                        <h2 className="font-medium text-foreground text-base">
+                          {t('providers:apiKeyFallbacks.title')}
+                        </h2>
+                        <p className="text-sm text-muted-foreground leading-normal">
+                          {t('providers:apiKeyFallbacks.description')}
+                        </p>
+                      </div>
+                      <Textarea
+                        className="min-h-[88px] font-mono text-sm"
+                        placeholder={t('providers:apiKeyFallbacks.placeholder')}
+                        value={fallbackKeysDraft}
+                        onChange={(e) => setFallbackKeysDraft(e.target.value)}
+                        onBlur={() => {
+                          const lines = fallbackKeysDraft
+                            .split(/\r?\n/)
+                            .map((l) => l.trim())
+                            .filter((l) => l.length > 0)
+                          const prev = provider.api_key_fallbacks ?? []
+                          if (JSON.stringify(lines) !== JSON.stringify(prev)) {
+                            updateProvider(providerName, {
+                              api_key_fallbacks: lines,
+                            })
+                          }
+                        }}
+                        spellCheck={false}
+                        autoComplete="off"
+                      />
+                    </div>
+                  </Card>
+                )}
+
               {/* Models */}
               <Card
                 header={
@@ -704,7 +753,7 @@ function ProviderDetail() {
                                 predefinedProviders.some(
                                   (p) => p.provider === provider.provider
                                 ) &&
-                                Boolean(provider.api_key?.length))) && (
+                                providerHasRemoteApiKeys(provider))) && (
                               <FavoriteModelAction model={model} />
                             )}
                             <DialogDeleteModel

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -209,11 +209,10 @@ function ProviderDetail() {
     const newSettings = [...provider.settings]
     const apiKeySettingIndex = newSettings.findIndex((s) => s.key === 'api-key')
     if (apiKeySettingIndex !== -1) {
-      ;(
-        newSettings[apiKeySettingIndex].controller_props as {
-          value: string | boolean | number
-        }
-      ).value = nextPrimary
+      const apiKeyProps = newSettings[apiKeySettingIndex].controller_props as {
+        value: string | boolean | number
+      }
+      apiKeyProps.value = nextPrimary
     }
 
     serviceHub.providers().updateSettings(providerName, newSettings)

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -889,50 +889,60 @@ function ProviderDetail() {
                               return (
                                 <div
                                   key={idx}
-                                  className="flex items-center gap-2"
+                                  className="grid grid-cols-[2.5rem_1fr_2rem] gap-x-2 gap-y-1 items-center"
                                 >
-                                  <div className="w-10 shrink-0 text-right text-xs font-mono text-muted-foreground">
+                                  <div className="text-right text-xs font-mono text-muted-foreground">
                                     #{keyIndex}
                                   </div>
 
-                                  <Input
-                                    type="password"
-                                    className="font-mono flex-1 min-w-0"
-                                    placeholder={t('providers:apiKeys.keyPlaceholder')}
-                                    value={keyValue}
-                                    onChange={(e) => {
-                                      setKeyAtIndex(idx, e.target.value)
-                                    }}
-                                    onBlur={commitApiKeysDraft}
-                                    spellCheck={false}
-                                    autoComplete="off"
-                                  />
-
-                                  {rowResult && (
-                                    <span
-                                      className={cn(
-                                        'text-xs font-medium shrink-0',
-                                        getStatusClass(rowResult.status)
-                                      )}
-                                      title={rowResult.detail}
-                                    >
-                                      {getStatusLabel(rowResult.status)}
-                                    </span>
-                                  )}
-
-                                  {idx !== 0 && (
-                                    <Button
-                                      size="icon-xs"
-                                      variant="outline"
-                                      onClick={() => {
-                                        setKeyCheckResults([])
-                                        removeKeyLine(idx)
+                                  <div className="min-w-0">
+                                    <Input
+                                      type="password"
+                                      className="font-mono w-full"
+                                      placeholder={t('providers:apiKeys.keyPlaceholder')}
+                                      value={keyValue}
+                                      onChange={(e) => {
+                                        setKeyAtIndex(idx, e.target.value)
                                       }}
-                                      title={t('providers:apiKeys.removeKey')}
-                                    >
-                                      -
-                                    </Button>
-                                  )}
+                                      onBlur={commitApiKeysDraft}
+                                      spellCheck={false}
+                                      autoComplete="off"
+                                    />
+                                  </div>
+
+                                  <div className="flex justify-end">
+                                    {idx !== 0 ? (
+                                      <Button
+                                        size="icon-xs"
+                                        variant="outline"
+                                        onClick={() => {
+                                          setKeyCheckResults([])
+                                          removeKeyLine(idx)
+                                        }}
+                                        title={t('providers:apiKeys.removeKey')}
+                                      >
+                                        -
+                                      </Button>
+                                    ) : (
+                                      <span aria-hidden>&nbsp;</span>
+                                    )}
+                                  </div>
+
+                                  <div aria-hidden />
+                                  <div className="min-w-0">
+                                    {rowResult && (
+                                      <div
+                                        className={cn(
+                                          'text-right text-xs font-medium',
+                                          getStatusClass(rowResult.status)
+                                        )}
+                                        title={rowResult.detail}
+                                      >
+                                        {getStatusLabel(rowResult.status)}
+                                      </div>
+                                    )}
+                                  </div>
+                                  <div aria-hidden />
                                 </div>
                               )
                             })}

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -21,7 +21,6 @@ import { useServiceHub } from '@/hooks/useServiceHub'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Switch } from '@/components/ui/switch'
-import { Textarea } from '@/components/ui/textarea'
 import {
   IconFolderPlus,
   IconLoader,
@@ -233,6 +232,23 @@ function ProviderDetail() {
     setApiKeysDraft([nextPrimary, ...rest].join('\n'))
   }
 
+  const advancedApiKeyLines = apiKeysDraft.split(/\r?\n/).map((l) => l.trim())
+  const setKeyAtIndex = (index: number, nextValue: string) => {
+    const next = [...advancedApiKeyLines]
+    next[index] = nextValue.trim()
+    setApiKeysDraft(next.join('\n'))
+  }
+
+  const addKeyLine = () => {
+    setApiKeysDraft([...advancedApiKeyLines, ''].join('\n'))
+  }
+
+  const removeKeyLine = (index: number) => {
+    if (index === 0) return
+    const next = advancedApiKeyLines.filter((_, i) => i !== index)
+    setApiKeysDraft((next.length > 0 ? next : ['']).join('\n'))
+  }
+
   const maskApiKey = useCallback((value: string) => {
     if (value.length <= 8) return `${value.slice(0, 2)}***`
     return `${value.slice(0, 4)}***${value.slice(-4)}`
@@ -243,11 +259,11 @@ function ProviderDetail() {
       case 'ok':
         return 'OK'
       case 'unauthorized':
-        return '401 Unauthorized'
+        return 'Invalid / revoked key (401)'
       case 'forbidden':
-        return '403 Forbidden'
+        return 'Forbidden (403)'
       case 'rate_limited':
-        return '429 Rate limited'
+        return 'Rate limited / out of credit (429)'
       case 'network_error':
         return 'Network error'
       default:
@@ -261,9 +277,10 @@ function ProviderDetail() {
         return 'text-green-600'
       case 'unauthorized':
       case 'forbidden':
-      case 'rate_limited':
       case 'http_error':
       case 'network_error':
+      case 'rate_limited':
+        return 'text-yellow-600'
       default:
         return 'text-destructive'
     }
@@ -277,11 +294,9 @@ function ProviderDetail() {
       return
     }
 
-    const keys = apiKeysDraft
-      .split(/\r?\n/)
-      .map((l) => l.trim())
-      .filter((l) => l.length > 0)
-    if (keys.length === 0) {
+    const keyDraftLines = apiKeysDraft.split(/\r?\n/).map((l) => l.trim())
+    const nonEmptyKeyCount = keyDraftLines.filter((l) => l.length > 0).length
+    if (nonEmptyKeyCount === 0) {
       toast.error(t('providers:models'), {
         description: t('providers:refreshModelsError'),
       })
@@ -293,8 +308,10 @@ function ProviderDetail() {
       const fetchImpl = serviceHub.providers().fetch()
       const results: { index: number; masked: string; status: string; detail: string }[] = []
 
-      for (let i = 0; i < keys.length; i++) {
-        const key = keys[i]
+      for (let i = 0; i < keyDraftLines.length; i++) {
+        const key = keyDraftLines[i]
+        const keyIndex = i + 1
+        if (!key) continue
         const headers: Record<string, string> = {
           'Content-Type': 'application/json',
           'x-api-key': key,
@@ -320,14 +337,14 @@ function ProviderDetail() {
           else if (response.status === 429) status = 'rate_limited'
 
           results.push({
-            index: i + 1,
+            index: keyIndex,
             masked: maskApiKey(key),
             status,
             detail: `${response.status} ${response.statusText}`,
           })
         } catch (err) {
           results.push({
-            index: i + 1,
+            index: keyIndex,
             masked: maskApiKey(key),
             status: 'network_error',
             detail: err instanceof Error ? err.message : 'Unknown error',
@@ -818,76 +835,121 @@ function ProviderDetail() {
                       )}
 
                       {showAdvancedApiKeys && (
-                        <div className="space-y-2">
-                          <Textarea
-                            className="min-h-[88px] font-mono text-sm"
-                            placeholder={t('providers:apiKeys.placeholder')}
-                            value={apiKeysDraft}
-                            onChange={(e) => setApiKeysDraft(e.target.value)}
-                            onBlur={commitApiKeysDraft}
-                            spellCheck={false}
-                            autoComplete="off"
-                          />
-
-                          <div className="flex items-center gap-2">
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              onClick={() => {
-                                commitApiKeysDraft()
-                                setShowAdvancedApiKeys(false)
-                                setKeyCheckResults([])
-                              }}
-                            >
-                              {t('providers:apiKeys.hideAdvanced')}
-                            </Button>
-
-                            <Button
-                              size="sm"
-                              variant="outline"
-                              onClick={handleTestApiKeys}
-                              disabled={isTestingKeys}
-                            >
-                              {isTestingKeys ? (
-                                <>
-                                  <IconLoader
-                                    size={14}
-                                    className="animate-spin"
-                                  />
-                                  {t('providers:apiKeys.testing')}
-                                </>
-                              ) : (
-                                t('providers:apiKeys.test')
-                              )}
-                            </Button>
+                        <div className="space-y-3">
+                          <div className="flex items-center justify-between gap-2">
+                            <div className="text-xs text-muted-foreground">
+                              {t('providers:apiKeys.testHint')}
+                            </div>
+                            <div className="flex items-center gap-2">
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => {
+                                  commitApiKeysDraft()
+                                  setShowAdvancedApiKeys(false)
+                                  setKeyCheckResults([])
+                                }}
+                              >
+                                {t('providers:apiKeys.hideAdvanced')}
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={handleTestApiKeys}
+                                disabled={isTestingKeys}
+                              >
+                                {isTestingKeys ? (
+                                  <>
+                                    <IconLoader
+                                      size={14}
+                                      className="animate-spin"
+                                    />
+                                    {t('providers:apiKeys.testing')}
+                                  </>
+                                ) : (
+                                  t('providers:apiKeys.test')
+                                )}
+                              </Button>
+                            </div>
                           </div>
 
-                          <span className="text-xs text-muted-foreground">
-                            {t('providers:apiKeys.testHint')}
-                          </span>
+                          <div className="text-xs text-muted-foreground">
+                            Primary key is <span className="font-medium">#1</span>. Jan
+                            retries the next key only on{' '}
+                            <span className="font-medium">401/403/429</span>.
+                          </div>
 
-                          {keyCheckResults.length > 0 && (
-                            <div className="space-y-1 rounded-md border border-border/60 p-2">
-                              {keyCheckResults.map((row) => (
+                          <div className="space-y-2">
+                            {advancedApiKeyLines.map((keyValue, idx) => {
+                              const keyIndex = idx + 1
+                              const rowResult = keyCheckResults.find(
+                                (r) => r.index === keyIndex
+                              )
+
+                              return (
                                 <div
-                                  key={`${row.index}-${row.masked}`}
-                                  className="flex items-center justify-between gap-3 text-xs"
+                                  key={idx}
+                                  className="flex items-center gap-2"
                                 >
-                                  <span className="font-mono text-muted-foreground">
-                                    #{row.index} {row.masked}
-                                  </span>
-                                  <span
-                                    className={cn(
-                                      'font-medium',
-                                      getStatusClass(row.status)
-                                    )}
-                                  >
-                                    {getStatusLabel(row.status)}
-                                  </span>
+                                  <div className="w-10 shrink-0 text-right text-xs font-mono text-muted-foreground">
+                                    #{keyIndex}
+                                  </div>
+
+                                  <Input
+                                    type="password"
+                                    className="font-mono flex-1 min-w-0"
+                                    placeholder={t('providers:apiKeys.keyPlaceholder')}
+                                    value={keyValue}
+                                    onChange={(e) => {
+                                      setKeyAtIndex(idx, e.target.value)
+                                    }}
+                                    onBlur={commitApiKeysDraft}
+                                    spellCheck={false}
+                                    autoComplete="off"
+                                  />
+
+                                  {rowResult && (
+                                    <span
+                                      className={cn(
+                                        'text-xs font-medium shrink-0',
+                                        getStatusClass(rowResult.status)
+                                      )}
+                                      title={rowResult.detail}
+                                    >
+                                      {getStatusLabel(rowResult.status)}
+                                    </span>
+                                  )}
+
+                                  {idx !== 0 && (
+                                    <Button
+                                      size="icon-xs"
+                                      variant="outline"
+                                      onClick={() => {
+                                        setKeyCheckResults([])
+                                        removeKeyLine(idx)
+                                      }}
+                                      title={t('providers:apiKeys.removeKey')}
+                                    >
+                                      -
+                                    </Button>
+                                  )}
                                 </div>
-                              ))}
+                              )
+                            })}
+
+                            <div className="flex items-center gap-2">
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                onClick={() => {
+                                  setKeyCheckResults([])
+                                  addKeyLine()
+                                }}
+                              >
+                                + {t('providers:apiKeys.addKey')}
+                              </Button>
                             </div>
-                          )}
+                          </div>
                         </div>
                       )}
                     </div>

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -37,7 +37,10 @@ import { basenameNoExt } from '@/lib/utils'
 import { useAppState } from '@/hooks/useAppState'
 import { useShallow } from 'zustand/shallow'
 import { DialogAddModel } from '@/containers/dialogs/AddModel'
-import { providerHasRemoteApiKeys } from '@/lib/provider-api-keys'
+import {
+  providerHasRemoteApiKeys,
+  providerRemoteApiKeyChain,
+} from '@/lib/provider-api-keys'
 
 // as route.threadsDetail
 export const Route = createFileRoute('/settings/providers/$providerName')({
@@ -62,7 +65,11 @@ function ProviderDetail() {
   const [isCheckingBackendUpdate, setIsCheckingBackendUpdate] = useState(false)
   const [isInstallingBackend, setIsInstallingBackend] = useState(false)
   const [importingModel, setImportingModel] = useState<string | null>(null)
-  const [fallbackKeysDraft, setFallbackKeysDraft] = useState('')
+  const [apiKeysDraft, setApiKeysDraft] = useState('')
+  const [isTestingKeys, setIsTestingKeys] = useState(false)
+  const [keyCheckResults, setKeyCheckResults] = useState<
+    { index: number; masked: string; status: string; detail: string }[]
+  >([])
   const { checkForUpdate: checkForBackendUpdate, installBackend } =
     useBackendUpdater()
   const { providerName } = useParams({ from: Route.id })
@@ -180,11 +187,151 @@ function ProviderDetail() {
   useEffect(() => {
     if (!provider) return
     if (provider.provider === 'llamacpp' || provider.provider === 'mlx') return
-    setFallbackKeysDraft((provider.api_key_fallbacks ?? []).join('\n'))
-  }, [
-    providerName,
-    JSON.stringify(provider?.api_key_fallbacks ?? []),
-  ])
+    setApiKeysDraft(providerRemoteApiKeyChain(provider).join('\n'))
+  }, [providerName, provider?.api_key, JSON.stringify(provider?.api_key_fallbacks ?? [])])
+
+  const commitApiKeysDraft = useCallback(() => {
+    if (!provider) return
+    const lines = apiKeysDraft
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0)
+    const nextPrimary = lines[0] ?? ''
+    const nextFallbacks = lines.slice(1)
+
+    const prevPrimary = provider.api_key ?? ''
+    const prevFallbacks = provider.api_key_fallbacks ?? []
+    const changed =
+      nextPrimary !== prevPrimary ||
+      JSON.stringify(nextFallbacks) !== JSON.stringify(prevFallbacks)
+    if (!changed) return
+
+    const newSettings = [...provider.settings]
+    const apiKeySettingIndex = newSettings.findIndex((s) => s.key === 'api-key')
+    if (apiKeySettingIndex !== -1) {
+      ;(
+        newSettings[apiKeySettingIndex].controller_props as {
+          value: string | boolean | number
+        }
+      ).value = nextPrimary
+    }
+
+    serviceHub.providers().updateSettings(providerName, newSettings)
+    updateProvider(providerName, {
+      ...provider,
+      settings: newSettings,
+      api_key: nextPrimary,
+      api_key_fallbacks: nextFallbacks,
+    })
+  }, [apiKeysDraft, provider, providerName, serviceHub, updateProvider])
+
+  const maskApiKey = useCallback((value: string) => {
+    if (value.length <= 8) return `${value.slice(0, 2)}***`
+    return `${value.slice(0, 4)}***${value.slice(-4)}`
+  }, [])
+
+  const getStatusLabel = useCallback((status: string) => {
+    switch (status) {
+      case 'ok':
+        return 'OK'
+      case 'unauthorized':
+        return '401 Unauthorized'
+      case 'forbidden':
+        return '403 Forbidden'
+      case 'rate_limited':
+        return '429 Rate limited'
+      case 'network_error':
+        return 'Network error'
+      default:
+        return 'Failed'
+    }
+  }, [])
+
+  const getStatusClass = useCallback((status: string) => {
+    switch (status) {
+      case 'ok':
+        return 'text-green-600'
+      case 'unauthorized':
+      case 'forbidden':
+      case 'rate_limited':
+      case 'http_error':
+      case 'network_error':
+      default:
+        return 'text-destructive'
+    }
+  }, [])
+
+  const handleTestApiKeys = useCallback(async () => {
+    if (!provider?.base_url) {
+      toast.error(t('providers:models'), {
+        description: t('providers:refreshModelsError'),
+      })
+      return
+    }
+
+    const keys = apiKeysDraft
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0)
+    if (keys.length === 0) {
+      toast.error(t('providers:models'), {
+        description: t('providers:refreshModelsError'),
+      })
+      return
+    }
+
+    setIsTestingKeys(true)
+    try {
+      const fetchImpl = serviceHub.providers().fetch()
+      const results: { index: number; masked: string; status: string; detail: string }[] = []
+
+      for (let i = 0; i < keys.length; i++) {
+        const key = keys[i]
+        const headers: Record<string, string> = {
+          'Content-Type': 'application/json',
+          'x-api-key': key,
+          Authorization: `Bearer ${key}`,
+        }
+        if (
+          provider.base_url.includes('localhost:') ||
+          provider.base_url.includes('127.0.0.1:')
+        ) {
+          headers['Origin'] = 'tauri://localhost'
+        }
+
+        try {
+          const response = await fetchImpl(`${provider.base_url}/models`, {
+            method: 'GET',
+            headers,
+          })
+
+          let status = 'http_error'
+          if (response.ok) status = 'ok'
+          else if (response.status === 401) status = 'unauthorized'
+          else if (response.status === 403) status = 'forbidden'
+          else if (response.status === 429) status = 'rate_limited'
+
+          results.push({
+            index: i + 1,
+            masked: maskApiKey(key),
+            status,
+            detail: `${response.status} ${response.statusText}`,
+          })
+        } catch (err) {
+          results.push({
+            index: i + 1,
+            masked: maskApiKey(key),
+            status: 'network_error',
+            detail: err instanceof Error ? err.message : 'Unknown error',
+          })
+        }
+      }
+
+      setKeyCheckResults(results)
+    } finally {
+      setIsTestingKeys(false)
+    }
+  }, [apiKeysDraft, maskApiKey, provider?.base_url, serviceHub, t])
 
   // Auto-refresh provider settings to get updated backend configuration
   const refreshSettings = useCallback(async () => {
@@ -416,6 +563,14 @@ function ProviderDetail() {
               {/* Settings */}
               <Card>
                 {provider?.settings.map((setting, settingIndex) => {
+                  if (
+                    setting.key === 'api-key' &&
+                    provider?.provider !== 'llamacpp' &&
+                    provider?.provider !== 'mlx'
+                  ) {
+                    return null
+                  }
+
                   // Use the DynamicController component
                   const actionComponent = (
                     <div className="mt-2">
@@ -618,32 +773,58 @@ function ProviderDetail() {
                     <div className="space-y-2">
                       <div className="space-y-1">
                         <h2 className="font-medium text-foreground text-base">
-                          {t('providers:apiKeyFallbacks.title')}
+                          {t('providers:apiKeys.title')}
                         </h2>
                         <p className="text-sm text-muted-foreground leading-normal">
-                          {t('providers:apiKeyFallbacks.description')}
+                          {t('providers:apiKeys.description')}
                         </p>
                       </div>
                       <Textarea
                         className="min-h-[88px] font-mono text-sm"
-                        placeholder={t('providers:apiKeyFallbacks.placeholder')}
-                        value={fallbackKeysDraft}
-                        onChange={(e) => setFallbackKeysDraft(e.target.value)}
-                        onBlur={() => {
-                          const lines = fallbackKeysDraft
-                            .split(/\r?\n/)
-                            .map((l) => l.trim())
-                            .filter((l) => l.length > 0)
-                          const prev = provider.api_key_fallbacks ?? []
-                          if (JSON.stringify(lines) !== JSON.stringify(prev)) {
-                            updateProvider(providerName, {
-                              api_key_fallbacks: lines,
-                            })
-                          }
-                        }}
+                        placeholder={t('providers:apiKeys.placeholder')}
+                        value={apiKeysDraft}
+                        onChange={(e) => setApiKeysDraft(e.target.value)}
+                        onBlur={commitApiKeysDraft}
                         spellCheck={false}
                         autoComplete="off"
                       />
+                      <div className="flex items-center gap-2">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={handleTestApiKeys}
+                          disabled={isTestingKeys}
+                        >
+                          {isTestingKeys ? (
+                            <>
+                              <IconLoader size={14} className="animate-spin" />
+                              {t('providers:apiKeys.testing')}
+                            </>
+                          ) : (
+                            t('providers:apiKeys.test')
+                          )}
+                        </Button>
+                        <span className="text-xs text-muted-foreground">
+                          {t('providers:apiKeys.testHint')}
+                        </span>
+                      </div>
+                      {keyCheckResults.length > 0 && (
+                        <div className="space-y-1 rounded-md border border-border/60 p-2">
+                          {keyCheckResults.map((row) => (
+                            <div
+                              key={`${row.index}-${row.masked}`}
+                              className="flex items-center justify-between gap-3 text-xs"
+                            >
+                              <span className="font-mono text-muted-foreground">
+                                #{row.index} {row.masked}
+                              </span>
+                              <span className={cn('font-medium', getStatusClass(row.status))}>
+                                {getStatusLabel(row.status)}
+                              </span>
+                            </div>
+                          ))}
+                        </div>
+                      )}
                     </div>
                   </Card>
                 )}

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -19,6 +19,7 @@ import { route } from '@/constants/routes'
 import DeleteProvider from '@/containers/dialogs/DeleteProvider'
 import { useServiceHub } from '@/hooks/useServiceHub'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
 import {
@@ -66,6 +67,7 @@ function ProviderDetail() {
   const [isInstallingBackend, setIsInstallingBackend] = useState(false)
   const [importingModel, setImportingModel] = useState<string | null>(null)
   const [apiKeysDraft, setApiKeysDraft] = useState('')
+  const [showAdvancedApiKeys, setShowAdvancedApiKeys] = useState(false)
   const [isTestingKeys, setIsTestingKeys] = useState(false)
   const [keyCheckResults, setKeyCheckResults] = useState<
     { index: number; masked: string; status: string; detail: string }[]
@@ -223,6 +225,13 @@ function ProviderDetail() {
       api_key_fallbacks: nextFallbacks,
     })
   }, [apiKeysDraft, provider, providerName, serviceHub, updateProvider])
+
+  const rawApiKeyLines = apiKeysDraft.split(/\r?\n/)
+  const primaryKeyDraft = (rawApiKeyLines[0] ?? '').trim()
+  const setPrimaryKeyDraft = (nextPrimary: string) => {
+    const rest = rawApiKeyLines.slice(1)
+    setApiKeysDraft([nextPrimary, ...rest].join('\n'))
+  }
 
   const maskApiKey = useCallback((value: string) => {
     if (value.length <= 8) return `${value.slice(0, 2)}***`
@@ -778,50 +787,107 @@ function ProviderDetail() {
                           {t('providers:apiKeys.description')}
                         </p>
                       </div>
-                      <Textarea
-                        className="min-h-[88px] font-mono text-sm"
-                        placeholder={t('providers:apiKeys.placeholder')}
-                        value={apiKeysDraft}
-                        onChange={(e) => setApiKeysDraft(e.target.value)}
-                        onBlur={commitApiKeysDraft}
-                        spellCheck={false}
-                        autoComplete="off"
-                      />
-                      <div className="flex items-center gap-2">
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={handleTestApiKeys}
-                          disabled={isTestingKeys}
-                        >
-                          {isTestingKeys ? (
-                            <>
-                              <IconLoader size={14} className="animate-spin" />
-                              {t('providers:apiKeys.testing')}
-                            </>
-                          ) : (
-                            t('providers:apiKeys.test')
-                          )}
-                        </Button>
-                        <span className="text-xs text-muted-foreground">
-                          {t('providers:apiKeys.testHint')}
-                        </span>
-                      </div>
-                      {keyCheckResults.length > 0 && (
-                        <div className="space-y-1 rounded-md border border-border/60 p-2">
-                          {keyCheckResults.map((row) => (
-                            <div
-                              key={`${row.index}-${row.masked}`}
-                              className="flex items-center justify-between gap-3 text-xs"
+                      {!showAdvancedApiKeys && (
+                        <div className="flex flex-col gap-2">
+                          <Input
+                            className="font-mono"
+                            placeholder={t('providers:apiKeys.primaryPlaceholder')}
+                            value={primaryKeyDraft}
+                            onChange={(e) => setPrimaryKeyDraft(e.target.value)}
+                            onBlur={() => commitApiKeysDraft()}
+                            spellCheck={false}
+                            autoComplete="off"
+                          />
+
+                          <div className="flex items-center justify-between gap-2">
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => {
+                                setShowAdvancedApiKeys(true)
+                                setKeyCheckResults([])
+                              }}
                             >
-                              <span className="font-mono text-muted-foreground">
-                                #{row.index} {row.masked}
-                              </span>
-                              <span className={cn('font-medium', getStatusClass(row.status))}>
-                                {getStatusLabel(row.status)}
-                              </span>
+                              {t('providers:apiKeys.advanced')}
+                            </Button>
+                            <span className="text-xs text-muted-foreground">
+                              {t('providers:apiKeys.oneKeyHint')}
+                            </span>
+                          </div>
+                        </div>
+                      )}
+
+                      {showAdvancedApiKeys && (
+                        <div className="space-y-2">
+                          <Textarea
+                            className="min-h-[88px] font-mono text-sm"
+                            placeholder={t('providers:apiKeys.placeholder')}
+                            value={apiKeysDraft}
+                            onChange={(e) => setApiKeysDraft(e.target.value)}
+                            onBlur={commitApiKeysDraft}
+                            spellCheck={false}
+                            autoComplete="off"
+                          />
+
+                          <div className="flex items-center gap-2">
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => {
+                                commitApiKeysDraft()
+                                setShowAdvancedApiKeys(false)
+                                setKeyCheckResults([])
+                              }}
+                            >
+                              {t('providers:apiKeys.hideAdvanced')}
+                            </Button>
+
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={handleTestApiKeys}
+                              disabled={isTestingKeys}
+                            >
+                              {isTestingKeys ? (
+                                <>
+                                  <IconLoader
+                                    size={14}
+                                    className="animate-spin"
+                                  />
+                                  {t('providers:apiKeys.testing')}
+                                </>
+                              ) : (
+                                t('providers:apiKeys.test')
+                              )}
+                            </Button>
+                          </div>
+
+                          <span className="text-xs text-muted-foreground">
+                            {t('providers:apiKeys.testHint')}
+                          </span>
+
+                          {keyCheckResults.length > 0 && (
+                            <div className="space-y-1 rounded-md border border-border/60 p-2">
+                              {keyCheckResults.map((row) => (
+                                <div
+                                  key={`${row.index}-${row.masked}`}
+                                  className="flex items-center justify-between gap-3 text-xs"
+                                >
+                                  <span className="font-mono text-muted-foreground">
+                                    #{row.index} {row.masked}
+                                  </span>
+                                  <span
+                                    className={cn(
+                                      'font-medium',
+                                      getStatusClass(row.status)
+                                    )}
+                                  >
+                                    {getStatusLabel(row.status)}
+                                  </span>
+                                </div>
+                              ))}
                             </div>
-                          ))}
+                          )}
                         </div>
                       )}
                     </div>

--- a/web-app/src/services/providers/tauri.ts
+++ b/web-app/src/services/providers/tauri.ts
@@ -11,6 +11,7 @@ import { ExtensionManager } from '@/lib/extension'
 import { fetch as fetchTauri } from '@tauri-apps/plugin-http'
 import { DefaultProvidersService } from './default'
 import { getModelCapabilities } from '@/lib/models'
+import { providerRemoteApiKeyChain } from '@/lib/provider-api-keys'
 
 export class TauriProvidersService extends DefaultProvidersService {
   fetch(): typeof fetch {
@@ -141,84 +142,101 @@ export class TauriProvidersService extends DefaultProvidersService {
     }
 
     try {
-      const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
-      }
+      const keyChain = providerRemoteApiKeyChain(provider)
+      const keyAttempts: (string | undefined)[] =
+        keyChain.length > 0 ? keyChain : [undefined]
 
-      // Add Origin header for local providers to avoid CORS issues
-      // Some local providers (like Ollama) require an Origin header
-      if (
-        provider.base_url.includes('localhost:') ||
-        provider.base_url.includes('127.0.0.1:')
-      ) {
-        headers['Origin'] = 'tauri://localhost'
-      }
+      let lastStatus = 0
+      let lastStatusText = ''
 
-      // Only add authentication headers if API key is provided
-      if (provider.api_key) {
-        headers['x-api-key'] = provider.api_key
-        headers['Authorization'] = `Bearer ${provider.api_key}`
-      }
+      for (let ki = 0; ki < keyAttempts.length; ki++) {
+        const key = keyAttempts[ki]
+        const headers: Record<string, string> = {
+          'Content-Type': 'application/json',
+        }
 
-      if (provider.custom_header) {
-        provider.custom_header.forEach((header) => {
-          headers[header.header] = header.value
+        if (
+          provider.base_url.includes('localhost:') ||
+          provider.base_url.includes('127.0.0.1:')
+        ) {
+          headers['Origin'] = 'tauri://localhost'
+        }
+
+        if (key) {
+          headers['x-api-key'] = key
+          headers['Authorization'] = `Bearer ${key}`
+        }
+
+        if (provider.custom_header) {
+          provider.custom_header.forEach((header) => {
+            headers[header.header] = header.value
+          })
+        }
+
+        const response = await fetchTauri(`${provider.base_url}/models`, {
+          method: 'GET',
+          headers,
         })
-      }
 
-      // Always use Tauri's fetch to avoid CORS issues
-      const response = await fetchTauri(`${provider.base_url}/models`, {
-        method: 'GET',
-        headers,
-      })
+        lastStatus = response.status
+        lastStatusText = response.statusText
 
-      if (!response.ok) {
-        // Provide more specific error messages based on status code (aligned with web implementation)
-        if (response.status === 401) {
-          throw new Error(
-            `Authentication failed: API key is required or invalid for ${provider.provider}`
-          )
-        } else if (response.status === 403) {
-          throw new Error(
-            `Access forbidden: Check your API key permissions for ${provider.provider}`
-          )
-        } else if (response.status === 404) {
-          throw new Error(
-            `Models endpoint not found for ${provider.provider}. Check the base URL configuration.`
-          )
-        } else {
+        if (
+          [401, 403, 429].includes(response.status) &&
+          ki < keyAttempts.length - 1
+        ) {
+          continue
+        }
+
+        if (!response.ok) {
+          if (response.status === 401) {
+            throw new Error(
+              `Authentication failed: API key is required or invalid for ${provider.provider}`
+            )
+          }
+          if (response.status === 403) {
+            throw new Error(
+              `Access forbidden: Check your API key permissions for ${provider.provider}`
+            )
+          }
+          if (response.status === 404) {
+            throw new Error(
+              `Models endpoint not found for ${provider.provider}. Check the base URL configuration.`
+            )
+          }
           throw new Error(
             `Failed to fetch models from ${provider.provider}: ${response.status} ${response.statusText}`
           )
         }
-      }
 
-      const data = await response.json()
+        const data = await response.json()
 
-      // Handle different response formats that providers might use
-      if (data.data && Array.isArray(data.data)) {
-        // OpenAI format: { data: [{ id: "model-id" }, ...] }
-        return data.data
-          .map((model: { id: string }) => model.id)
-          .filter(Boolean)
-      } else if (Array.isArray(data)) {
-        // Direct array format: ["model-id1", "model-id2", ...]
-        return data
-          .filter(Boolean)
-          .map((model) =>
-            typeof model === 'object' && 'id' in model ? model.id : model
-          )
-      } else if (data.models && Array.isArray(data.models)) {
-        // Alternative format: { models: [...] }
-        return data.models
-          .map((model: string | { id: string }) =>
-            typeof model === 'string' ? model : model.id
-          )
-          .filter(Boolean)
-      } else {
+        if (data.data && Array.isArray(data.data)) {
+          return data.data
+            .map((model: { id: string }) => model.id)
+            .filter(Boolean)
+        }
+        if (Array.isArray(data)) {
+          return data
+            .filter(Boolean)
+            .map((model) =>
+              typeof model === 'object' && 'id' in model ? model.id : model
+            )
+        }
+        if (data.models && Array.isArray(data.models)) {
+          return data.models
+            .map((model: string | { id: string }) =>
+              typeof model === 'string' ? model : model.id
+            )
+            .filter(Boolean)
+        }
         console.warn('Unexpected response format from provider API:', data)
         return []
       }
+
+      throw new Error(
+        `Failed to fetch models from ${provider.provider}: ${lastStatus} ${lastStatusText}`
+      )
     } catch (error) {
       console.error('Error fetching models from provider:', error)
 

--- a/web-app/src/types/modelProviders.d.ts
+++ b/web-app/src/types/modelProviders.d.ts
@@ -49,6 +49,8 @@ type ProviderObject = {
   provider: string
   explore_models_url?: string
   api_key?: string
+  /** Extra keys used after `api_key` when the API returns 401, 403, or 429. */
+  api_key_fallbacks?: string[]
   base_url?: string
   settings: ProviderSetting[]
   models: Model[]


### PR DESCRIPTION
## Describe Your Changes
This PR adds support for multiple API keys per remote provider (e.g. Gemini/OpenAI-compatible flows) and automatic fallback when a key is rejected or rate-limited.

## What users get

- Keep the existing main API key field.
- Optional fallback API keys (one per line). Jan tries the main key first, then each fallback in order.
- On 401, 403, or 429, the next key is used without manual switching.
## Implementation overview
- Web: api_key_fallbacks on provider state; settings UI + registration payload to the backend.
- Tauri / Rust: ProviderConfig extended with an ordered key list; proxy and orchestration paths retry with the next key on the statuses above.
- In-app inference: Multi-key providers use a rotating fetch wrapper for OpenAI, Anthropic, xAI, and OpenAI-compatible models.
- Refresh models (desktop): Same retry behavior when listing models.

## Fixes Issues

- Closes #7723 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
