### PR TITLE
fix: drag-and-drop functionality and bugs in Tauri 2.0

### DIFF
--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -24,7 +24,7 @@
           "effects": ["fullScreenUI", "mica", "tabbed", "blur", "acrylic"],
           "state": "active"
         },
-        "dragDropEnabled": false
+        "dragDropEnabled": true
       }
     ]
   },

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -24,7 +24,7 @@
           "effects": ["fullScreenUI", "mica", "tabbed", "blur", "acrylic"],
           "state": "active"
         },
-        "dragDropEnabled": false
+        "dragDropEnabled": true
       }
     ]
   },

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -21,17 +21,33 @@
         "decorations": false,
         "titleBarStyle": "Overlay",
         "windowEffects": {
-          "effects": ["fullScreenUI", "mica", "tabbed", "blur", "acrylic"],
+          "effects": [
+            "fullScreenUI",
+            "mica",
+            "tabbed",
+            "blur",
+            "acrylic"
+          ],
           "state": "active"
         },
-        "dragDropEnabled": false
+        "dragDropEnabled": true
       }
     ]
   },
   "bundle": {
-    "targets": ["nsis", "msi"],
-    "resources": ["resources/pre-install/**/*", "resources/LICENSE", "resources/bin/jan-cli.exe"],
-    "externalBin": ["resources/bin/bun", "resources/bin/uv"],
+    "targets": [
+      "nsis",
+      "msi"
+    ],
+    "resources": [
+      "resources/pre-install/**/*",
+      "resources/LICENSE",
+      "resources/bin/jan-cli.exe"
+    ],
+    "externalBin": [
+      "resources/bin/bun",
+      "resources/bin/uv"
+    ],
     "windows": {
       "webviewInstallMode": {
         "silent": true,

--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -788,7 +788,181 @@ const ChatInput = memo(function ChatInput({
     ]
   )
 
+  const processNewDocumentAttachmentsRef = useRef(processNewDocumentAttachments)
+  const hasMmprojRef = useRef(hasMmproj)
+  const attachmentsEnabledRef = useRef(attachmentsEnabled)
+  const maxFileSizeMBRef = useRef(maxFileSizeMB)
+  const parsePreferenceRef = useRef(parsePreference)
+
+  useEffect(() => {
+    processNewDocumentAttachmentsRef.current = processNewDocumentAttachments
+    hasMmprojRef.current = hasMmproj
+    attachmentsEnabledRef.current = attachmentsEnabled
+    maxFileSizeMBRef.current = maxFileSizeMB
+    parsePreferenceRef.current = parsePreference
+  }, [
+    processNewDocumentAttachments,
+    hasMmproj,
+    attachmentsEnabled,
+    maxFileSizeMB,
+    parsePreference,
+  ])
+
+  useEffect(() => {
+    if (!isPlatformTauri()) return
+
+    let unlisten: (() => void) | undefined
+    let cleanedUp = false
+
+    const setupListener = async () => {
+      try {
+        const { getCurrentWebviewWindow } = await import('@tauri-apps/api/webviewWindow')
+        const appWindow = getCurrentWebviewWindow()
+
+        const unbind = await appWindow.onDragDropEvent(async (event) => {
+          if (!attachmentsEnabledRef.current) return
+
+          if (event.payload.type === 'enter' || event.payload.type === 'over') {
+            setIsDragOver(true)
+          } else if (event.payload.type === 'leave') {
+            setIsDragOver(false)
+          } else if (event.payload.type === 'drop') {
+            setIsDragOver(false)
+            const paths = event.payload.paths
+            if (!paths.length) return
+
+            const IMAGE_EXTS = new Set(['jpg', 'jpeg', 'png'])
+            const imagePaths: string[] = []
+            const docPaths: string[] = []
+
+            for (const p of paths) {
+              const ext = p.split('.').pop()?.toLowerCase() ?? ''
+              if (IMAGE_EXTS.has(ext)) {
+                imagePaths.push(p)
+              } else {
+                docPaths.push(p)
+              }
+            }
+
+            // Process images: convert via tauri asset protocol, then run through image pipeline
+            if (imagePaths.length > 0 && hasMmprojRef.current) {
+              try {
+                const { convertFileSrc } = await import('@tauri-apps/api/core')
+                const files: File[] = []
+                for (const p of imagePaths) {
+                  try {
+                    const fileUrl = convertFileSrc(p)
+                    const response = await fetch(fileUrl)
+                    if (!response.ok) throw new Error(`Failed to fetch: ${response.statusText}`)
+                    const blob = await response.blob()
+                    const fileName = p.split(/[/\\]/).pop() ?? 'image'
+                    const ext = fileName.toLowerCase().split('.').pop() ?? 'jpg'
+                    const mimeType = ext === 'png' ? 'image/png' : 'image/jpeg'
+                    files.push(new File([blob], fileName, { type: mimeType }))
+                  } catch (err) {
+                    console.error('Failed to load dropped image:', err)
+                  }
+                }
+                if (files.length > 0) {
+                  void processImageFiles(files)
+                }
+              } catch (err) {
+                console.error('Failed to process dropped images:', err)
+              }
+            }
+
+            // Process documents: mirror handleAttachDocsIngest logic
+            if (docPaths.length > 0) {
+              try {
+                const { fs: coreFs } = await import('@janhq/core')
+                const { createDocumentAttachment: createDoc } = await import('@/types/attachment')
+                const maxBytes =
+                  typeof maxFileSizeMBRef.current === 'number' && maxFileSizeMBRef.current > 0
+                    ? maxFileSizeMBRef.current * 1024 * 1024
+                    : undefined
+
+                const prepared: Attachment[] = []
+                for (const p of docPaths) {
+                  const name = p.split(/[/\\]/).pop() ?? p
+                  const fileType = name.split('.').pop()?.toLowerCase()
+                  let size: number | undefined
+                  try {
+                    const stat = await coreFs.fileStat(p)
+                    size = stat?.size ? Number(stat.size) : undefined
+                  } catch {
+                    // size unknown, proceed anyway
+                  }
+
+                  if (maxBytes !== undefined && size !== undefined && size > maxBytes) {
+                    toast.error('File too large', {
+                      description: `${name} exceeds the ${maxFileSizeMBRef.current}MB limit`,
+                    })
+                    continue
+                  }
+
+                  prepared.push(createDoc({ name, path: p, fileType, size, parseMode: parsePreferenceRef.current }))
+                }
+
+                if (prepared.length === 0) return
+
+                let newDocAttachments: Attachment[] = []
+                let duplicates: string[] = []
+
+                setAttachmentsForThread(attachmentsKeyRef.current, (current) => {
+                  const existingPaths = new Set(
+                    current.filter((a) => a.type === 'document' && a.path).map((a) => a.path)
+                  )
+                  duplicates = []
+                  newDocAttachments = []
+                  for (const att of prepared) {
+                    if (existingPaths.has(att.path)) {
+                      duplicates.push(att.name)
+                    } else {
+                      newDocAttachments.push(att)
+                    }
+                  }
+                  return newDocAttachments.length > 0 ? [...current, ...newDocAttachments] : current
+                })
+
+                if (duplicates.length > 0) {
+                  toast.warning('Files already attached', {
+                    description: `${duplicates.join(', ')} ${duplicates.length === 1 ? 'is' : 'are'} already in the list`,
+                  })
+                }
+
+                if (newDocAttachments.length > 0) {
+                  await processNewDocumentAttachmentsRef.current(newDocAttachments)
+                }
+              } catch (err) {
+                console.error('Failed to process dropped documents:', err)
+                toast.error('Failed to attach documents', {
+                  description: err instanceof Error ? err.message : String(err),
+                })
+              }
+            }
+          }
+        })
+
+        if (cleanedUp) {
+          unbind()
+        } else {
+          unlisten = unbind
+        }
+      } catch (error) {
+        console.warn('Failed to setup native drag-drop listener in ChatInput:', error)
+      }
+    }
+
+    setupListener()
+    return () => {
+      cleanedUp = true
+      if (unlisten) unlisten()
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   const handleAttachDocsIngest = async () => {
+
     try {
       if (!attachmentsEnabled) {
         toast.info('Attachments are disabled in Settings')
@@ -1421,7 +1595,8 @@ const ChatInput = memo(function ChatInput({
   const handleDragEnter = (e: React.DragEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    // Only allow drag if model supports mmproj
+    // Visual highlight is driven by the native Tauri onDragDropEvent listener.
+    // This handler only runs in non-Tauri (web) contexts where hasMmproj is the gate.
     if (hasMmproj) {
       setIsDragOver(true)
     }
@@ -1430,8 +1605,7 @@ const ChatInput = memo(function ChatInput({
   const handleDragLeave = (e: React.DragEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    // Only set dragOver to false if we're leaving the drop zone entirely
-    // In Tauri, relatedTarget can be null, so we need to handle that case
+    // Only clear if leaving the drop zone entirely (relatedTarget can be null in Tauri)
     const relatedTarget = e.relatedTarget as Node | null
     if (!relatedTarget || !e.currentTarget.contains(relatedTarget)) {
       setIsDragOver(false)
@@ -1441,7 +1615,8 @@ const ChatInput = memo(function ChatInput({
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    // Ensure drag state is maintained during drag over
+    // preventDefault() is required for the browser to allow the drop event.
+    // Highlight state is managed by the native Tauri listener.
     if (hasMmproj) {
       setIsDragOver(true)
     }
@@ -1609,11 +1784,11 @@ const ChatInput = memo(function ChatInput({
               isFocused && 'ring-1 ring-ring/50',
               isDragOver && 'ring-2 ring-ring/50 border-primary'
             )}
-            data-drop-zone={hasMmproj ? 'true' : undefined}
-            onDragEnter={hasMmproj ? handleDragEnter : undefined}
-            onDragLeave={hasMmproj ? handleDragLeave : undefined}
-            onDragOver={hasMmproj ? handleDragOver : undefined}
-            onDrop={hasMmproj ? handleDrop : undefined}
+            data-drop-zone={attachmentsEnabled ? 'true' : undefined}
+            onDragEnter={attachmentsEnabled ? handleDragEnter : undefined}
+            onDragLeave={attachmentsEnabled ? handleDragLeave : undefined}
+            onDragOver={attachmentsEnabled ? handleDragOver : undefined}
+            onDrop={attachmentsEnabled ? handleDrop : undefined}
           >
             {attachments.length > 0 && (
               <div className="flex flex-col gap-2 p-2 pb-0">

--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -147,7 +147,7 @@ const ChatInput = memo(function ChatInput({
   useTools()
   const router = useRouter()
   const createThread = useThreads((state) => state.createThread)
-  const { 
+  const {
     loading,
     currentAssistant,
     setCurrentAssistant,
@@ -208,9 +208,9 @@ const ChatInput = memo(function ChatInput({
 
   const avatar = currentThread
     ? assistants.find((a) => a.id === currentThread?.assistants?.[0]?.id)
-        ?.avatar ||
-      currentThread?.assistants?.[0]?.avatar ||
-      ''
+      ?.avatar ||
+    currentThread?.assistants?.[0]?.avatar ||
+    ''
     : assistants.find((a) => a.id === selectedAssistantId)?.avatar || ''
 
   const assistantCount = assistants?.length || 0
@@ -328,14 +328,14 @@ const ChatInput = memo(function ChatInput({
           prev.map((att) =>
             att.name === fileName
               ? {
-                  ...att,
-                  ...updatedAttachment,
-                  processing: status === 'processing',
-                  processed:
-                    status === 'done'
-                      ? true
-                      : (updatedAttachment?.processed ?? att.processed),
-                }
+                ...att,
+                ...updatedAttachment,
+                processing: status === 'processing',
+                processed:
+                  status === 'done'
+                    ? true
+                    : (updatedAttachment?.processed ?? att.processed),
+              }
               : att
           )
         )
@@ -628,17 +628,17 @@ const ChatInput = memo(function ChatInput({
       const rawContextThreshold =
         typeof modelContextLength === 'number' && modelContextLength > 0
           ? Math.floor(
-              modelContextLength *
-                (typeof autoInlineContextRatio === 'number'
-                  ? autoInlineContextRatio
-                  : 0.75)
-            )
+            modelContextLength *
+            (typeof autoInlineContextRatio === 'number'
+              ? autoInlineContextRatio
+              : 0.75)
+          )
           : undefined
 
       const contextThreshold =
         typeof rawContextThreshold === 'number' &&
-        Number.isFinite(rawContextThreshold) &&
-        rawContextThreshold > 0
+          Number.isFinite(rawContextThreshold) &&
+          rawContextThreshold > 0
           ? rawContextThreshold
           : undefined
 
@@ -789,11 +789,13 @@ const ChatInput = memo(function ChatInput({
   )
 
   const processNewDocumentAttachmentsRef = useRef(processNewDocumentAttachments)
+  const processImageFilesRef = useRef<((files: File[]) => Promise<void>) | null>(null)
   const hasMmprojRef = useRef(hasMmproj)
   const attachmentsEnabledRef = useRef(attachmentsEnabled)
   const maxFileSizeMBRef = useRef(maxFileSizeMB)
   const parsePreferenceRef = useRef(parsePreference)
 
+  // Keep these refs fresh so the stable listener always picks up latest values
   useEffect(() => {
     processNewDocumentAttachmentsRef.current = processNewDocumentAttachments
     hasMmprojRef.current = hasMmproj
@@ -808,6 +810,10 @@ const ChatInput = memo(function ChatInput({
     parsePreference,
   ])
 
+  const dropZoneRef = useRef<HTMLDivElement>(null)
+
+  // One native Tauri listener for the whole component lifetime.
+  // Skip this entirely in web mode since there's no Tauri API there.
   useEffect(() => {
     if (!isPlatformTauri()) return
 
@@ -819,18 +825,31 @@ const ChatInput = memo(function ChatInput({
         const { getCurrentWebviewWindow } = await import('@tauri-apps/api/webviewWindow')
         const appWindow = getCurrentWebviewWindow()
 
+        const isInsideDropZone = (position: { x: number; y: number }) => {
+          if (!dropZoneRef.current) return false
+          const rect = dropZoneRef.current.getBoundingClientRect()
+          const dpr = window.devicePixelRatio || 1
+          const x = position.x / dpr
+          const y = position.y / dpr
+          return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom
+        }
+
         const unbind = await appWindow.onDragDropEvent(async (event) => {
           if (!attachmentsEnabledRef.current) return
 
           if (event.payload.type === 'enter' || event.payload.type === 'over') {
-            setIsDragOver(true)
+            setIsDragOver(isInsideDropZone(event.payload.position))
           } else if (event.payload.type === 'leave') {
             setIsDragOver(false)
           } else if (event.payload.type === 'drop') {
+            const wasInside = isInsideDropZone(event.payload.position)
             setIsDragOver(false)
+            
+            if (!wasInside) return
             const paths = event.payload.paths
             if (!paths.length) return
 
+            // Split dropped paths into images vs docs — each goes to its own pipeline.
             const IMAGE_EXTS = new Set(['jpg', 'jpeg', 'png'])
             const imagePaths: string[] = []
             const docPaths: string[] = []
@@ -845,33 +864,42 @@ const ChatInput = memo(function ChatInput({
             }
 
             // Process images: convert via tauri asset protocol, then run through image pipeline
-            if (imagePaths.length > 0 && hasMmprojRef.current) {
-              try {
-                const { convertFileSrc } = await import('@tauri-apps/api/core')
-                const files: File[] = []
-                for (const p of imagePaths) {
-                  try {
-                    const fileUrl = convertFileSrc(p)
-                    const response = await fetch(fileUrl)
-                    if (!response.ok) throw new Error(`Failed to fetch: ${response.statusText}`)
-                    const blob = await response.blob()
-                    const fileName = p.split(/[/\\]/).pop() ?? 'image'
-                    const ext = fileName.toLowerCase().split('.').pop() ?? 'jpg'
-                    const mimeType = ext === 'png' ? 'image/png' : 'image/jpeg'
-                    files.push(new File([blob], fileName, { type: mimeType }))
-                  } catch (err) {
-                    console.error('Failed to load dropped image:', err)
+            // Images need a vision-capable model loaded. Tell the user if they don't have one, similar to what the image picker button does.
+            if (imagePaths.length > 0) {
+              if (!hasMmprojRef.current) {
+                toast.info('Vision model required', {
+                  description: 'Load a vision-capable model to attach images.',
+                })
+              } else {
+                try {
+                  const { convertFileSrc } = await import('@tauri-apps/api/core')
+                  const files: File[] = []
+                  for (const p of imagePaths) {
+                    try {
+                      const fileUrl = convertFileSrc(p)
+                      const response = await fetch(fileUrl)
+                      if (!response.ok) throw new Error(`Failed to fetch: ${response.statusText}`)
+                      const blob = await response.blob()
+                      const fileName = p.split(/[/\\]/).pop() ?? 'image'
+                      const ext = fileName.toLowerCase().split('.').pop() ?? 'jpg'
+                      const mimeType = ext === 'png' ? 'image/png' : 'image/jpeg'
+                      files.push(new File([blob], fileName, { type: mimeType }))
+                    } catch (err) {
+                      console.error('Failed to load dropped image:', err)
+                    }
                   }
+                  if (files.length > 0) {
+                    if (processImageFilesRef.current) {
+                      void processImageFilesRef.current(files)
+                    }
+                  }
+                } catch (err) {
+                  console.error('Failed to process dropped images:', err)
                 }
-                if (files.length > 0) {
-                  void processImageFiles(files)
-                }
-              } catch (err) {
-                console.error('Failed to process dropped images:', err)
               }
             }
 
-            // Process documents: mirror handleAttachDocsIngest logic
+            // Anything that's not an image goes through the document pipeline, same logic as the "Add documents or files" button.
             if (docPaths.length > 0) {
               try {
                 const { fs: coreFs } = await import('@janhq/core')
@@ -958,7 +986,7 @@ const ChatInput = memo(function ChatInput({
       cleanedUp = true
       if (unlisten) unlisten()
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const handleAttachDocsIngest = async () => {
@@ -1397,11 +1425,11 @@ const ChatInput = memo(function ChatInput({
                 prev.map((a) =>
                   matchImg(a)
                     ? {
-                        ...a,
-                        processing: false,
-                        processed: true,
-                        id: result.id,
-                      }
+                      ...a,
+                      processing: false,
+                      processed: true,
+                      id: result.id,
+                    }
                     : a
                 )
               )
@@ -1453,6 +1481,10 @@ const ChatInput = memo(function ChatInput({
       setMessage('')
     }
   }
+
+  useEffect(() => {
+    processImageFilesRef.current = processImageFiles
+  }, [processImageFiles])
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files
@@ -1592,11 +1624,13 @@ const ChatInput = memo(function ChatInput({
     ]
   )
 
+  // ---- Browser-side drag handlers ----
+  // In Tauri, the native listener above handles highlight + file processing.
+  // These exist so the browser allows the drop (preventDefault is required) and
+  // as a fallback for non-Tauri builds where hasMmproj still gates image drops.
   const handleDragEnter = (e: React.DragEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    // Visual highlight is driven by the native Tauri onDragDropEvent listener.
-    // This handler only runs in non-Tauri (web) contexts where hasMmproj is the gate.
     if (hasMmproj) {
       setIsDragOver(true)
     }
@@ -1605,7 +1639,7 @@ const ChatInput = memo(function ChatInput({
   const handleDragLeave = (e: React.DragEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    // Only clear if leaving the drop zone entirely (relatedTarget can be null in Tauri)
+    // Only clear when actually leaving the zone (relatedTarget can be null in Tauri)
     const relatedTarget = e.relatedTarget as Node | null
     if (!relatedTarget || !e.currentTarget.contains(relatedTarget)) {
       setIsDragOver(false)
@@ -1615,8 +1649,8 @@ const ChatInput = memo(function ChatInput({
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    // preventDefault() is required for the browser to allow the drop event.
-    // Highlight state is managed by the native Tauri listener.
+    // preventDefault() tells the browser drops are welcome here.
+    // The native listener drives the actual isDragOver state in Tauri.
     if (hasMmproj) {
       setIsDragOver(true)
     }
@@ -1779,6 +1813,7 @@ const ChatInput = memo(function ChatInput({
           )}
 
           <div
+            ref={dropZoneRef}
             className={cn(
               'relative z-20 px-0 pb-10 border rounded-3xl border-input bg-white dark:bg-input/30',
               isFocused && 'ring-1 ring-ring/50',
@@ -1963,67 +1998,67 @@ const ChatInput = memo(function ChatInput({
               >
                 {/* Dropdown for attachments — hidden in agent mode */}
                 {!effectiveAgentMode && (
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button variant="secondary" size="icon-sm" className='rounded-full mr-2 mb-1'>
-                      <PlusIcon size={18} className="text-muted-foreground" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="start">
-                    {/* Vision image attachment - always enabled, prompts to download vision model if needed */}
-                    <DropdownMenuItem onClick={handleImagePickerClick}>
-                      <IconPhoto size={18} className="text-muted-foreground" />
-                      <span>Add Images</span>
-                      <input
-                        type="file"
-                        ref={fileInputRef}
-                        className="hidden"
-                        multiple
-                        onChange={handleFileChange}
-                      />
-                    </DropdownMenuItem>
-                    {/* RAG document attachments - desktop-only via dialog; shown when feature enabled */}
-                    <DropdownMenuItem
-                      onClick={handleAttachDocsIngest}
-                      disabled={!selectedModel?.capabilities?.includes('tools')}
-                    >
-                      {ingestingDocs ? (
-                        <IconLoader2
-                          size={18}
-                          className="text-muted-foreground animate-spin"
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="secondary" size="icon-sm" className='rounded-full mr-2 mb-1'>
+                        <PlusIcon size={18} className="text-muted-foreground" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="start">
+                      {/* Vision image attachment - always enabled, prompts to download vision model if needed */}
+                      <DropdownMenuItem onClick={handleImagePickerClick}>
+                        <IconPhoto size={18} className="text-muted-foreground" />
+                        <span>Add Images</span>
+                        <input
+                          type="file"
+                          ref={fileInputRef}
+                          className="hidden"
+                          multiple
+                          onChange={handleFileChange}
                         />
-                      ) : (
-                        <IconPaperclip
-                          size={18}
-                          className="text-muted-foreground"
-                        />
-                      )}
-                      <span>
-                        {ingestingDocs
-                          ? 'Indexing documents…'
-                          : 'Add documents or files'}
-                      </span>
-                    </DropdownMenuItem>
-                    {/* Use Assistant - only show when no projectId */}
-                    {!projectId && assistantCount < 2 && (
-                      <DropdownMenuSub>
-                        <DropdownMenuSubTrigger>
-                          <IconUser size={18} className="text-muted-foreground" />
-                          <span>Use Assistant</span>
-                        </DropdownMenuSubTrigger>
-                        <DropdownMenuSubContent className="max-h-64 overflow-y-auto">
-                          <AssistantsMenu
-                            selectedAssistant={selectedAssistantId}
-                            setSelectedAssistant={setSelectedAssistantId}
-                            currentThread={currentThread}
-                            updateCurrentThreadAssistant={
-                              updateCurrentThreadAssistant
-                            }
-                            assistants={assistants}
+                      </DropdownMenuItem>
+                      {/* RAG document attachments - desktop-only via dialog; shown when feature enabled */}
+                      <DropdownMenuItem
+                        onClick={handleAttachDocsIngest}
+                        disabled={!selectedModel?.capabilities?.includes('tools')}
+                      >
+                        {ingestingDocs ? (
+                          <IconLoader2
+                            size={18}
+                            className="text-muted-foreground animate-spin"
                           />
-                        </DropdownMenuSubContent>
-                      </DropdownMenuSub>
-                    )}
+                        ) : (
+                          <IconPaperclip
+                            size={18}
+                            className="text-muted-foreground"
+                          />
+                        )}
+                        <span>
+                          {ingestingDocs
+                            ? 'Indexing documents…'
+                            : 'Add documents or files'}
+                        </span>
+                      </DropdownMenuItem>
+                      {/* Use Assistant - only show when no projectId */}
+                      {!projectId && assistantCount < 2 && (
+                        <DropdownMenuSub>
+                          <DropdownMenuSubTrigger>
+                            <IconUser size={18} className="text-muted-foreground" />
+                            <span>Use Assistant</span>
+                          </DropdownMenuSubTrigger>
+                          <DropdownMenuSubContent className="max-h-64 overflow-y-auto">
+                            <AssistantsMenu
+                              selectedAssistant={selectedAssistantId}
+                              setSelectedAssistant={setSelectedAssistantId}
+                              currentThread={currentThread}
+                              updateCurrentThreadAssistant={
+                                updateCurrentThreadAssistant
+                              }
+                              assistants={assistants}
+                            />
+                          </DropdownMenuSubContent>
+                        </DropdownMenuSub>
+                      )}
                     </DropdownMenuContent>
                   </DropdownMenu>
                 )}
@@ -2144,9 +2179,9 @@ const ChatInput = memo(function ChatInput({
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Button
-                          variant="ghost"
-                          size="icon-xs"
-                        >
+                        variant="ghost"
+                        size="icon-xs"
+                      >
                         <IconCodeCircle2
                           size={18}
                           className="text-muted-foreground"

--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -850,7 +850,7 @@ const ChatInput = memo(function ChatInput({
             if (!paths.length) return
 
             // Split dropped paths into images vs docs — each goes to its own pipeline.
-            const IMAGE_EXTS = new Set(['jpg', 'jpeg', 'png'])
+            const IMAGE_EXTS = new Set(['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp'])
             const imagePaths: string[] = []
             const docPaths: string[] = []
 
@@ -882,7 +882,15 @@ const ChatInput = memo(function ChatInput({
                       const blob = await response.blob()
                       const fileName = p.split(/[/\\]/).pop() ?? 'image'
                       const ext = fileName.toLowerCase().split('.').pop() ?? 'jpg'
-                      const mimeType = ext === 'png' ? 'image/png' : 'image/jpeg'
+                      const mimeMap: Record<string, string> = {
+                        png: 'image/png',
+                        gif: 'image/gif',
+                        webp: 'image/webp',
+                        bmp: 'image/bmp',
+                        jpeg: 'image/jpeg',
+                        jpg: 'image/jpeg',
+                      }
+                      const mimeType = mimeMap[ext] || 'image/jpeg'
                       files.push(new File([blob], fileName, { type: mimeType }))
                     } catch (err) {
                       console.error('Failed to load dropped image:', err)
@@ -1265,15 +1273,15 @@ const ChatInput = memo(function ChatInput({
 
   const getFileTypeFromExtension = (fileName: string): string => {
     const extension = fileName.toLowerCase().split('.').pop()
-    switch (extension) {
-      case 'jpg':
-      case 'jpeg':
-        return 'image/jpeg'
-      case 'png':
-        return 'image/png'
-      default:
-        return ''
+    const mimeTypes: Record<string, string> = {
+      jpg: 'image/jpeg',
+      jpeg: 'image/jpeg',
+      png: 'image/png',
+      gif: 'image/gif',
+      webp: 'image/webp',
+      bmp: 'image/bmp'
     }
+    return extension && mimeTypes[extension] ? mimeTypes[extension] : ''
   }
 
   const formatBytes = (bytes?: number): string => {
@@ -1302,7 +1310,14 @@ const ChatInput = memo(function ChatInput({
     const oversizedFiles: string[] = []
     const invalidTypeFiles: string[] = []
 
-    const allowedTypes = ['image/jpg', 'image/jpeg', 'image/png']
+    const allowedTypes = [
+      'image/jpg',
+      'image/jpeg',
+      'image/png',
+      'image/gif',
+      'image/webp',
+      'image/bmp'
+    ]
     const validFiles: File[] = []
 
     // First pass: validate file size and type (no duplicate check yet)
@@ -1626,12 +1641,11 @@ const ChatInput = memo(function ChatInput({
 
   // ---- Browser-side drag handlers ----
   // In Tauri, the native listener above handles highlight + file processing.
-  // These exist so the browser allows the drop (preventDefault is required) and
-  // as a fallback for non-Tauri builds where hasMmproj still gates image drops.
+  // These exist so the browser allows the drop (preventDefault is required)
   const handleDragEnter = (e: React.DragEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    if (hasMmproj) {
+    if (attachmentsEnabled) {
       setIsDragOver(true)
     }
   }
@@ -1639,7 +1653,7 @@ const ChatInput = memo(function ChatInput({
   const handleDragLeave = (e: React.DragEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    // Only clear when actually leaving the zone (relatedTarget can be null in Tauri)
+    // Only clear when actually leaving the zone
     const relatedTarget = e.relatedTarget as Node | null
     if (!relatedTarget || !e.currentTarget.contains(relatedTarget)) {
       setIsDragOver(false)
@@ -1649,9 +1663,7 @@ const ChatInput = memo(function ChatInput({
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    // preventDefault() tells the browser drops are welcome here.
-    // The native listener drives the actual isDragOver state in Tauri.
-    if (hasMmproj) {
+    if (attachmentsEnabled) {
       setIsDragOver(true)
     }
   }
@@ -1661,8 +1673,8 @@ const ChatInput = memo(function ChatInput({
     e.stopPropagation()
     setIsDragOver(false)
 
-    // Only allow drop if model supports mmproj
-    if (!hasMmproj) {
+    // Only allow drop if attachments exist
+    if (!attachmentsEnabled) {
       return
     }
 
@@ -1820,10 +1832,26 @@ const ChatInput = memo(function ChatInput({
               isDragOver && 'ring-2 ring-ring/50 border-primary'
             )}
             data-drop-zone={attachmentsEnabled ? 'true' : undefined}
-            onDragEnter={attachmentsEnabled ? handleDragEnter : undefined}
-            onDragLeave={attachmentsEnabled ? handleDragLeave : undefined}
-            onDragOver={attachmentsEnabled ? handleDragOver : undefined}
-            onDrop={attachmentsEnabled ? handleDrop : undefined}
+            onDragEnter={
+              attachmentsEnabled && !isPlatformTauri()
+                ? handleDragEnter
+                : undefined
+            }
+            onDragLeave={
+              attachmentsEnabled && !isPlatformTauri()
+                ? handleDragLeave
+                : undefined
+            }
+            onDragOver={
+              attachmentsEnabled && !isPlatformTauri()
+                ? handleDragOver
+                : undefined
+            }
+            onDrop={
+              attachmentsEnabled && !isPlatformTauri()
+                ? handleDrop
+                : undefined
+            }
           >
             {attachments.length > 0 && (
               <div className="flex flex-col gap-2 p-2 pb-0">

--- a/web-app/src/containers/ProjectFiles.tsx
+++ b/web-app/src/containers/ProjectFiles.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { FileText, Trash2, UploadIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -262,9 +262,10 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
     loadProjectFiles()
   }, [loadProjectFiles])
 
+
   const processFilePaths = useCallback(
     async (paths: string[]) => {
-      if (!paths.length) return
+      if (!paths.length || uploading) return
 
       // Get files from paths (recursively for directories)
       const filePaths = await getFilesFromPaths(paths)
@@ -371,14 +372,66 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
         setUploading(false)
       }
     },
-    [files, loadProjectFiles, maxFileSizeMB, projectId, serviceHub, t]
+    [files, loadProjectFiles, maxFileSizeMB, projectId, serviceHub, t, uploading]
   )
+
+  const processFilePathsRef = useRef(processFilePaths)
+  const attachmentsEnabledRef = useRef(attachmentsEnabled)
+
+  useEffect(() => {
+    processFilePathsRef.current = processFilePaths
+    attachmentsEnabledRef.current = attachmentsEnabled
+  }, [processFilePaths, attachmentsEnabled])
+
+  useEffect(() => {
+    let unlisten: (() => void) | undefined
+    let cleanedUp = false
+
+    const setupListener = async () => {
+      try {
+        const { getCurrentWebviewWindow } = await import('@tauri-apps/api/webviewWindow')
+        const appWindow = getCurrentWebviewWindow()
+
+        const unbind = await appWindow.onDragDropEvent((event) => {
+          if (!attachmentsEnabledRef.current) return
+
+          if (event.payload.type === 'enter' || event.payload.type === 'over') {
+            setIsDragging(true)
+          } else if (
+            event.payload.type === 'leave' ||
+            event.payload.type === 'cancelled'
+          ) {
+            setIsDragging(false)
+          } else if (event.payload.type === 'drop') {
+            setIsDragging(false)
+            if (event.payload.paths.length > 0) {
+              void processFilePathsRef.current(event.payload.paths)
+            }
+          }
+        })
+
+        if (cleanedUp) {
+          unbind()
+        } else {
+          unlisten = unbind
+        }
+      } catch (error) {
+        console.warn('Failed to setup native drag-drop listener:', error)
+      }
+    }
+
+    setupListener()
+    return () => {
+      cleanedUp = true
+      if (unlisten) unlisten()
+    }
+  }, [])
 
   const handleUpload = async () => {
     if (!attachmentsEnabled) {
       toast.info(
         t('common:toast.attachmentsDisabledInfo.title') ??
-          'Attachments are disabled in Settings'
+        'Attachments are disabled in Settings'
       )
       return
     }
@@ -417,57 +470,17 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    setIsDragging(true)
   }
 
   const handleDragLeave = (e: React.DragEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    setIsDragging(false)
   }
 
   const handleDrop = async (e: React.DragEvent) => {
     e.preventDefault()
     e.stopPropagation()
     setIsDragging(false)
-
-    if (!attachmentsEnabled) {
-      toast.info(
-        t('common:toast.attachmentsDisabledInfo.title') ??
-          'Attachments are disabled in Settings'
-      )
-      return
-    }
-
-    // Get file paths from the drop event (Tauri provides paths directly)
-    const paths: string[] = []
-    const items = e.dataTransfer.items
-    if (items) {
-      for (let i = 0; i < items.length; i++) {
-        const item = items[i]
-        if (item.kind === 'file') {
-          const file = item.getAsFile()
-          if (file && 'path' in file && typeof file.path === 'string') {
-            paths.push(file.path)
-          }
-        }
-      }
-    }
-
-    if (paths.length === 0) {
-      // Fallback for web: check dataTransfer.files
-      const dtFiles = e.dataTransfer.files
-      for (let i = 0; i < dtFiles.length; i++) {
-        const file = dtFiles[i]
-        if ('path' in file && typeof file.path === 'string') {
-          paths.push(file.path)
-        }
-      }
-    }
-
-    if (paths.length > 0) {
-      await processFilePaths(paths)
-    }
   }
 
   const handleDeleteFile = async (fileId: string) => {
@@ -586,22 +599,22 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
           ))}
 
           <div
-          className={cn(
-            'flex mt-2 flex-col items-center justify-center py-8 px-4 rounded-lg border border-dashed cursor-pointer transition-colors',
-            isDragging
-              ? 'bg-primary/10 border-primary'
-              : 'bg-secondary/30 border-border hover:bg-secondary/50'
-          )}
-          onClick={handleUpload}
-          onDragOver={handleDragOver}
-          onDragLeave={handleDragLeave}
-          onDrop={handleDrop}
-        >
-          <FileText className="size-8 text-muted-foreground/50 mb-3" />
-          <p className="text-sm text-muted-foreground text-center">
-            {t('common:projects.filesDescription')}
-          </p>
-        </div>
+            className={cn(
+              'flex mt-2 flex-col items-center justify-center py-8 px-4 rounded-lg border border-dashed cursor-pointer transition-colors',
+              isDragging
+                ? 'bg-primary/10 border-primary'
+                : 'bg-secondary/30 border-border hover:bg-secondary/50'
+            )}
+            onClick={handleUpload}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+            onDrop={handleDrop}
+          >
+            <FileText className="size-8 text-muted-foreground/50 mb-3" />
+            <p className="text-sm text-muted-foreground text-center">
+              {t('common:projects.filesDescription')}
+            </p>
+          </div>
         </div>
       )}
     </div>

--- a/web-app/src/containers/ProjectFiles.tsx
+++ b/web-app/src/containers/ProjectFiles.tsx
@@ -383,6 +383,10 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
     attachmentsEnabledRef.current = attachmentsEnabled
   }, [processFilePaths, attachmentsEnabled])
 
+  const dropZoneRef = useRef<HTMLDivElement>(null)
+
+  // Stable listener that lives for the whole component lifetime.
+  // We use refs above so it always calls the freshest version of processFilePaths.
   useEffect(() => {
     let unlisten: (() => void) | undefined
     let cleanedUp = false
@@ -392,21 +396,35 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
         const { getCurrentWebviewWindow } = await import('@tauri-apps/api/webviewWindow')
         const appWindow = getCurrentWebviewWindow()
 
+        const isInsideDropZone = (position: { x: number; y: number }) => {
+          if (!dropZoneRef.current) return false
+          const rect = dropZoneRef.current.getBoundingClientRect()
+          const dpr = window.devicePixelRatio || 1
+          const x = position.x / dpr
+          const y = position.y / dpr
+          return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom
+        }
+
         const unbind = await appWindow.onDragDropEvent((event) => {
+          // Bail early if attachments are turned off in Settings
           if (!attachmentsEnabledRef.current) return
 
           if (event.payload.type === 'enter' || event.payload.type === 'over') {
-            setIsDragging(true)
+            setIsDragging(isInsideDropZone(event.payload.position))
           } else if (event.payload.type === 'leave') {
             setIsDragging(false)
           } else if (event.payload.type === 'drop') {
+            const wasInside = isInsideDropZone(event.payload.position)
             setIsDragging(false)
+            if (!wasInside) return
+
             if (event.payload.paths.length > 0) {
               void processFilePathsRef.current(event.payload.paths)
             }
           }
         })
 
+        // Guard against the listener resolving after the component already unmounted
         if (cleanedUp) {
           unbind()
         } else {
@@ -531,6 +549,7 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
         </div>
       ) : isEmpty ? (
         <div
+          ref={dropZoneRef}
           className={cn(
             'flex flex-col items-center justify-center py-8 px-4 rounded-lg border border-dashed cursor-pointer transition-colors',
             isDragging
@@ -549,6 +568,7 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
         </div>
       ) : (
         <div
+          ref={dropZoneRef}
           className={cn(
             'space-y-2 rounded-lg p-1 -m-1 transition-colors',
             isDragging && 'bg-primary/10 ring-2 ring-primary ring-dashed'

--- a/web-app/src/containers/ProjectFiles.tsx
+++ b/web-app/src/containers/ProjectFiles.tsx
@@ -397,10 +397,7 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
 
           if (event.payload.type === 'enter' || event.payload.type === 'over') {
             setIsDragging(true)
-          } else if (
-            event.payload.type === 'leave' ||
-            event.payload.type === 'cancelled'
-          ) {
+          } else if (event.payload.type === 'leave') {
             setIsDragging(false)
           } else if (event.payload.type === 'drop') {
             setIsDragging(false)

--- a/web-app/src/containers/ProjectFiles.tsx
+++ b/web-app/src/containers/ProjectFiles.tsx
@@ -15,6 +15,7 @@ import { useAttachments } from '@/hooks/useAttachments'
 import { ExtensionTypeEnum, FileStat, VectorDBExtension } from '@janhq/core'
 import { ExtensionManager } from '@/lib/extension'
 import { IconLoader2, IconPaperclip } from '@tabler/icons-react'
+import { isPlatformTauri } from '@/lib/platform/utils'
 
 type ProjectFilesProps = {
   projectId: string
@@ -263,9 +264,14 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
   }, [loadProjectFiles])
 
 
+  const uploadingRef = useRef(uploading)
+  useEffect(() => {
+    uploadingRef.current = uploading
+  }, [uploading])
+
   const processFilePaths = useCallback(
     async (paths: string[]) => {
-      if (!paths.length || uploading) return
+      if (!paths.length || uploadingRef.current) return
 
       // Get files from paths (recursively for directories)
       const filePaths = await getFilesFromPaths(paths)
@@ -372,7 +378,7 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
         setUploading(false)
       }
     },
-    [files, loadProjectFiles, maxFileSizeMB, projectId, serviceHub, t, uploading]
+    [files, loadProjectFiles, maxFileSizeMB, projectId, serviceHub, t]
   )
 
   const processFilePathsRef = useRef(processFilePaths)
@@ -388,6 +394,8 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
   // Stable listener that lives for the whole component lifetime.
   // We use refs above so it always calls the freshest version of processFilePaths.
   useEffect(() => {
+    if (!isPlatformTauri()) return
+
     let unlisten: (() => void) | undefined
     let cleanedUp = false
 
@@ -496,6 +504,13 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
     e.preventDefault()
     e.stopPropagation()
     setIsDragging(false)
+    if (!attachmentsEnabled) return
+
+    if (!isPlatformTauri()) {
+      toast.info('Browser dragging unsupported', {
+         description: 'Drag and drop for Project attachments is not supported in the web browser. Please use the Upload button.'
+      })
+    }
   }
 
   const handleDeleteFile = async (fileId: string) => {
@@ -525,7 +540,7 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
   const isEmpty = !loading && files.length === 0
 
   return (
-    <div className="p-4">
+    <div ref={dropZoneRef} className="p-4">
       <div className="flex items-center justify-between mb-3">
         <h3 className="text-sm font-medium">{t('common:projects.files')}</h3>
         <Button
@@ -549,7 +564,6 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
         </div>
       ) : isEmpty ? (
         <div
-          ref={dropZoneRef}
           className={cn(
             'flex flex-col items-center justify-center py-8 px-4 rounded-lg border border-dashed cursor-pointer transition-colors',
             isDragging
@@ -557,9 +571,9 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
               : 'bg-secondary/30 border-border hover:bg-secondary/50'
           )}
           onClick={handleUpload}
-          onDragOver={handleDragOver}
-          onDragLeave={handleDragLeave}
-          onDrop={handleDrop}
+          onDragOver={attachmentsEnabled && !isPlatformTauri() ? handleDragOver : undefined}
+          onDragLeave={attachmentsEnabled && !isPlatformTauri() ? handleDragLeave : undefined}
+          onDrop={attachmentsEnabled && !isPlatformTauri() ? handleDrop : undefined}
         >
           <FileText className="size-8 text-muted-foreground/50 mb-3" />
           <p className="text-sm text-muted-foreground text-center">
@@ -568,14 +582,13 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
         </div>
       ) : (
         <div
-          ref={dropZoneRef}
           className={cn(
             'space-y-2 rounded-lg p-1 -m-1 transition-colors',
             isDragging && 'bg-primary/10 ring-2 ring-primary ring-dashed'
           )}
-          onDragOver={handleDragOver}
-          onDragLeave={handleDragLeave}
-          onDrop={handleDrop}
+          onDragOver={attachmentsEnabled && !isPlatformTauri() ? handleDragOver : undefined}
+          onDragLeave={attachmentsEnabled && !isPlatformTauri() ? handleDragLeave : undefined}
+          onDrop={attachmentsEnabled && !isPlatformTauri() ? handleDrop : undefined}
         >
           {files.map((file) => (
             <div


### PR DESCRIPTION
## Describe Your Changes
- Enabled native drag-and-drop in window configurations. Used Tauri native drop event listener to correctly retrieve absolute file paths. Stabilized drop event listener with React refs to prevent duplicate processing.

- Dragging a file anywhere over the app window would incorrectly trigger the highlight state for both the Project Files and Chat Input sections. This was because Tauri's `onDragDropEvent` is window global. We now accurately check the payload's physical position coordinates against the bounding area of the targeted components using `window.devicePixelRatio` scaling. Also restored drag highlight indication.

- Also fixed a bug where dropping image files into a newly opened project chat session resulted in "ghost attachments". They ingested into the database completely but stayed invisible within the UI without a refresh. This happened because the drag-and-drop listener was holding onto an outdated reference of the active chat thread (from when the app first loaded). To fix this, we wrapped the image processing function in a `useRef` so the listener always uses the current thread's ID.

## Fixes Issues

- Closes #7840 

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed



https://github.com/user-attachments/assets/a3f7b622-5ee4-4c65-9029-d3742e0778e1

[jan-drag-drop-fix.webm](https://github.com/user-attachments/assets/51e13928-b2d9-45a5-8981-63d63a678487)


note: Tested on Windows 11 only!