### PR TITLE
Feat/reproducible builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,6 @@ src-tauri/plugins/tauri-plugin-foundation-models/swift-server/Package.resolved
 
 ## cargo
 target
-Cargo.lock
 src-tauri/resources/
 
 ## test

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ endif
 all:
 	@echo "Specify a target to run"
 
-# Installs yarn dependencies and builds core and extensions
-install-and-build:
+# Installs yarn dependencies and s core and extensions
+install-and-:
 ifeq ($(DETECTED_OS),Windows)
 	echo "skip"
 else ifeq ($(DETECTED_OS),Linux)
@@ -130,10 +130,10 @@ endif
 	yarn build:icon
 	yarn build:mlx-server
 	make build-cli
-	cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --features test-tauri -- --test-threads=1
-	cargo test --manifest-path src-tauri/plugins/tauri-plugin-hardware/Cargo.toml
-	cargo test --manifest-path src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
-	cargo test --manifest-path src-tauri/utils/Cargo.toml
+	cargo test --locked --manifest-path src-tauri/Cargo.toml --no-default-features --features test-tauri -- --test-threads=1
+	cargo test --locked --manifest-path src-tauri/plugins/tauri-plugin-hardware/Cargo.toml
+	cargo test --locked --manifest-path src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
+	cargo test --locked --manifest-path src-tauri/utils/Cargo.toml
 
 # Build MLX server (macOS Apple Silicon only) - always builds
 build-mlx-server:
@@ -185,11 +185,13 @@ else
 	@echo "Skipping MLX server build (macOS only)"
 endif
 
+CARGO_CLI_FLAGS := --locked --release --features cli --bin jan-cli
+
 # Build jan CLI (release, platform-aware) → src-tauri/resources/bin/jan[.exe]
 build-cli:
 ifeq ($(DETECTED_OS),Darwin)
-	cd src-tauri && cargo build --release --features cli --bin jan-cli --target aarch64-apple-darwin
-	cd src-tauri && cargo build --release --features cli --bin jan-cli --target x86_64-apple-darwin
+	cd src-tauri && cargo build $(CARGO_CLI_FLAGS) --target aarch64-apple-darwin
+	cd src-tauri && cargo build $(CARGO_CLI_FLAGS) --target x86_64-apple-darwin
 	lipo -create \
 		src-tauri/target/aarch64-apple-darwin/release/jan-cli \
 		src-tauri/target/x86_64-apple-darwin/release/jan-cli \
@@ -209,14 +211,14 @@ ifeq ($(DETECTED_OS),Darwin)
 
 	cp src-tauri/resources/bin/jan-cli src-tauri/target/universal-apple-darwin/release/jan-cli
 else ifeq ($(DETECTED_OS),Windows)
-	cd src-tauri && cargo build --release --features cli --bin jan-cli
+	cd src-tauri && cargo build $(CARGO_CLI_FLAGS)
 	cp src-tauri/target/release/jan-cli.exe src-tauri/resources/bin/jan-cli.exe
 else
-	cd src-tauri && cargo build --release --features cli --bin jan-cli
+	cd src-tauri && cargo build $(CARGO_CLI_FLAGS)
 	cp src-tauri/target/release/jan-cli src-tauri/resources/bin/jan-cli
 endif
 
-# Debug build for local dev (faster, native arch only)
+# Debug build for local dev (faster, native arch only, without enforcing lockfile)
 build-cli-dev:
 	$(call MKDIR,'src-tauri/resources/bin')	
 	cd src-tauri && cargo build --features cli --bin jan-cli

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ endif
 all:
 	@echo "Specify a target to run"
 
-# Installs yarn dependencies and s core and extensions
-install-and-:
+# Installs yarn dependencies and builds core and extensions
+install-and-build:
 ifeq ($(DETECTED_OS),Windows)
 	echo "skip"
 else ifeq ($(DETECTED_OS),Linux)


### PR DESCRIPTION
## Describe Your Changes

Cargo by default will re-resolve dependencies if `Cargo.lock` is out of sync, silently testing against and building with any newer semantic version compatible crate versions, potentially resulting in hard to track down non-bugs that automated tests could have caught, and difficult/impossible to audit non-deterministic builds that differ from what the committed lock file would indicate.

I had a look in `.github/workflows` and am pretty sure CI relies upon the Makefile?

Something I'm unclear on is whether dependabot already catches this, I'm not familiar enough with it to say.

Cargo test and build commands in the `Makefile` have been made to enforce the validity of `Cargo.lock` by passing option `--locked` (documented here [1](https://doc.rust-lang.org/cargo/commands/cargo-test.html#option-cargo-test---locked)[2](https://doc.rust-lang.org/cargo/commands/cargo-build.html#option-cargo-build---locked)).

I've omitted `--locked` from `build-cli-dev`; seemed the right call for DX.

I also removed `Cargo.lock` from `.gitignore`.

## Fixes Issues

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

## Next action

Improve reproducibility further by adding a `rust-toolchain.toml` to pin the `rustc` version; dependabot [supports](https://github.blog/changelog/2025-08-19-dependabot-now-supports-rust-toolchain-updates/) meaning it'll open a PR when a new toolchain version is available.
I wasn't sure what to pin, so didn't do this, and besides, nice timing for this might be upon the next stable release.