### PR TITLE
fix: restore Gemini SDK adapter for MCP tool calls (#7535)

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^2.0.0",
+    "@ai-sdk/google": "^2.0.0",
     "@ai-sdk/openai": "^2.0.0",
     "@ai-sdk/openai-compatible": "^1.0.28",
     "@ai-sdk/react": "^2.0.109",

--- a/web-app/src/lib/__tests__/model-factory.gemini-regression.test.ts
+++ b/web-app/src/lib/__tests__/model-factory.gemini-regression.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createGoogleGenerativeAI } from '@ai-sdk/google'
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
+import type { ProviderObject } from '@janhq/core'
+import { ModelFactory } from '../model-factory'
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+
+vi.mock('@tauri-apps/plugin-http', () => ({
+  fetch: vi.fn(),
+}))
+
+vi.mock('@ai-sdk/openai-compatible', () => ({
+  createOpenAICompatible: vi.fn(() => ({
+    languageModel: vi.fn(() => ({ type: 'openai-compatible' })),
+  })),
+  OpenAICompatibleChatLanguageModel: vi.fn(),
+  MetadataExtractor: vi.fn(),
+}))
+
+vi.mock('@ai-sdk/anthropic', () => ({
+  createAnthropic: vi.fn(() => vi.fn(() => ({ type: 'anthropic' }))),
+}))
+
+vi.mock('@ai-sdk/google', () => ({
+  createGoogleGenerativeAI: vi.fn(() => vi.fn(() => ({ type: 'google' }))),
+}))
+
+vi.mock('@ai-sdk/openai', () => ({
+  createOpenAI: vi.fn(() => vi.fn(() => ({ type: 'openai' }))),
+}))
+
+vi.mock('@ai-sdk/xai', () => ({
+  createXai: vi.fn(() => vi.fn(() => ({ type: 'xai' }))),
+}))
+
+vi.mock('ai', () => ({
+  wrapLanguageModel: vi.fn(({ model }) => model),
+  extractReasoningMiddleware: vi.fn(() => ({})),
+}))
+
+const mockedCreateGoogleGenerativeAI = vi.mocked(createGoogleGenerativeAI)
+const mockedCreateOpenAICompatible = vi.mocked(createOpenAICompatible)
+
+describe('ModelFactory Gemini regression', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('routes Gemini OpenAI endpoint providers through the Google SDK path', async () => {
+    const provider: ProviderObject = {
+      provider: 'gemini',
+      api_key: 'test-api-key',
+      base_url: 'https://generativelanguage.googleapis.com/v1beta/openai',
+      models: [],
+      settings: [],
+      active: true,
+    }
+
+    const model = await ModelFactory.createModel('gemini-2.5-flash', provider)
+
+    expect(model).toEqual({ type: 'google' })
+    expect(mockedCreateGoogleGenerativeAI).toHaveBeenCalledWith({
+      apiKey: 'test-api-key',
+      baseURL: 'https://generativelanguage.googleapis.com/v1beta/openai',
+      headers: undefined,
+    })
+    expect(mockedCreateOpenAICompatible).not.toHaveBeenCalled()
+  })
+
+  it('keeps non-Gemini providers on the OpenAI-compatible path', async () => {
+    const provider: ProviderObject = {
+      provider: 'groq',
+      api_key: 'test-api-key',
+      base_url: 'https://api.groq.com/openai/v1',
+      models: [],
+      settings: [],
+      active: true,
+    }
+
+    const model = await ModelFactory.createModel('llama-3', provider)
+
+    expect(model).toEqual({ type: 'openai-compatible' })
+    expect(mockedCreateOpenAICompatible).toHaveBeenCalledTimes(1)
+    expect(mockedCreateGoogleGenerativeAI).not.toHaveBeenCalled()
+  })
+})

--- a/web-app/src/lib/__tests__/model-factory.gemini-regression.test.ts
+++ b/web-app/src/lib/__tests__/model-factory.gemini-regression.test.ts
@@ -66,6 +66,7 @@ describe('ModelFactory Gemini regression', () => {
       apiKey: 'test-api-key',
       baseURL: 'https://generativelanguage.googleapis.com/v1beta/openai',
       headers: undefined,
+      fetch: expect.any(Function),
     })
     expect(mockedCreateOpenAICompatible).not.toHaveBeenCalled()
   })

