### PR TITLE
fix: don't select CUDA backend if GPU has insufficient memory

### DIFF
--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/backend.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/backend.rs
@@ -525,9 +525,6 @@ pub async fn prioritize_backends(
         ]
     } else {
         vec![
-            "cuda-cu13.0",
-            "cuda-cu12.0",
-            "cuda-cu11.7",
             "common_cpus",
             "avx512",
             "avx2",


### PR DESCRIPTION
## Describe Your Changes

When there is not enough GPU memory, the selection for that code branch list still includes CUDA backends. This PR removes GPU powered backends from the list.

## Fixes Issues

- Closes https://github.com/janhq/jan/issues/7881

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
