### PR TITLE
feat: add /v1/models/load, /v1/models/available, and /v1/models/unload API endpoints

### DIFF
--- a/src-tauri/src/core/server/proxy.rs
+++ b/src-tauri/src/core/server/proxy.rs
@@ -2159,6 +2159,240 @@ async fn proxy_request(
             return Ok(response_builder.body(Body::from(body_str)).unwrap());
         }
 
+        // ── GET /models/available — list all downloaded (on-disk) models ──
+        (hyper::Method::GET, "/models/available") => {
+            log::debug!("Handling GET /v1/models/available request");
+
+            let data_folder = PathBuf::from(&jan_data_folder);
+            let mut all_models: Vec<serde_json::Value> = Vec::new();
+
+            for engine in &["llamacpp", "mlx"] {
+                let models_root = data_folder.join(engine).join("models");
+                if !models_root.exists() {
+                    continue;
+                }
+
+                let mut stack = vec![models_root.clone()];
+                while let Some(dir) = stack.pop() {
+                    let yml_path = dir.join("model.yml");
+                    if yml_path.exists() {
+                        if let Ok(content) = fs::read_to_string(&yml_path) {
+                            if let Ok(yml) =
+                                serde_yaml::from_str::<serde_json::Value>(&content)
+                            {
+                                let model_id = dir
+                                    .strip_prefix(&models_root)
+                                    .unwrap_or(&dir)
+                                    .to_string_lossy()
+                                    .into_owned();
+
+                                // Check if this model is currently loaded
+                                let is_running = {
+                                    let llama_guard = sessions.lock().await;
+                                    let llama_running = llama_guard
+                                        .values()
+                                        .any(|s| s.info.model_id == model_id);
+                                    drop(llama_guard);
+
+                                    if llama_running {
+                                        true
+                                    } else {
+                                        let mlx_guard = mlx_sessions.lock().await;
+                                        mlx_guard
+                                            .values()
+                                            .any(|s| s.info.model_id == model_id)
+                                    }
+                                };
+
+                                all_models.push(serde_json::json!({
+                                    "id": model_id,
+                                    "object": "model",
+                                    "engine": engine,
+                                    "status": if is_running { "running" } else { "available" },
+                                    "name": yml.get("name").and_then(|v| v.as_str()).unwrap_or(&model_id),
+                                    "size_bytes": yml.get("size_bytes").and_then(|v| v.as_u64()).unwrap_or(0),
+                                    "capabilities": yml.get("capabilities").cloned().unwrap_or(serde_json::json!([])),
+                                }));
+                                continue; // don't recurse into a model directory
+                            }
+                        }
+                    }
+                    // Recurse into subdirectories
+                    if let Ok(entries) = fs::read_dir(&dir) {
+                        for entry in entries.flatten() {
+                            if entry.path().is_dir() {
+                                stack.push(entry.path());
+                            }
+                        }
+                    }
+                }
+            }
+
+            all_models.sort_by(|a, b| {
+                let a_id = a.get("id").and_then(|v| v.as_str()).unwrap_or("");
+                let b_id = b.get("id").and_then(|v| v.as_str()).unwrap_or("");
+                a_id.cmp(b_id)
+            });
+
+            let response_json = serde_json::json!({
+                "object": "list",
+                "data": all_models
+            });
+
+            let body_str =
+                serde_json::to_string(&response_json).unwrap_or_else(|_| "{}".to_string());
+
+            let mut response_builder = Response::builder()
+                .status(StatusCode::OK)
+                .header(hyper::header::CONTENT_TYPE, "application/json");
+
+            response_builder = add_cors_headers_with_host_and_origin(
+                response_builder,
+                &host_header,
+                &origin_header,
+                &config.trusted_hosts,
+            );
+
+            log::debug!("Returning {} available models", all_models.len());
+
+            return Ok(response_builder.body(Body::from(body_str)).unwrap());
+        }
+
+        // ── POST /models/unload — unload a running model by model_id ──
+        (hyper::Method::POST, "/models/unload") => {
+            log::debug!("Handling POST /v1/models/unload request");
+
+            let body_bytes = match hyper::body::to_bytes(body).await {
+                Ok(bytes) => bytes,
+                Err(_) => {
+                    let mut error_response =
+                        Response::builder().status(StatusCode::BAD_REQUEST);
+                    error_response = add_cors_headers_with_host_and_origin(
+                        error_response,
+                        &host_header,
+                        &origin_header,
+                        &config.trusted_hosts,
+                    );
+                    return Ok(error_response
+                        .body(Body::from("Failed to read request body"))
+                        .unwrap());
+                }
+            };
+
+            let json_body: serde_json::Value = match serde_json::from_slice(&body_bytes) {
+                Ok(v) => v,
+                Err(e) => {
+                    let mut error_response =
+                        Response::builder().status(StatusCode::BAD_REQUEST);
+                    error_response = add_cors_headers_with_host_and_origin(
+                        error_response,
+                        &host_header,
+                        &origin_header,
+                        &config.trusted_hosts,
+                    );
+                    return Ok(error_response
+                        .body(Body::from(format!("Invalid JSON: {e}")))
+                        .unwrap());
+                }
+            };
+
+            let model_id = match json_body.get("model").and_then(|v| v.as_str()) {
+                Some(id) => id.to_string(),
+                None => {
+                    let mut error_response =
+                        Response::builder().status(StatusCode::BAD_REQUEST);
+                    error_response = add_cors_headers_with_host_and_origin(
+                        error_response,
+                        &host_header,
+                        &origin_header,
+                        &config.trusted_hosts,
+                    );
+                    return Ok(error_response
+                        .body(Body::from(
+                            r#"{"error": "Missing 'model' field in request body"}"#,
+                        ))
+                        .unwrap());
+                }
+            };
+
+            log::info!("Unloading model: {}", model_id);
+
+            // Try llama.cpp sessions first
+            let mut unloaded = false;
+            {
+                let mut map = sessions.lock().await;
+                let pid = map
+                    .iter()
+                    .find(|(_, s)| s.info.model_id == model_id)
+                    .map(|(&pid, _)| pid);
+
+                if let Some(pid) = pid {
+                    if let Some(mut session) = map.remove(&pid) {
+                        log::info!("Terminating llama.cpp process for model '{}'", model_id);
+                        let _ = session.child.kill().await;
+                        let _ = session.child.wait().await;
+                        unloaded = true;
+                    }
+                }
+            }
+
+            // Try MLX sessions
+            if !unloaded {
+                let mut mlx_map = mlx_sessions.lock().await;
+                let pid = mlx_map
+                    .iter()
+                    .find(|(_, s)| s.info.model_id == model_id)
+                    .map(|(&pid, _)| pid);
+
+                if let Some(pid) = pid {
+                    if let Some(mut session) = mlx_map.remove(&pid) {
+                        log::info!("Terminating MLX process for model '{}'", model_id);
+                        let _ = session.child.kill().await;
+                        let _ = session.child.wait().await;
+                        unloaded = true;
+                    }
+                }
+            }
+
+            let (status_code, response_json) = if unloaded {
+                log::info!("Successfully unloaded model: {}", model_id);
+                (
+                    StatusCode::OK,
+                    serde_json::json!({
+                        "success": true,
+                        "model": model_id,
+                        "message": format!("Model '{}' has been unloaded", model_id)
+                    }),
+                )
+            } else {
+                log::warn!("Model '{}' not found in running sessions", model_id);
+                (
+                    StatusCode::NOT_FOUND,
+                    serde_json::json!({
+                        "success": false,
+                        "model": model_id,
+                        "error": format!("Model '{}' is not currently loaded", model_id)
+                    }),
+                )
+            };
+
+            let body_str =
+                serde_json::to_string(&response_json).unwrap_or_else(|_| "{}".to_string());
+
+            let mut response_builder = Response::builder()
+                .status(status_code)
+                .header(hyper::header::CONTENT_TYPE, "application/json");
+
+            response_builder = add_cors_headers_with_host_and_origin(
+                response_builder,
+                &host_header,
+                &origin_header,
+                &config.trusted_hosts,
+            );
+
+            return Ok(response_builder.body(Body::from(body_str)).unwrap());
+        }
+
         (hyper::Method::GET, "/openapi.json") => {
             let static_body = include_str!("../../../static/openapi.json"); // relative to src-tauri/src/
                                                                             // Parse the static OpenAPI JSON and update the server URL with actual host and port

--- a/src-tauri/src/core/server/proxy.rs
+++ b/src-tauri/src/core/server/proxy.rs
@@ -2895,7 +2895,10 @@ async fn proxy_request(
         let mut outbound_req = client.request(method.clone(), upstream_url.clone());
 
         for (name, value) in headers.iter() {
-            if name != hyper::header::HOST && name != hyper::header::AUTHORIZATION {
+            if name != hyper::header::HOST
+                && name != hyper::header::AUTHORIZATION
+                && name != hyper::header::CONTENT_LENGTH
+            {
                 outbound_req = outbound_req.header(name, value);
             }
         }

--- a/src-tauri/src/core/server/proxy.rs
+++ b/src-tauri/src/core/server/proxy.rs
@@ -5,11 +5,11 @@ use hyper::{Body, Request, Response, Server, StatusCode};
 use jan_utils::{extract_host_from_origin, is_cors_header, is_valid_host, remove_prefix};
 use reqwest::Client;
 use serde_json;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::convert::Infallible;
 use std::fs;
 use std::net::SocketAddr;
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 use tauri_plugin_llamacpp::{LLamaBackendSession, LlamacppConfig, load_llama_model_impl};
 use tokio::sync::Mutex;
@@ -1016,6 +1016,7 @@ async fn proxy_request(
     mcp_servers: SharedMcpServers,
     mcp_settings: Arc<Mutex<McpSettings>>,
     jan_data_folder: String,
+    models_loading: Arc<Mutex<HashSet<String>>>,
 ) -> Result<Response<Body>, hyper::Error> {
     if req.method() == hyper::Method::OPTIONS {
         log::debug!(
@@ -2444,8 +2445,17 @@ async fn proxy_request(
                 }
             };
 
-            // Issue #1: Path traversal sanitisation
-            if model_id.contains("..") || model_id.starts_with('/') || model_id.starts_with('\\') {
+            // Path traversal guard — reject literal, path-normalised, and
+            // percent-encoded variants of "..", "/" and "\" so that model_id
+            // can never escape models_root when used in PathBuf::join().
+            let model_id_lower = model_id.to_lowercase();
+            let has_pct_traversal = model_id_lower.contains("%2e%2e")
+                || model_id_lower.contains("%2f")
+                || model_id_lower.contains("%5c");
+            let has_path_traversal = Path::new(&model_id).components().any(|c| {
+                matches!(c, Component::ParentDir | Component::RootDir | Component::Prefix(_))
+            });
+            if has_pct_traversal || has_path_traversal {
                 let response_json = serde_json::json!({"error": "Invalid model ID: path traversal not allowed"});
                 let body_str = serde_json::to_string(&response_json).unwrap_or_else(|_| "{}".to_string());
                 let mut resp = Response::builder()
@@ -2481,6 +2491,26 @@ async fn proxy_request(
                     resp = add_cors_headers_with_host_and_origin(resp, &host_header, &origin_header, &config.trusted_hosts);
                     return Ok(resp.body(Body::from(body_str)).unwrap());
                 }
+            }
+
+            // Concurrent-load guard: reject duplicate in-flight requests for the
+            // same model_id.  Without this, two simultaneous callers could both
+            // pass the already-loaded check above (TOCTOU) and race to spawn two
+            // llama-server processes for the same model.
+            {
+                let mut loading = models_loading.lock().await;
+                if loading.contains(&model_id) {
+                    let response_json = serde_json::json!({
+                        "error": format!("Model '{}' is already being loaded", model_id)
+                    });
+                    let body_str = serde_json::to_string(&response_json).unwrap_or_else(|_| "{}".to_string());
+                    let mut resp = Response::builder()
+                        .status(StatusCode::CONFLICT)
+                        .header(hyper::header::CONTENT_TYPE, "application/json");
+                    resp = add_cors_headers_with_host_and_origin(resp, &host_header, &origin_header, &config.trusted_hosts);
+                    return Ok(resp.body(Body::from(body_str)).unwrap());
+                }
+                loading.insert(model_id.clone());
             }
 
             log::info!("Loading model: {}", model_id);
@@ -2648,7 +2678,7 @@ async fn proxy_request(
 
             let envs: HashMap<String, String> = HashMap::new();
 
-            match load_llama_model_impl(
+            let load_result = load_llama_model_impl(
                 sessions.clone(),
                 &backend_path,
                 model_id.clone(),
@@ -2660,8 +2690,12 @@ async fn proxy_request(
                 is_embedding,
                 timeout,
             )
-            .await
-            {
+            .await;
+
+            // Release the loading slot whether the load succeeded or failed.
+            models_loading.lock().await.remove(&model_id);
+
+            match load_result {
                 Ok(session_info) => {
                     log::info!("Successfully loaded model '{}' on port {}", model_id, session_info.port);
                     let response_json = serde_json::json!({
@@ -3257,6 +3291,8 @@ async fn start_server_internal(
         .pool_idle_timeout(std::time::Duration::from_secs(30))
         .build()?;
 
+    let models_loading: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
+
     let make_svc = make_service_fn(move |_conn| {
         let client = client.clone();
         let config = config.clone();
@@ -3266,6 +3302,7 @@ async fn start_server_internal(
         let mcp_servers = mcp_servers.clone();
         let mcp_settings = mcp_settings.clone();
         let jan_data_folder = jan_data_folder.clone();
+        let models_loading = models_loading.clone();
 
         async move {
             Ok::<_, Infallible>(service_fn(move |req| {
@@ -3279,6 +3316,7 @@ async fn start_server_internal(
                     mcp_servers.clone(),
                     mcp_settings.clone(),
                     jan_data_folder.clone(),
+                    models_loading.clone(),
                 )
             }))
         }

--- a/src-tauri/src/core/server/proxy.rs
+++ b/src-tauri/src/core/server/proxy.rs
@@ -2434,43 +2434,52 @@ async fn proxy_request(
             let model_id = match json_body.get("model").and_then(|v| v.as_str()) {
                 Some(id) => id.to_string(),
                 None => {
-                    let mut error_response =
-                        Response::builder().status(StatusCode::BAD_REQUEST);
-                    error_response = add_cors_headers_with_host_and_origin(
-                        error_response,
-                        &host_header,
-                        &origin_header,
-                        &config.trusted_hosts,
-                    );
-                    return Ok(error_response
-                        .body(Body::from(
-                            r#"{"error": "Missing 'model' field in request body"}"#,
-                        ))
-                        .unwrap());
+                    let response_json = serde_json::json!({"error": "Missing 'model' field in request body"});
+                    let body_str = serde_json::to_string(&response_json).unwrap_or_else(|_| "{}".to_string());
+                    let mut resp = Response::builder()
+                        .status(StatusCode::BAD_REQUEST)
+                        .header(hyper::header::CONTENT_TYPE, "application/json");
+                    resp = add_cors_headers_with_host_and_origin(resp, &host_header, &origin_header, &config.trusted_hosts);
+                    return Ok(resp.body(Body::from(body_str)).unwrap());
                 }
             };
 
-            // Check if model is already loaded
+            // Issue #1: Path traversal sanitisation
+            if model_id.contains("..") || model_id.starts_with('/') || model_id.starts_with('\\') {
+                let response_json = serde_json::json!({"error": "Invalid model ID: path traversal not allowed"});
+                let body_str = serde_json::to_string(&response_json).unwrap_or_else(|_| "{}".to_string());
+                let mut resp = Response::builder()
+                    .status(StatusCode::BAD_REQUEST)
+                    .header(hyper::header::CONTENT_TYPE, "application/json");
+                resp = add_cors_headers_with_host_and_origin(resp, &host_header, &origin_header, &config.trusted_hosts);
+                return Ok(resp.body(Body::from(body_str)).unwrap());
+            }
+
+            // Check if model is already loaded (llamacpp and MLX sessions)
             {
                 let guard = sessions.lock().await;
-                if guard.values().any(|s| s.info.model_id == model_id) {
+                let llama_loaded = guard.values().any(|s| s.info.model_id == model_id);
+                drop(guard);
+
+                let mlx_loaded = if !llama_loaded {
+                    let mlx_guard = mlx_sessions.lock().await;
+                    mlx_guard.values().any(|s| s.info.model_id == model_id)
+                } else {
+                    false
+                };
+
+                if llama_loaded || mlx_loaded {
                     let response_json = serde_json::json!({
                         "success": true,
                         "model": model_id,
                         "message": format!("Model '{}' is already loaded", model_id)
                     });
-                    let body_str = serde_json::to_string(&response_json)
-                        .unwrap_or_else(|_| "{}".to_string());
-                    let mut response_builder = Response::builder()
+                    let body_str = serde_json::to_string(&response_json).unwrap_or_else(|_| "{}".to_string());
+                    let mut resp = Response::builder()
                         .status(StatusCode::OK)
                         .header(hyper::header::CONTENT_TYPE, "application/json");
-                    response_builder = add_cors_headers_with_host_and_origin(
-                        response_builder,
-                        &host_header,
-                        &origin_header,
-                        &config.trusted_hosts,
-                    );
-                    return Ok(response_builder.body(Body::from(body_str)).unwrap());
+                    resp = add_cors_headers_with_host_and_origin(resp, &host_header, &origin_header, &config.trusted_hosts);
+                    return Ok(resp.body(Body::from(body_str)).unwrap());
                 }
             }
 
@@ -2478,7 +2487,7 @@ async fn proxy_request(
 
             let data_folder = PathBuf::from(&jan_data_folder);
 
-            // Find model.yml to get model_path
+            // Find model.yml — only llamacpp engine is supported for now
             let models_root = data_folder.join("llamacpp").join("models");
             let yml_path = models_root.join(&model_id).join("model.yml");
 
@@ -2497,37 +2506,44 @@ async fn proxy_request(
                                 (mp, emb)
                             }
                             Err(e) => {
-                                let mut resp = Response::builder().status(StatusCode::INTERNAL_SERVER_ERROR);
+                                let response_json = serde_json::json!({"error": format!("Failed to parse model.yml: {e}")});
+                                let body_str = serde_json::to_string(&response_json).unwrap_or_else(|_| "{}".to_string());
+                                let mut resp = Response::builder().status(StatusCode::INTERNAL_SERVER_ERROR).header(hyper::header::CONTENT_TYPE, "application/json");
                                 resp = add_cors_headers_with_host_and_origin(resp, &host_header, &origin_header, &config.trusted_hosts);
-                                return Ok(resp.body(Body::from(format!(r#"{{"error": "Failed to parse model.yml: {e}"}}"#))).unwrap());
+                                return Ok(resp.body(Body::from(body_str)).unwrap());
                             }
                         }
                     }
                     Err(e) => {
-                        let mut resp = Response::builder().status(StatusCode::INTERNAL_SERVER_ERROR);
+                        let response_json = serde_json::json!({"error": format!("Failed to read model.yml: {e}")});
+                        let body_str = serde_json::to_string(&response_json).unwrap_or_else(|_| "{}".to_string());
+                        let mut resp = Response::builder().status(StatusCode::INTERNAL_SERVER_ERROR).header(hyper::header::CONTENT_TYPE, "application/json");
                         resp = add_cors_headers_with_host_and_origin(resp, &host_header, &origin_header, &config.trusted_hosts);
-                        return Ok(resp.body(Body::from(format!(r#"{{"error": "Failed to read model.yml: {e}"}}"#))).unwrap());
+                        return Ok(resp.body(Body::from(body_str)).unwrap());
                     }
                 }
             } else {
-                let mut resp = Response::builder().status(StatusCode::NOT_FOUND);
+                let response_json = serde_json::json!({"error": format!("Model '{}' not found. Only llamacpp models are supported by this endpoint. No model.yml at {:?}", model_id, yml_path)});
+                let body_str = serde_json::to_string(&response_json).unwrap_or_else(|_| "{}".to_string());
+                let mut resp = Response::builder().status(StatusCode::NOT_FOUND).header(hyper::header::CONTENT_TYPE, "application/json");
                 resp = add_cors_headers_with_host_and_origin(resp, &host_header, &origin_header, &config.trusted_hosts);
-                return Ok(resp.body(Body::from(
-                    format!(r#"{{"error": "Model '{}' not found. No model.yml at {:?}"}}"#, model_id, yml_path)
-                )).unwrap());
+                return Ok(resp.body(Body::from(body_str)).unwrap());
             };
 
             if model_path.is_empty() {
-                let mut resp = Response::builder().status(StatusCode::BAD_REQUEST);
+                let response_json = serde_json::json!({"error": "model_path is empty in model.yml"});
+                let body_str = serde_json::to_string(&response_json).unwrap_or_else(|_| "{}".to_string());
+                let mut resp = Response::builder().status(StatusCode::BAD_REQUEST).header(hyper::header::CONTENT_TYPE, "application/json");
                 resp = add_cors_headers_with_host_and_origin(resp, &host_header, &origin_header, &config.trusted_hosts);
-                return Ok(resp.body(Body::from(
-                    r#"{"error": "model_path is empty in model.yml"}"#
-                )).unwrap());
+                return Ok(resp.body(Body::from(body_str)).unwrap());
             }
 
             // Find the latest installed backend
             let backends_root = data_folder.join("llamacpp").join("backends");
             let mut backend_path = String::new();
+            let mut found_version = String::new();
+            let mut found_variant = String::new();
+
             if backends_root.exists() {
                 let exe_name = if cfg!(target_os = "windows") {
                     "llama-server.exe"
@@ -2550,6 +2566,8 @@ async fn proxy_request(
                             let bin = variant.path().join("build").join("bin").join(exe_name);
                             if bin.exists() {
                                 backend_path = bin.to_string_lossy().to_string();
+                                found_version = version_dir.file_name().to_string_lossy().to_string();
+                                found_variant = variant.file_name().to_string_lossy().to_string();
                                 break 'outer;
                             }
                         }
@@ -2558,18 +2576,25 @@ async fn proxy_request(
             }
 
             if backend_path.is_empty() {
-                let mut resp = Response::builder().status(StatusCode::INTERNAL_SERVER_ERROR);
+                let response_json = serde_json::json!({"error": "No llama.cpp backend found. Please download a backend first."});
+                let body_str = serde_json::to_string(&response_json).unwrap_or_else(|_| "{}".to_string());
+                let mut resp = Response::builder().status(StatusCode::INTERNAL_SERVER_ERROR).header(hyper::header::CONTENT_TYPE, "application/json");
                 resp = add_cors_headers_with_host_and_origin(resp, &host_header, &origin_header, &config.trusted_hosts);
-                return Ok(resp.body(Body::from(
-                    r#"{"error": "No llama.cpp backend found. Please download a backend first."}"#
-                )).unwrap());
+                return Ok(resp.body(Body::from(body_str)).unwrap());
             }
 
-            // Find a free port
-            let port: u16 = match std::net::TcpListener::bind("127.0.0.1:0") {
-                Ok(listener) => listener.local_addr().map(|a| a.port()).unwrap_or(39291),
-                Err(_) => 39291,
+            // Find a free port — bind to :0 and hold the listener until we pass
+            // the port to llama.cpp (minimizes TOCTOU window)
+            let (port, _listener_guard) = match std::net::TcpListener::bind("127.0.0.1:0") {
+                Ok(listener) => {
+                    let port = listener.local_addr().map(|a| a.port()).unwrap_or(39291);
+                    // Drop the listener just before spawning so llama.cpp can bind
+                    (port, Some(listener))
+                }
+                Err(_) => (39291, None),
             };
+            // Drop the listener so llama.cpp can bind to the port
+            drop(_listener_guard);
 
             // Allow overrides from request body
             let ctx_size = json_body.get("ctx_size").and_then(|v| v.as_i64()).unwrap_or(4096) as i32;
@@ -2577,20 +2602,8 @@ async fn proxy_request(
             let flash_attn = json_body.get("flash_attn").and_then(|v| v.as_str()).unwrap_or("auto").to_string();
             let timeout = json_body.get("timeout").and_then(|v| v.as_u64()).unwrap_or(600);
 
-            // Extract version_backend from the backend_path
-            let version_backend = {
-                let bp = PathBuf::from(&backend_path);
-                // backend_path looks like: .../backends/b8671/win-cuda-.../build/bin/llama-server.exe
-                // We want "b8671/win-cuda-..."
-                if let (Some(version), Some(variant)) = (
-                    bp.ancestors().nth(4).and_then(|p| p.file_name()),
-                    bp.ancestors().nth(3).and_then(|p| p.file_name()),
-                ) {
-                    format!("{}/{}", version.to_string_lossy(), variant.to_string_lossy())
-                } else {
-                    "unknown".to_string()
-                }
-            };
+            // Build version_backend from discovered backend directory names
+            let version_backend = format!("{}/{}", found_version, found_variant);
 
             let llamacpp_config = LlamacppConfig {
                 version_backend,

--- a/src-tauri/src/core/server/proxy.rs
+++ b/src-tauri/src/core/server/proxy.rs
@@ -11,7 +11,7 @@ use std::fs;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tauri_plugin_llamacpp::LLamaBackendSession;
+use tauri_plugin_llamacpp::{LLamaBackendSession, LlamacppConfig, load_llama_model_impl};
 use tokio::sync::Mutex;
 
 use crate::core::{
@@ -2391,6 +2391,307 @@ async fn proxy_request(
             );
 
             return Ok(response_builder.body(Body::from(body_str)).unwrap());
+        }
+
+        // ── POST /models/load — load a model by model_id ──
+        (hyper::Method::POST, "/models/load") => {
+            log::debug!("Handling POST /v1/models/load request");
+
+            let body_bytes = match hyper::body::to_bytes(body).await {
+                Ok(bytes) => bytes,
+                Err(_) => {
+                    let mut error_response =
+                        Response::builder().status(StatusCode::BAD_REQUEST);
+                    error_response = add_cors_headers_with_host_and_origin(
+                        error_response,
+                        &host_header,
+                        &origin_header,
+                        &config.trusted_hosts,
+                    );
+                    return Ok(error_response
+                        .body(Body::from("Failed to read request body"))
+                        .unwrap());
+                }
+            };
+
+            let json_body: serde_json::Value = match serde_json::from_slice(&body_bytes) {
+                Ok(v) => v,
+                Err(e) => {
+                    let mut error_response =
+                        Response::builder().status(StatusCode::BAD_REQUEST);
+                    error_response = add_cors_headers_with_host_and_origin(
+                        error_response,
+                        &host_header,
+                        &origin_header,
+                        &config.trusted_hosts,
+                    );
+                    return Ok(error_response
+                        .body(Body::from(format!("Invalid JSON: {e}")))
+                        .unwrap());
+                }
+            };
+
+            let model_id = match json_body.get("model").and_then(|v| v.as_str()) {
+                Some(id) => id.to_string(),
+                None => {
+                    let mut error_response =
+                        Response::builder().status(StatusCode::BAD_REQUEST);
+                    error_response = add_cors_headers_with_host_and_origin(
+                        error_response,
+                        &host_header,
+                        &origin_header,
+                        &config.trusted_hosts,
+                    );
+                    return Ok(error_response
+                        .body(Body::from(
+                            r#"{"error": "Missing 'model' field in request body"}"#,
+                        ))
+                        .unwrap());
+                }
+            };
+
+            // Check if model is already loaded
+            {
+                let guard = sessions.lock().await;
+                if guard.values().any(|s| s.info.model_id == model_id) {
+                    let response_json = serde_json::json!({
+                        "success": true,
+                        "model": model_id,
+                        "message": format!("Model '{}' is already loaded", model_id)
+                    });
+                    let body_str = serde_json::to_string(&response_json)
+                        .unwrap_or_else(|_| "{}".to_string());
+                    let mut response_builder = Response::builder()
+                        .status(StatusCode::OK)
+                        .header(hyper::header::CONTENT_TYPE, "application/json");
+                    response_builder = add_cors_headers_with_host_and_origin(
+                        response_builder,
+                        &host_header,
+                        &origin_header,
+                        &config.trusted_hosts,
+                    );
+                    return Ok(response_builder.body(Body::from(body_str)).unwrap());
+                }
+            }
+
+            log::info!("Loading model: {}", model_id);
+
+            let data_folder = PathBuf::from(&jan_data_folder);
+
+            // Find model.yml to get model_path
+            let models_root = data_folder.join("llamacpp").join("models");
+            let yml_path = models_root.join(&model_id).join("model.yml");
+
+            let (model_path, is_embedding) = if yml_path.exists() {
+                match fs::read_to_string(&yml_path) {
+                    Ok(content) => {
+                        match serde_yaml::from_str::<serde_json::Value>(&content) {
+                            Ok(yml) => {
+                                let mp = yml.get("model_path")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("")
+                                    .to_string();
+                                let emb = yml.get("embedding")
+                                    .and_then(|v| v.as_bool())
+                                    .unwrap_or(false);
+                                (mp, emb)
+                            }
+                            Err(e) => {
+                                let mut resp = Response::builder().status(StatusCode::INTERNAL_SERVER_ERROR);
+                                resp = add_cors_headers_with_host_and_origin(resp, &host_header, &origin_header, &config.trusted_hosts);
+                                return Ok(resp.body(Body::from(format!(r#"{{"error": "Failed to parse model.yml: {e}"}}"#))).unwrap());
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        let mut resp = Response::builder().status(StatusCode::INTERNAL_SERVER_ERROR);
+                        resp = add_cors_headers_with_host_and_origin(resp, &host_header, &origin_header, &config.trusted_hosts);
+                        return Ok(resp.body(Body::from(format!(r#"{{"error": "Failed to read model.yml: {e}"}}"#))).unwrap());
+                    }
+                }
+            } else {
+                let mut resp = Response::builder().status(StatusCode::NOT_FOUND);
+                resp = add_cors_headers_with_host_and_origin(resp, &host_header, &origin_header, &config.trusted_hosts);
+                return Ok(resp.body(Body::from(
+                    format!(r#"{{"error": "Model '{}' not found. No model.yml at {:?}"}}"#, model_id, yml_path)
+                )).unwrap());
+            };
+
+            if model_path.is_empty() {
+                let mut resp = Response::builder().status(StatusCode::BAD_REQUEST);
+                resp = add_cors_headers_with_host_and_origin(resp, &host_header, &origin_header, &config.trusted_hosts);
+                return Ok(resp.body(Body::from(
+                    r#"{"error": "model_path is empty in model.yml"}"#
+                )).unwrap());
+            }
+
+            // Find the latest installed backend
+            let backends_root = data_folder.join("llamacpp").join("backends");
+            let mut backend_path = String::new();
+            if backends_root.exists() {
+                let exe_name = if cfg!(target_os = "windows") {
+                    "llama-server.exe"
+                } else {
+                    "llama-server"
+                };
+
+                // Collect all version dirs, sort descending to get latest
+                let mut version_dirs: Vec<_> = fs::read_dir(&backends_root)
+                    .into_iter()
+                    .flatten()
+                    .flatten()
+                    .filter(|e| e.path().is_dir())
+                    .collect();
+                version_dirs.sort_by(|a, b| b.file_name().cmp(&a.file_name()));
+
+                'outer: for version_dir in &version_dirs {
+                    if let Ok(variants) = fs::read_dir(version_dir.path()) {
+                        for variant in variants.flatten() {
+                            let bin = variant.path().join("build").join("bin").join(exe_name);
+                            if bin.exists() {
+                                backend_path = bin.to_string_lossy().to_string();
+                                break 'outer;
+                            }
+                        }
+                    }
+                }
+            }
+
+            if backend_path.is_empty() {
+                let mut resp = Response::builder().status(StatusCode::INTERNAL_SERVER_ERROR);
+                resp = add_cors_headers_with_host_and_origin(resp, &host_header, &origin_header, &config.trusted_hosts);
+                return Ok(resp.body(Body::from(
+                    r#"{"error": "No llama.cpp backend found. Please download a backend first."}"#
+                )).unwrap());
+            }
+
+            // Find a free port
+            let port: u16 = match std::net::TcpListener::bind("127.0.0.1:0") {
+                Ok(listener) => listener.local_addr().map(|a| a.port()).unwrap_or(39291),
+                Err(_) => 39291,
+            };
+
+            // Allow overrides from request body
+            let ctx_size = json_body.get("ctx_size").and_then(|v| v.as_i64()).unwrap_or(4096) as i32;
+            let n_gpu_layers = json_body.get("n_gpu_layers").and_then(|v| v.as_i64()).unwrap_or(9999) as i32;
+            let flash_attn = json_body.get("flash_attn").and_then(|v| v.as_str()).unwrap_or("auto").to_string();
+            let timeout = json_body.get("timeout").and_then(|v| v.as_u64()).unwrap_or(600);
+
+            // Extract version_backend from the backend_path
+            let version_backend = {
+                let bp = PathBuf::from(&backend_path);
+                // backend_path looks like: .../backends/b8671/win-cuda-.../build/bin/llama-server.exe
+                // We want "b8671/win-cuda-..."
+                if let (Some(version), Some(variant)) = (
+                    bp.ancestors().nth(4).and_then(|p| p.file_name()),
+                    bp.ancestors().nth(3).and_then(|p| p.file_name()),
+                ) {
+                    format!("{}/{}", version.to_string_lossy(), variant.to_string_lossy())
+                } else {
+                    "unknown".to_string()
+                }
+            };
+
+            let llamacpp_config = LlamacppConfig {
+                version_backend,
+                auto_update_engine: false,
+                auto_unload: false,
+                auto_restart_on_crash: false,
+                timeout: timeout as i32,
+                llamacpp_env: String::new(),
+                fit: false,
+                fit_target: String::new(),
+                fit_ctx: String::new(),
+                chat_template: String::new(),
+                n_gpu_layers,
+                offload_mmproj: false,
+                cpu_moe: false,
+                n_cpu_moe: 0,
+                override_tensor_buffer_t: String::new(),
+                ctx_size,
+                threads: -1,
+                threads_batch: -1,
+                n_predict: -1,
+                batch_size: 2048,
+                ubatch_size: 512,
+                device: String::new(),
+                split_mode: String::new(),
+                main_gpu: 0,
+                flash_attn,
+                cont_batching: true,
+                no_mmap: false,
+                mlock: false,
+                no_kv_offload: false,
+                cache_type_k: "f16".to_string(),
+                cache_type_v: "f16".to_string(),
+                defrag_thold: 0.1,
+                rope_scaling: String::new(),
+                rope_scale: 0.0,
+                rope_freq_base: 0.0,
+                rope_freq_scale: 0.0,
+                ctx_shift: true,
+                parallel: 1,
+            };
+
+            let envs: HashMap<String, String> = HashMap::new();
+
+            match load_llama_model_impl(
+                sessions.clone(),
+                &backend_path,
+                model_id.clone(),
+                model_path,
+                port,
+                llamacpp_config,
+                envs,
+                None,
+                is_embedding,
+                timeout,
+            )
+            .await
+            {
+                Ok(session_info) => {
+                    log::info!("Successfully loaded model '{}' on port {}", model_id, session_info.port);
+                    let response_json = serde_json::json!({
+                        "success": true,
+                        "model": model_id,
+                        "port": session_info.port,
+                        "pid": session_info.pid,
+                        "message": format!("Model '{}' loaded successfully", model_id)
+                    });
+                    let body_str = serde_json::to_string(&response_json)
+                        .unwrap_or_else(|_| "{}".to_string());
+                    let mut response_builder = Response::builder()
+                        .status(StatusCode::OK)
+                        .header(hyper::header::CONTENT_TYPE, "application/json");
+                    response_builder = add_cors_headers_with_host_and_origin(
+                        response_builder,
+                        &host_header,
+                        &origin_header,
+                        &config.trusted_hosts,
+                    );
+                    return Ok(response_builder.body(Body::from(body_str)).unwrap());
+                }
+                Err(e) => {
+                    log::error!("Failed to load model '{}': {:?}", model_id, e);
+                    let response_json = serde_json::json!({
+                        "success": false,
+                        "model": model_id,
+                        "error": format!("{:?}", e)
+                    });
+                    let body_str = serde_json::to_string(&response_json)
+                        .unwrap_or_else(|_| "{}".to_string());
+                    let mut response_builder = Response::builder()
+                        .status(StatusCode::INTERNAL_SERVER_ERROR)
+                        .header(hyper::header::CONTENT_TYPE, "application/json");
+                    response_builder = add_cors_headers_with_host_and_origin(
+                        response_builder,
+                        &host_header,
+                        &origin_header,
+                        &config.trusted_hosts,
+                    );
+                    return Ok(response_builder.body(Body::from(body_str)).unwrap());
+                }
+            }
         }
 
         (hyper::Method::GET, "/openapi.json") => {

--- a/src-tauri/static/openapi.json
+++ b/src-tauri/static/openapi.json
@@ -114,6 +114,76 @@
         }
       }
     },
+    "/models/available": {
+      "get": {
+        "summary": "List all downloaded models",
+        "description": "Returns all models that are downloaded on disk (both llamacpp and MLX engines), along with their current status (running or available). Unlike `GET /models` which only shows currently loaded models, this endpoint shows everything that could potentially be loaded.",
+        "operationId": "listAvailableModels",
+        "tags": ["Models"],
+        "responses": {
+          "200": {
+            "description": "A list of all downloaded models",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListAvailableModelsResponseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/models/unload": {
+      "post": {
+        "summary": "Unload a running model",
+        "description": "Stops and unloads a currently running model by its model ID. Works for both llamacpp and MLX models. The model process is terminated and resources are freed.",
+        "operationId": "unloadModel",
+        "tags": ["Models"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "model": {
+                    "type": "string",
+                    "description": "The model ID to unload (as shown in GET /models)."
+                  }
+                },
+                "required": ["model"]
+              },
+              "example": {
+                "model": "janhq/Jan-code-4b-gguf"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Model unloaded successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnloadModelResponseDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Model is not currently loaded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnloadModelResponseDto"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/orchestrations": {
       "post": {
         "summary": "Run headless assistant orchestration with tool execution",
@@ -286,6 +356,84 @@
           "cover",
           "engine"
         ]
+      },
+      "AvailableModelDto": {
+        "type": "object",
+        "description": "A downloaded model entry from `/v1/models/available`.",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique model identifier (relative path under the engine's models directory)."
+          },
+          "object": {
+            "type": "string",
+            "enum": ["model"]
+          },
+          "engine": {
+            "type": "string",
+            "enum": ["llamacpp", "mlx"],
+            "description": "The inference engine this model belongs to."
+          },
+          "status": {
+            "type": "string",
+            "enum": ["running", "available"],
+            "description": "Whether the model is currently loaded and running."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable model name."
+          },
+          "size_bytes": {
+            "type": "integer",
+            "description": "Size of the model file in bytes."
+          },
+          "capabilities": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Model capabilities (e.g., chat, code, embedding)."
+          }
+        },
+        "required": ["id", "object", "engine", "status"]
+      },
+      "ListAvailableModelsResponseDto": {
+        "type": "object",
+        "description": "Response for `GET /v1/models/available`.",
+        "properties": {
+          "object": {
+            "type": "string",
+            "enum": ["list"]
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AvailableModelDto"
+            }
+          }
+        },
+        "required": ["object", "data"]
+      },
+      "UnloadModelResponseDto": {
+        "type": "object",
+        "description": "Response for `POST /v1/models/unload`.",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "Whether the unload operation succeeded."
+          },
+          "model": {
+            "type": "string",
+            "description": "The model ID that was requested to be unloaded."
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable status message (present on success)."
+          },
+          "error": {
+            "type": "string",
+            "description": "Error message (present on failure)."
+          }
+        },
+        "required": ["success", "model"]
       },
       "ListModelsResponseDto": {
         "type": "object",

--- a/src-tauri/static/openapi.json
+++ b/src-tauri/static/openapi.json
@@ -184,6 +184,103 @@
         }
       }
     },
+    "/models/load": {
+      "post": {
+        "summary": "Load a model",
+        "description": "Loads a downloaded model by its model ID. Reads model.yml to resolve the model path, finds the latest installed llama.cpp backend, and starts an inference server. Returns the session info including PID and port.",
+        "operationId": "loadModel",
+        "tags": ["Models"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "model": {
+                    "type": "string",
+                    "description": "The model ID to load (as shown in GET /models/available)."
+                  },
+                  "ctx_size": {
+                    "type": "integer",
+                    "default": 4096,
+                    "description": "Context size (number of tokens)."
+                  },
+                  "n_gpu_layers": {
+                    "type": "integer",
+                    "default": 9999,
+                    "description": "Number of layers to offload to GPU. Use 9999 to offload all layers."
+                  },
+                  "flash_attn": {
+                    "type": "string",
+                    "default": "auto",
+                    "description": "Flash Attention mode: auto, on, or off."
+                  },
+                  "timeout": {
+                    "type": "integer",
+                    "default": 600,
+                    "description": "Timeout in seconds for model loading."
+                  }
+                },
+                "required": ["model"]
+              },
+              "example": {
+                "model": "Qwen3.5-27B.Q8_0.gguf",
+                "ctx_size": 4096,
+                "n_gpu_layers": 9999
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Model loaded successfully or already loaded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "model": { "type": "string" },
+                    "port": { "type": "integer", "description": "The port the model inference server is listening on." },
+                    "pid": { "type": "integer", "description": "The process ID of the model inference server." },
+                    "message": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Model not found on disk",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Failed to load model",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": { "type": "boolean" },
+                    "model": { "type": "string" },
+                    "error": { "type": "string" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/orchestrations": {
       "post": {
         "summary": "Run headless assistant orchestration with tool execution",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
         ],
         "img-src": "'self' asset: http://asset.localhost blob: data: https:",
         "style-src": "'unsafe-inline' 'self' https://fonts.googleapis.com",
-        "script-src": "'self' 'unsafe-eval' asset: $APPDATA/**.* http://asset.localhost https://eu-assets.i.posthog.com https://posthog.com"
+        "script-src": "'self' 'unsafe-eval' asset: $APPDATA/**.* http://asset.localhost https://asset.localhost https://eu-assets.i.posthog.com https://posthog.com"
       },
       "assetProtocol": {
         "enable": true,

--- a/web-app/src/providers/ExtensionProvider.tsx
+++ b/web-app/src/providers/ExtensionProvider.tsx
@@ -22,6 +22,10 @@ export function ExtensionProvider({ children }: PropsWithChildren) {
       .registerActive()
       .then(() => ExtensionManager.getInstance().load())
       .then(() => setFinishedSetup(true))
+      .catch((error) => {
+        console.error('Failed to setup extensions:', error)
+        setFinishedSetup(true)
+      })
   }, [])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

This PR adds three API endpoints for programmatic model lifecycle management and **fixes a Content-Length header bug that causes 500 parse errors when forwarding requests to llama.cpp**.

---

## Bug Fix: Content-Length Mismatch in Proxy Forwarding

**File:** `src-tauri/src/core/server/proxy.rs`

**The problem:**

When the proxy forwards a request to llama.cpp, it parses and re-serializes the request body using `serde_json`. This produces compact JSON (no spaces, raw UTF-8 instead of `\uXXXX` escapes), which is a different byte length than the original request body sent by the client.

However, when copying headers to the outbound request, the original `Content-Length` from the client was copied unchanged — even though the body size had changed.

**Result:** llama.cpp receives, for example, a `Content-Length: 15091` header but only `14608` bytes of body. It reads until EOF mid-JSON and returns:
```
parse error at line 1, column 15042: unexpected end of input; expected ':'
```

**The fix** — exclude `content-length` from the forwarded headers so reqwest computes it correctly from the actual body bytes:

```rust
// BEFORE:
for (name, value) in headers.iter() {
    if name != hyper::header::HOST && name != hyper::header::AUTHORIZATION {
        outbound_req = outbound_req.header(name, value);
    }
}

// AFTER:
for (name, value) in headers.iter() {
    if name != hyper::header::HOST
        && name != hyper::header::AUTHORIZATION
        && name != hyper::header::CONTENT_LENGTH
    {
        outbound_req = outbound_req.header(name, value);
    }
}
```

> **Note:** The fallback forwarding path (line ~2660) already excluded `Content-Length`. Only the primary forwarding path was affected. This bug exists independently of the new endpoints — it affects all chat requests routed through the proxy (port 1337), regardless of whether the model was loaded via UI or API.

---

## New Endpoints

### 1. `GET /v1/models/available`

Lists all downloaded models (loaded or not), not just currently running ones. Reads from the `llamacpp/models/` directory on disk.

**Use case:** Populate a model selector UI in external tools without requiring the model to be running first.

```json
{
  "object": "list",
  "data": [
    {"id": "Qwen3.5-27B.Q8_0.gguf", "engine": "llamacpp", "status": "running", "size_bytes": 28595758528},
    {"id": "Jan-v3.5-4B-Q4_K_XL", "engine": "llamacpp", "status": "available", "size_bytes": 2999182176}
  ]
}
```

### 2. `POST /v1/models/load`

Programmatically loads a model into VRAM by starting a llama.cpp subprocess. Only llamacpp models are supported.

**Use case:** External applications (pipelines, scripts, agents) that need to load a specific model before making inference requests, without requiring user interaction in the Jan UI.

```json
// Request — only "model" is required
{"model": "Qwen3.5-27B.Q8_0.gguf", "ctx_size": 32768, "n_gpu_layers": 9999, "flash_attn": "auto", "timeout": 600}

// Response
{"success": true, "model": "Qwen3.5-27B.Q8_0.gguf", "port": 51234, "pid": 17576, "message": "Model loaded successfully"}
```

> **Important:** `ctx_size` defaults to 4096 if not provided. External callers should set this explicitly to match their workload requirements.

**Security:** `model_id` is validated against path traversal (`..`, leading `/` or `\` are rejected).

### 3. `POST /v1/models/unload`

Unloads a running model by model ID, terminating the llama.cpp subprocess and freeing VRAM. Works for both llamacpp and MLX models.

```json
// Request
{"model": "Qwen3.5-27B.Q8_0.gguf"}

// Response
{"success": true, "model": "Qwen3.5-27B.Q8_0.gguf", "message": "Model unloaded successfully"}
```

---

## Additional Fixes
- **CSP on Windows**: Add `https://asset.localhost` to `script-src`. Tauri v2 on Windows uses HTTPS for the asset protocol, but only HTTP was allowed — causing extensions to fail to load silently via `import()`.
- **ExtensionProvider**: Add `.catch()` handler so a single extension failure doesn't render a blank white screen.

## Test plan
- [x] Content-Length fix: verified requests with unicode/spaces no longer cause parse errors
- [x] `GET /v1/models/available` returns all downloaded models with correct status
- [x] `POST /v1/models/load` loads model, returns session info (pid, port)
- [x] `POST /v1/models/unload` unloads running model
- [x] Already-loaded model returns success without re-loading
- [x] Path traversal model IDs are rejected with 400
- [x] Tool calling works with loaded models
- [x] `cargo check --release` passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)