### PR TITLE
fix: hide llama.cpp backend update prompt when provider is disabled

### DIFF
--- a/web-app/src/containers/dialogs/BackendUpdater.tsx
+++ b/web-app/src/containers/dialogs/BackendUpdater.tsx
@@ -1,4 +1,5 @@
 import { useBackendUpdater } from '@/hooks/useBackendUpdater'
+import { useModelProvider } from '@/hooks/useModelProvider'
 
 import { IconDownload } from '@tabler/icons-react'
 import { Button } from '@/components/ui/button'
@@ -10,6 +11,9 @@ import { toast } from 'sonner'
 
 const BackendUpdater = () => {
   const { t } = useTranslation()
+  const isLlamacppEnabled = useModelProvider(
+    (s) => s.getProviderByName('llamacpp')?.active === true
+  )
   const { updateState, updateBackend, checkForUpdate, setRemindMeLater } =
     useBackendUpdater()
 
@@ -24,10 +28,10 @@ const BackendUpdater = () => {
     }
   }
 
-  // Check for updates when component mounts
+  // Check when the shell mounts or when the llamacpp provider is toggled on/off
   useEffect(() => {
     checkForUpdate()
-  }, [checkForUpdate])
+  }, [checkForUpdate, isLlamacppEnabled])
 
   const [backendUpdateState, setBackendUpdateState] = useState({
     remindMeLater: false,
@@ -40,6 +44,11 @@ const BackendUpdater = () => {
       isUpdateAvailable: updateState.isUpdateAvailable,
     })
   }, [updateState])
+
+  // Don't prompt for the Llama.cpp engine when the provider is disabled (jan#7901)
+  if (!isLlamacppEnabled) {
+    return null
+  }
 
   // Don't show if user clicked remind me later
   if (backendUpdateState.remindMeLater) {

--- a/web-app/src/hooks/useBackendUpdater.ts
+++ b/web-app/src/hooks/useBackendUpdater.ts
@@ -1,6 +1,13 @@
 import { useState, useCallback, useEffect } from 'react'
 import { events } from '@janhq/core'
 import { ExtensionManager } from '@/lib/extension'
+import { useModelProvider } from '@/hooks/useModelProvider'
+
+/** Llama.cpp engine updates only apply when the llamacpp model provider is enabled. */
+function isLlamacppProviderActive(): boolean {
+  const p = useModelProvider.getState().getProviderByName('llamacpp')
+  return p?.active === true
+}
 
 export interface BackendUpdateInfo {
   updateNeeded: boolean
@@ -158,6 +165,19 @@ export const useBackendUpdater = () => {
           syncStateToOtherInstances(newState)
         }
 
+        if (!isLlamacppProviderActive()) {
+          const newState = {
+            isUpdateAvailable: false,
+            updateInfo: null,
+          }
+          setUpdateState((prev) => ({
+            ...prev,
+            ...newState,
+          }))
+          syncStateToOtherInstances(newState)
+          return null
+        }
+
         // Get llamacpp extension instance
         const allExtensions = ExtensionManager.getInstance().listExtensions()
 
@@ -254,6 +274,20 @@ export const useBackendUpdater = () => {
 
   const updateBackend = useCallback(async () => {
     if (!updateState.updateInfo) return
+
+    if (!isLlamacppProviderActive()) {
+      const newState = {
+        isUpdateAvailable: false,
+        updateInfo: null,
+        isUpdating: false,
+      }
+      setUpdateState((prev) => ({
+        ...prev,
+        ...newState,
+      }))
+      syncStateToOtherInstances(newState)
+      return
+    }
 
     try {
       // If an update is already in progress, avoid triggering a duplicate update.


### PR DESCRIPTION
## Describe Your Changes

- Gate Llama.cpp engine update checks and the global backend-update banner on the **llamacpp** model provider `active` flag: when Llama.cpp is disabled under Settings → Model providers, skip `checkBackendForUpdates`, clear pending update state, and avoid running `updateBackend`. Re-run the check when the provider is toggled so disabling clears the prompt and enabling can detect updates again.

## Fixes Issues

- Closes: https://github.com/janhq/jan/issues/7901

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
