### PR TITLE
fix: rename bundled uv to jan-uv to avoid .deb package collision

### DIFF
--- a/scripts/download-bin.mjs
+++ b/scripts/download-bin.mjs
@@ -317,6 +317,23 @@ async function main() {
   } catch (err) {
     // Expect EEXIST error
   }
+  if (platform === 'linux') {
+    const janUvSrc = path.join(binDir, 'uv')
+    const janUvDest = path.join(binDir, 'jan-uv')
+    const janUvTripleDest = path.join(binDir, 'jan-uv-' + uvPlatform)
+
+    try {
+      fs.copyFileSync(janUvSrc, janUvDest)
+      fs.chmodSync(janUvDest, 0o755)
+      console.log('Created jan-uv binary for Linux packaging')
+
+      fs.copyFileSync(janUvSrc, janUvTripleDest)
+      fs.chmodSync(janUvTripleDest, 0o755)
+      console.log('Created jan-uv triple binary (' + uvPlatform + ') for Linux packaging')
+    } catch (err) {
+      console.error('Error creating jan-uv binaries:', err)
+    }
+  }
   try {
     copySync(path.join(tempBinDir, 'uv.exe'), path.join(binDir))
     if (platform === 'win32') {

--- a/src-tauri/src/core/mcp/helpers.rs
+++ b/src-tauri/src/core/mcp/helpers.rs
@@ -7,7 +7,7 @@ use rmcp::{
     ServiceExt,
 };
 use serde_json::Value;
-use std::{collections::HashMap, env, process::Stdio, sync::Arc, time::Duration};
+use std::{collections::HashMap, env, path::PathBuf, process::Stdio, sync::Arc, time::Duration};
 use tauri::{AppHandle, Emitter, Manager, Runtime, State};
 use tauri_plugin_http::reqwest;
 use tokio::{
@@ -573,7 +573,20 @@ async fn schedule_mcp_start_task<R: Runtime>(
         let uv_path = if cfg!(windows) {
             bin_path.join("uv.exe")
         } else {
-            bin_path.join("uv")
+            let jan_uv_path = bin_path.join("jan-uv");
+            let bundled_uv = bin_path.join("uv");
+
+            if jan_uv_path.exists() {
+                jan_uv_path
+            } else if bundled_uv.exists() {
+                bundled_uv
+            } else {
+                log::warn!(
+                    "Neither jan-uv nor bundled uv found in {:?}; falling back to system uv",
+                    bin_path
+                );
+                PathBuf::from("uv")
+            }
         };
         if config_params.command.clone() == "uvx" && can_override_uvx(uv_path.display().to_string())
         {

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -31,7 +31,7 @@
   "bundle": {
     "targets": ["deb", "appimage"],
     "resources": ["resources/pre-install/**/*", "resources/LICENSE", "resources/bin/jan-cli"],
-    "externalBin": ["resources/bin/uv"],
+    "externalBin": ["resources/bin/jan-uv"],
     "linux": {
       "appimage": {
         "bundleMediaFramework": false,
@@ -39,7 +39,8 @@
       },
       "deb": {
         "files": {
-          "usr/bin/bun": "resources/bin/bun"
+          "usr/bin/bun": "resources/bin/bun",
+          "usr/bin/jan-uv": "resources/bin/jan-uv"
         }
       }
     }


### PR DESCRIPTION
## Summary

This PR fixes a file collision bug where the Jan .deb package fails to install on Debian/Ubuntu systems that already have the official `uv` Python package manager installed. Both packages were attempting to install `/usr/bin/uv`, violating Debian packaging policy.

Fixes: #3602

## Changes

- **scripts/download-bin.mjs**: Creates `jan-uv` as a copy of `uv` on Linux builds only
- **src-tauri/tauri.linux.conf.json**: 
  - Changes `externalBin` from `uv` to `jan-uv`
  - Adds `deb.files` mapping for `usr/bin/jan-uv`
- **src-tauri/src/core/mcp/helpers.rs**: 
  - Checks for `jan-uv` first (Linux .deb)
  - Falls back to bundled `uv` (macOS compatibility)
  - Falls back to system `uv` (last resort)

## Testing

Tested on Debian Trixie with system `uv` package installed:
- ✅ System uv preserved at `/usr/bin/uv`
- ✅ Jan's uv installs at `/usr/bin/jan-uv` (no collision)
- ✅ Both binaries functional
- ✅ MCP servers work correctly with bundled uv

## Scope

- **In Scope**: Linux .deb packaging only
- **Out of Scope**: macOS, Windows, Flatpak, AppImage (unchanged)

## Verification

```
$ dpkg -l uv
ii  uv  0.11.6-1+trixie  amd64  Python package manager

$ ls -la /usr/bin/uv /usr/bin/jan-uv
-rwxr-xr-x root root /usr/bin/uv      (system)
-rwxr-xr-x root root /usr/bin/jan-uv  (Jan's bundled)
```

No file collision, both packages coexist.