### PR TITLE
feat: File attachment progress bar

### DIFF
--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -4,6 +4,7 @@ import { usePrompt } from '@/hooks/usePrompt'
 import { useThreads } from '@/hooks/useThreads'
 import { useCallback, useEffect, useMemo, useRef, useState, memo } from 'react'
 import { Button } from '@/components/ui/button'
+import { Progress } from '@/components/ui/progress'
 import {
   Tooltip,
   TooltipContent,
@@ -295,6 +296,11 @@ const ChatInput = memo(function ChatInput({
     (a) => a.type === 'document' && a.processing
   )
   const ingestingAny = attachments.some((a) => a.processing)
+
+  const [fileIngestProgress, setFileIngestProgress] = useState<{
+    completed: number
+    total: number
+  } | null>(null)
 
   // Queued messages for this thread (shown as chips in the input area)
   const queuedMessages = useMessageQueue(
@@ -762,6 +768,7 @@ const ChatInput = memo(function ChatInput({
             parsePreference,
             perFileChoices: docChoices.size > 0 ? docChoices : undefined,
             updateAttachmentProcessing,
+            onIngestProgress: setFileIngestProgress,
           })
 
         if (processedAttachments.length > 0) {
@@ -787,6 +794,8 @@ const ChatInput = memo(function ChatInput({
         }
       } catch (e) {
         console.error('Failed to process attachments:', e)
+      } finally {
+        setFileIngestProgress(null)
       }
     },
     [
@@ -1221,50 +1230,61 @@ const ChatInput = memo(function ChatInput({
     )
 
     if (currentThreadId && newFiles.length > 0) {
+      const ingestTotal = newFiles.length
       void (async () => {
-        for (const img of newFiles) {
-          const matchImg = (a: Attachment) =>
-            a.type === 'image' &&
-            (img.contentHash ? a.contentHash === img.contentHash : a.name === img.name)
+        setFileIngestProgress({ completed: 0, total: ingestTotal })
+        try {
+          for (let i = 0; i < newFiles.length; i++) {
+            const img = newFiles[i]
+            const matchImg = (a: Attachment) =>
+              a.type === 'image' &&
+              (img.contentHash
+                ? a.contentHash === img.contentHash
+                : a.name === img.name)
 
-          try {
-            // Mark as processing
-            setAttachmentsForThread(attachmentsKey, (prev) =>
-              prev.map((a) => (matchImg(a) ? { ...a, processing: true } : a))
-            )
-
-            const result = await serviceHub
-              .uploads()
-              .ingestImage(currentThreadId, img)
-
-            if (result?.id) {
-              // Mark as processed with ID
+            try {
               setAttachmentsForThread(attachmentsKey, (prev) =>
-                prev.map((a) =>
-                  matchImg(a)
-                    ? {
-                        ...a,
-                        processing: false,
-                        processed: true,
-                        id: result.id,
-                      }
-                    : a
-                )
+                prev.map((a) => (matchImg(a) ? { ...a, processing: true } : a))
               )
-            } else {
-              throw new Error('No ID returned from image ingestion')
+
+              const result = await serviceHub
+                .uploads()
+                .ingestImage(currentThreadId, img)
+
+              if (result?.id) {
+                setAttachmentsForThread(attachmentsKey, (prev) =>
+                  prev.map((a) =>
+                    matchImg(a)
+                      ? {
+                          ...a,
+                          processing: false,
+                          processed: true,
+                          id: result.id,
+                        }
+                      : a
+                  )
+                )
+              } else {
+                throw new Error('No ID returned from image ingestion')
+              }
+            } catch (error) {
+              console.error('Failed to ingest image:', error)
+              setAttachmentsForThread(attachmentsKey, (prev) =>
+                prev.filter((a) => !matchImg(a))
+              )
+              toast.error(`Failed to ingest ${img.name}`, {
+                description:
+                  error instanceof Error ? error.message : String(error),
+              })
+            } finally {
+              setFileIngestProgress({
+                completed: i + 1,
+                total: ingestTotal,
+              })
             }
-          } catch (error) {
-            console.error('Failed to ingest image:', error)
-            // Remove failed image
-            setAttachmentsForThread(attachmentsKey, (prev) =>
-              prev.filter((a) => !matchImg(a))
-            )
-            toast.error(`Failed to ingest ${img.name}`, {
-              description:
-                error instanceof Error ? error.message : String(error),
-            })
           }
+        } finally {
+          setFileIngestProgress(null)
         }
       })()
     }
@@ -1713,6 +1733,24 @@ const ChatInput = memo(function ChatInput({
                       )
                     })}
                 </div>
+                {fileIngestProgress && fileIngestProgress.total > 0 && (
+                  <div className="space-y-1.5 pr-1">
+                    <div className="flex justify-between gap-2 text-xs text-muted-foreground">
+                      <span>{t('common:uploadingAttachments')}</span>
+                      <span className="tabular-nums shrink-0">
+                        {fileIngestProgress.completed} /{' '}
+                        {fileIngestProgress.total}
+                      </span>
+                    </div>
+                    <Progress
+                      value={
+                        (fileIngestProgress.completed /
+                          fileIngestProgress.total) *
+                        100
+                      }
+                    />
+                  </div>
+                )}
               </div>
             )}
             {queuedMessages.length > 0 && (

--- a/web-app/src/containers/ProjectFiles.tsx
+++ b/web-app/src/containers/ProjectFiles.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { FileText, Trash2, UploadIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { Progress } from '@/components/ui/progress'
 import {
   Tooltip,
   TooltipContent,
@@ -237,6 +238,10 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
   const [files, setFiles] = useState<ProjectFile[]>([])
   const [loading, setLoading] = useState(true)
   const [uploading, setUploading] = useState(false)
+  const [uploadProgress, setUploadProgress] = useState<{
+    current: number
+    total: number
+  } | null>(null)
   const [isDragging, setIsDragging] = useState(false)
 
   const loadProjectFiles = useCallback(async () => {
@@ -344,15 +349,19 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
 
       if (newAttachments.length === 0) return
 
+      const total = newAttachments.length
       setUploading(true)
+      setUploadProgress({ current: 0, total })
       try {
-        for (const att of newAttachments) {
+        for (let i = 0; i < newAttachments.length; i++) {
+          const att = newAttachments[i]
           const result = await serviceHub
             .uploads()
             .ingestFileAttachmentForProject(projectId, att)
           if (!result.id) {
             throw new Error('Failed to ingest file')
           }
+          setUploadProgress({ current: i + 1, total })
         }
         toast.success(
           t('common:toast.fileUploaded.title') ?? 'File uploaded successfully'
@@ -368,6 +377,7 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
           }
         )
       } finally {
+        setUploadProgress(null)
         setUploading(false)
       }
     },
@@ -514,6 +524,22 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
           <span>Upload</span>
         </Button>
       </div>
+
+      {uploadProgress && uploadProgress.total > 0 && (
+        <div className="mb-3 space-y-1.5">
+          <div className="flex justify-between gap-2 text-xs text-muted-foreground">
+            <span>
+              {t('common:projects.uploadingFiles') ?? 'Uploading files…'}
+            </span>
+            <span className="tabular-nums shrink-0">
+              {uploadProgress.current} / {uploadProgress.total}
+            </span>
+          </div>
+          <Progress
+            value={(uploadProgress.current / uploadProgress.total) * 100}
+          />
+        </div>
+      )}
 
       {loading ? (
         <div className="flex items-center justify-center py-8">

--- a/web-app/src/containers/ProjectFiles.tsx
+++ b/web-app/src/containers/ProjectFiles.tsx
@@ -529,7 +529,7 @@ export default function ProjectFiles({ projectId, lng }: ProjectFilesProps) {
         <div className="mb-3 space-y-1.5">
           <div className="flex justify-between gap-2 text-xs text-muted-foreground">
             <span>
-              {t('common:projects.uploadingFiles') ?? 'Uploading files…'}
+              {t('common:projects.uploadingFiles')}
             </span>
             <span className="tabular-nums shrink-0">
               {uploadProgress.current} / {uploadProgress.total}

--- a/web-app/src/lib/attachmentProcessing.ts
+++ b/web-app/src/lib/attachmentProcessing.ts
@@ -4,6 +4,11 @@ import { toast } from 'sonner'
 
 type AttachmentProcessingStatus = 'processing' | 'done' | 'error' | 'clear_all'
 
+export type AttachmentIngestProgress = {
+  completed: number
+  total: number
+}
+
 type AttachmentProcessingOptions = {
   attachments: Attachment[]
   threadId: string
@@ -20,6 +25,8 @@ type AttachmentProcessingOptions = {
     status: AttachmentProcessingStatus,
     updatedAttachment?: Partial<Attachment>
   ) => void
+  /** Fired when attachment ingestion advances (multi-file uploads). */
+  onIngestProgress?: (state: AttachmentIngestProgress) => void
 }
 
 export type AttachmentProcessingResult = {
@@ -82,10 +89,33 @@ export const processAttachmentsForSend = async (
     autoFallbackMode,
     perFileChoices,
     updateAttachmentProcessing,
+    onIngestProgress,
   } = options
 
   const processedAttachments: Attachment[] = []
   let hasEmbeddedDocuments = false
+
+  const imagesToProcess = attachments.filter(
+    (img) => img.type === 'image' && !(img.processed && img.id)
+  )
+  const documentsToProcess = attachments.filter(
+    (doc) =>
+      doc.type === 'document' &&
+      !(doc.processed && (doc.id || doc.injectionMode === 'inline'))
+  )
+  const ingestTotal = imagesToProcess.length + documentsToProcess.length
+  let ingestCompleted = 0
+  const bumpIngest = () => {
+    if (!onIngestProgress || ingestTotal <= 0) return
+    ingestCompleted += 1
+    onIngestProgress({
+      completed: Math.min(ingestCompleted, ingestTotal),
+      total: ingestTotal,
+    })
+  }
+  if (onIngestProgress && ingestTotal > 0) {
+    onIngestProgress({ completed: 0, total: ingestTotal })
+  }
   const effectiveContextThreshold =
     typeof contextThreshold === 'number' &&
     Number.isFinite(contextThreshold) &&
@@ -122,6 +152,7 @@ export const processAttachmentsForSend = async (
           processed: true,
           processing: false,
         })
+        bumpIngest()
       } catch (err) {
         console.error(`Failed to ingest image ${img.name}:`, err)
         notifyUpdate(img.name, 'error')
@@ -225,6 +256,7 @@ export const processAttachmentsForSend = async (
           inlineContent: parsedContent,
           injectionMode: 'inline',
         })
+        bumpIngest()
         continue
       }
 
@@ -254,6 +286,7 @@ export const processAttachmentsForSend = async (
         processed: true,
         injectionMode: 'embeddings',
       })
+      bumpIngest()
     } catch (err) {
       console.error(`Failed to ingest ${doc.name}:`, err)
       notifyUpdate(doc.name, 'error')

--- a/web-app/src/lib/attachmentProcessing.ts
+++ b/web-app/src/lib/attachmentProcessing.ts
@@ -260,7 +260,9 @@ export const processAttachmentsForSend = async (
         continue
       }
 
-      // Default: ingest as embeddings
+      // Default: ingest as embeddings.
+      // Also reached when targetMode is 'inline' but parsedContent is absent
+      // (i.e. parsing failed above) — intentional: embeddings is the safe fallback.
       notifyUpdate(doc.name, 'processing')
 
       const res = projectId

--- a/web-app/src/locales/ca/common.json
+++ b/web-app/src/locales/ca/common.json
@@ -68,6 +68,7 @@
   "noThreadsYetDesc": "Inicia una conversa nova per veure aquí l’historial dels teus fils.",
   "downloads": "Descàrregues",
   "downloading": "S’està descarregant",
+  "uploadingAttachments": "S’estan pujant els fitxers adjunts…",
   "cancelDownload": "Cancel·la la descàrrega",
   "downloadCancelled": "Descàrrega cancel·lada",
   "downloadComplete": "Descàrrega completada",
@@ -290,7 +291,8 @@
     "update": "Actualitza",
     "searchProjects": "Cerca projectes...",
     "noProjectsFound": "No s’han trobat projectes",
-    "tryDifferentSearch": "Prova amb un terme de cerca diferent"
+    "tryDifferentSearch": "Prova amb un terme de cerca diferent",
+    "uploadingFiles": "S’estan pujant els fitxers…"
   },
   "attachmentsIngestion": {
     "title": "Tria com ingerir els adjunts",

--- a/web-app/src/locales/cs/common.json
+++ b/web-app/src/locales/cs/common.json
@@ -76,6 +76,7 @@
   "noThreadsYetDesc": "Začněte novou konverzaci a uvidíte zde historii vláken.",
   "downloads": "Stahování",
   "downloading": "Stahování",
+  "uploadingAttachments": "Nahrávání příloh…",
   "cancelDownload": "Zrušit stahování",
   "downloadCancelled": "Stahování zrušeno",
   "downloadComplete": "Stahování dokončeno",
@@ -299,7 +300,8 @@
     "update": "Aktualizovat",
     "searchProjects": "Hledat projekty...",
     "noProjectsFound": "Nebyly nalezeny žádné projekty",
-    "tryDifferentSearch": "Zkuste jiný vyhledávací výraz"
+    "tryDifferentSearch": "Zkuste jiný vyhledávací výraz",
+    "uploadingFiles": "Nahrávání souborů…"
   },
   "toast": {
     "allThreadsUnfavorited": {

--- a/web-app/src/locales/de-DE/common.json
+++ b/web-app/src/locales/de-DE/common.json
@@ -76,6 +76,7 @@
   "noThreadsYetDesc": "Starte eine neue Unterhaltung, um deinen Threadverlauf hier anzuzeigen.",
   "downloads": "Downloads",
   "downloading": "Downloading",
+  "uploadingAttachments": "Anhänge werden hochgeladen…",
   "cancelDownload": "Download abbrechen",
   "downloadCancelled": "Download wurde abgebrochen",
   "downloadComplete": "Download abgeschlossen",
@@ -299,7 +300,8 @@
     "update": "Aktualisieren",
     "searchProjects": "Projekte durchsuchen...",
     "noProjectsFound": "Keine Projekte gefunden",
-    "tryDifferentSearch": "Versuchen Sie einen anderen Suchbegriff"
+    "tryDifferentSearch": "Versuchen Sie einen anderen Suchbegriff",
+    "uploadingFiles": "Dateien werden hochgeladen…"
   },
   "toast": {
     "allThreadsUnfavorited": {

--- a/web-app/src/locales/en/common.json
+++ b/web-app/src/locales/en/common.json
@@ -86,6 +86,7 @@
   "noThreadsYetDesc": "Start a new conversation to see your thread history here.",
   "downloads": "Downloads",
   "downloading": "Downloading",
+  "uploadingAttachments": "Uploading attachments…",
   "cancelDownload": "Cancel download",
   "downloadCancelled": "Download Cancelled",
   "downloadComplete": "Download Complete",
@@ -281,6 +282,7 @@
     "noAssistantAssigned": "No assistant assigned to this project",
     "files": "Files",
     "filesDescription": "Add PDFs, documents, or other text to reference in this project.",
+    "uploadingFiles": "Uploading files…",
     "deleteProjectDialog": {
       "title": "Delete Project",
       "permanentDelete": "This will permanently delete all threads.",

--- a/web-app/src/locales/es/common.json
+++ b/web-app/src/locales/es/common.json
@@ -88,6 +88,7 @@
   "noThreadsYetDesc": "Inicia una nueva conversación para ver tu historial de hilos aquí.",
   "downloads": "Descargas",
   "downloading": "Descargando",
+  "uploadingAttachments": "Subiendo archivos adjuntos…",
   "cancelDownload": "Cancelar descarga",
   "downloadCancelled": "Descarga cancelada",
   "downloadComplete": "Descarga completa",
@@ -283,6 +284,7 @@
     "noAssistantAssigned": "No hay asistente asignado a este proyecto",
     "files": "Archivos",
     "filesDescription": "Agrega PDFs, documentos u otros textos para usar como referencia en este proyecto.",
+    "uploadingFiles": "Subiendo archivos…",
     "deleteProjectDialog": {
       "title": "Eliminar proyecto",
       "permanentDelete": "Esto eliminará permanentemente todos los hilos.",

--- a/web-app/src/locales/fr/common.json
+++ b/web-app/src/locales/fr/common.json
@@ -76,6 +76,7 @@
   "noThreadsYetDesc": "Commencez une nouvelle conversation pour voir l'historique de vos discussions ici.",
   "downloads": "Téléchargements",
   "downloading": "Téléchargement en cours",
+  "uploadingAttachments": "Téléversement des pièces jointes…",
   "cancelDownload": "Annuler le téléchargement",
   "downloadCancelled": "Téléchargement annulé",
   "downloadComplete": "Téléchargement terminé",
@@ -298,7 +299,8 @@
     "update": "Mettre à jour",
     "searchProjects": "Rechercher des projets...",
     "noProjectsFound": "Aucun projet trouvé",
-    "tryDifferentSearch": "Essayez un autre terme de recherche"
+    "tryDifferentSearch": "Essayez un autre terme de recherche",
+    "uploadingFiles": "Téléversement des fichiers…"
   },
   "toast": {
     "allThreadsUnfavorited": {

--- a/web-app/src/locales/id/common.json
+++ b/web-app/src/locales/id/common.json
@@ -76,6 +76,7 @@
   "noThreadsYetDesc": "Mulai percakapan baru untuk melihat riwayat utas Anda di sini.",
   "downloads": "Unduhan",
   "downloading": "Mengunduh",
+  "uploadingAttachments": "Mengunggah lampiran…",
   "cancelDownload": "Batalkan unduhan",
   "downloadCancelled": "Unduhan Dibatalkan",
   "downloadComplete": "Unduhan Selesai",
@@ -381,6 +382,7 @@
     "update": "Perbarui",
     "searchProjects": "Cari proyek...",
     "noProjectsFound": "Tidak ada proyek ditemukan",
-    "tryDifferentSearch": "Coba kata kunci pencarian lain"
+    "tryDifferentSearch": "Coba kata kunci pencarian lain",
+    "uploadingFiles": "Mengunggah file…"
   }
 }

--- a/web-app/src/locales/ja/common.json
+++ b/web-app/src/locales/ja/common.json
@@ -76,6 +76,7 @@
   "noThreadsYetDesc": "新しい会話を始めると、ここにスレッドの履歴が表示されます。",
   "downloads": "ダウンロード",
   "downloading": "ダウンロード中",
+  "uploadingAttachments": "添付ファイルをアップロードしています…",
   "cancelDownload": "ダウンロードをキャンセル",
   "downloadCancelled": "ダウンロードがキャンセルされました",
   "downloadComplete": "ダウンロード完了",
@@ -290,7 +291,8 @@
     "updated": "更新日時:",
     "collapseThreads": "スレッドを折りたたむ",
     "expandThreads": "スレッドを展開する",
-    "update": "更新"
+    "update": "更新",
+    "uploadingFiles": "ファイルをアップロードしています…"
   },
   "toast": {
     "allThreadsUnfavorited": {

--- a/web-app/src/locales/ko/common.json
+++ b/web-app/src/locales/ko/common.json
@@ -86,6 +86,7 @@
   "noThreadsYetDesc": "새 대화를 시작하면 여기에 스레드 기록이 표시됩니다.",
   "downloads": "다운로드",
   "downloading": "다운로드 중",
+  "uploadingAttachments": "첨부 파일 업로드 중…",
   "cancelDownload": "다운로드 취소",
   "downloadCancelled": "다운로드 취소됨",
   "downloadComplete": "다운로드 완료",
@@ -281,6 +282,7 @@
     "noAssistantAssigned": "이 프로젝트에 할당된 어시스턴트가 없습니다",
     "files": "파일",
     "filesDescription": "이 프로젝트에서 참조할 PDF, 문서 또는 기타 텍스트를 추가하세요.",
+    "uploadingFiles": "파일 업로드 중…",
     "deleteProjectDialog": {
       "title": "프로젝트 삭제",
       "permanentDelete": "모든 스레드가 영구적으로 삭제됩니다.",

--- a/web-app/src/locales/pl/common.json
+++ b/web-app/src/locales/pl/common.json
@@ -76,6 +76,7 @@
   "noThreadsYetDesc": "Rozpocznij nową rozmowę aby zobaczyć tutaj historię wątków.",
   "downloads": "Pobrane",
   "downloading": "Pobieranie",
+  "uploadingAttachments": "Przesyłanie załączników…",
   "cancelDownload": "Anuluj Pobieranie",
   "downloadCancelled": "Pobieranie anulowane",
   "downloadComplete": "Pobieranie zakończone",
@@ -293,7 +294,8 @@
     "update": "Aktualizuj",
     "searchProjects": "Szukaj projektów...",
     "noProjectsFound": "Nie znaleziono projektów",
-    "tryDifferentSearch": "Spróbuj innego wyszukiwania"
+    "tryDifferentSearch": "Spróbuj innego wyszukiwania",
+    "uploadingFiles": "Przesyłanie plików…"
   },
   "toast": {
     "allThreadsUnfavorited": {

--- a/web-app/src/locales/pt-BR/common.json
+++ b/web-app/src/locales/pt-BR/common.json
@@ -75,6 +75,7 @@
   "noThreadsYetDesc": "Inicie uma nova conversa para ver seu histórico de conversas aqui.",
   "downloads": "Downloads",
   "downloading": "Baixando",
+  "uploadingAttachments": "Enviando anexos…",
   "cancelDownload": "Cancelar download",
   "downloadCancelled": "Download Cancelado",
   "downloadComplete": "Download Concluído",
@@ -296,7 +297,8 @@
     "update": "Atualizar",
     "searchProjects": "Buscar projetos...",
     "noProjectsFound": "Nenhum projeto encontrado",
-    "tryDifferentSearch": "Tente um termo de busca diferente"
+    "tryDifferentSearch": "Tente um termo de busca diferente",
+    "uploadingFiles": "Enviando arquivos…"
   },
   "toast": {
     "allThreadsUnfavorited": {

--- a/web-app/src/locales/ru/common.json
+++ b/web-app/src/locales/ru/common.json
@@ -76,6 +76,7 @@
   "noThreadsYetDesc": "Начните новый диалог, чтобы увидеть историю ваших обсуждений.",
   "downloads": "Загрузки",
   "downloading": "Загрузка",
+  "uploadingAttachments": "Загрузка вложений…",
   "cancelDownload": "Отменить загрузку",
   "downloadCancelled": "Загрузка отменена",
   "downloadComplete": "Загрузка завершена",
@@ -299,7 +300,8 @@
     "update": "Обновить",
     "searchProjects": "Поиск проектов...",
     "noProjectsFound": "Проекты не найдены",
-    "tryDifferentSearch": "Попробуйте другой поисковый запрос"
+    "tryDifferentSearch": "Попробуйте другой поисковый запрос",
+    "uploadingFiles": "Загрузка файлов…"
   },
   "attachmentsIngestion": {
     "title": "Выберите способ обработки вложений",

--- a/web-app/src/locales/vn/common.json
+++ b/web-app/src/locales/vn/common.json
@@ -76,6 +76,7 @@
   "noThreadsYetDesc": "Bắt đầu một cuộc trò chuyện mới để xem lịch sử chủ đề của bạn ở đây.",
   "downloads": "Tải xuống",
   "downloading": "Đang tải xuống",
+  "uploadingAttachments": "Đang tải lên tệp đính kèm…",
   "cancelDownload": "Hủy tải xuống",
   "downloadCancelled": "Đã hủy tải xuống",
   "downloadComplete": "Tải xuống hoàn tất",
@@ -253,6 +254,7 @@
     "searchProjects": "Tìm kiếm dự án...",
     "noProjectsFound": "Không tìm thấy dự án nào",
     "tryDifferentSearch": "Thử từ khóa tìm kiếm khác",
+    "uploadingFiles": "Đang tải lên tệp…",
     "deleteProjectDialog": {
       "title": "Xóa dự án",
       "permanentDelete": "Điều này sẽ xóa vĩnh viễn tất cả các chủ đề.",

--- a/web-app/src/locales/zh-CN/common.json
+++ b/web-app/src/locales/zh-CN/common.json
@@ -76,6 +76,7 @@
   "noThreadsYetDesc": "开始新的对话以在此处查看您的会话历史记录。",
   "downloads": "下载",
   "downloading": "下载中",
+  "uploadingAttachments": "正在上传附件…",
   "cancelDownload": "取消下载",
   "downloadCancelled": "下载已取消",
   "downloadComplete": "下载完成",
@@ -252,6 +253,7 @@
     "searchProjects": "搜索项目...",
     "noProjectsFound": "未找到项目",
     "tryDifferentSearch": "尝试不同的搜索词",
+    "uploadingFiles": "正在上传文件…",
     "createNewProject": "创建新项目",
     "deleteProjectDialog": {
       "title": "删除项目",

--- a/web-app/src/locales/zh-TW/common.json
+++ b/web-app/src/locales/zh-TW/common.json
@@ -76,6 +76,7 @@
   "noThreadsYetDesc": "開始一個新的對話以在此處查看您的對話歷史記錄。",
   "downloads": "下載",
   "downloading": "下載中",
+  "uploadingAttachments": "正在上傳附件…",
   "cancelDownload": "取消下載",
   "downloadCancelled": "下載已取消",
   "downloadComplete": "下載完成",
@@ -252,6 +253,7 @@
     "searchProjects": "搜尋專案...",
     "noProjectsFound": "找不到專案",
     "tryDifferentSearch": "嘗試不同的搜尋詞",
+    "uploadingFiles": "正在上傳檔案…",
     "createNewProject": "建立新專案",
     "deleteProjectDialog": {
       "title": "刪除專案",


### PR DESCRIPTION
## Changes
Adds visible upload/indexing progress for multi-file flows in the web app: a linear progress bar with **completed / total** counts, instead of only spinners or ambiguous “processing” state.

### UI
- **Project files** (`ProjectFiles.tsx`): While ingesting multiple documents into a project, shows a progress bar and `current / total` under the files header.
- **Chat** (`ChatInput.tsx`): While images or documents are being ingested after attach, shows a progress bar below the attachment chips with the same fraction.
### Logic
- **`attachmentProcessing.ts`**: Optional `onIngestProgress?: ({ completed, total }) => void` on `processAttachmentsForSend`, exported type `AttachmentIngestProgress`. Progress counts only attachments that actually run ingestion (skips already-processed / inline-only docs). Fires once at `0 / total`, then after each successful step.
### i18n
- **`common.uploadingAttachments`** — chat progress label.
- **`common.projects.uploadingFiles`** — project files progress label.
- Strings added across all locale `common.json` files under `web-app/src/locales/`.

https://github.com/user-attachments/assets/54a86c38-f16c-41f0-99c3-c9efc1bf9c58


## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
