### PR TITLE
Hide Gemma models reasoning tags

### DIFF
--- a/web-app/src/lib/__tests__/messages.test.ts
+++ b/web-app/src/lib/__tests__/messages.test.ts
@@ -24,10 +24,30 @@ describe('parseReasoning', () => {
     expect(result).toEqual({ reasoningSegment: '<think>thinking...', textSegment: '' })
   })
 
+  it('detects in-progress <thought> tag (no closing)', () => {
+    const result = parseReasoning('<thought>thinking...')
+    expect(result).toEqual({ reasoningSegment: '<thought>thinking...', textSegment: '' })
+  })
+
   it('detects completed <think> tag', () => {
     const result = parseReasoning('<think>reason</think>answer')
     expect(result.reasoningSegment).toBe('<think>reason</think>')
     expect(result.textSegment).toBe('answer')
+  })
+
+  it('detects completed <thought> tag', () => {
+    const result = parseReasoning('<thought>reason</thought>answer')
+    expect(result.reasoningSegment).toBe('<thought>reason</thought>')
+    expect(result.textSegment).toBe('answer')
+  })
+
+  it('handles text before closed reasoning tags', () => {
+    const text = 'Some prefix <think>Internal thought</think>Some suffix'
+    const result = parseReasoning(text)
+    expect(result).toEqual({
+      reasoningSegment: 'Some prefix <think>Internal thought</think>',
+      textSegment: 'Some suffix',
+    })
   })
 
   it('detects in-progress analysis channel', () => {
@@ -42,6 +62,15 @@ describe('parseReasoning', () => {
     const result = parseReasoning(text)
     expect(result.reasoningSegment).toContain('<|channel|>analysis')
     expect(result.textSegment).toBe('reply')
+  })
+
+  it('handles multiple tags by splitting at the first closed tag', () => {
+    const text = '<think>First</think><think>Second</think>Answer'
+    const result = parseReasoning(text)
+    expect(result).toEqual({
+      reasoningSegment: '<think>First</think>',
+      textSegment: '<think>Second</think>Answer',
+    })
   })
 })
 
@@ -511,6 +540,7 @@ describe('extractContentPartsFromUIMessage', () => {
           type: 'tool-search',
           toolCallId: 'tc-1',
           input: { q: 'test' },
+          state: 'output-available',
           output: 'result',
         },
       ],