--- a/web-app/src/lib/__tests__/model-factory.test.ts
+++ b/web-app/src/lib/__tests__/model-factory.test.ts
@@ -5,6 +5,8 @@ import { invoke } from '@tauri-apps/api/core'
 import { createGoogleGenerativeAI } from '@ai-sdk/google'
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 
+const mockGlobalFetch = vi.fn()
+
 // Mock the Tauri invoke function
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
@@ -63,6 +65,8 @@ describe('ModelFactory', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockStartModel.mockResolvedValue(undefined)
+    mockGlobalFetch.mockResolvedValue(new Response('{}'))
+    vi.stubGlobal('fetch', mockGlobalFetch)
   })
 
   describe('createModel', () => {
@@ -101,6 +105,7 @@ describe('ModelFactory', () => {
         apiKey: 'test-api-key',
         baseURL: 'https://generativelanguage.googleapis.com/v1',
         headers: undefined,
+        fetch: expect.any(Function),
       })
       expect(mockedCreateOpenAICompatible).not.toHaveBeenCalled()
     })
@@ -122,8 +127,46 @@ describe('ModelFactory', () => {
         apiKey: 'test-api-key',
         baseURL: 'https://generativelanguage.googleapis.com/v1',
         headers: undefined,
+        fetch: expect.any(Function),
       })
       expect(mockedCreateOpenAICompatible).not.toHaveBeenCalled()
