### PR TITLE
fix: improve llama.cpp context meter for tool-heavy chats

### DIFF
--- a/web-app/src/components/TokenCounter.tsx
+++ b/web-app/src/components/TokenCounter.tsx
@@ -14,6 +14,7 @@ interface TokenCounterProps {
   className?: string
   compact?: boolean
   additionalTokens?: number // For vision tokens or other additions
+  additionalContextText?: string
   uploadedFiles?: Array<{
     name: string
     type: string
@@ -27,11 +28,13 @@ export const TokenCounter = memo(function TokenCounter({
   messages = [],
   className,
   additionalTokens = 0,
+  additionalContextText,
   uploadedFiles = [],
 }: TokenCounterProps) {
   const { calculateTokens, ...tokenData } = useTokensCount(
     messages,
-    uploadedFiles
+    uploadedFiles,
+    additionalContextText
   )
 
   const [isAnimating, setIsAnimating] = useState(false)

--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -215,20 +215,9 @@ const ChatInput = memo(function ChatInput({
 
   const assistantCount = assistants?.length || 0
 
+  // Tool schemas sent to the model are not part of ThreadMessage[]; add them here only.
+  // Do not include system instructions — they are already present in messages and counted by useTokensCount.
   const tokenCounterAdditionalContext = useMemo(() => {
-    const activeAssistant =
-      currentThread?.assistants?.[0] ??
-      (currentAssistant
-        ? {
-            instructions: currentAssistant.instructions,
-          }
-        : undefined)
-
-    const systemInstructions =
-      typeof activeAssistant?.instructions === 'string'
-        ? activeAssistant.instructions.trim()
-        : ''
-
     const toolsText = tools
       .map((tool) => {
         const schema = (() => {
@@ -242,15 +231,9 @@ const ChatInput = memo(function ChatInput({
       })
       .join('\n\n')
 
-    const chunks = []
-    if (systemInstructions) {
-      chunks.push(`System instructions:\n${systemInstructions}`)
-    }
-    if (toolsText) {
-      chunks.push(`Available tools:\n${toolsText}`)
-    }
-    return chunks.join('\n\n')
-  }, [tools, currentThread, currentAssistant])
+    if (!toolsText) return ''
+    return `Available tools:\n${toolsText}`
+  }, [tools])
 
   // No auto-selection: let the user explicitly pick an assistant
 

--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -215,6 +215,43 @@ const ChatInput = memo(function ChatInput({
 
   const assistantCount = assistants?.length || 0
 
+  const tokenCounterAdditionalContext = useMemo(() => {
+    const activeAssistant =
+      currentThread?.assistants?.[0] ??
+      (currentAssistant
+        ? {
+            instructions: currentAssistant.instructions,
+          }
+        : undefined)
+
+    const systemInstructions =
+      typeof activeAssistant?.instructions === 'string'
+        ? activeAssistant.instructions.trim()
+        : ''
+
+    const toolsText = tools
+      .map((tool) => {
+        const schema = (() => {
+          try {
+            return JSON.stringify(tool.inputSchema ?? {})
+          } catch {
+            return '{}'
+          }
+        })()
+        return `Tool ${tool.server}::${tool.name}\nDescription: ${tool.description}\nSchema: ${schema}`
+      })
+      .join('\n\n')
+
+    const chunks = []
+    if (systemInstructions) {
+      chunks.push(`System instructions:\n${systemInstructions}`)
+    }
+    if (toolsText) {
+      chunks.push(`Available tools:\n${toolsText}`)
+    }
+    return chunks.join('\n\n')
+  }, [tools, currentThread, currentAssistant])
+
   // No auto-selection: let the user explicitly pick an assistant
 
   // Jan Browser Extension hook
@@ -2124,6 +2161,7 @@ const ChatInput = memo(function ChatInput({
                     <TokenCounter
                       messages={threadMessages || []}
                       compact={true}
+                      additionalContextText={tokenCounterAdditionalContext}
                       uploadedFiles={attachments
                         .filter((a) => a.type === 'image' && a.dataUrl)
                         .map((a) => ({
@@ -2205,6 +2243,7 @@ const ChatInput = memo(function ChatInput({
           <div className="flex-1 w-full flex justify-start px-2">
             <TokenCounter
               messages={threadMessages || []}
+              additionalContextText={tokenCounterAdditionalContext}
               uploadedFiles={attachments
                 .filter((a) => a.type === 'image' && a.dataUrl)
                 .map((a) => ({

--- a/web-app/src/hooks/useTokensCount.ts
+++ b/web-app/src/hooks/useTokensCount.ts
@@ -48,7 +48,8 @@ export const useTokensCount = (
     size: number
     base64: string
     dataUrl: string
-  }>
+  }>,
+  additionalContextText?: string
 ) => {
   const [tokenData, setTokenData] = useState<TokenCountData>({
     tokenCount: 0,
@@ -101,6 +102,22 @@ export const useTokensCount = (
         } as ThreadMessage)
       }
     }
+
+    if (additionalContextText?.trim()) {
+      result.push({
+        id: 'temp-runtime-context',
+        thread_id: '',
+        role: 'system',
+        content: [
+          {
+            type: ContentType.Text,
+            text: { value: additionalContextText.trim() },
+          },
+        ],
+        created_at: Date.now(),
+      } as ThreadMessage)
+    }
+
     return result.map((e) => {
       // Pull inline file contents stored on the message metadata
       const inlineFileContents = getInlineFileContents(e.metadata)
@@ -129,7 +146,7 @@ export const useTokensCount = (
         })),
       }
     })
-  }, [messages, prompt, uploadedFiles])
+  }, [messages, prompt, uploadedFiles, additionalContextText])
 
   // Debounced calculation that includes current prompt
   const runTokenCalculation = useCallback(async () => {

--- a/web-app/src/services/models/__tests__/tokenCountToolContext.test.ts
+++ b/web-app/src/services/models/__tests__/tokenCountToolContext.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+import { ContentType } from '@janhq/core'
+import {
+  stringifyToolOutputForTokenCount,
+  MAX_STRINGIFY_DEPTH_FOR_COUNT,
+  MAX_TOOL_OUTPUT_CHARS_FOR_COUNT,
+  extractToolContextFromMetadata,
+  extractToolContextFromContent,
+} from '../tokenCountToolContext'
+import type { ThreadMessage } from '@janhq/core'
+
+describe('stringifyToolOutputForTokenCount', () => {
+  it('returns empty string for null and undefined', () => {
+    expect(stringifyToolOutputForTokenCount(null)).toBe('')
+    expect(stringifyToolOutputForTokenCount(undefined)).toBe('')
+  })
+
+  it('stringifies primitives', () => {
+    expect(stringifyToolOutputForTokenCount('hello')).toBe('hello')
+    expect(stringifyToolOutputForTokenCount(42)).toBe('42')
+    expect(stringifyToolOutputForTokenCount(true)).toBe('true')
+  })
+
+  it('joins array elements with newlines', () => {
+    expect(stringifyToolOutputForTokenCount([1, 'a', false])).toBe('1\na\nfalse')
+  })
+
+  it('extracts text from objects with a content array', () => {
+    const v = {
+      content: [
+        { type: 'text', text: 'line1' },
+        { type: 'text', text: { nested: 'skip' } },
+      ],
+    }
+    const out = stringifyToolOutputForTokenCount(v)
+    expect(out).toContain('line1')
+  })
+
+  it('falls back to JSON for plain objects', () => {
+    expect(stringifyToolOutputForTokenCount({ a: 1 })).toBe('{"a":1}')
+  })
+
+  it('stops recursing past max depth', () => {
+    let nested: unknown = 'leaf'
+    for (let i = 0; i < MAX_STRINGIFY_DEPTH_FOR_COUNT + 3; i++) {
+      nested = [nested]
+    }
+    const out = stringifyToolOutputForTokenCount(nested)
+    expect(out.length).toBe(0)
+  })
+
+  it('truncates very long strings', () => {
+    const long = 'x'.repeat(MAX_TOOL_OUTPUT_CHARS_FOR_COUNT + 100)
+    const out = stringifyToolOutputForTokenCount(long)
+    expect(out.length).toBe(MAX_TOOL_OUTPUT_CHARS_FOR_COUNT + 1)
+    expect(out.endsWith('…')).toBe(true)
+  })
+})
+
+describe('extractToolContextFromMetadata', () => {
+  it('formats tool_calls output', () => {
+    const message = {
+      metadata: {
+        tool_calls: [
+          {
+            name: 'search',
+            response: { ok: true },
+          },
+        ],
+      },
+    } as unknown as ThreadMessage
+    const out = extractToolContextFromMetadata(message)
+    expect(out).toContain('Tool search output')
+    expect(out).toContain('"ok":true')
+  })
+})
+
+describe('extractToolContextFromContent', () => {
+  it('formats tool_call blocks', () => {
+    const message = {
+      content: [
+        {
+          type: ContentType.ToolCall,
+          tool_name: 'exa',
+          input: { q: 'test' },
+          output: 'results',
+        },
+      ],
+    } as unknown as ThreadMessage
+    const out = extractToolContextFromContent(message)
+    expect(out).toContain('Tool exa call')
+    expect(out).toContain('Input:')
+    expect(out).toContain('Output:')
+  })
+})

--- a/web-app/src/services/models/default.ts
+++ b/web-app/src/services/models/default.ts
@@ -614,6 +614,112 @@ export class DefaultModelsService implements ModelsService {
       }
 
       if (engine && typeof engine.getTokensCount === 'function') {
+        const stringifyToolOutput = (value: unknown): string => {
+          if (value == null) return ''
+          if (typeof value === 'string') return value
+          if (typeof value === 'number' || typeof value === 'boolean') {
+            return String(value)
+          }
+          if (Array.isArray(value)) {
+            return value
+              .map((item) => stringifyToolOutput(item))
+              .filter((item) => item.length > 0)
+              .join('\n')
+          }
+          if (typeof value === 'object') {
+            const record = value as Record<string, unknown>
+            if (Array.isArray(record.content)) {
+              const contentText = record.content
+                .map((item) => {
+                  if (!item || typeof item !== 'object') return ''
+                  const contentItem = item as {
+                    type?: string
+                    text?: unknown
+                    content?: unknown
+                  }
+                  if (typeof contentItem.text === 'string') return contentItem.text
+                  if (contentItem.text != null) {
+                    return stringifyToolOutput(contentItem.text)
+                  }
+                  if (contentItem.content != null) {
+                    return stringifyToolOutput(contentItem.content)
+                  }
+                  return ''
+                })
+                .filter((item) => item.length > 0)
+                .join('\n')
+              if (contentText.length > 0) return contentText
+            }
+            try {
+              return JSON.stringify(record)
+            } catch {
+              return ''
+            }
+          }
+          return ''
+        }
+
+        const extractToolContextText = (message: ThreadMessage): string => {
+          const metadata = message.metadata as
+            | {
+                tool_calls?: Array<{
+                  tool?: { function?: { name?: string } }
+                  name?: string
+                  response?: unknown
+                  output?: unknown
+                }>
+              }
+            | undefined
+
+          if (!Array.isArray(metadata?.tool_calls)) return ''
+
+          return metadata.tool_calls
+            .map((toolCall) => {
+              const toolName = toolCall.tool?.function?.name || toolCall.name || 'tool'
+              const payload =
+                toolCall.response != null ? toolCall.response : toolCall.output
+              const outputText = stringifyToolOutput(payload).trim()
+              if (!outputText) return ''
+              return `Tool ${toolName} output:\n${outputText}`
+            })
+            .filter((entry) => entry.length > 0)
+            .join('\n\n')
+        }
+
+        const extractToolContextFromContent = (message: ThreadMessage): string => {
+          if (!Array.isArray(message.content)) return ''
+
+          return message.content
+            .map((contentItem) => {
+              const contentType = String(contentItem.type)
+              if (
+                contentType !== String(ContentType.ToolCall) &&
+                contentType !== 'tool_call'
+              ) {
+                return ''
+              }
+
+              const toolItem = contentItem as unknown as {
+                tool_name?: string
+                input?: unknown
+                output?: unknown
+              }
+
+              const toolName = toolItem.tool_name || 'tool'
+              const inputText = stringifyToolOutput(toolItem.input).trim()
+              const outputText = stringifyToolOutput(toolItem.output).trim()
+
+              const parts = []
+              if (inputText) parts.push(`Input:\n${inputText}`)
+              if (outputText) parts.push(`Output:\n${outputText}`)
+              if (parts.length === 0) return ''
+
+              return `Tool ${toolName} call:\n${parts.join('\n\n')}`
+            })
+            .filter((entry) => entry.length > 0)
+            .join('\n\n')
+        }
+
         // Transform Jan's ThreadMessage format to OpenAI chat completion format
         const transformedMessages = messages
           .map((message) => {
@@ -669,6 +775,26 @@ export class DefaultModelsService implements ModelsService {
                   .map((content) => content.text?.value || '')
 
                 content = textContents.join(' ')
+              }
+            }
+
+            const toolContextFromContent = extractToolContextFromContent(message)
+            const toolContextFromMetadata =
+              toolContextFromContent.length > 0 ? '' : extractToolContextText(message)
+            const toolContext = [toolContextFromContent, toolContextFromMetadata]
+              .filter((entry) => entry.length > 0)
+              .join('\n\n')
+            if (toolContext.length > 0) {
+              if (typeof content === 'string') {
+                content = content ? `${content}\n\n${toolContext}` : toolContext
+              } else if (Array.isArray(content)) {
+                content = [
+                  ...content,
+                  {
+                    type: 'text',
+                    text: toolContext,
+                  },
+                ]
               }
             }
 

--- a/web-app/src/services/models/default.ts
+++ b/web-app/src/services/models/default.ts
@@ -23,6 +23,10 @@ import type {
   CatalogModel,
   ModelValidationResult,
 } from './types'
+import {
+  extractToolContextFromContent,
+  extractToolContextFromMetadata,
+} from './tokenCountToolContext'
 
 // TODO: Replace this with the actual provider later
 const defaultProvider = 'llamacpp'
@@ -614,112 +618,6 @@ export class DefaultModelsService implements ModelsService {
       }
 
       if (engine && typeof engine.getTokensCount === 'function') {
-        const stringifyToolOutput = (value: unknown): string => {
-          if (value == null) return ''
-          if (typeof value === 'string') return value
-          if (typeof value === 'number' || typeof value === 'boolean') {
-            return String(value)
-          }
-          if (Array.isArray(value)) {
-            return value
-              .map((item) => stringifyToolOutput(item))
-              .filter((item) => item.length > 0)
-              .join('\n')
-          }
-          if (typeof value === 'object') {
-            const record = value as Record<string, unknown>
-            if (Array.isArray(record.content)) {
-              const contentText = record.content
-                .map((item) => {
-                  if (!item || typeof item !== 'object') return ''
-                  const contentItem = item as {
-                    type?: string
-                    text?: unknown
-                    content?: unknown
-                  }
-                  if (typeof contentItem.text === 'string') return contentItem.text
-                  if (contentItem.text != null) {
-                    return stringifyToolOutput(contentItem.text)
-                  }
-                  if (contentItem.content != null) {
-                    return stringifyToolOutput(contentItem.content)
-                  }
-                  return ''
-                })
-                .filter((item) => item.length > 0)
-                .join('\n')
-              if (contentText.length > 0) return contentText
-            }
-            try {
-              return JSON.stringify(record)
-            } catch {
-              return ''
-            }
-          }
-          return ''
-        }
-
-        const extractToolContextText = (message: ThreadMessage): string => {
-          const metadata = message.metadata as
-            | {
-                tool_calls?: Array<{
-                  tool?: { function?: { name?: string } }
-                  name?: string
-                  response?: unknown
-                  output?: unknown
-                }>
-              }
-            | undefined
-
-          if (!Array.isArray(metadata?.tool_calls)) return ''
-
-          return metadata.tool_calls
-            .map((toolCall) => {
-              const toolName = toolCall.tool?.function?.name || toolCall.name || 'tool'
-              const payload =
-                toolCall.response != null ? toolCall.response : toolCall.output
-              const outputText = stringifyToolOutput(payload).trim()
-              if (!outputText) return ''
-              return `Tool ${toolName} output:\n${outputText}`
-            })
-            .filter((entry) => entry.length > 0)
-            .join('\n\n')
-        }
-
-        const extractToolContextFromContent = (message: ThreadMessage): string => {
-          if (!Array.isArray(message.content)) return ''
-
-          return message.content
-            .map((contentItem) => {
-              const contentType = String(contentItem.type)
-              if (
-                contentType !== String(ContentType.ToolCall) &&
-                contentType !== 'tool_call'
-              ) {
-                return ''
-              }
-
-              const toolItem = contentItem as unknown as {
-                tool_name?: string
-                input?: unknown
-                output?: unknown
-              }
-
-              const toolName = toolItem.tool_name || 'tool'
-              const inputText = stringifyToolOutput(toolItem.input).trim()
-              const outputText = stringifyToolOutput(toolItem.output).trim()
-
-              const parts = []
-              if (inputText) parts.push(`Input:\n${inputText}`)
-              if (outputText) parts.push(`Output:\n${outputText}`)
-              if (parts.length === 0) return ''
-
-              return `Tool ${toolName} call:\n${parts.join('\n\n')}`
-            })
-            .filter((entry) => entry.length > 0)
-            .join('\n\n')
-        }
-
         // Transform Jan's ThreadMessage format to OpenAI chat completion format
         const transformedMessages = messages
           .map((message) => {
@@ -780,7 +678,9 @@ export class DefaultModelsService implements ModelsService {
 
             const toolContextFromContent = extractToolContextFromContent(message)
             const toolContextFromMetadata =
-              toolContextFromContent.length > 0 ? '' : extractToolContextText(message)
+              toolContextFromContent.length > 0
+                ? ''
+                : extractToolContextFromMetadata(message)
             const toolContext = [toolContextFromContent, toolContextFromMetadata]
               .filter((entry) => entry.length > 0)
               .join('\n\n')

--- a/web-app/src/services/models/tokenCountToolContext.ts
+++ b/web-app/src/services/models/tokenCountToolContext.ts
@@ -1,0 +1,132 @@
+/**
+ * Helpers for estimating llama.cpp token counts from tool outputs and tool_call
+ * message content. Kept separate from DefaultModelsService so tests and limits stay clear.
+ */
+
+import { ContentType, type ThreadMessage } from '@janhq/core'
+
+/** Max recursion depth when walking MCP / tool payloads (avoids stack overflow). */
+export const MAX_STRINGIFY_DEPTH_FOR_COUNT = 5
+
+/** Cap serialized tool text so token counting stays bounded on huge MCP responses. */
+export const MAX_TOOL_OUTPUT_CHARS_FOR_COUNT = 32_000
+
+function truncateForTokenCount(s: string): string {
+  if (s.length <= MAX_TOOL_OUTPUT_CHARS_FOR_COUNT) return s
+  return `${s.slice(0, MAX_TOOL_OUTPUT_CHARS_FOR_COUNT)}…`
+}
+
+/**
+ * Flattens tool/MCP payloads to plain text for token estimation.
+ * Depth-limited; results are truncated to {@link MAX_TOOL_OUTPUT_CHARS_FOR_COUNT}.
+ */
+export function stringifyToolOutputForTokenCount(
+  value: unknown,
+  depth = 0
+): string {
+  if (depth > MAX_STRINGIFY_DEPTH_FOR_COUNT) return ''
+  if (value == null) return ''
+  if (typeof value === 'string') return truncateForTokenCount(value)
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+  if (Array.isArray(value)) {
+    const inner = value
+      .map((item) => stringifyToolOutputForTokenCount(item, depth + 1))
+      .filter((item) => item.length > 0)
+      .join('\n')
+    return truncateForTokenCount(inner)
+  }
+  if (typeof value === 'object') {
+    const record = value as Record<string, unknown>
+    if (Array.isArray(record.content)) {
+      const contentText = record.content
+        .map((item) => {
+          if (!item || typeof item !== 'object') return ''
+          const contentItem = item as {
+            type?: string
+            text?: unknown
+            content?: unknown
+          }
+          if (typeof contentItem.text === 'string') {
+            return truncateForTokenCount(contentItem.text)
+          }
+          if (contentItem.text != null) {
+            return stringifyToolOutputForTokenCount(contentItem.text, depth + 1)
+          }
+          if (contentItem.content != null) {
+            return stringifyToolOutputForTokenCount(contentItem.content, depth + 1)
+          }
+          return ''
+        })
+        .filter((item) => item.length > 0)
+        .join('\n')
+      if (contentText.length > 0) return truncateForTokenCount(contentText)
+    }
+    try {
+      return truncateForTokenCount(JSON.stringify(record))
+    } catch {
+      return ''
+    }
+  }
+  return ''
+}
+
+export function extractToolContextFromMetadata(message: ThreadMessage): string {
+  const metadata = message.metadata as
+    | {
+        tool_calls?: Array<{
+          tool?: { function?: { name?: string } }
+          name?: string
+          response?: unknown
+          output?: unknown
+        }>
+      }
+    | undefined
+
+  if (!Array.isArray(metadata?.tool_calls)) return ''
+
+  return metadata.tool_calls
+    .map((toolCall) => {
+      const toolName = toolCall.tool?.function?.name || toolCall.name || 'tool'
+      const payload =
+        toolCall.response != null ? toolCall.response : toolCall.output
+      const outputText = stringifyToolOutputForTokenCount(payload).trim()
+      if (!outputText) return ''
+      return `Tool ${toolName} output:\n${outputText}`
+    })
+    .filter((entry) => entry.length > 0)
+    .join('\n\n')
+}
+
+export function extractToolContextFromContent(message: ThreadMessage): string {
+  if (!Array.isArray(message.content)) return ''
+
+  return message.content
+    .map((contentItem) => {
+      if (contentItem.type !== ContentType.ToolCall) {
+        return ''
+      }
+
+      const toolItem = contentItem as {
+        tool_name?: string
+        input?: unknown
+        output?: unknown
+      }
+
+      const toolName = toolItem.tool_name || 'tool'
+      const inputText = stringifyToolOutputForTokenCount(toolItem.input).trim()
+      const outputText = stringifyToolOutputForTokenCount(
+        toolItem.output
+      ).trim()
+
+      const parts = []
+      if (inputText) parts.push(`Input:\n${inputText}`)
+      if (outputText) parts.push(`Output:\n${outputText}`)
+      if (parts.length === 0) return ''
+
+      return `Tool ${toolName} call:\n${parts.join('\n\n')}`
+    })
+    .filter((entry) => entry.length > 0)
+    .join('\n\n')
+}


### PR DESCRIPTION
## Describe Your Changes

- Improved llama.cpp token meter accuracy by expanding `getTokensCount` inputs to better match real runtime prompt composition.
- Included tool-generated context in token counting from both:
  - legacy metadata (`metadata.tool_calls`) and
  - persisted content (`content.type === "tool_call"` with input/output payloads).
- Added robust tool payload stringification for nested/structured tool outputs so large MCP/Exa responses are counted instead of skipped.
- Included additional runtime context in the meter pipeline (assistant/system instruction context and available tool definitions) via `TokenCounter` -> `useTokensCount`.
- Kept backward compatibility and avoided double-counting by preferring content-based tool context and falling back to metadata only when needed.

## Fixes Issues

- Closes: https://github.com/janhq/jan/issues/7857

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
