### PR TITLE
fix: verify stdio MCP tools/list before emitting ready event

### DIFF
--- a/src-tauri/src/core/mcp/helpers.rs
+++ b/src-tauri/src/core/mcp/helpers.rs
@@ -684,6 +684,65 @@ async fn schedule_mcp_start_task<R: Runtime>(
             return Err(format!("MCP server {name} quit immediately after starting"));
         }
 
+        // Verify tools/list is reachable before emitting the ready event.
+        // Stdio servers (especially via npx mcp-remote) may need extra time
+        // after serve() completes before the transport is ready for JSON-RPC.
+        const MAX_TOOL_VERIFY_ATTEMPTS: u32 = 3;
+        const TOOL_VERIFY_TIMEOUT_SECS: u64 = 5;
+        const TOOL_VERIFY_BACKOFF_MS: u64 = 1000;
+
+        for attempt in 1..=MAX_TOOL_VERIFY_ATTEMPTS {
+            let verify_result = {
+                let servers_map = servers.lock().await;
+                if let Some(service) = servers_map.get(&name) {
+                    Some(
+                        timeout(
+                            Duration::from_secs(TOOL_VERIFY_TIMEOUT_SECS),
+                            service.list_all_tools(),
+                        )
+                        .await,
+                    )
+                } else {
+                    log::info!(
+                        "MCP server {name} was removed during tools/list verification; skipping"
+                    );
+                    None
+                }
+            };
+
+            match verify_result {
+                None => {
+                    // Server was removed from state (e.g., user toggled it off).
+                    // Skip emitting the event entirely — this is intentional.
+                    return Ok(());
+                }
+                Some(Ok(Ok(_tools))) => {
+                    log::info!(
+                        "MCP server {name} tools/list verified on attempt {attempt}"
+                    );
+                    break;
+                }
+                Some(Ok(Err(e))) => {
+                    log::warn!(
+                        "MCP server {name} tools/list failed on attempt {attempt}/{MAX_TOOL_VERIFY_ATTEMPTS}: {e}"
+                    );
+                    if attempt < MAX_TOOL_VERIFY_ATTEMPTS {
+                        sleep(Duration::from_millis(TOOL_VERIFY_BACKOFF_MS)).await;
+                    }
+                }
+                Some(Err(_)) => {
+                    log::warn!(
+                        "MCP server {name} tools/list timed out on attempt {attempt}/{MAX_TOOL_VERIFY_ATTEMPTS}"
+                    );
+                    if attempt < MAX_TOOL_VERIFY_ATTEMPTS {
+                        sleep(Duration::from_millis(TOOL_VERIFY_BACKOFF_MS)).await;
+                    }
+                }
+            }
+        }
+        // If all attempts failed, we still proceed to emit the event.
+        // The health monitor will handle ongoing reconnection.
+
         // Create lock file for Jan Browser MCP
         if name == "Jan Browser MCP" {
             if let Some(port_str) = config_params.envs.get("BRIDGE_PORT") {

--- a/src-tauri/src/core/mcp/helpers.rs
+++ b/src-tauri/src/core/mcp/helpers.rs
@@ -688,7 +688,7 @@ async fn schedule_mcp_start_task<R: Runtime>(
         // Stdio servers (especially via npx mcp-remote) may need extra time
         // after serve() completes before the transport is ready for JSON-RPC.
         const MAX_TOOL_VERIFY_ATTEMPTS: u32 = 3;
-        const TOOL_VERIFY_TIMEOUT_SECS: u64 = 5;
+        const TOOL_VERIFY_TIMEOUT_SECS: u64 = 2;
         const TOOL_VERIFY_BACKOFF_MS: u64 = 1000;
 
         for attempt in 1..=MAX_TOOL_VERIFY_ATTEMPTS {


### PR DESCRIPTION
## Describe Your Changes

### Problem

Stdio MCP servers (e.g., `npx mcp-remote`) fail to expose tools on first connection. Jan sends `tools/list` immediately after spawning the stdio process, before the MCP initialization handshake has fully settled on the transport. The response is "Transport closed" because the stdio pipe isn't ready for JSON-RPC yet.

The existing 500ms stability delay (which catches servers that quit immediately) is not sufficient for stdio servers that need to establish an HTTP bridge to a remote endpoint. All `tools/list` attempts happen within the same 1-second window and fail for the same reason. The server is then removed from state by `get_tools`, making tools permanently unavailable until manual restart.

HTTP/SSE transports don't hit this because their `serve()` handshake completes synchronously over the network connection.

**Log evidence:**
```
[23:53:29] Server Oracle started successfully            <- stdio process alive
[23:53:29] WARN failed to list tools: Transport closed   <- tools/list too early
[23:53:29] WARN failed to list tools: Transport closed   <- retries all fail
[23:53:29] MCP server Oracle initialized successfully    <- init completes AFTER tools/list
```

### Why this matters

This is a blocker for users who rely on `mcp-remote` to connect to OAuth-protected MCP servers (e.g., enterprise APIs behind SSO). Until Jan supports MCP authorization natively (#6353), `mcp-remote` via stdio is the only path — and this race condition makes it non-functional.

### Fix

After the existing 500ms stability check and before emitting `mcp-update`, verify that `tools/list` actually succeeds for stdio servers. Retry up to 3 times with 1-second backoff and a 2-second timeout per attempt (matching the health monitor's existing timeout).

- If verification succeeds -> emit `mcp-update` as normal
- If the server is removed during verification (user toggled it off) -> return early, skip event
- If all attempts fail -> still emit the event so the health monitor (#7791) can take over

**Files changed:**
- `src-tauri/src/core/mcp/helpers.rs` — added tools/list verification loop in the stdio startup path of `schedule_mcp_start_task()`

## Fixes Issues

- Closes #7891
- Closes #6775

### Related

- #6353 — native MCP authorization support (open feature request). Until that lands, `mcp-remote` via stdio is the workaround, and this fix unblocks it.
- #7791 — added health monitor + auto-reconnect for stdio servers, but didn't address the initial startup race

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
