### PR TITLE
fix: migrate remaining raw localStorage usages to fileStorage to prevent settings reset on restart

### DIFF
--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -51,7 +51,7 @@ import {
   SESSION_STORAGE_KEY,
   SESSION_STORAGE_PREFIX,
 } from '@/constants/chat'
-import { localStorageKey } from '@/constants/localStorage'
+import { useLastUsedModel } from '@/hooks/useLastUsedModel'
 import { defaultModel } from '@/lib/models'
 import { useAssistant } from '@/hooks/useAssistant'
 import DropdownToolsAvailable from '@/containers/DropdownToolsAvailable'
@@ -1378,14 +1378,7 @@ const ChatInput = memo(function ChatInput({
     (modelId: string) => {
       setShowVisionModelPrompt(false)
 
-      try {
-        localStorage.setItem(
-          localStorageKey.lastUsedModel,
-          JSON.stringify({ provider: 'llamacpp', model: modelId })
-        )
-      } catch {
-        // Ignore localStorage errors
-      }
+      useLastUsedModel.getState().setLastUsedModel('llamacpp', modelId)
 
       setTimeout(() => {
         const provider = getProviderByName('llamacpp')

--- a/web-app/src/containers/DropdownModelProvider.tsx
+++ b/web-app/src/containers/DropdownModelProvider.tsx
@@ -17,13 +17,13 @@ import { ModelSetting } from '@/containers/ModelSetting'
 import ProvidersAvatar from '@/containers/ProvidersAvatar'
 import { ModelSupportStatus } from '@/containers/ModelSupportStatus'
 import { Fzf } from 'fzf'
-import { localStorageKey } from '@/constants/localStorage'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { useFavoriteModel } from '@/hooks/useFavoriteModel'
 import { predefinedProviders } from '@/constants/providers'
 import { providerHasRemoteApiKeys } from '@/lib/provider-api-keys'
 import { useServiceHub } from '@/hooks/useServiceHub'
 import { getLastUsedModel } from '@/utils/getModelToStart'
+import { useLastUsedModel as lastUsedModelStore } from '@/hooks/useLastUsedModel'
 import { ChevronsUpDown } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 
@@ -40,16 +40,8 @@ interface SearchableModel {
   highlightedId?: string
 }
 
-// Helper functions for localStorage
 const setLastUsedModel = (provider: string, model: string) => {
-  try {
-    localStorage.setItem(
-      localStorageKey.lastUsedModel,
-      JSON.stringify({ provider, model })
-    )
-  } catch (error) {
-    console.debug('Failed to set last used model in localStorage:', error)
-  }
+  lastUsedModelStore.getState().setLastUsedModel(provider, model)
 }
 
 const DropdownModelProvider = memo(function DropdownModelProvider({

--- a/web-app/src/containers/SetupScreen.tsx
+++ b/web-app/src/containers/SetupScreen.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from '@tanstack/react-router'
 import { route } from '@/constants/routes'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { localStorageKey, CACHE_EXPIRY_MS } from '@/constants/localStorage'
+import { useLastUsedModel } from '@/hooks/useLastUsedModel'
 import { useDownloadStore } from '@/hooks/useDownloadStore'
 import { useServiceHub } from '@/hooks/useServiceHub'
 import { useEffect, useMemo, useCallback, useState, useRef } from 'react'
@@ -333,11 +334,8 @@ function SetupScreen() {
       const modelId = found ? found.id : catalogId
 
       toast.dismiss(`model-validation-started-${catalogId}`)
-      localStorage.setItem(localStorageKey.setupCompleted, 'true')
-      localStorage.setItem(
-        localStorageKey.lastUsedModel,
-        JSON.stringify({ provider: 'llamacpp', model: modelId })
-      )
+      useGeneralSetting.getState().setSetupCompleted(true)
+      useLastUsedModel.getState().setLastUsedModel('llamacpp', modelId)
       navigate({
         to: route.home,
         replace: true,

--- a/web-app/src/containers/ThreadList.tsx
+++ b/web-app/src/containers/ThreadList.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/components/ui/sidebar'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { memo, useMemo, useState } from 'react'
+import { useGeneralSetting } from '@/hooks/useGeneralSetting'
 import { Link } from '@tanstack/react-router'
 import { RenameThreadDialog, DeleteThreadDialog } from '@/containers/dialogs'
 import { toast } from 'sonner'
@@ -47,6 +48,7 @@ const ThreadItem = memo(
     const { t } = useTranslation()
     const [renameOpen, setRenameOpen] = useState(false)
     const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
+    const setupCompleted = useGeneralSetting((s) => s.setupCompleted)
 
     const serviceHub = useServiceHub()
     const getMessages = useMessages((state) => state.getMessages)
@@ -227,9 +229,9 @@ const ThreadItem = memo(
             <DropdownMenuSeparator />
             <DropdownMenuItem
               variant="destructive"
-              disabled={thread.title === 'What is Jan?' && !localStorage.getItem('setup-completed')}
+              disabled={thread.title === 'What is Jan?' && !setupCompleted}
               onSelect={() => {
-                if (thread.title !== 'What is Jan?' || localStorage.getItem('setup-completed')) {
+                if (thread.title !== 'What is Jan?' || setupCompleted) {
                   setDeleteConfirmOpen(true)
                 }
               }}

--- a/web-app/src/containers/dialogs/SearchDialog.tsx
+++ b/web-app/src/containers/dialogs/SearchDialog.tsx
@@ -14,12 +14,11 @@ import {
   IconFolder,
 } from '@tabler/icons-react'
 import { useThreads } from '@/hooks/useThreads'
-import { localStorageKey } from '@/constants/localStorage'
+import { useRecentSearches } from '@/hooks/useRecentSearches'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { cn } from '@/lib/utils'
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden'
 
-const MAX_RECENT_SEARCHES = 5
 
 interface SearchDialogProps {
   open: boolean
@@ -31,12 +30,12 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
   const { t } = useTranslation()
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedIndex, setSelectedIndex] = useState(0)
-  const [recentVersion, setRecentVersion] = useState(0)
   const inputRef = useRef<HTMLInputElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
 
   const threads = useThreads((state) => state.threads)
   const getFilteredThreads = useThreads((state) => state.getFilteredThreads)
+  const { threadIds: recentThreadIds, addSearch, clearSearches } = useRecentSearches()
 
   // Focus input when dialog opens
   useEffect(() => {
@@ -49,30 +48,17 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
     }
   }, [open])
 
-  // Load recent searches from localStorage
   const recentSearches = useMemo(() => {
     if (!open) return []
-
-    const stored = localStorage.getItem(localStorageKey.recentSearches)
-    if (!stored) return []
-
-    try {
-      const threadIds = JSON.parse(stored) as string[]
-      return threadIds
-        .map((id) => threads[id])
-        .filter((thread): thread is Thread => thread !== undefined)
-        .slice(0, MAX_RECENT_SEARCHES)
-    } catch {
-      return []
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, threads, recentVersion])
+    return recentThreadIds
+      .map((id) => threads[id])
+      .filter((thread): thread is Thread => thread !== undefined)
+  }, [open, threads, recentThreadIds])
 
   const handleClearRecent = (e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    localStorage.removeItem(localStorageKey.recentSearches)
-    setRecentVersion((v) => v + 1)
+    clearSearches()
   }
 
   const handleClose = () => {
@@ -81,30 +67,7 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
   }
 
   const handleSelectThread = (threadId: string) => {
-    // Save to recent searches
-    const stored = localStorage.getItem(localStorageKey.recentSearches)
-    let threadIds: string[] = []
-
-    if (stored) {
-      try {
-        threadIds = JSON.parse(stored) as string[]
-      } catch {
-        threadIds = []
-      }
-    }
-
-    // Remove if already exists and add to front
-    threadIds = threadIds.filter((id) => id !== threadId)
-    threadIds.unshift(threadId)
-
-    // Keep only MAX_RECENT_SEARCHES
-    threadIds = threadIds.slice(0, MAX_RECENT_SEARCHES)
-
-    localStorage.setItem(
-      localStorageKey.recentSearches,
-      JSON.stringify(threadIds)
-    )
-
+    addSearch(threadId)
     handleClose()
     navigate({ to: route.threadsDetail, params: { threadId } })
   }

--- a/web-app/src/hooks/useAssistant.ts
+++ b/web-app/src/hooks/useAssistant.ts
@@ -198,6 +198,21 @@ export const useAssistant = create<AssistantState>()(
         lastUsedAssistantId: state.lastUsedAssistantId,
         defaultAssistantId: state.defaultAssistantId,
       }),
+      version: 1,
+      migrate: (persistedState: unknown, version: number) => {
+        if (version < 1 && typeof persistedState === 'string') {
+          // Old format stored a plain assistant ID string.
+          // Convert it to the new { lastUsedAssistantId, defaultAssistantId } shape.
+          return {
+            lastUsedAssistantId: persistedState,
+            defaultAssistantId: '',
+          }
+        }
+        return persistedState as {
+          lastUsedAssistantId: string
+          defaultAssistantId: string
+        }
+      },
       onRehydrateStorage: () => (rehydratedState) => {
         if (!rehydratedState) return
 

--- a/web-app/src/hooks/useAssistant.ts
+++ b/web-app/src/hooks/useAssistant.ts
@@ -64,9 +64,10 @@ function resolveCurrentAssistant(
   assistants: Assistant[],
   lastUsedAssistantId: string,
   defaultAssistantId: string
-): Assistant {
+): Assistant | undefined {
   const byDefault = assistants.find((a) => a.id === defaultAssistantId)
   const byLastUsed = assistants.find((a) => a.id === lastUsedAssistantId)
+  if (!byDefault && lastUsedAssistantId === '') return undefined
   return byDefault ?? byLastUsed ?? defaultAssistant
 }
 

--- a/web-app/src/hooks/useAssistant.ts
+++ b/web-app/src/hooks/useAssistant.ts
@@ -1,12 +1,16 @@
 import { getServiceHub } from '@/hooks/useServiceHub'
 import { Assistant as CoreAssistant } from '@janhq/core'
 import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
 import { localStorageKey } from '@/constants/localStorage'
+import { fileStorage } from '@/lib/fileStorage'
 
 interface AssistantState {
   assistants: Assistant[]
   currentAssistant: Assistant | undefined
   loading: boolean
+  // Persisted fields — only these two survive across sessions
+  lastUsedAssistantId: string
   defaultAssistantId: string
   addAssistant: (assistant: Assistant) => void
   updateAssistant: (assistant: Assistant) => void
@@ -17,14 +21,6 @@ interface AssistantState {
   ) => void
   setDefaultAssistant: (id: string) => void
   setAssistants: (assistants: Assistant[] | null) => void
-}
-
-const setLastUsedAssistantId = (assistantId: string) => {
-  try {
-    localStorage.setItem(localStorageKey.lastUsedAssistant, assistantId)
-  } catch (error) {
-    console.debug('Failed to set last used assistant in localStorage:', error)
-  }
 }
 
 export const defaultAssistant: Assistant = {
@@ -62,157 +58,172 @@ You have tools to search for and access real-time, up-to-date data. Use them. Se
 Current date: {{current_date}}`,
 }
 
-const getLastUsedAssistantId = (assistants: Assistant[]): string => {
-  let lastUsedId
-  try {
-    lastUsedId = localStorage.getItem(localStorageKey.lastUsedAssistant)
-  } catch (error) {
-    console.debug('Failed to get last used assistant from localStorage:', error)
-  }
-
-  if (lastUsedId) {
-    const lastUsedAssistant = assistants.find((a) => a.id === lastUsedId)
-    if (lastUsedAssistant) {
-      return lastUsedId
-    }
-  }
-
-  if (lastUsedId === '') return ''
-
-  return defaultAssistant.id
+// Re-compute currentAssistant from a loaded assistants list given the
+// persisted preference IDs.  Exported so onRehydrateStorage can call it too.
+function resolveCurrentAssistant(
+  assistants: Assistant[],
+  lastUsedAssistantId: string,
+  defaultAssistantId: string
+): Assistant {
+  const byDefault = assistants.find((a) => a.id === defaultAssistantId)
+  const byLastUsed = assistants.find((a) => a.id === lastUsedAssistantId)
+  return byDefault ?? byLastUsed ?? defaultAssistant
 }
 
-const getDefaultAssistantId = (): string | null => {
-  let defaultAssistantId: string | null = null
+export const useAssistant = create<AssistantState>()(
+  persist(
+    (set, get) => ({
+      assistants: [defaultAssistant],
+      currentAssistant: defaultAssistant,
+      lastUsedAssistantId: defaultAssistant.id,
+      defaultAssistantId: '',
+      loading: true,
 
-  try {
-    defaultAssistantId = localStorage.getItem(localStorageKey.defaultAssistantId)
-  } catch (error) {
-    console.debug('Failed to get last used assistant from localStorage:', error)
-  }
+      addAssistant: (assistant) => {
+        set({ assistants: [...get().assistants, assistant] })
+        getServiceHub()
+          .assistants()
+          .createAssistant(assistant as unknown as CoreAssistant)
+          .catch((error) => {
+            console.error('Failed to create assistant:', error)
+          })
+      },
 
-  return defaultAssistantId
-}
+      updateAssistant: (assistant) => {
+        const state = get()
+        set({
+          assistants: state.assistants.map((a) =>
+            a.id === assistant.id ? assistant : a
+          ),
+          currentAssistant:
+            state.currentAssistant?.id === assistant.id
+              ? assistant
+              : state.currentAssistant,
+        })
+        getServiceHub()
+          .assistants()
+          .createAssistant(assistant as unknown as CoreAssistant)
+          .catch((error) => {
+            console.error('Failed to update assistant:', error)
+          })
+      },
 
-const setDefaultAssistantId = (assistantId: string) => {
-  try {
-    if (!assistantId) {
-      localStorage.removeItem(localStorageKey.defaultAssistantId)
+      deleteAssistant: (id) => {
+        const state = get()
+        getServiceHub()
+          .assistants()
+          .deleteAssistant(
+            state.assistants.find((e) => e.id === id) as unknown as CoreAssistant
+          )
+          .catch((error) => {
+            console.error('Failed to delete assistant:', error)
+          })
+
+        const wasCurrentAssistant = state.currentAssistant?.id === id
+        const wasDefaultAssistant = state.defaultAssistantId === id
+
+        const remainingAssistants = state.assistants.filter((a) => a.id !== id)
+        const fallback = remainingAssistants.find(
+          (a) => a.id === defaultAssistant.id
+        )
+
+        const update: Partial<AssistantState> = {
+          assistants: remainingAssistants,
+        }
+
+        if (wasCurrentAssistant) {
+          update.currentAssistant = fallback
+          update.lastUsedAssistantId = defaultAssistant.id
+        }
+
+        if (wasDefaultAssistant) {
+          update.defaultAssistantId = defaultAssistant.id
+        }
+
+        set(update)
+      },
+
+      setDefaultAssistant: (id) => {
+        const newAssistant = get().assistants?.find((a) => a.id === id)
+        if (newAssistant) {
+          set({
+            defaultAssistantId: id,
+            currentAssistant: newAssistant,
+            lastUsedAssistantId: id,
+          })
+        } else {
+          set({ defaultAssistantId: id })
+        }
+      },
+
+      setCurrentAssistant: (assistant, saveToStorage = true) => {
+        const { currentAssistant, defaultAssistantId } = get()
+        if (defaultAssistantId && currentAssistant?.id === defaultAssistantId) return
+        if (currentAssistant === assistant) return
+
+        const update: Partial<AssistantState> = { currentAssistant: assistant }
+        if (saveToStorage) {
+          update.lastUsedAssistantId = assistant?.id || ''
+        }
+        set(update)
+      },
+
+      setAssistants: (assistants) => {
+        if (!assistants) {
+          set({ loading: false })
+          return
+        }
+
+        // Ensure IDs are plain strings, not String objects
+        assistants.forEach((a) => (a.id = a.id?.toString()))
+
+        const { lastUsedAssistantId, defaultAssistantId } = get()
+        set({
+          assistants,
+          currentAssistant: resolveCurrentAssistant(
+            assistants,
+            lastUsedAssistantId,
+            defaultAssistantId
+          ),
+          loading: false,
+        })
+      },
+    }),
+    {
+      name: localStorageKey.lastUsedAssistant,
+      storage: createJSONStorage(() => fileStorage),
+      // Only persist the preference IDs — runtime state like the assistants
+      // list and currentAssistant are rebuilt on each session
+      partialize: (state) => ({
+        lastUsedAssistantId: state.lastUsedAssistantId,
+        defaultAssistantId: state.defaultAssistantId,
+      }),
+      onRehydrateStorage: () => (rehydratedState) => {
+        if (!rehydratedState) return
+
+        const { assistants, lastUsedAssistantId, defaultAssistantId } =
+          rehydratedState
+
+        // If setAssistants hasn't run yet (only the placeholder default in
+        // the list), there's nothing to re-select — setAssistants will pick
+        // the right assistant once it runs with the hydrated IDs already set.
+        if (
+          assistants.length === 1 &&
+          assistants[0].id === defaultAssistant.id
+        ) {
+          return
+        }
+
+        // Assistants were already loaded before hydration completed, so
+        // re-resolve currentAssistant now that we have the real preferences.
+        useAssistant.setState({
+          currentAssistant: resolveCurrentAssistant(
+            assistants,
+            lastUsedAssistantId,
+            defaultAssistantId
+          ),
+        })
+      },
     }
-    else {
-      localStorage.setItem(localStorageKey.defaultAssistantId, assistantId)
-    }
-  } catch (error) {
-    console.debug('Failed to set default assistant in localStorage:', error)
-  }
-}
-
-// Platform-aware initial state
-const getInitialAssistantState = () => {
-  return {
-    assistants: [defaultAssistant],
-    currentAssistant: defaultAssistant,
-    defaultAssistantId: '',
-    loading: true,
-  }
-}
-
-export const useAssistant = create<AssistantState>((set, get) => ({
-  ...getInitialAssistantState(),
-  addAssistant: (assistant) => {
-    set({ assistants: [...get().assistants, assistant] })
-    getServiceHub()
-      .assistants()
-      .createAssistant(assistant as unknown as CoreAssistant)
-      .catch((error) => {
-        console.error('Failed to create assistant:', error)
-      })
-  },
-  updateAssistant: (assistant) => {
-    const state = get()
-    set({
-      assistants: state.assistants.map((a) =>
-        a.id === assistant.id ? assistant : a
-      ),
-      // Update currentAssistant if it's the same assistant being updated
-      currentAssistant:
-        state.currentAssistant?.id === assistant.id
-          ? assistant
-          : state.currentAssistant,
-    })
-    // Create assistant already cover update logic
-    getServiceHub()
-      .assistants()
-      .createAssistant(assistant as unknown as CoreAssistant)
-      .catch((error) => {
-        console.error('Failed to update assistant:', error)
-      })
-  },
-  deleteAssistant: (id) => {
-    const state = get()
-    getServiceHub()
-      .assistants()
-      .deleteAssistant(
-        state.assistants.find((e) => e.id === id) as unknown as CoreAssistant
-      )
-      .catch((error) => {
-        console.error('Failed to delete assistant:', error)
-      })
-
-    // Check if we're deleting the current or default assistant
-    const wasCurrentAssistant = state.currentAssistant?.id === id
-    const wasDefaultAssistant = state.defaultAssistantId === id
-
-    set({ assistants: state.assistants.filter((a) => a.id !== id) })
-
-    // If the deleted assistant was current, fallback to default and update localStorage
-    if (wasCurrentAssistant) {
-      set({ currentAssistant: state.assistants.find(a => a.id === defaultAssistant.id) })
-      setLastUsedAssistantId(defaultAssistant.id)
-    }
-
-    // If the deleted assistant was the default, reset to the built-in default
-    if (wasDefaultAssistant) {
-      setDefaultAssistantId(defaultAssistant.id)
-    }
-  },
-  setDefaultAssistant: (id) => {
-    const newAssistant = get().assistants?.find(a => a.id === id)
-    if (newAssistant) {
-      set({ defaultAssistantId: id, currentAssistant: newAssistant })
-      setLastUsedAssistantId(id)
-    }
-    else {
-      set({ defaultAssistantId: id })
-    }
-    setDefaultAssistantId(id)
-  },
-  setCurrentAssistant: (assistant, saveToStorage = true) => {
-    const currentAssistant = get().currentAssistant
-    const defaultAssistantId = get().defaultAssistantId
-    if (defaultAssistantId && currentAssistant?.id === defaultAssistantId) return
-    if (currentAssistant !== assistant) {
-      set({ currentAssistant: assistant })
-      if (saveToStorage) {
-        setLastUsedAssistantId(assistant?.id || '')
-      }
-    }
-  },
-  setAssistants: (assistants) => {
-    if (assistants) {
-      assistants.forEach((a) => (a.id = a.id?.toString())) // new String("id") !== "id"
-      const lastUsedId = getLastUsedAssistantId(assistants)
-      const lastUsedAssist = assistants.find((a) => a.id === lastUsedId)
-      const defaultAssistantId = getDefaultAssistantId() || ''
-      const defaultAssistant = assistants.find((a) => a.id === defaultAssistantId)
-      set({
-        assistants,
-        currentAssistant: defaultAssistant || lastUsedAssist,
-        defaultAssistantId,
-        loading: false
-      })
-    } else {
-      set({ loading: false })
-    }
-  },
-}))
+  )
+)

--- a/web-app/src/hooks/useClaudeCodeModel.ts
+++ b/web-app/src/hooks/useClaudeCodeModel.ts
@@ -1,4 +1,6 @@
-import { useState, useCallback } from 'react'
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import { fileStorage } from '@/lib/fileStorage'
 
 export type ClaudeCodeModelType = 'big' | 'medium' | 'small'
 
@@ -15,7 +17,13 @@ interface ClaudeCodeModels {
   customCli: string
 }
 
-const STORAGE_KEY = 'claude-code-helper-models'
+interface ClaudeCodeState {
+  models: ClaudeCodeModels
+  setModel: (type: ClaudeCodeModelType, modelId: string | null) => void
+  setEnvVars: (envVars: EnvVar[]) => void
+  setCustomCli: (customCli: string) => void
+  clearModels: () => void
+}
 
 const defaultModels: ClaudeCodeModels = {
   big: null,
@@ -25,85 +33,32 @@ const defaultModels: ClaudeCodeModels = {
   customCli: '',
 }
 
-// Load from localStorage once
-const loadFromStorage = (): ClaudeCodeModels => {
-  if (typeof window === 'undefined') return defaultModels
+const STORAGE_KEY = 'claude-code-helper-models'
 
-  try {
-    const stored = localStorage.getItem(STORAGE_KEY)
-    if (stored) {
-      const parsed = JSON.parse(stored)
-      // Validate the structure
-      if (
-        typeof parsed === 'object' &&
-        parsed !== null &&
-        'big' in parsed &&
-        'medium' in parsed &&
-        'small' in parsed &&
-        Array.isArray(parsed.envVars) &&
-        typeof parsed.customCli === 'string'
-      ) {
-        return {
-          big: parsed.big ?? null,
-          medium: parsed.medium ?? null,
-          small: parsed.small ?? null,
-          envVars: parsed.envVars ?? [],
-          customCli: parsed.customCli ?? '',
-        }
-      }
+export const useClaudeCodeModel = create<ClaudeCodeState>()(
+  persist(
+    (set, get) => ({
+      models: defaultModels,
+
+      setModel: (type, modelId) => {
+        set({ models: { ...get().models, [type]: modelId } })
+      },
+
+      setEnvVars: (envVars) => {
+        set({ models: { ...get().models, envVars } })
+      },
+
+      setCustomCli: (customCli) => {
+        set({ models: { ...get().models, customCli } })
+      },
+
+      clearModels: () => {
+        set({ models: defaultModels })
+      },
+    }),
+    {
+      name: STORAGE_KEY,
+      storage: createJSONStorage(() => fileStorage),
     }
-  } catch {
-    console.warn('Failed to load claude-code helper models from localStorage')
-  }
-  return defaultModels
-}
-
-export function useClaudeCodeModel() {
-  const [models, setModels] = useState<ClaudeCodeModels>(loadFromStorage)
-
-  // Save to localStorage - only when models actually changes
-  const saveToStorage = useCallback((data: ClaudeCodeModels) => {
-    try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(data))
-    } catch {
-      console.warn('Failed to save claude-code helper models to localStorage')
-    }
-  }, [])
-
-  const setModel = useCallback((type: ClaudeCodeModelType, modelId: string | null) => {
-    setModels((prev) => {
-      const newModels = { ...prev, [type]: modelId }
-      saveToStorage(newModels)
-      return newModels
-    })
-  }, [saveToStorage])
-
-  const setEnvVars = useCallback((envVars: EnvVar[]) => {
-    setModels((prev) => {
-      const newModels = { ...prev, envVars }
-      saveToStorage(newModels)
-      return newModels
-    })
-  }, [saveToStorage])
-
-  const setCustomCli = useCallback((customCli: string) => {
-    setModels((prev) => {
-      const newModels = { ...prev, customCli }
-      saveToStorage(newModels)
-      return newModels
-    })
-  }, [saveToStorage])
-
-  const clearModels = useCallback(() => {
-    setModels(defaultModels)
-    saveToStorage(defaultModels)
-  }, [saveToStorage])
-
-  return {
-    models,
-    setModel,
-    setEnvVars,
-    setCustomCli,
-    clearModels,
-  }
-}
+  )
+)

--- a/web-app/src/hooks/useGeneralSetting.ts
+++ b/web-app/src/hooks/useGeneralSetting.ts
@@ -8,10 +8,12 @@ type GeneralSettingState = {
   spellCheckChatInput: boolean
   tokenCounterCompact: boolean
   huggingfaceToken?: string
+  setupCompleted: boolean
   setHuggingfaceToken: (token: string) => void
   setSpellCheckChatInput: (value: boolean) => void
   setTokenCounterCompact: (value: boolean) => void
   setCurrentLanguage: (value: Language) => void
+  setSetupCompleted: (value: boolean) => void
 }
 
 export const useGeneralSetting = create<GeneralSettingState>()(
@@ -21,9 +23,11 @@ export const useGeneralSetting = create<GeneralSettingState>()(
       spellCheckChatInput: true,
       tokenCounterCompact: true,
       huggingfaceToken: undefined,
+      setupCompleted: false,
       setSpellCheckChatInput: (value) => set({ spellCheckChatInput: value }),
       setTokenCounterCompact: (value) => set({ tokenCounterCompact: value }),
       setCurrentLanguage: (value) => set({ currentLanguage: value }),
+      setSetupCompleted: (value) => set({ setupCompleted: value }),
       setHuggingfaceToken: (token) => {
         set({ huggingfaceToken: token })
         ExtensionManager.getInstance()

--- a/web-app/src/hooks/useGeneralSetting.ts
+++ b/web-app/src/hooks/useGeneralSetting.ts
@@ -51,6 +51,18 @@ export const useGeneralSetting = create<GeneralSettingState>()(
     {
       name: localStorageKey.settingGeneral,
       storage: createJSONStorage(() => fileStorage),
+      version: 1,
+      migrate: (persistedState: unknown, version: number) => {
+        const state = persistedState as Partial<GeneralSettingState>
+        if (version < 1) {
+          // Existing users already have persisted data, so they must have
+          // completed setup. Without this migration they would rehydrate
+          // with the default (false) and lose the ability to delete the
+          // "What is Jan?" thread.
+          state.setupCompleted = true
+        }
+        return state as GeneralSettingState
+      },
     }
   )
 )

--- a/web-app/src/hooks/useLastUsedModel.ts
+++ b/web-app/src/hooks/useLastUsedModel.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import { localStorageKey } from '@/constants/localStorage'
+import { fileStorage } from '@/lib/fileStorage'
+
+interface LastUsedModelState {
+  provider: string | null
+  model: string | null
+  setLastUsedModel: (provider: string, model: string) => void
+  clear: () => void
+}
+
+// Replaces direct localStorage access for the last-used-model key across
+// DropdownModelProvider, ChatInput, SetupScreen, and getModelToStart.
+export const useLastUsedModel = create<LastUsedModelState>()(
+  persist(
+    (set) => ({
+      provider: null,
+      model: null,
+      setLastUsedModel: (provider, model) => set({ provider, model }),
+      clear: () => set({ provider: null, model: null }),
+    }),
+    {
+      name: localStorageKey.lastUsedModel,
+      storage: createJSONStorage(() => fileStorage),
+    }
+  )
+)

--- a/web-app/src/hooks/useModelProvider.ts
+++ b/web-app/src/hooks/useModelProvider.ts
@@ -63,8 +63,8 @@ export const useModelProvider = create<ModelProviderState>()(
           // One-time migration from the legacy llama.cpp provider name.
           // The flag lives in persisted state so it isn't lost when
           // migrateAllLocalStorageKeys clears the old localStorage entry.
-          const ranCortexMigration = !state.cortexMigrated
-          if (ranCortexMigration) {
+          const needsCortexMigration = !state.cortexMigrated
+          if (needsCortexMigration) {
             legacyModels = state.providers.find(
               (e) => e.provider === 'llama.cpp'
             )?.models
@@ -167,7 +167,7 @@ export const useModelProvider = create<ModelProviderState>()(
                 (e) => !updatedProviders.some((p) => p.provider === e.provider)
               ),
             ],
-            ...(ranCortexMigration ? { cortexMigrated: true } : {}),
+            ...(needsCortexMigration ? { cortexMigrated: true } : {}),
           }
         }),
       updateProvider: (providerName, data) => {

--- a/web-app/src/hooks/useModelProvider.ts
+++ b/web-app/src/hooks/useModelProvider.ts
@@ -10,6 +10,10 @@ type ModelProviderState = {
   selectedProvider: string
   selectedModel: Model | null
   deletedModels: string[]
+  // Tracks whether the one-time cortex model settings migration has run.
+  // Kept in persisted state so we don't rely on a raw localStorage flag that
+  // gets destroyed by migrateAllLocalStorageKeys on each startup.
+  cortexMigrated: boolean
   getModelBy: (modelId: string) => Model | undefined
   setProviders: (providers: ModelProvider[]) => void
   getProviderByName: (providerName: string) => ModelProvider | undefined
@@ -30,6 +34,7 @@ export const useModelProvider = create<ModelProviderState>()(
       selectedProvider: 'llamacpp',
       selectedModel: null,
       deletedModels: [],
+      cortexMigrated: false,
       getModelBy: (modelId: string) => {
         const provider = get().providers.find(
           (provider) => provider.provider === get().selectedProvider
@@ -55,14 +60,14 @@ export const useModelProvider = create<ModelProviderState>()(
             })
 
           let legacyModels: Model[] | undefined = []
-          /// Cortex Migration
-          if (
-            localStorage.getItem('cortex_model_settings_migrated') !== 'true'
-          ) {
+          // One-time migration from the legacy llama.cpp provider name.
+          // The flag lives in persisted state so it isn't lost when
+          // migrateAllLocalStorageKeys clears the old localStorage entry.
+          const ranCortexMigration = !state.cortexMigrated
+          if (ranCortexMigration) {
             legacyModels = state.providers.find(
               (e) => e.provider === 'llama.cpp'
             )?.models
-            localStorage.setItem('cortex_model_settings_migrated', 'true')
           }
           // Ensure deletedModels is always an array
           const currentDeletedModels = Array.isArray(state.deletedModels)
@@ -162,6 +167,7 @@ export const useModelProvider = create<ModelProviderState>()(
                 (e) => !updatedProviders.some((p) => p.provider === e.provider)
               ),
             ],
+            ...(ranCortexMigration ? { cortexMigrated: true } : {}),
           }
         }),
       updateProvider: (providerName, data) => {
@@ -541,7 +547,7 @@ export const useModelProvider = create<ModelProviderState>()(
         }
         return state
       },
-      version: 11,
+      version: 12,
     }
   )
 )

--- a/web-app/src/hooks/useRecentSearches.ts
+++ b/web-app/src/hooks/useRecentSearches.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import { localStorageKey } from '@/constants/localStorage'
+import { fileStorage } from '@/lib/fileStorage'
+
+const MAX_ENTRIES = 5
+
+interface RecentSearchesState {
+  threadIds: string[]
+  addSearch: (threadId: string) => void
+  clearSearches: () => void
+}
+
+export const useRecentSearches = create<RecentSearchesState>()(
+  persist(
+    (set, get) => ({
+      threadIds: [],
+
+      addSearch: (threadId) => {
+        const deduped = get().threadIds.filter((id) => id !== threadId)
+        set({ threadIds: [threadId, ...deduped].slice(0, MAX_ENTRIES) })
+      },
+
+      clearSearches: () => set({ threadIds: [] }),
+    }),
+    {
+      name: localStorageKey.recentSearches,
+      storage: createJSONStorage(() => fileStorage),
+    }
+  )
+)

--- a/web-app/src/services/projects/default.ts
+++ b/web-app/src/services/projects/default.ts
@@ -1,35 +1,36 @@
 /**
- * Default Projects Service - localStorage implementation
+ * Default Projects Service - file-backed storage implementation
  */
 
 import { ulid } from 'ulidx'
 import type { ProjectsService, ThreadFolder } from './types'
 import { localStorageKey } from '@/constants/localStorage'
+import { fileStorage } from '@/lib/fileStorage'
 
 export class DefaultProjectsService implements ProjectsService {
   private storageKey = localStorageKey.threadManagement
 
-  private loadFromStorage(): ThreadFolder[] {
+  private async loadFromStorage(): Promise<ThreadFolder[]> {
     try {
-      const stored = localStorage.getItem(this.storageKey)
+      const stored = await fileStorage.getItem(this.storageKey)
       if (!stored) return []
       const data = JSON.parse(stored)
       return data.state?.folders || []
     } catch (error) {
-      console.error('Error loading projects from localStorage:', error)
+      console.error('Error loading projects from storage:', error)
       return []
     }
   }
 
-  private saveToStorage(projects: ThreadFolder[]): void {
+  private async saveToStorage(projects: ThreadFolder[]): Promise<void> {
     try {
       const data = {
         state: { folders: projects },
         version: 0,
       }
-      localStorage.setItem(this.storageKey, JSON.stringify(data))
+      await fileStorage.setItem(this.storageKey, JSON.stringify(data))
     } catch (error) {
-      console.error('Error saving projects to localStorage:', error)
+      console.error('Error saving projects to storage:', error)
     }
   }
 
@@ -45,35 +46,32 @@ export class DefaultProjectsService implements ProjectsService {
       assistantId,
     }
 
-    const projects = this.loadFromStorage()
-    const updatedProjects = [...projects, newProject]
-    this.saveToStorage(updatedProjects)
-
+    const projects = await this.loadFromStorage()
+    await this.saveToStorage([...projects, newProject])
     return newProject
   }
 
   async updateProject(id: string, name: string, assistantId?: string): Promise<void> {
-    const projects = this.loadFromStorage()
-    const updatedProjects = projects.map((project) =>
+    const projects = await this.loadFromStorage()
+    const updated = projects.map((project) =>
       project.id === id
         ? { ...project, name, updated_at: Date.now(), assistantId }
         : project
     )
-    this.saveToStorage(updatedProjects)
+    await this.saveToStorage(updated)
   }
 
   async deleteProject(id: string): Promise<void> {
-    const projects = this.loadFromStorage()
-    const updatedProjects = projects.filter((project) => project.id !== id)
-    this.saveToStorage(updatedProjects)
+    const projects = await this.loadFromStorage()
+    await this.saveToStorage(projects.filter((project) => project.id !== id))
   }
 
   async getProjectById(id: string): Promise<ThreadFolder | undefined> {
-    const projects = this.loadFromStorage()
+    const projects = await this.loadFromStorage()
     return projects.find((project) => project.id === id)
   }
 
   async setProjects(projects: ThreadFolder[]): Promise<void> {
-    this.saveToStorage(projects)
+    await this.saveToStorage(projects)
   }
 }

--- a/web-app/src/services/window/tauri.ts
+++ b/web-app/src/services/window/tauri.ts
@@ -25,8 +25,8 @@ export class TauriWindowService extends DefaultWindowService {
           theme = 'light'
           break
         case 'auto':
-          // Let the OS decide; isDark reflects the current OS preference
-          theme = isDark ? 'dark' : 'light'
+          // Let the OS / Tauri pick the theme for new windows
+          theme = undefined
           break
         default:
           theme = undefined

--- a/web-app/src/services/window/tauri.ts
+++ b/web-app/src/services/window/tauri.ts
@@ -14,7 +14,7 @@ export class TauriWindowService extends DefaultWindowService {
     try {
       // Read theme directly from the zustand store — always in sync and
       // doesn't depend on localStorage or any storage key name assumptions.
-      const { activeTheme, isDark } = useTheme.getState()
+      const { activeTheme } = useTheme.getState()
       let theme: 'light' | 'dark' | undefined = undefined
 
       switch (activeTheme) {

--- a/web-app/src/services/window/tauri.ts
+++ b/web-app/src/services/window/tauri.ts
@@ -5,39 +5,31 @@
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow'
 import type { WindowConfig, WebviewWindowInstance } from './types'
 import { DefaultWindowService } from './default'
+import { useTheme } from '@/hooks/useTheme'
 
 export class TauriWindowService extends DefaultWindowService {
   async createWebviewWindow(
     config: WindowConfig
   ): Promise<WebviewWindowInstance> {
     try {
-      // Get current theme from localStorage
-      const storedTheme = localStorage.getItem('jan-theme')
+      // Read theme directly from the zustand store — always in sync and
+      // doesn't depend on localStorage or any storage key name assumptions.
+      const { activeTheme, isDark } = useTheme.getState()
       let theme: 'light' | 'dark' | undefined = undefined
 
-      if (storedTheme) {
-        try {
-          const themeData = JSON.parse(storedTheme)
-          const activeTheme = themeData?.state?.activeTheme
-          const isDark = themeData?.state?.isDark
-
-          // Set theme based on stored preference
-          if (activeTheme === 'auto') {
-            theme = undefined // Let OS decide
-          } else if (
-            activeTheme === 'dark' ||
-            (activeTheme === 'auto' && isDark)
-          ) {
-            theme = 'dark'
-          } else if (
-            activeTheme === 'light' ||
-            (activeTheme === 'auto' && !isDark)
-          ) {
-            theme = 'light'
-          }
-        } catch (e) {
-          console.warn('Failed to parse theme from localStorage:', e)
-        }
+      switch (activeTheme) {
+        case 'dark':
+          theme = 'dark'
+          break
+        case 'light':
+          theme = 'light'
+          break
+        case 'auto':
+          // Let the OS decide; isDark reflects the current OS preference
+          theme = isDark ? 'dark' : 'light'
+          break
+        default:
+          theme = undefined
       }
 
       const webviewWindow = new WebviewWindow(config.label, {

--- a/web-app/src/utils/getModelToStart.ts
+++ b/web-app/src/utils/getModelToStart.ts
@@ -1,17 +1,13 @@
-import { localStorageKey } from '@/constants/localStorage'
 import type { ModelInfo } from '@janhq/core'
+import { useLastUsedModel } from '@/hooks/useLastUsedModel'
 
 export const getLastUsedModel = (): {
   provider: string
   model: string
 } | null => {
-  try {
-    const stored = localStorage.getItem(localStorageKey.lastUsedModel)
-    return stored ? JSON.parse(stored) : null
-  } catch (error) {
-    console.debug('Failed to get last used model from localStorage:', error)
-    return null
-  }
+  const { provider, model } = useLastUsedModel.getState()
+  if (provider && model) return { provider, model }
+  return null
 }
 
 // Helper function to determine which model to start


### PR DESCRIPTION
## Describe Your Changes

After #7821 migrated zustand stores to `fileStorage`, several places were left still writing directly to raw `localStorage`. On each restart, `migrateAllLocalStorageKeys()` would find those keys already in `settings.json` and silently delete the newer `localStorage` values without updating the file - causing settings to revert every session.

This PR finishes the migration for all remaining raw `localStorage` usages:

- **Last-used assistant & default assistant** - `useAssistant` now uses `persist` with `partialize` (only the two ID fields are saved). An `onRehydrateStorage` callback re-resolves `currentAssistant` if the assistant list loaded before hydration finished.
- **Last-used model** - new `useLastUsedModel` store replaces direct `localStorage` calls across `DropdownModelProvider`, `ChatInput`, `SetupScreen`, and `getModelToStart`.
- **llamacpp engine settings** - the `cortex_model_settings_migrated` flag is now a `cortexMigrated: boolean` field inside the `useModelProvider` persisted state (version bumped to 12), so it no longer gets destroyed by the bulk migration. The flag update is returned atomically inside the same `set()` call instead of a nested `set()`.
- **Claude Code env vars & model selections** - `useClaudeCodeModel` converted from `useState` + raw `localStorage` to a proper zustand `persist` store; the same API surface is kept so consumers need no changes.
- **Setup completed flag** - `setupCompleted` added to `useGeneralSetting`; `SetupScreen` and `ThreadList` now read/write through the store.
- **Recent searches** - new `useRecentSearches` store replaces the raw `localStorage` read/write/version-bump pattern in `SearchDialog`.
- **Thread folders** - `DefaultProjectsService` methods are now async and use `fileStorage` directly; the on-disk format is unchanged.
- **New window theme** - `TauriWindowService` was reading a key `jan-theme` that never existed (the store uses key `theme`). It now reads `useTheme.getState()` directly, which is always correct and needs no parsing.

## Fixes Issues
- Closes #8015 
- Closes #6847 

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