+    })
+
+    it('should forward Gemini parameters through the injected fetch', async () => {
+      const provider: ProviderObject = {
+        provider: 'gemini',
+        api_key: 'test-api-key',
+        base_url: 'https://generativelanguage.googleapis.com/v1',
+        models: [],
+        settings: [],
+        active: true,
+      }
+
+      await ModelFactory.createModel('gemini-pro', provider, {
+        temperature: 0.2,
+        max_output_tokens: 256,
+        ctx_len: 4096,
+      })
+
+      const googleConfig = mockedCreateGoogleGenerativeAI.mock.calls[0]?.[0]
+      expect(googleConfig).toBeDefined()
+      expect(googleConfig?.fetch).toEqual(expect.any(Function))
+
+      await googleConfig!.fetch!(
+        'https://example.com/v1/chat/completions',
+        {
+          method: 'POST',
+          body: JSON.stringify({ prompt: 'hello' }),
+        }
+      )
+
+      expect(mockGlobalFetch).toHaveBeenCalledTimes(1)
+      const [, requestInit] = mockGlobalFetch.mock.calls[0]!
+      expect(JSON.parse(String(requestInit?.body))).toEqual({
+        prompt: 'hello',
+        temperature: 0.2,
+        max_tokens: 256,
+      })
     })
 
     it('should create an OpenAI-compatible model for openai provider', async () => {

--- a/web-app/src/lib/__tests__/model-factory.test.ts
+++ b/web-app/src/lib/__tests__/model-factory.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ModelFactory } from '../model-factory'
 import type { ProviderObject } from '@janhq/core'
 import { invoke } from '@tauri-apps/api/core'
+import { createGoogleGenerativeAI } from '@ai-sdk/google'
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 
 // Mock the Tauri invoke function
 vi.mock('@tauri-apps/api/core', () => ({
@@ -54,6 +56,8 @@ vi.mock('@/hooks/useServiceHub', () => ({
 }))
 
 const mockedInvoke = vi.mocked(invoke)
+const mockedCreateGoogleGenerativeAI = vi.mocked(createGoogleGenerativeAI)
+const mockedCreateOpenAICompatible = vi.mocked(createOpenAICompatible)
 
 describe('ModelFactory', () => {
   beforeEach(() => {
@@ -92,7 +96,13 @@ describe('ModelFactory', () => {
 
       const model = await ModelFactory.createModel('gemini-pro', provider)
       expect(model).toBeDefined()
-      expect(model.type).toBe('openai-compatible')
+      expect(model.type).toBe('google')
+      expect(mockedCreateGoogleGenerativeAI).toHaveBeenCalledWith({
+        apiKey: 'test-api-key',
+        baseURL: 'https://generativelanguage.googleapis.com/v1',
+        headers: undefined,
+      })
+      expect(mockedCreateOpenAICompatible).not.toHaveBeenCalled()
     })
 
     it('should create a Google model for gemini provider', async () => {
@@ -107,7 +117,13 @@ describe('ModelFactory', () => {
 
       const model = await ModelFactory.createModel('gemini-pro', provider)
       expect(model).toBeDefined()
-      expect(model.type).toBe('openai-compatible')
+      expect(model.type).toBe('google')
+      expect(mockedCreateGoogleGenerativeAI).toHaveBeenCalledWith({
+        apiKey: 'test-api-key',
+        baseURL: 'https://generativelanguage.googleapis.com/v1',
+        headers: undefined,
+      })
+      expect(mockedCreateOpenAICompatible).not.toHaveBeenCalled()
     })
 
     it('should create an OpenAI-compatible model for openai provider', async () => {

--- a/web-app/src/lib/model-factory.ts
+++ b/web-app/src/lib/model-factory.ts
@@ -333,7 +333,7 @@ export class ModelFactory {
         return this.createOpenAIModel(modelId, provider, parameters)
       case 'google':
       case 'gemini':
-        return this.createGoogleModel(modelId, provider)
+        return this.createGoogleModel(modelId, provider, parameters)
       case 'azure':
       case 'groq':
       case 'together':
@@ -622,7 +622,8 @@ export class ModelFactory {
    */
   private static createGoogleModel(
     modelId: string,
-    provider: ProviderObject
+    provider: ProviderObject,
+    parameters: Record<string, unknown> = {}
   ): LanguageModel {
     const headers: Record<string, string> = {}
 
@@ -634,10 +635,21 @@ export class ModelFactory {
     }
 
     const keyChain = providerRemoteApiKeyChain(provider)
+    const fetchImpl =
+      keyChain.length > 1
+        ? createApiKeyRotatingFetch(
+            getRuntimeFetch(),
+            keyChain,
+            parameters,
+            'x-api-key'
+          )
+        : createCustomFetch(getRuntimeFetch(), parameters)
+
     const google = createGoogleGenerativeAI({
       apiKey: keyChain[0] ?? provider.api_key ?? '',
       baseURL: provider.base_url,
       headers: Object.keys(headers).length > 0 ? headers : undefined,
+      fetch: fetchImpl,
     })
 
     return google(modelId)

--- a/web-app/src/lib/model-factory.ts
+++ b/web-app/src/lib/model-factory.ts
@@ -53,6 +53,7 @@ import {
   OpenAICompatibleChatLanguageModel,
 } from '@ai-sdk/openai-compatible'
 import { createAnthropic } from '@ai-sdk/anthropic'
+import { createGoogleGenerativeAI } from '@ai-sdk/google'
 import { createXai } from '@ai-sdk/xai'
 import { invoke } from '@tauri-apps/api/core'
 import { SessionInfo } from '@janhq/core'
@@ -332,6 +333,7 @@ export class ModelFactory {
         return this.createOpenAIModel(modelId, provider, parameters)
       case 'google':
       case 'gemini':
+        return this.createGoogleModel(modelId, provider)
       case 'azure':
       case 'groq':
       case 'together':
@@ -613,6 +615,32 @@ export class ModelFactory {
     })
 
     return anthropic(modelId)
+  }
+
+  /**
+   * Create a Google/Gemini model using the official AI SDK
+   */
+  private static createGoogleModel(
+    modelId: string,
+    provider: ProviderObject
+  ): LanguageModel {
+    const headers: Record<string, string> = {}
+
+    // Add custom headers if specified
+    if (provider.custom_header) {
+      provider.custom_header.forEach((customHeader) => {
+        headers[customHeader.header] = customHeader.value
+      })
+    }
+
+    const keyChain = providerRemoteApiKeyChain(provider)
+    const google = createGoogleGenerativeAI({
+      apiKey: keyChain[0] ?? provider.api_key ?? '',
+      baseURL: provider.base_url,
+      headers: Object.keys(headers).length > 0 ? headers : undefined,
+    })
+
+    return google(modelId)
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,6 +50,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ai-sdk/google@npm:^2.0.0":
+  version: 2.0.67
+  resolution: "@ai-sdk/google@npm:2.0.67"
+  dependencies:
+    "@ai-sdk/provider": "npm:2.0.1"
+    "@ai-sdk/provider-utils": "npm:3.0.23"
+  peerDependencies:
+    zod: ^3.25.76 || ^4.1.8
+  checksum: 10c0/0fa1bbd1ebb1286fb3641579ad1fa3cb7f075936d8016e238dab2082d7af9a56c829d5af4b5e9305d243dfeaa5fa504eae44343da48e30dd01e8ebe905f77d97
+  languageName: node
+  linkType: hard
+
 "@ai-sdk/openai-compatible@npm:1.0.33, @ai-sdk/openai-compatible@npm:^1.0.28":
   version: 1.0.33
   resolution: "@ai-sdk/openai-compatible@npm:1.0.33"
@@ -97,6 +109,19 @@ __metadata:
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
   checksum: 10c0/272645109b4990c1367d46fd8982ee3436f88f4f5ec96d78f98c928052dcee6e9a7df326558d908d73901a5c0a84b3374c31722bb78579c2efd3417afb2100fb
+  languageName: node
+  linkType: hard
+
+"@ai-sdk/provider-utils@npm:3.0.23":
+  version: 3.0.23
+  resolution: "@ai-sdk/provider-utils@npm:3.0.23"
+  dependencies:
+    "@ai-sdk/provider": "npm:2.0.1"
+    "@standard-schema/spec": "npm:^1.0.0"
+    eventsource-parser: "npm:^3.0.6"
+  peerDependencies:
+    zod: ^3.25.76 || ^4.1.8
+  checksum: 10c0/7b2adcbea13a09f7c8c0c6c5a77cde5c9973689acea2c3a7f79742d7edf463d1cbc90df38911e0235efeae89e37af43cfea2d856dedea4acdc5b0c3e65bf7d1b
   languageName: node
   linkType: hard
 
@@ -2774,6 +2799,7 @@ __metadata:
   resolution: "@janhq/web-app@workspace:web-app"
   dependencies:
     "@ai-sdk/anthropic": "npm:^2.0.0"
+    "@ai-sdk/google": "npm:^2.0.0"
     "@ai-sdk/openai": "npm:^2.0.0"
     "@ai-sdk/openai-compatible": "npm:^1.0.28"
     "@ai-sdk/react": "npm:^2.0.109"

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,18 +50,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ai-sdk/google@npm:^2.0.0":
-  version: 2.0.67
-  resolution: "@ai-sdk/google@npm:2.0.67"
-  dependencies:
-    "@ai-sdk/provider": "npm:2.0.1"
-    "@ai-sdk/provider-utils": "npm:3.0.23"
-  peerDependencies:
-    zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/0fa1bbd1ebb1286fb3641579ad1fa3cb7f075936d8016e238dab2082d7af9a56c829d5af4b5e9305d243dfeaa5fa504eae44343da48e30dd01e8ebe905f77d97
-  languageName: node
-  linkType: hard
-
 "@ai-sdk/openai-compatible@npm:1.0.33, @ai-sdk/openai-compatible@npm:^1.0.28":
   version: 1.0.33
   resolution: "@ai-sdk/openai-compatible@npm:1.0.33"
@@ -109,19 +97,6 @@ __metadata:
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
   checksum: 10c0/272645109b4990c1367d46fd8982ee3436f88f4f5ec96d78f98c928052dcee6e9a7df326558d908d73901a5c0a84b3374c31722bb78579c2efd3417afb2100fb
-  languageName: node
-  linkType: hard
-
-"@ai-sdk/provider-utils@npm:3.0.23":
-  version: 3.0.23
-  resolution: "@ai-sdk/provider-utils@npm:3.0.23"
-  dependencies:
-    "@ai-sdk/provider": "npm:2.0.1"
-    "@standard-schema/spec": "npm:^1.0.0"
-    eventsource-parser: "npm:^3.0.6"
-  peerDependencies:
-    zod: ^3.25.76 || ^4.1.8
-  checksum: 10c0/7b2adcbea13a09f7c8c0c6c5a77cde5c9973689acea2c3a7f79742d7edf463d1cbc90df38911e0235efeae89e37af43cfea2d856dedea4acdc5b0c3e65bf7d1b
   languageName: node
   linkType: hard
 
@@ -2799,7 +2774,6 @@ __metadata:
   resolution: "@janhq/web-app@workspace:web-app"
   dependencies:
     "@ai-sdk/anthropic": "npm:^2.0.0"
-    "@ai-sdk/google": "npm:^2.0.0"
     "@ai-sdk/openai": "npm:^2.0.0"
     "@ai-sdk/openai-compatible": "npm:^1.0.28"
     "@ai-sdk/react": "npm:^2.0.109"


### PR DESCRIPTION
## Describe Your Changes

- Restore the dedicated Gemini/Google provider path in `web-app/src/lib/model-factory.ts` by routing `google` and `gemini` through `@ai-sdk/google` instead of `@ai-sdk/openai-compatible`
- Re-add `@ai-sdk/google` to `web-app/package.json` and update `yarn.lock`
- Update `web-app/src/lib/__tests__/model-factory.test.ts` so Gemini/Google assertions verify the Google SDK path rather than the OpenAI-compatible path
- Add `web-app/src/lib/__tests__/model-factory.gemini-regression.test.ts` to prevent regressions where Gemini is pointed at Google’s OpenAI-style endpoint but accidentally routed back through the incompatible OpenAI-compatible adapter

- **Root cause:** Gemini had been routed through the OpenAI-compatible adapter, but its streamed tool-call payload does not fully match that adapter’s expected schema. As a result, MCP tool calls failed with the invalid_union validation error.

- **Why it was removed**: This happened in PR #7397, fix: openai raw tool call issue, where Google/Gemini was moved to the OpenAI-compatible path to avoid an earlier OpenAI tool-call regression and simplify provider handling.

- **Why re-add is needed**: Gemini needs its dedicated `@ai-sdk/google` path for correct tool-call handling. Re-adding it restores MCP compatibility without changing the providers that are truly

## Fixes Issues

- Closes #7535

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
