### PR TITLE
fix: add Flatpak CUDA library path discovery and GL extension support for NVIDIA GPU access

### DIFF
--- a/flatpak/ai.jan.Jan.yml
+++ b/flatpak/ai.jan.Jan.yml
@@ -6,10 +6,19 @@ command: Jan
 finish-args:
   - --socket=wayland # Permission needed to show the window
   - --socket=fallback-x11 # Permission needed to show the window on X11
-  - --device=dri
+  - --device=all # Full GPU access including NVIDIA CUDA compute
   - --share=ipc
   - --share=network
   - --socket=pulseaudio # for future multimodality
+  - --env=LD_LIBRARY_PATH=/app/lib:/usr/lib/extensions/vulkan/nvidia/lib:/usr/lib/extensions/cuda/lib
+
+add-extensions:
+  org.freedesktop.Platform.GL:
+    directory: lib/GL
+    merge-dirs: vulkan/icd.d;glvnd/egl_vendor.d;OpenCL/vendors;lib
+    subdirectories: true
+    no-autodownload: true
+    autodelete: false
 
 cleanup:
   - /include
@@ -97,3 +106,4 @@ modules:
       - install -Dm644 usr/share/icons/hicolor/32x32/apps/Jan.png /app/share/icons/hicolor/32x32/apps/ai.jan.Jan.png
       - install -Dm644 usr/share/icons/hicolor/256x256@2/apps/Jan.png /app/share/icons/hicolor/256x256@2/apps/ai.jan.Jan.png
       - install -Dm644 ai.jan.Jan.metainfo.xml /app/share/metainfo/ai.jan.Jan.metainfo.xml
+      - mkdir -p /app/lib/GL

--- a/src-tauri/utils/src/system.rs
+++ b/src-tauri/utils/src/system.rs
@@ -1,5 +1,10 @@
 use std::path::Path;
 
+/// Returns true when the current process is running inside a Flatpak sandbox
+pub fn is_flatpak() -> bool {
+    Path::new("/.flatpak-info").exists()
+}
+
 /// Checks if npx can be overridden with bun binary
 pub fn can_override_npx(bun_path: String) -> bool {
     // We need to check the CPU for the AVX2 instruction support if we are running under MacOS
@@ -268,6 +273,11 @@ pub fn add_cuda_paths_linux(command: &mut tokio::process::Command) -> bool {
         }
     }
 
+    // Inside Flatpak, NVIDIA drivers are mounted via GL extensions at different paths
+    if is_flatpak() {
+        collect_flatpak_gl_paths(&mut cuda_lib_paths);
+    }
+
     // Version-specific installs like /usr/local/cuda-12.2
     if let Ok(entries) = std::fs::read_dir("/usr/local") {
         for entry in entries.flatten() {
@@ -337,6 +347,47 @@ pub fn add_cuda_paths_linux(command: &mut tokio::process::Command) -> bool {
     }
 
     modified
+}
+
+/// Collects NVIDIA library paths from Flatpak GL extension mount points
+#[cfg(target_os = "linux")]
+fn collect_flatpak_gl_paths(cuda_lib_paths: &mut std::collections::HashSet<String>) {
+    let flatpak_gl_paths = [
+        "/usr/lib/extensions/vulkan/nvidia/lib",
+        "/usr/lib/extensions/cuda/lib",
+        "/usr/lib/GL/lib",
+        "/usr/lib/GL",
+        "/app/lib/GL",
+    ];
+
+    for path in &flatpak_gl_paths {
+        if Path::new(path).exists() {
+            cuda_lib_paths.insert(path.to_string());
+        }
+    }
+
+    // Flatpak GL extensions can have versioned subdirectories
+    for base_dir in ["/usr/lib/extensions", "/usr/lib/GL/lib"] {
+        if let Ok(entries) = std::fs::read_dir(base_dir) {
+            for entry in entries.flatten() {
+                let entry_path = entry.path();
+                if !entry_path.is_dir() {
+                    continue;
+                }
+
+                // Prefer the lib subdirectory, fall back to the directory itself
+                let lib_sub = entry_path.join("lib");
+                if lib_sub.exists() {
+                    cuda_lib_paths.insert(lib_sub.to_string_lossy().to_string());
+                } else {
+                    cuda_lib_paths.insert(entry_path.to_string_lossy().to_string());
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "logging")]
+    log::info!("Searched Flatpak GL extension paths for NVIDIA libraries");
 }
 
 /// Setup Windows-specific process creation flags


### PR DESCRIPTION
## Describe Your Changes

The Flatpak version fails to load llama-server with CUDA because the sandbox hides host NVIDIA libraries from standard paths. This fix adds two things:

**Flatpak manifest (`flatpak/ai.jan.Jan.yml`):**
- `--device=all` instead of `--device=dri` for full GPU compute access
- `org.freedesktop.Platform.GL` extension declaration so Flatpak can mount host NVIDIA drivers into the sandbox
- `LD_LIBRARY_PATH` seeded with Flatpak GL extension mount points
- `/app/lib/GL` directory created as the extension mount point

**Rust CUDA path discovery (`src-tauri/utils/src/system.rs`):**
- `is_flatpak()` detection via `/.flatpak-info` sentinel file
- `collect_flatpak_gl_paths()` scans Flatpak-specific GL extension directories where NVIDIA libraries are mounted
- Called from existing `add_cuda_paths_linux()` only when running inside a Flatpak sandbox
- No behavior change on non-Flatpak systems

## Fixes Issues

- Closes #7825

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed