### PR TITLE
fix: include Metal shader library in macOS app bundle

### DIFF
--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -30,7 +30,7 @@
   },
   "bundle": {
     "targets": ["app", "dmg"],
-    "resources": ["resources/pre-install/**/*", "resources/LICENSE", "resources/bin/mlx-server", "resources/bin/mlx-swift_Cmlx.bundle", "resources/bin/jan-cli"],
+    "resources": ["resources/pre-install/**/*", "resources/LICENSE", "resources/bin/mlx-server", "resources/bin/mlx-swift_Cmlx.bundle/**/*", "resources/bin/jan-cli"],
     "externalBin": ["resources/bin/bun", "resources/bin/uv"],
     "macOS": {
       "entitlements": "./Entitlements.plist"


### PR DESCRIPTION
## Describe Your Changes

- The mlx-swift_Cmlx.bundle is a directory containing the .metallib file required by the MLX runtime. Using a plain path in Tauri's bundle resources treated it as a single file, so the directory contents were never copied into jan.app. Use a glob pattern to recursively include all files within the bundle.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
