### PR TITLE
fix: remove toaster position offset

### DIFF
--- a/web-app/src/components/ui/dialog.tsx
+++ b/web-app/src/components/ui/dialog.tsx
@@ -60,7 +60,7 @@ function DialogContent({
         data-slot="dialog-content"
         aria-describedby={undefined}
         className={cn(
-          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg lg:max-w-2xl xl:max-w-3xl max-h-[85vh] overflow-y-auto",
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg lg:max-w-xl xl:max-w-2xl max-h-[85vh] overflow-y-auto",
           className
         )}
         {...props}

--- a/web-app/src/providers/ToasterProvider.tsx
+++ b/web-app/src/providers/ToasterProvider.tsx
@@ -1,6 +1,5 @@
 import { Toaster } from '@/components/ui/sonner'
 import { useInterfaceSettings } from '@/hooks/useInterfaceSettings'
-import { getToastOffset } from '@/utils/toastPlacement'
 
 export function ToasterProvider() {
   const notificationPosition = useInterfaceSettings(
@@ -11,7 +10,6 @@ export function ToasterProvider() {
     <Toaster
       richColors
       position={notificationPosition}
-      offset={getToastOffset(notificationPosition)}
       visibleToasts={5}
       toastOptions={{
         style: {


### PR DESCRIPTION
## Describe Your Changes

The position alignment is off because of the offset. Someone added the offset due to concerns about the drag-and-drop header or overlapping UI. Since the toaster only shows for a couple of seconds, it should be fine

<img width="1335" height="944" alt="Screenshot 2026-04-07 at 15 11 42" src="https://github.com/user-attachments/assets/325c3cba-1d39-48b5-85e6-e82b8f1e70d9" />

## Fixes Issues

<img width="1335" height="944" alt="Screenshot 2026-04-07 at 15 12 48" src="https://github.com/user-attachments/assets/15e03b37-c664-4523-a7f8-f130ada0d90d" />


- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
