### PR TITLE
fix: restore no-mmproj-offload flag wiring for multimodal models (#7924)

### DIFF
--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/args.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/args.rs
@@ -184,6 +184,10 @@ impl ArgumentBuilder {
         if let Some(path) = mmproj_path.filter(|p| !p.is_empty()) {
             self.args.push("--mmproj".to_string());
             self.args.push(path);
+
+            if !self.config.offload_mmproj {
+                self.args.push("--no-mmproj-offload".to_string());
+            }
         }
     }
 
@@ -702,6 +706,41 @@ mod tests {
         let args = builder.build("test", "/path", 8080, Some(String::new()));
 
         assert_no_flag(&args, "--mmproj");
+        assert_no_flag(&args, "--no-mmproj-offload");
+    }
+
+    #[test]
+    fn test_mmproj_offload_disabled_adds_no_mmproj_offload_flag() {
+        let mut config = default_config();
+        config.offload_mmproj = false;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, Some("/path/to/mmproj".to_string()));
+
+        assert_arg_pair(&args, "--mmproj", "/path/to/mmproj");
+        assert_has_flag(&args, "--no-mmproj-offload");
+    }
+
+    #[test]
+    fn test_mmproj_offload_enabled_does_not_add_no_mmproj_offload_flag() {
+        let config = default_config();
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, Some("/path/to/mmproj".to_string()));
+
+        assert_arg_pair(&args, "--mmproj", "/path/to/mmproj");
+        assert_no_flag(&args, "--no-mmproj-offload");
+    }
+
+    #[test]
+    fn test_mmproj_offload_disabled_without_mmproj_does_not_add_flag() {
+        let mut config = default_config();
+        config.offload_mmproj = false;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--mmproj");
+        assert_no_flag(&args, "--no-mmproj-offload");
     }
 
     #[test]


### PR DESCRIPTION
## Describe Your Changes

Restore the missing `offload_mmproj` backend wiring in `tauri-plugin-llamacpp` by emitting `--no-mmproj-offload` when a model has an `mmproj` file and the setting is turned off. 
This fixes the incomplete refactor that left the UI option functional in the frontend but ignored in the Rust argument builder, and adds targeted tests to verify multimodal models receive the flag only when expected while non-multimodal models remain unaffected.

## Fixes Issues

- Closes #7924

## Root cause

The UI setting is still created and passed through the app, but the current Rust argument builder never turns `offload_mmproj=false` into the `llama.cpp` CLI flag.

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
