### PR TITLE
fix: avoid CoT wrapper when group has no reasoning parts

### DIFF
--- a/web-app/src/containers/MessageItem.tsx
+++ b/web-app/src/containers/MessageItem.tsx
@@ -328,6 +328,17 @@ export const MessageItem = memo(
       groupKey: string,
       hasFollowingContent: boolean
     ) => {
+      const hasReasoning = entries.some(
+        (e) => e.part.type === CONTENT_TYPE.REASONING
+      )
+
+      // No reasoning in this group — render tool parts directly, no CoT wrapper
+      if (!hasReasoning) {
+        return entries.map(({ part, index: partIndex }) =>
+          renderToolInline(part, partIndex)
+        )
+      }
+
       const lastEntryIndex = entries[entries.length - 1].index
       const groupIsStreaming =
         isStreaming && lastEntryIndex === message.parts.length - 1


### PR DESCRIPTION
## Describe Your Changes

From #7897

Detect if a message group contains any REASONING parts and, if none are present, render tool parts directly (via renderToolInline) instead of wrapping them in a chain-of-thought container. Prevents incorrect CoT markup/behavior for groups composed solely of tool output.


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