--- a/web-app/src/lib/messages.ts
+++ b/web-app/src/lib/messages.ts
@@ -135,7 +135,9 @@ export type ToolResult = {
  */
 export const parseReasoning = (text: string) => {
   // Check for thinking formats
-  const hasThinkTag = text.includes('<think>') && !text.includes('</think>')
+  const hasThinkTag =
+    (text.includes('<think>') && !text.includes('</think>')) ||
+    (text.includes('<thought>') && !text.includes('</thought>'))
   const hasAnalysisChannel =
     text.includes('<|channel|>analysis<|message|>') &&
     !text.includes('<|start|>assistant<|channel|>final<|message|>')
@@ -144,7 +146,7 @@ export const parseReasoning = (text: string) => {
     return { reasoningSegment: text, textSegment: '' }
 
   // Check for completed think tag format
-  const thinkMatch = text.match(/<think>([\s\S]*?)<\/think>/)
+  const thinkMatch = text.match(/<(think|thought)>([\s\S]*?)<\/\1>/)
   if (thinkMatch?.index !== undefined) {
     const splitIndex = thinkMatch.index + thinkMatch[0].length
     return {
@@ -194,22 +196,22 @@ export function convertThreadMessageToUIMessage(
 
       // BACKWARD COMPATIBILITY: Handle old format with <think> tags
       if (reasoningSegment) {
-        // Extract reasoning text from <think> tags
+        // Extract reasoning text from <think> or <thought> tags
         const completedMatch = reasoningSegment.match(
-          /<think>([\s\S]*)<\/think>/
+          /<(think|thought)>([\s\S]*)<\/\1>/
         )
         if (completedMatch) {
           parts.push({
             type: 'reasoning',
-            text: completedMatch[1],
+            text: completedMatch[2],
           })
         } else {
-          // In-progress reasoning - extract content after <think> tag
-          const inProgressMatch = reasoningSegment.match(/<think>([\s\S]*)/)
+          // In-progress reasoning - extract content after <think> or <thought> tag
+          const inProgressMatch = reasoningSegment.match(/<(think|thought)>([\s\S]*)/)
           if (inProgressMatch) {
             parts.push({
               type: 'reasoning',
-              text: inProgressMatch[1],
+              text: inProgressMatch[2],
             })
           }
         }

--- a/web-app/src/lib/model-factory.ts
+++ b/web-app/src/lib/model-factory.ts
@@ -303,13 +303,20 @@ function createFoundationModelsFetch(
 
 /**
  * Map of model keywords to their respective reasoning tags.
+ * Used for models that use tags other than the default 'think'.
  */
 const REASONING_TAG_MAP: Record<string, string> = {
   gemma: 'thought',
 }
 
 /**
+ * The default tag used for reasoning extraction if no specific override is found.
+ */
+const DEFAULT_REASONING_TAG = 'think'
+
+/**
  * Determines the reasoning tag name based on the model ID.
+ * Defaults to 'think' if no specific override is found in the map.
  */
 function getReasoningTagName(modelId: string): string {
   const lowerId = modelId.toLowerCase()
@@ -318,7 +325,7 @@ function getReasoningTagName(modelId: string): string {
       return tag
     }
   }
-  return 'think'
+  return DEFAULT_REASONING_TAG
 }
 
 /**

--- a/web-app/src/lib/model-factory.ts
+++ b/web-app/src/lib/model-factory.ts
@@ -409,7 +409,7 @@ export class ModelFactory {
     return wrapLanguageModel({
       model,
       middleware: extractReasoningMiddleware({
-        tagName: 'think',
+        tagName: modelId.toLowerCase().includes('gemma') ? 'thought' : 'think',
         separator: '\n',
       }),
     })
@@ -499,7 +499,7 @@ export class ModelFactory {
     return wrapLanguageModel({
       model: model,
       middleware: extractReasoningMiddleware({
-        tagName: 'think',
+        tagName: modelId.toLowerCase().includes('gemma') ? 'thought' : 'think',
         separator: '\n',
       }),
     })
@@ -573,7 +573,7 @@ export class ModelFactory {
     return wrapLanguageModel({
       model,
       middleware: extractReasoningMiddleware({
-        tagName: 'think',
+        tagName: modelId.toLowerCase().includes('gemma') ? 'thought' : 'think',
         separator: '\n',
       }),
     })
@@ -771,6 +771,14 @@ export class ModelFactory {
       fetch: fetchImpl,
     })
 
-    return openAICompatible.languageModel(modelId)
+    const model = openAICompatible.languageModel(modelId)
+
+    return wrapLanguageModel({
+      model,
+      middleware: extractReasoningMiddleware({
+        tagName: modelId.toLowerCase().includes('gemma') ? 'thought' : 'think',
+        separator: '\n',
+      }),
+    })
   }
 }

--- a/web-app/src/lib/model-factory.ts
+++ b/web-app/src/lib/model-factory.ts
@@ -302,6 +302,26 @@ function createFoundationModelsFetch(
 }
 
 /**
+ * Map of model keywords to their respective reasoning tags.
+ */
+const REASONING_TAG_MAP: Record<string, string> = {
+  gemma: 'thought',
+}
+
+/**
+ * Determines the reasoning tag name based on the model ID.
+ */
+function getReasoningTagName(modelId: string): string {
+  const lowerId = modelId.toLowerCase()
+  for (const [keyword, tag] of Object.entries(REASONING_TAG_MAP)) {
+    if (lowerId.includes(keyword)) {
+      return tag
+    }
+  }
+  return 'think'
+}
+
+/**
  * Factory for creating language models based on provider type.
  * Supports native AI SDK providers (Anthropic, Google) and OpenAI-compatible providers.
  */
@@ -409,7 +429,7 @@ export class ModelFactory {
     return wrapLanguageModel({
       model,
       middleware: extractReasoningMiddleware({
-        tagName: modelId.toLowerCase().includes('gemma') ? 'thought' : 'think',
+        tagName: getReasoningTagName(modelId),
         separator: '\n',
       }),
     })
@@ -499,7 +519,7 @@ export class ModelFactory {
     return wrapLanguageModel({
       model: model,
       middleware: extractReasoningMiddleware({
-        tagName: modelId.toLowerCase().includes('gemma') ? 'thought' : 'think',
+        tagName: getReasoningTagName(modelId),
         separator: '\n',
       }),
     })
@@ -573,7 +593,7 @@ export class ModelFactory {
     return wrapLanguageModel({
       model,
       middleware: extractReasoningMiddleware({
-        tagName: modelId.toLowerCase().includes('gemma') ? 'thought' : 'think',
+        tagName: getReasoningTagName(modelId),
         separator: '\n',
       }),
     })
@@ -776,7 +796,7 @@ export class ModelFactory {
     return wrapLanguageModel({
       model,
       middleware: extractReasoningMiddleware({
-        tagName: modelId.toLowerCase().includes('gemma') ? 'thought' : 'think',
+        tagName: getReasoningTagName(modelId),
         separator: '\n',
       }),
     })


### PR DESCRIPTION
## Describe Your Changes
Fixed an issue where reasoning/thought tags (e.g., `<thought>...</thought>`) remained visible in the chat UI during the streaming of a new response, despite being correctly hidden in the message history.

The issue was caused by the `extractReasoningMiddleware` not correctly utilizing the model-specific `tagName` during the streaming process. I updated the logic to ensure that reasoning tags are properly detected and extracted based on the current model configuration in real-time, ensuring a consistent user experience between active streaming and message history.

__Before:__ `<thought>` tags were rendered as plain text in the UI during the first response of a new chat.
 __After:__ `<thought>` tags are correctly extracted and hidden/collapsed during streaming, matching the behavior of the message history.


## Fixes Issues
- Closes #7947

<img width="1016" height="727" alt="image" src="https://github.com/user-attachments/assets/5959dc6b-bb4a-41b9-952d-cf73184a0f12" />
