### PR TITLE
feat: add option to play sound when AI finishes responding

### DIFF
--- a/web-app/src/hooks/__tests__/useInterfaceSettings.test.ts
+++ b/web-app/src/hooks/__tests__/useInterfaceSettings.test.ts
@@ -46,8 +46,10 @@ describe('useInterfaceSettings', () => {
     expect(result.current.fontSize).toBe('16px')
     expect(result.current.accentColor).toBe('gray')
     expect(result.current.notificationPosition).toBe('top-right')
+    expect(result.current.playSoundOnComplete).toBe(false)
     expect(typeof result.current.setFontSize).toBe('function')
     expect(typeof result.current.setAccentColor).toBe('function')
+    expect(typeof result.current.setPlaySoundOnComplete).toBe('function')
     expect(typeof result.current.resetInterface).toBe('function')
   })
 
@@ -98,6 +100,7 @@ describe('useInterfaceSettings', () => {
     act(() => {
       result.current.setFontSize('18px')
       result.current.setAccentColor('blue')
+      result.current.setPlaySoundOnComplete(true)
     })
 
     // Reset
@@ -108,6 +111,25 @@ describe('useInterfaceSettings', () => {
     expect(result.current.fontSize).toBe('16px')
     expect(result.current.accentColor).toBe('gray')
     expect(result.current.notificationPosition).toBe('top-right')
+    expect(result.current.playSoundOnComplete).toBe(false)
+  })
+
+  it('should update play sound on complete setting', () => {
+    const { result } = renderHook(() => useInterfaceSettings())
+
+    expect(result.current.playSoundOnComplete).toBe(false)
+
+    act(() => {
+      result.current.setPlaySoundOnComplete(true)
+    })
+
+    expect(result.current.playSoundOnComplete).toBe(true)
+
+    act(() => {
+      result.current.setPlaySoundOnComplete(false)
+    })
+
+    expect(result.current.playSoundOnComplete).toBe(false)
   })
 
   it('should update notification position', () => {

--- a/web-app/src/hooks/useInterfaceSettings.ts
+++ b/web-app/src/hooks/useInterfaceSettings.ts
@@ -109,9 +109,11 @@ interface InterfaceSettingsState {
   fontSize: FontSize
   accentColor: AccentColorValue
   notificationPosition: NotificationPosition
+  playSoundOnComplete: boolean
   setFontSize: (size: FontSize) => void
   setAccentColor: (color: AccentColorValue) => void
   setNotificationPosition: (position: NotificationPosition) => void
+  setPlaySoundOnComplete: (enabled: boolean) => void
   resetInterface: () => void
 }
 
@@ -121,6 +123,7 @@ type InterfaceSettingsPersistedSlice = Omit<
   | 'setFontSize'
   | 'setAccentColor'
   | 'setNotificationPosition'
+  | 'setPlaySoundOnComplete'
 >
 
 export const fontSizeOptions = [
@@ -138,6 +141,7 @@ const createDefaultInterfaceValues = (): InterfaceSettingsPersistedSlice => {
     fontSize: defaultFontSize,
     accentColor: DEFAULT_ACCENT_COLOR,
     notificationPosition: getDefaultNotificationPosition(),
+    playSoundOnComplete: false,
   }
 }
 
@@ -173,6 +177,7 @@ export const useInterfaceSettings = create<InterfaceSettingsState>()(
             fontSize: defaultFontSize,
             accentColor: DEFAULT_ACCENT_COLOR,
             notificationPosition: getDefaultNotificationPosition(),
+            playSoundOnComplete: false,
           })
         },
 
@@ -196,6 +201,10 @@ export const useInterfaceSettings = create<InterfaceSettingsState>()(
           if (!isNotificationPosition(position)) return
           set({ notificationPosition: position })
         },
+
+        setPlaySoundOnComplete: (enabled: boolean) => {
+          set({ playSoundOnComplete: enabled })
+        },
       }
     },
     {
@@ -205,6 +214,7 @@ export const useInterfaceSettings = create<InterfaceSettingsState>()(
         fontSize: state.fontSize,
         accentColor: state.accentColor,
         notificationPosition: state.notificationPosition,
+        playSoundOnComplete: state.playSoundOnComplete,
       }),
       // Apply settings when hydrating from storage
       onRehydrateStorage: () => (state) => {

--- a/web-app/src/locales/en/settings.json
+++ b/web-app/src/locales/en/settings.json
@@ -94,6 +94,8 @@
     "notificationPositionTopLeft": "Top left",
     "notificationPositionBottomRight": "Bottom right",
     "notificationPositionBottomLeft": "Bottom left",
+    "playSoundOnComplete": "Play sound on completion",
+    "playSoundOnCompleteDesc": "Play a notification sound when the model finishes responding.",
     "windowBackground": "Window Background",
     "windowBackgroundDesc": "Set the app window's background color.",
     "appMainView": "App Main View",

--- a/web-app/src/routes/settings/__tests__/interface.test.tsx
+++ b/web-app/src/routes/settings/__tests__/interface.test.tsx
@@ -50,6 +50,8 @@ vi.mock('@/containers/NotificationPositionSwitcher', () => ({
 vi.mock('@/hooks/useInterfaceSettings', () => ({
   useInterfaceSettings: () => ({
     resetInterface: vi.fn(),
+    playSoundOnComplete: false,
+    setPlaySoundOnComplete: vi.fn(),
   }),
 }))
 
@@ -57,6 +59,12 @@ vi.mock('@/i18n/react-i18next-compat', () => ({
   useTranslation: () => ({
     t: (key: string) => key,
   }),
+}))
+
+vi.mock('@/components/ui/switch', () => ({
+  Switch: ({ checked, onCheckedChange, ...props }: { checked?: boolean; onCheckedChange?: (v: boolean) => void; [key: string]: any }) => (
+    <button data-testid="switch" role="switch" aria-checked={checked} onClick={() => onCheckedChange?.(!checked)} {...props} />
+  ),
 }))
 
 vi.mock('@/components/ui/button', () => ({
@@ -171,6 +179,15 @@ describe('Interface Settings Route', () => {
     )
 
     expect(responsiveItems.length).toBeGreaterThan(0)
+  })
+
+  it('should render play sound on complete switch', () => {
+    const Component = InterfaceRoute.component as React.ComponentType
+    render(<Component />)
+
+    const switchEl = screen.getByTestId('switch')
+    expect(switchEl).toBeInTheDocument()
+    expect(switchEl).toHaveAttribute('aria-checked', 'false')
   })
 
   it('should render main layout structure', () => {

--- a/web-app/src/routes/settings/interface.tsx
+++ b/web-app/src/routes/settings/interface.tsx
@@ -10,6 +10,7 @@ import { AccentColorPicker } from '@/containers/AccentColorPicker'
 import { NotificationPositionSwitcher } from '@/containers/NotificationPositionSwitcher'
 import { useInterfaceSettings } from '@/hooks/useInterfaceSettings'
 import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
 import { toast } from 'sonner'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -19,7 +20,7 @@ export const Route = createFileRoute(route.settings.interface as any)({
 
 function InterfaceSettings() {
   const { t } = useTranslation()
-  const { resetInterface } = useInterfaceSettings()
+  const { resetInterface, playSoundOnComplete, setPlaySoundOnComplete } = useInterfaceSettings()
 
   return (
     <div className="flex flex-col h-svh w-full">
@@ -54,6 +55,16 @@ function InterfaceSettings() {
                 title={t('settings:interface.notificationPosition')}
                 description={t('settings:interface.notificationPositionDesc')}
                 actions={<NotificationPositionSwitcher />}
+              />
+              <CardItem
+                title={t('settings:interface.playSoundOnComplete')}
+                description={t('settings:interface.playSoundOnCompleteDesc')}
+                actions={
+                  <Switch
+                    checked={playSoundOnComplete}
+                    onCheckedChange={setPlaySoundOnComplete}
+                  />
+                }
               />
               <CardItem
                 title={t('settings:interface.resetToDefault')}

--- a/web-app/src/stores/chat-session-store.ts
+++ b/web-app/src/stores/chat-session-store.ts
@@ -4,6 +4,8 @@ import type { Chat, UIMessage } from "@ai-sdk/react";
 import type { ChatStatus } from "ai";
 import { CustomChatTransport } from "@/lib/custom-chat-transport";
 import { useMessageQueue } from "@/stores/message-queue-store";
+import { hapticFeedback } from "@/lib/haptic";
+import { useInterfaceSettings } from "@/hooks/useInterfaceSettings";
 // import { showChatCompletionToast } from "@/components/toasts/chat-completion-toast";
 
 export type SessionData = {
@@ -131,6 +133,8 @@ export const useChatSessions = create<ChatSessionState>((set, get) => ({
     return standaloneData[sessionId];
   },
   updateStatus: (sessionId, status) => {
+    const wasPreviouslyStreaming = get().sessions[sessionId]?.isStreaming ?? false;
+
     set((state) => {
       const existing = state.sessions[sessionId];
       if (!existing) {
@@ -173,6 +177,16 @@ export const useChatSessions = create<ChatSessionState>((set, get) => ({
         },
       };
     });
+
+    if (wasPreviouslyStreaming && status === 'ready') {
+      const updated = get().sessions[sessionId];
+      if (updated && updated.chat.messages.length > 0 && updated.data.tools.length === 0) {
+        const { playSoundOnComplete } = useInterfaceSettings.getState()
+        if (playSoundOnComplete) {
+          hapticFeedback('double')
+        }
+      }
+    }
   },
   setSessionTitle: (sessionId, title) => {
     if (!title) return;


### PR DESCRIPTION
Closes #6093

## Describe Your Changes

Add an optional notification sound when the AI model finishes responding. When enabled in Settings > Appearance, a synthesized double-pip tone plays upon response completion. This helps users who have Jan in the background know when the model is done without checking the window.

**Changes:**
- Add "Play sound on completion" toggle in Settings > Appearance
- Trigger sound via existing Web Audio API haptic system when streaming status transitions to ready
- Persist setting with Zustand + fileStorage (same pattern as other interface settings)
- Add tests for the new setting and UI toggle

## Demo

https://github.com/user-attachments/assets/60a5b6ae-c429-40da-b1ed-464547134c5d

## Fixes Issues

- Closes #6093

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [x] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed