### PR TITLE
fix: centralize Jan data folder path resolution (#7522)

### DIFF
--- a/extensions/llamacpp-extension/src/test/backend.test.ts
+++ b/extensions/llamacpp-extension/src/test/backend.test.ts
@@ -9,6 +9,7 @@ import { getSystemInfo } from '@janhq/tauri-plugin-hardware-api'
 import { fs, getJanDataFolderPath, events } from '@janhq/core'
 import { invoke } from '@tauri-apps/api/core'
 import { dirname } from '@tauri-apps/api/path'
+import { isCudaInstalledFromRust } from '@janhq/tauri-plugin-llamacpp-api'
 
 // Mock constants: Hardcode path string directly inside the mock to avoid hoisting issues
 const MOCK_JAN_PATH_STRING = '/path/to/jan'
@@ -41,6 +42,16 @@ vi.mock('@tauri-apps/api/path', () => ({
   dirname: vi.fn(async (path) => path.split('/').slice(0, -1).join('/')),
   basename: vi.fn(async (path) => path.split('/').pop()),
 }))
+vi.mock('@janhq/tauri-plugin-llamacpp-api', async () => {
+  const actual = await vi.importActual<
+    typeof import('@janhq/tauri-plugin-llamacpp-api')
+  >('@janhq/tauri-plugin-llamacpp-api')
+
+  return {
+    ...actual,
+    isCudaInstalledFromRust: vi.fn().mockResolvedValue(false),
+  }
+})
 
 // Mock the global fetch function
 global.fetch = vi.fn()
@@ -91,6 +102,7 @@ describe('Backend functions', () => {
       mockDownloadManager
     )
     vi.mocked(mockDownloadManager.downloadFiles).mockClear()
+    vi.mocked(isCudaInstalledFromRust).mockResolvedValue(false)
   })
 
   afterEach(() => {
@@ -206,8 +218,14 @@ describe('Backend functions', () => {
       expect(downloadItems[0].url).toContain(
         'win-cuda-12-common_cpus-x64.tar.gz'
       )
+      expect(downloadItems[0].save_path).toBe(
+        `${MOCK_JAN_PATH_STRING}/llamacpp/backends/v1.0.0/win-cuda-12-common_cpus-x64/backend.tar.gz`
+      )
       expect(downloadItems[1].url).toContain(
         'cudart-llama-bin-win-cu12.0-x64.tar.gz'
+      )
+      expect(downloadItems[1].save_path).toBe(
+        `${MOCK_JAN_PATH_STRING}/llamacpp/backends/v1.0.0/win-cuda-12-common_cpus-x64/build/bin/cuda12.tar.gz`
       )
     })
 
@@ -233,8 +251,14 @@ describe('Backend functions', () => {
       expect(downloadItems[0].url).toContain(
         'linux-avx2-cuda-cu11.7-x64.tar.gz'
       )
+      expect(downloadItems[0].save_path).toBe(
+        `${MOCK_JAN_PATH_STRING}/llamacpp/backends/v1.0.0/linux-avx2-cuda-cu11.7-x64/backend.tar.gz`
+      )
       expect(downloadItems[1].url).toContain(
         'cudart-llama-bin-linux-cu11.7-x64.tar.gz'
+      )
+      expect(downloadItems[1].save_path).toBe(
+        `${MOCK_JAN_PATH_STRING}/llamacpp/backends/v1.0.0/linux-avx2-cuda-cu11.7-x64/build/bin/cuda11.tar.gz`
       )
     })
 

--- a/src-tauri/src/core/downloads/commands.rs
+++ b/src-tauri/src/core/downloads/commands.rs
@@ -1,6 +1,7 @@
 use super::helpers::{_download_files_internal, err_to_string};
 use super::models::DownloadItem;
 use crate::core::app::commands::get_jan_data_folder_path;
+use crate::core::filesystem::helpers::resolve_path_within_jan_data_folder;
 use crate::core::state::AppState;
 use std::collections::HashMap;
 use tauri::{Runtime, State};
@@ -47,8 +48,11 @@ pub async fn download_files<R: Runtime>(
     if cancel_token.is_cancelled() {
         let jan_data_folder = get_jan_data_folder_path(app.clone());
         for item in items {
-            let save_path = jan_data_folder.join(&item.save_path);
-            let _ = std::fs::remove_file(&save_path); // don't check error
+            if let Ok((_, save_path)) =
+                resolve_path_within_jan_data_folder(&jan_data_folder, &item.save_path)
+            {
+                let _ = std::fs::remove_file(&save_path); // don't check error
+            }
         }
     }
 

--- a/src-tauri/src/core/downloads/helpers.rs
+++ b/src-tauri/src/core/downloads/helpers.rs
@@ -1,9 +1,9 @@
 use super::models::{DownloadEvent, DownloadItem, ProgressTracker, ProxyConfig};
 use crate::core::app::commands::get_jan_data_folder_path;
-use crate::core::updater::session::get_session_id;
+use crate::core::filesystem::helpers::resolve_path_within_jan_data_folder;
 use crate::core::updater::hmac_client::SignedRequestHeaders;
+use crate::core::updater::session::get_session_id;
 use futures_util::StreamExt;
-use jan_utils::normalize_path;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use std::collections::HashMap;
 use std::path::Path;
@@ -60,9 +60,12 @@ pub fn err_to_string<E: std::fmt::Display>(e: E) -> String {
 pub fn convert_to_mirror_url(url: &str) -> Option<String> {
     let parsed = Url::parse(url).ok()?;
     let host = parsed.host_str()?;
-    
+
     // Check if the domain should use mirror
-    if MIRROR_DOMAINS.iter().any(|domain| host == *domain || host.ends_with(&format!(".{}", domain))) {
+    if MIRROR_DOMAINS
+        .iter()
+        .any(|domain| host == *domain || host.ends_with(&format!(".{}", domain)))
+    {
         // Remove the scheme (https://) and prepend mirror prefix
         let url_without_scheme = url
             .strip_prefix("https://")
@@ -412,16 +415,8 @@ pub async fn _download_files_internal(
     let mut download_tasks = Vec::new();
 
     for (index, item) in items.iter().enumerate() {
-        let save_path = jan_data_folder.join(&item.save_path);
-        let save_path = normalize_path(&save_path);
-
-        if !save_path.starts_with(&jan_data_folder) {
-            return Err(format!(
-                "Path {} is outside of Jan data folder {}",
-                save_path.display(),
-                jan_data_folder.display()
-            ));
-        }
+        let (canonical_data, save_path) =
+            resolve_path_within_jan_data_folder(&jan_data_folder, &item.save_path)?;
 
         // Spawn download task for each file
         let item_clone = item.clone();
@@ -438,6 +433,11 @@ pub async fn _download_files_internal(
         };
 
         let task = tokio::spawn(async move {
+            log::debug!(
+                "Downloading {} into Jan data folder {}",
+                item_clone.url,
+                canonical_data.display()
+            );
             download_single_file(app_clone, &item_clone, &save_path, file_id, file_size, ctx).await
         });
 
@@ -622,12 +622,12 @@ async fn download_single_file(
         // Use mirror fallback for new downloads
         _get_maybe_resume_with_fallback(&client, &item.url, 0).await?
     };
-    
+
     // Log which URL is being used for download
     if actual_url != item.url {
         log::info!("Downloading via Jan mirror: {}", actual_url);
     }
-    
+
     let mut stream = resp.bytes_stream();
 
     let file = if should_resume {
@@ -731,11 +731,14 @@ pub async fn _get_maybe_resume_with_fallback(
                 return Ok((resp, mirror_url));
             }
             Err(e) => {
-                log::warn!("Jan mirror download failed: {}. Falling back to original URL...", e);
+                log::warn!(
+                    "Jan mirror download failed: {}. Falling back to original URL...",
+                    e
+                );
             }
         }
     }
-    
+
     // Fallback to original URL (no HMAC headers needed)
     log::info!("Downloading from original URL: {}", url);
     let resp = _get_maybe_resume_internal(client, url, start_bytes).await?;
@@ -752,7 +755,7 @@ async fn _get_maybe_resume_with_hmac(
     let nonce_seed = get_download_nonce_seed();
     let app_version = get_app_version();
     let signed_headers = SignedRequestHeaders::new(SECRET_KEY, &nonce_seed, app_version);
-    
+
     let mut request = if start_bytes > 0 {
         client
             .get(url)
@@ -760,14 +763,14 @@ async fn _get_maybe_resume_with_hmac(
     } else {
         client.get(url)
     };
-    
+
     // Add HMAC headers
     for (key, value) in signed_headers.to_header_pairs() {
         request = request.header(key, value);
     }
-    
+
     let resp = request.send().await.map_err(err_to_string)?;
-    
+
     if start_bytes > 0 {
         if resp.status() != reqwest::StatusCode::PARTIAL_CONTENT {
             return Err(format!(
@@ -783,7 +786,7 @@ async fn _get_maybe_resume_with_hmac(
             resp.text().await.unwrap_or_default()
         ));
     }
-    
+
     Ok(resp)
 }
 

--- a/src-tauri/src/core/downloads/tests.rs
+++ b/src-tauri/src/core/downloads/tests.rs
@@ -1,5 +1,6 @@
 use super::helpers::*;
 use super::models::*;
+use crate::core::filesystem::helpers::resolve_path_within_jan_data_folder;
 use reqwest::header::HeaderMap;
 use std::collections::HashMap;
 
@@ -269,6 +270,38 @@ fn test_download_item_creation() {
 
     assert_eq!(item.url, "https://example.com/file.tar.gz");
     assert_eq!(item.save_path, "models/test.tar.gz");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_download_scope_accepts_absolute_path_inside_canonical_root() {
+    use std::fs;
+    use std::os::unix::fs::symlink;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let base_dir = std::env::temp_dir().join(format!("jan-download-scope-{unique}"));
+    let configured_root = base_dir.join("home").join("user").join("jan-data");
+    let canonical_root = base_dir
+        .join("var")
+        .join("home")
+        .join("user")
+        .join("jan-data");
+    fs::create_dir_all(&canonical_root).unwrap();
+    fs::create_dir_all(configured_root.parent().unwrap()).unwrap();
+    symlink(&canonical_root, &configured_root).unwrap();
+
+    let candidate = canonical_root.join("llamacpp/backends/v1/backend.tar.gz");
+    let (_, resolved_path) =
+        resolve_path_within_jan_data_folder(&configured_root, candidate.to_string_lossy().as_ref())
+            .unwrap();
+
+    assert_eq!(resolved_path, candidate);
+
+    let _ = fs::remove_dir_all(&base_dir);
 }
 
 #[test]

--- a/src-tauri/src/core/downloads/tests.rs
+++ b/src-tauri/src/core/downloads/tests.rs
@@ -299,7 +299,7 @@ fn test_download_scope_accepts_absolute_path_inside_canonical_root() {
         resolve_path_within_jan_data_folder(&configured_root, candidate.to_string_lossy().as_ref())
             .unwrap();
 
-    assert_eq!(resolved_path, candidate);
+    assert_eq!(resolved_path, candidate.canonicalize().unwrap());
 
     let _ = fs::remove_dir_all(&base_dir);
 }

--- a/src-tauri/src/core/downloads/tests.rs
+++ b/src-tauri/src/core/downloads/tests.rs
@@ -299,7 +299,11 @@ fn test_download_scope_accepts_absolute_path_inside_canonical_root() {
         resolve_path_within_jan_data_folder(&configured_root, candidate.to_string_lossy().as_ref())
             .unwrap();
 
-    assert_eq!(resolved_path, candidate.canonicalize().unwrap());
+    let expected_path = canonical_root
+        .canonicalize()
+        .unwrap()
+        .join("llamacpp/backends/v1/backend.tar.gz");
+    assert_eq!(resolved_path, expected_path);
 
     let _ = fs::remove_dir_all(&base_dir);
 }

--- a/src-tauri/src/core/filesystem/commands.rs
+++ b/src-tauri/src/core/filesystem/commands.rs
@@ -1,6 +1,6 @@
 // WARNING: These APIs will be deprecated soon due to removing FS API access from frontend.
 // It's added to ensure the legacy implementation from frontend still functions before removal.
-use super::helpers::resolve_path;
+use super::helpers::{resolve_app_path_within_jan_data_folder, resolve_path};
 use super::models::{DialogOpenOptions, FileStat};
 use rfd::AsyncFileDialog;
 use std::fs;
@@ -12,15 +12,12 @@ pub fn rm<R: Runtime>(app_handle: tauri::AppHandle<R>, args: Vec<String>) -> Res
         return Err("rm error: Invalid argument".to_string());
     }
 
-    let jan_data_folder =
-        crate::core::app::commands::get_jan_data_folder_path(app_handle.clone());
-    let path = resolve_path(app_handle, &args[0]);
-    let canonical_data = jan_data_folder.canonicalize().unwrap_or(jan_data_folder);
-    let canonical_path = path.canonicalize().unwrap_or_else(|_| path.clone());
-    if !canonical_path.starts_with(&canonical_data) {
+    let (canonical_data, path) = resolve_app_path_within_jan_data_folder(app_handle, &args[0])
+        .map_err(|_| format!("rm error: path {} is not under jan data folder", args[0]))?;
+    if !path.starts_with(&canonical_data) {
         return Err(format!(
             "rm error: path {} is not under jan data folder {}",
-            canonical_path.display(),
+            path.display(),
             canonical_data.display()
         ));
     }
@@ -158,15 +155,7 @@ pub fn write_yaml(
     save_path: &str,
 ) -> Result<(), String> {
     // TODO: have an internal function to check scope
-    let jan_data_folder = crate::core::app::commands::get_jan_data_folder_path(app.clone());
-    let save_path = jan_utils::normalize_path(&jan_data_folder.join(save_path));
-    if !save_path.starts_with(&jan_data_folder) {
-        return Err(format!(
-            "Error: save path {} is not under jan_data_folder {}",
-            save_path.to_string_lossy(),
-            jan_data_folder.to_string_lossy(),
-        ));
-    }
+    let (_jan_data_folder, save_path) = resolve_app_path_within_jan_data_folder(app, save_path)?;
     let file = fs::File::create(&save_path).map_err(|e| e.to_string())?;
     let mut writer = std::io::BufWriter::new(file);
     serde_yaml::to_writer(&mut writer, &data).map_err(|e| e.to_string())?;
@@ -178,15 +167,7 @@ pub fn read_yaml<R: Runtime>(
     app: tauri::AppHandle<R>,
     path: &str,
 ) -> Result<serde_json::Value, String> {
-    let jan_data_folder = crate::core::app::commands::get_jan_data_folder_path(app.clone());
-    let path = jan_utils::normalize_path(&jan_data_folder.join(path));
-    if !path.starts_with(&jan_data_folder) {
-        return Err(format!(
-            "Error: path {} is not under jan_data_folder {}",
-            path.to_string_lossy(),
-            jan_data_folder.to_string_lossy(),
-        ));
-    }
+    let (_jan_data_folder, path) = resolve_app_path_within_jan_data_folder(app, path)?;
     let file = fs::File::open(&path).map_err(|e| e.to_string())?;
     let reader = std::io::BufReader::new(file);
     let data: serde_json::Value = serde_yaml::from_reader(reader).map_err(|e| e.to_string())?;
@@ -199,17 +180,9 @@ pub fn decompress<R: Runtime>(
     path: &str,
     output_dir: &str,
 ) -> Result<(), String> {
-    let jan_data_folder = crate::core::app::commands::get_jan_data_folder_path(app.clone());
-    let path_buf = jan_utils::normalize_path(&jan_data_folder.join(path));
-
-    let output_dir_buf = jan_utils::normalize_path(&jan_data_folder.join(output_dir));
-    if !output_dir_buf.starts_with(&jan_data_folder) {
-        return Err(format!(
-            "Error: output directory {} is not under jan_data_folder {}",
-            output_dir_buf.to_string_lossy(),
-            jan_data_folder.to_string_lossy(),
-        ));
-    }
+    let (_jan_data_folder, path_buf) = resolve_app_path_within_jan_data_folder(app.clone(), path)?;
+    let (_jan_data_folder, output_dir_buf) =
+        resolve_app_path_within_jan_data_folder(app, output_dir)?;
 
     // Ensure output directory exists
     fs::create_dir_all(&output_dir_buf).map_err(|e| {

--- a/src-tauri/src/core/filesystem/helpers.rs
+++ b/src-tauri/src/core/filesystem/helpers.rs
@@ -62,18 +62,30 @@ fn canonicalize_for_scope(path: &Path) -> PathBuf {
     normalize_path(&canonical_parent.join(suffix))
 }
 
+fn normalize_scope_path(path: PathBuf) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let path_str = path.to_string_lossy();
+        if let Some(stripped) = path_str.strip_prefix(r"\\?\") {
+            return normalize_path(Path::new(stripped));
+        }
+    }
+
+    normalize_path(&path)
+}
+
 pub fn resolve_path_within_jan_data_folder(
     jan_data_folder: &Path,
     path: &str,
 ) -> Result<(PathBuf, PathBuf), String> {
-    let canonical_data = canonicalize_for_scope(jan_data_folder);
+    let canonical_data = normalize_scope_path(canonicalize_for_scope(jan_data_folder));
     let input_path = resolve_path_input(path, jan_data_folder);
     let resolved_path = if input_path.is_absolute() {
         normalize_path(&input_path)
     } else {
         normalize_path(&canonical_data.join(input_path))
     };
-    let canonical_path = canonicalize_for_scope(&resolved_path);
+    let canonical_path = normalize_scope_path(canonicalize_for_scope(&resolved_path));
 
     if !canonical_path.starts_with(&canonical_data) {
         return Err(format!(

--- a/src-tauri/src/core/filesystem/helpers.rs
+++ b/src-tauri/src/core/filesystem/helpers.rs
@@ -1,6 +1,6 @@
 use crate::core::app::commands::get_jan_data_folder_path;
-use jan_utils::normalize_file_path;
-use std::path::PathBuf;
+use jan_utils::{normalize_file_path, normalize_path};
+use std::path::{Path, PathBuf};
 use tauri::Runtime;
 
 pub fn resolve_path<R: Runtime>(app_handle: tauri::AppHandle<R>, path: &str) -> PathBuf {
@@ -20,4 +20,76 @@ pub fn resolve_path<R: Runtime>(app_handle: tauri::AppHandle<R>, path: &str) -> 
     } else {
         path.canonicalize().unwrap_or(path)
     }
+}
+
+fn resolve_path_input(path: &str, jan_data_folder: &Path) -> PathBuf {
+    if path.starts_with("file:/") || path.starts_with("file:\\") {
+        let normalized = normalize_file_path(path);
+        let relative_normalized = normalized
+            .trim_start_matches(std::path::MAIN_SEPARATOR)
+            .trim_start_matches('/')
+            .trim_start_matches('\\');
+        jan_data_folder.join(relative_normalized)
+    } else {
+        PathBuf::from(path)
+    }
+}
+
+fn canonicalize_for_scope(path: &Path) -> PathBuf {
+    if let Ok(canonical) = path.canonicalize() {
+        return canonical;
+    }
+
+    let normalized = normalize_path(path);
+    let mut current = normalized.clone();
+
+    while !current.exists() {
+        let Some(parent) = current.parent() else {
+            return normalized;
+        };
+        current = parent.to_path_buf();
+    }
+
+    let Ok(canonical_parent) = current.canonicalize() else {
+        return normalized;
+    };
+
+    let suffix = normalized
+        .strip_prefix(&current)
+        .map(|value| value.to_path_buf())
+        .unwrap_or_default();
+
+    normalize_path(&canonical_parent.join(suffix))
+}
+
+pub fn resolve_path_within_jan_data_folder(
+    jan_data_folder: &Path,
+    path: &str,
+) -> Result<(PathBuf, PathBuf), String> {
+    let canonical_data = canonicalize_for_scope(jan_data_folder);
+    let input_path = resolve_path_input(path, jan_data_folder);
+    let resolved_path = if input_path.is_absolute() {
+        normalize_path(&input_path)
+    } else {
+        normalize_path(&canonical_data.join(input_path))
+    };
+    let canonical_path = canonicalize_for_scope(&resolved_path);
+
+    if !canonical_path.starts_with(&canonical_data) {
+        return Err(format!(
+            "Path {} is outside of Jan data folder {}",
+            canonical_path.display(),
+            canonical_data.display()
+        ));
+    }
+
+    Ok((canonical_data, canonical_path))
+}
+
+pub fn resolve_app_path_within_jan_data_folder<R: Runtime>(
+    app_handle: tauri::AppHandle<R>,
+    path: &str,
+) -> Result<(PathBuf, PathBuf), String> {
+    let jan_data_folder = get_jan_data_folder_path(app_handle);
+    resolve_path_within_jan_data_folder(&jan_data_folder, path)
 }

--- a/src-tauri/src/core/filesystem/tests.rs
+++ b/src-tauri/src/core/filesystem/tests.rs
@@ -127,17 +127,16 @@ fn test_resolve_jan_scoped_path_accepts_relative_path_inside_root() {
     let jan_data_folder = unique_test_dir("relative");
     fs::create_dir_all(&jan_data_folder).unwrap();
 
-    let (_, resolved_path) = resolve_path_within_jan_data_folder(
+    let (resolved_root, resolved_path) = resolve_path_within_jan_data_folder(
         &jan_data_folder,
         "llamacpp/backends/v1/backend.tar.gz",
     )
     .unwrap();
 
+    assert!(resolved_path.starts_with(&resolved_root));
     assert_eq!(
-        resolved_path,
-        jan_data_folder
-            .join("llamacpp/backends/v1/backend.tar.gz")
-            .to_path_buf()
+        resolved_path.file_name().and_then(|name| name.to_str()),
+        Some("backend.tar.gz")
     );
 
     let _ = fs::remove_dir_all(&jan_data_folder);

--- a/src-tauri/src/core/filesystem/tests.rs
+++ b/src-tauri/src/core/filesystem/tests.rs
@@ -117,7 +117,7 @@ fn test_resolve_jan_scoped_path_allows_canonicalized_home_symlink_target() {
         resolve_path_within_jan_data_folder(&configured_root, candidate.to_string_lossy().as_ref())
             .unwrap();
 
-    assert_eq!(resolved_path, candidate);
+    assert_eq!(resolved_path, candidate.canonicalize().unwrap());
 
     let _ = fs::remove_dir_all(&base_dir);
 }
@@ -134,6 +134,7 @@ fn test_resolve_jan_scoped_path_accepts_relative_path_inside_root() {
     .unwrap();
 
     assert!(resolved_path.starts_with(&resolved_root));
+    assert_eq!(resolved_root, jan_data_folder.canonicalize().unwrap());
     assert_eq!(
         resolved_path.file_name().and_then(|name| name.to_str()),
         Some("backend.tar.gz")

--- a/src-tauri/src/core/filesystem/tests.rs
+++ b/src-tauri/src/core/filesystem/tests.rs
@@ -1,9 +1,10 @@
 use super::commands::*;
 use super::helpers::resolve_path_within_jan_data_folder;
 use crate::core::app::commands::get_jan_data_folder_path;
+use jan_utils::normalize_path;
 use std::fs::{self, File};
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tauri::test::mock_app;
 
 #[test]
@@ -117,7 +118,11 @@ fn test_resolve_jan_scoped_path_allows_canonicalized_home_symlink_target() {
         resolve_path_within_jan_data_folder(&configured_root, candidate.to_string_lossy().as_ref())
             .unwrap();
 
-    assert_eq!(resolved_path, candidate.canonicalize().unwrap());
+    let expected_path = canonical_root
+        .canonicalize()
+        .unwrap()
+        .join("llamacpp/backends/v1/backend.tar.gz");
+    assert_eq!(resolved_path, expected_path);
 
     let _ = fs::remove_dir_all(&base_dir);
 }
@@ -134,7 +139,10 @@ fn test_resolve_jan_scoped_path_accepts_relative_path_inside_root() {
     .unwrap();
 
     assert!(resolved_path.starts_with(&resolved_root));
-    assert_eq!(resolved_root, jan_data_folder.canonicalize().unwrap());
+    assert_eq!(
+        normalize_test_path(&resolved_root),
+        normalize_test_path(&jan_data_folder.canonicalize().unwrap())
+    );
     assert_eq!(
         resolved_path.file_name().and_then(|name| name.to_str()),
         Some("backend.tar.gz")
@@ -179,4 +187,16 @@ fn unique_test_dir(label: &str) -> PathBuf {
         .unwrap()
         .as_nanos();
     std::env::temp_dir().join(format!("jan-filesystem-{label}-{unique}"))
+}
+
+fn normalize_test_path(path: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let path_str = path.to_string_lossy();
+        if let Some(stripped) = path_str.strip_prefix(r"\\?\") {
+            return normalize_path(Path::new(stripped));
+        }
+    }
+
+    normalize_path(path)
 }

--- a/src-tauri/src/core/filesystem/tests.rs
+++ b/src-tauri/src/core/filesystem/tests.rs
@@ -1,7 +1,9 @@
 use super::commands::*;
+use super::helpers::resolve_path_within_jan_data_folder;
 use crate::core::app::commands::get_jan_data_folder_path;
 use std::fs::{self, File};
 use std::io::Write;
+use std::path::PathBuf;
 use tauri::test::mock_app;
 
 #[test]
@@ -87,4 +89,94 @@ fn test_readdir_sync() {
     assert_eq!(result.len(), 2);
 
     let _ = fs::remove_dir_all(dir_path);
+}
+
+#[cfg(unix)]
+#[test]
+fn test_resolve_jan_scoped_path_allows_canonicalized_home_symlink_target() {
+    use std::os::unix::fs::symlink;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let base_dir = std::env::temp_dir().join(format!("jan-path-scope-{unique}"));
+    let configured_root = base_dir.join("home").join("user").join("jan-data");
+    let canonical_root = base_dir
+        .join("var")
+        .join("home")
+        .join("user")
+        .join("jan-data");
+    fs::create_dir_all(&canonical_root).unwrap();
+    fs::create_dir_all(configured_root.parent().unwrap()).unwrap();
+    symlink(&canonical_root, &configured_root).unwrap();
+
+    let candidate = canonical_root.join("llamacpp/backends/v1/backend.tar.gz");
+    let (_, resolved_path) =
+        resolve_path_within_jan_data_folder(&configured_root, candidate.to_string_lossy().as_ref())
+            .unwrap();
+
+    assert_eq!(resolved_path, candidate);
+
+    let _ = fs::remove_dir_all(&base_dir);
+}
+
+#[test]
+fn test_resolve_jan_scoped_path_accepts_relative_path_inside_root() {
+    let jan_data_folder = unique_test_dir("relative");
+    fs::create_dir_all(&jan_data_folder).unwrap();
+
+    let (_, resolved_path) = resolve_path_within_jan_data_folder(
+        &jan_data_folder,
+        "llamacpp/backends/v1/backend.tar.gz",
+    )
+    .unwrap();
+
+    assert_eq!(
+        resolved_path,
+        jan_data_folder
+            .join("llamacpp/backends/v1/backend.tar.gz")
+            .to_path_buf()
+    );
+
+    let _ = fs::remove_dir_all(&jan_data_folder);
+}
+
+#[test]
+fn test_resolve_jan_scoped_path_rejects_escape_outside_data_folder() {
+    let jan_data_folder = unique_test_dir("escape");
+    fs::create_dir_all(&jan_data_folder).unwrap();
+
+    let result = resolve_path_within_jan_data_folder(&jan_data_folder, "../outside.txt");
+    assert!(result.is_err());
+
+    let _ = fs::remove_dir_all(&jan_data_folder);
+}
+
+#[test]
+fn test_resolve_jan_scoped_path_rejects_absolute_path_outside_root() {
+    let jan_data_folder = unique_test_dir("absolute-inside");
+    let outside_path = unique_test_dir("absolute-outside").join("file.txt");
+    fs::create_dir_all(&jan_data_folder).unwrap();
+    fs::create_dir_all(outside_path.parent().unwrap()).unwrap();
+
+    let result = resolve_path_within_jan_data_folder(
+        &jan_data_folder,
+        outside_path.to_string_lossy().as_ref(),
+    );
+    assert!(result.is_err());
+
+    let _ = fs::remove_dir_all(&jan_data_folder);
+    let _ = fs::remove_dir_all(outside_path.parent().unwrap());
+}
+
+fn unique_test_dir(label: &str) -> PathBuf {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("jan-filesystem-{label}-{unique}"))
 }


### PR DESCRIPTION
## Describe Your Changes

- Before: backend download fails on `Bazzite/Flatpak` with `/home` vs `/var/home` mismatch

- After: canonicalized in-root paths are accepted consistently across download and filesystem commands

- Test evidence: Rust regression tests for canonicalized root matching and escape rejection

- Root cause: Jan validates download and filesystem paths against the configured data folder using inconsistent path normalization. On immutable Linux distributions such as Bazzite, the configured path may be stored under `/home/... `while runtime path resolution canonicalizes to `/var/home/...`; Jan then compares these as different paths and incorrectly rejects valid in-folder paths as being outside the Jan data directory.

## Fixes Issues

- Closes #7522

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
