### PR TITLE
fix: handle non-UTF-8 paths in MCP helpers to prevent panic

### DIFF
--- a/src-tauri/src/core/mcp/helpers.rs
+++ b/src-tauri/src/core/mcp/helpers.rs
@@ -63,12 +63,9 @@ pub async fn run_mcp_commands<R: Runtime>(
     servers_state: SharedMcpServers,
 ) -> Result<(), String> {
     let app_path = get_jan_data_folder_path(app.clone());
-    let app_path_str = app_path.to_str().unwrap().to_string();
-    log::trace!(
-        "Load MCP configs from {}",
-        app_path_str.clone() + "/mcp_config.json"
-    );
-    let config_content = std::fs::read_to_string(app_path_str + "/mcp_config.json")
+    let config_path = app_path.join("mcp_config.json");
+    log::trace!("Load MCP configs from {}", config_path.display());
+    let config_content = std::fs::read_to_string(&config_path)
         .map_err(|e| format!("Failed to read config file: {e}"))?;
 
     let mcp_servers: serde_json::Value = serde_json::from_str(&config_content)
@@ -567,7 +564,7 @@ async fn schedule_mcp_start_task<R: Runtime>(
             cache_dir.push(".npx");
             cmd = Command::new(bun_x_path.display().to_string());
             cmd.arg("x");
-            cmd.env("BUN_INSTALL", cache_dir.to_str().unwrap());
+            cmd.env("BUN_INSTALL", &cache_dir);
         }
 
         let uv_path = if cfg!(windows) {
@@ -582,7 +579,7 @@ async fn schedule_mcp_start_task<R: Runtime>(
             cmd = Command::new(uv_path);
             cmd.arg("tool");
             cmd.arg("run");
-            cmd.env("UV_CACHE_DIR", cache_dir.to_str().unwrap());
+            cmd.env("UV_CACHE_DIR", &cache_dir);
         }
         #[cfg(windows)]
         {


### PR DESCRIPTION
## Describe Your Changes

Replaces three panicking `to_str().unwrap()` calls in `src-tauri/src/core/mcp/helpers.rs` with safe path handling. On Windows with certain locales (e.g. CJK legacy encodings), the Jan data folder path can contain characters that aren't valid UTF-8, which causes `to_str()` to return `None` and `.unwrap()` to panic during MCP server startup.

**Line 66** — config path construction:
```rust
// Before: panics if app_path is not valid UTF-8
let app_path_str = app_path.to_str().unwrap().to_string();
let config_content = std::fs::read_to_string(app_path_str + "/mcp_config.json")

// After: uses Path::join (no string conversion needed)
let config_path = app_path.join("mcp_config.json");
let config_content = std::fs::read_to_string(&config_path)
```

**Lines 570, 585** — environment variable for npx/uvx cache dir:
```rust
// Before: panics if cache_dir is not valid UTF-8
cmd.env("BUN_INSTALL", cache_dir.to_str().unwrap());

// After: PathBuf implements AsRef<OsStr>, pass directly
cmd.env("BUN_INSTALL", &cache_dir);
```

This follows the same class of fix merged in #7577 for `commands.rs`. The test file (`tests.rs` line 26) already uses `app_path.join("mcp_config.json")` — this change aligns the production code with that convention.

No remaining `to_str().unwrap()` calls in `helpers.rs` after this change (confirmed via grep).

## Fixes Issues

- Closes #7571

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [x] Updated docs (for bug fixes / features)
- [x] Created issues for follow-up changes or refactoring needed