### PR TITLE
Create .gitattributes to suppress local Cargo.lock diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 Cargo.lock -diff
-yarn.lock -diff


### PR DESCRIPTION
## Describe Your Changes

Suppress cargo lockfile git diffs.

## Fixes Issues

QoL DX improvement, initially I created this PR to enable Cargo.lock being added to version control, but I now see it's being tracked already.

This change resolves the issue mentioned in [August 2025](https://github.com/orgs/janhq/discussions/6048#discussioncomment-13998270), that lock file changes were adding noise to git diffs.

The method I have used to suppress git diffs is documented by git [here](https://git-scm.com/docs/gitattributes#_marking_files_as_binary).

Note that GitHub does [not](https://github.com/github-linguist/linguist/issues/4262) respect this .gitattributes setting when displaying Pull Request diffs, however since [2018](https://github.com/github-linguist/linguist/issues/3988) cargo.lock files have been marked as linguist-generated by default, and therefore will [not](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github) be displayed in diffs.

I [initially](https://github.com/DuncanBetts/jan/commit/83aeea71ba0d4f285b00c35426f6f593ff31c53d) also suppressed yarn.lock diffs, but after looking into it in more [detail](https://github.com/github-linguist/linguist/pull/4459) changed my mind.

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
