### PR TITLE
feat: Add folder-based GGUF import in Llamacpp UI

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -26,6 +26,7 @@
   },
   "devDependencies": {
     "@npmcli/arborist": "^7.1.0",
+    "@tauri-apps/api": "2.8.0",
     "@types/node": "^22.10.0",
     "@types/react": "19.1.2",
     "@vitest/coverage-v8": "^2.1.8",
@@ -47,7 +48,13 @@
     "ulidx": "^2.3.0"
   },
   "peerDependencies": {
+    "@tauri-apps/api": "^2.8.0",
     "react": "19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@tauri-apps/api": {
+      "optional": true
+    }
   },
   "packageManager": "yarn@4.5.3"
 }

--- a/core/rolldown.config.mjs
+++ b/core/rolldown.config.mjs
@@ -10,7 +10,13 @@ export default defineConfig([
       sourcemap: true,
     },
     platform: 'browser',
-    external: ['path', 'react', 'react-dom', 'react/jsx-runtime'],
+    external: [
+      'path',
+      'react',
+      'react-dom',
+      'react/jsx-runtime',
+      '@tauri-apps/api/core',
+    ],
     define: {
       NODE: JSON.stringify(`${pkgJson.name}/${pkgJson.node}`),
       VERSION: JSON.stringify(pkgJson.version),

--- a/core/src/browser/fs.ts
+++ b/core/src/browser/fs.ts
@@ -71,13 +71,18 @@ const copyFile: (src: string, dest: string) => Promise<void> = (src, dest) =>
   globalThis.core.api?.copyFile(src, dest)
 
 /**
- * Gets the list of gguf files in a directory
- *
- * @param path - The paths to the file.
- * @returns {Promise<{any}>} - A promise that resolves with the list of gguf and non-gguf files
+ * Lists importable `.gguf` model files under each given directory (recursive).
+ * Skips files whose lowercase name contains `mmproj`.
+ * When `core.api.getGgufFiles` is not provided, uses the desktop `get_gguf_files` Tauri command.
  */
-const getGgufFiles: (paths: string[]) => Promise<any> = (paths) =>
-  globalThis.core.api?.getGgufFiles(paths)
+const getGgufFiles: (paths: string[]) => Promise<string[]> = async (paths) => {
+  if (globalThis.core.api?.getGgufFiles) {
+    const result = await globalThis.core.api.getGgufFiles(paths)
+    return Array.isArray(result) ? result : []
+  }
+  const { invoke } = await import('@tauri-apps/api/core')
+  return invoke<string[]>('get_gguf_files', { paths })
+}
 
 /**
  * Gets the file's stats.

--- a/src-tauri/src/core/filesystem/commands.rs
+++ b/src-tauri/src/core/filesystem/commands.rs
@@ -4,7 +4,32 @@ use super::helpers::{resolve_app_path_within_jan_data_folder, resolve_path};
 use super::models::{DialogOpenOptions, FileStat};
 use rfd::AsyncFileDialog;
 use std::fs;
+use std::path::Path;
 use tauri::Runtime;
+
+fn collect_gguf_files_recursive(dir: &Path, out: &mut Vec<String>) -> Result<(), String> {
+    if !dir.is_dir() {
+        return Ok(());
+    }
+    for entry in fs::read_dir(dir).map_err(|e| e.to_string())? {
+        let entry = entry.map_err(|e| e.to_string())?;
+        let path = entry.path();
+        let meta = fs::metadata(&path).map_err(|e| e.to_string())?;
+        if meta.is_dir() {
+            collect_gguf_files_recursive(&path, out)?;
+        } else {
+            let name = path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("")
+                .to_lowercase();
+            if name.ends_with(".gguf") && !name.contains("mmproj") {
+                out.push(path.to_string_lossy().to_string());
+            }
+        }
+    }
+    Ok(())
+}
 
 #[tauri::command]
 pub fn rm<R: Runtime>(app_handle: tauri::AppHandle<R>, args: Vec<String>) -> Result<(), String> {
@@ -128,6 +153,26 @@ pub fn write_file_sync<R: Runtime>(
     let path = resolve_path(app_handle, &args[0]);
     let content = &args[1];
     fs::write(&path, content).map_err(|e| e.to_string())
+}
+
+/// Recursively lists importable `.gguf` files under the given directories (absolute paths).
+/// Excludes files whose names contain `mmproj` (case-insensitive), matching folder-import UX.
+#[tauri::command]
+pub fn get_gguf_files<R: Runtime>(
+    app_handle: tauri::AppHandle<R>,
+    paths: Vec<String>,
+) -> Result<Vec<String>, String> {
+    let mut out: Vec<String> = Vec::new();
+    for root in paths {
+        if root.is_empty() {
+            continue;
+        }
+        let resolved = resolve_path(app_handle.clone(), &root);
+        collect_gguf_files_recursive(&resolved, &mut out)?;
+    }
+    out.sort();
+    out.dedup();
+    Ok(out)
 }
 
 #[tauri::command]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -33,6 +33,7 @@ macro_rules! invoke_commands_with_extras {
         core::filesystem::commands::rm,
         core::filesystem::commands::mv,
         core::filesystem::commands::file_stat,
+        core::filesystem::commands::get_gguf_files,
         core::filesystem::commands::write_file_sync,
         core::filesystem::commands::write_yaml,
         core::filesystem::commands::read_yaml,

--- a/web-app/src/containers/ProjectFiles.tsx
+++ b/web-app/src/containers/ProjectFiles.tsx
@@ -16,6 +16,7 @@ import { useAttachments } from '@/hooks/useAttachments'
 import { ExtensionTypeEnum, FileStat, VectorDBExtension } from '@janhq/core'
 import { ExtensionManager } from '@/lib/extension'
 import { IconLoader2, IconPaperclip } from '@tabler/icons-react'
+import { join } from '@tauri-apps/api/path'
 
 type ProjectFilesProps = {
   projectId: string
@@ -181,6 +182,17 @@ const SUPPORTED_EXTENSIONS = [
   'gitignore',
 ]
 
+/** `readdirSync` may return basenames or full paths depending on the host; join when needed. */
+async function resolveDirectoryEntry(
+  dirPath: string,
+  entry: string
+): Promise<string> {
+  if (entry.includes('/') || entry.includes('\\')) {
+    return entry
+  }
+  return join(dirPath, entry)
+}
+
 async function getFilesFromPaths(paths: string[]): Promise<string[]> {
   const files: string[] = []
   const { fs } = await import('@janhq/core')
@@ -211,15 +223,16 @@ async function getFilesFromDirectory(
   try {
     const entries = await fs.readdirSync(dirPath)
     for (const entry of entries) {
-      console.log('Reading entry:', entry)
-      const stat = await fs.fileStat(entry)
+      const fullPath = await resolveDirectoryEntry(dirPath, entry)
+      console.log('Reading entry:', fullPath)
+      const stat = await fs.fileStat(fullPath)
       if (stat?.isDirectory) {
-        const nestedFiles = await getFilesFromDirectory(entry, fs)
+        const nestedFiles = await getFilesFromDirectory(fullPath, fs)
         files.push(...nestedFiles)
       } else if (!stat?.isDirectory) {
-        const ext = entry.split('.').pop()?.toLowerCase()
+        const ext = fullPath.split('.').pop()?.toLowerCase()
         if (ext && SUPPORTED_EXTENSIONS.includes(ext)) {
-          files.push(entry)
+          files.push(fullPath)
         }
       }
     }

--- a/web-app/src/containers/dialogs/ImportVisionModelDialog.tsx
+++ b/web-app/src/containers/dialogs/ImportVisionModelDialog.tsx
@@ -11,7 +11,7 @@ import { Switch } from '@/components/ui/switch'
 import { useServiceHub } from '@/hooks/useServiceHub'
 import { useState, useEffect, useCallback } from 'react'
 import { toast } from 'sonner'
-import { sanitizeModelId } from '@/lib/utils'
+import { buildModelIdFromPath } from '@/lib/buildModelIdFromPath'
 import { fs } from '@janhq/core'
 import {
   IconLoader2,
@@ -47,6 +47,10 @@ export const ImportVisionModelDialog = ({
   const [importMode, setImportMode] = useState<'file' | 'directory'>('file')
   const [modelDirectory, setModelDirectory] = useState<string | null>(null)
   const [discoveredModelFiles, setDiscoveredModelFiles] = useState<string[]>([])
+  const [folderImportProgress, setFolderImportProgress] = useState<{
+    current: number
+    total: number
+  } | null>(null)
 
   const validateGgufFile = useCallback(
     async (filePath: string, fileType: 'model' | 'mmproj'): Promise<void> => {
@@ -194,37 +198,6 @@ export const ImportVisionModelDialog = ({
     }
   }
 
-  const listGgufFilesFromDirectory = useCallback(
-    async (dirPath: string): Promise<string[]> => {
-      const files: string[] = []
-      const entries = await fs.readdirSync(dirPath)
-
-      for (const entry of entries) {
-        const stat = await fs.fileStat(entry)
-        if (stat?.isDirectory) {
-          const nestedFiles = await listGgufFilesFromDirectory(entry)
-          files.push(...nestedFiles)
-          continue
-        }
-
-        const isGguf = entry.toLowerCase().endsWith('.gguf')
-        const isMmproj = entry.toLowerCase().includes('mmproj')
-        if (isGguf && !isMmproj) {
-          files.push(entry)
-        }
-      }
-
-      return files
-    },
-    []
-  )
-
-  const buildModelIdFromPath = (filePath: string): string => {
-    const fileName = filePath.split(/[\\/]/).pop() || ''
-    const baseName = fileName.replace(/\.(gguf|GGUF)$/, '')
-    return sanitizeModelId(baseName.replace(/\s/g, '-'))
-  }
-
   const handleDirectorySelect = async () => {
     setImportMode('directory')
     setModelFile(null)
@@ -243,7 +216,7 @@ export const ImportVisionModelDialog = ({
     if (!selectedDirectory || typeof selectedDirectory !== 'string') return
 
     try {
-      const modelFiles = await listGgufFilesFromDirectory(selectedDirectory)
+      const modelFiles = await fs.getGgufFiles([selectedDirectory])
       setModelDirectory(selectedDirectory)
       setDiscoveredModelFiles(modelFiles)
       if (modelFiles.length === 0) {
@@ -275,31 +248,77 @@ export const ImportVisionModelDialog = ({
       }
 
       setImporting(true)
+      setFolderImportProgress({ current: 0, total: discoveredModelFiles.length })
       try {
         const existingIds = new Set(provider.models.map((model) => model.id))
         const seenIds = new Set<string>()
         let importedCount = 0
         let skippedCount = 0
+        let emptyModelIdCount = 0
+        const failures: { path: string; message: string }[] = []
 
-        for (const filePath of discoveredModelFiles) {
+        for (let i = 0; i < discoveredModelFiles.length; i++) {
+          const filePath = discoveredModelFiles[i]
+          setFolderImportProgress({
+            current: i + 1,
+            total: discoveredModelFiles.length,
+          })
+
           const modelId = buildModelIdFromPath(filePath)
-          if (!modelId || existingIds.has(modelId) || seenIds.has(modelId)) {
+          if (!modelId) {
+            emptyModelIdCount += 1
+            skippedCount += 1
+            console.warn(
+              'Skipping GGUF file: could not derive a model id from filename:',
+              filePath
+            )
+            continue
+          }
+          if (existingIds.has(modelId) || seenIds.has(modelId)) {
             skippedCount += 1
             continue
           }
 
-          await serviceHub.models().pullModel(modelId, filePath)
-          seenIds.add(modelId)
-          importedCount += 1
+          try {
+            await serviceHub.models().pullModel(modelId, filePath)
+            seenIds.add(modelId)
+            importedCount += 1
+          } catch (err) {
+            const message =
+              err instanceof Error ? err.message : 'Unknown error occurred'
+            failures.push({ path: filePath, message })
+            console.error('Folder import failed for file:', filePath, err)
+          }
         }
 
-        if (importedCount > 0) {
+        if (importedCount > 0 && failures.length === 0) {
           toast.success('Folder import completed', {
-            description: `Imported ${importedCount} model${importedCount > 1 ? 's' : ''}${skippedCount > 0 ? `, skipped ${skippedCount}` : ''}.`,
+            description: [
+              `Imported ${importedCount} model${importedCount > 1 ? 's' : ''}`,
+              skippedCount > 0 ? `, skipped ${skippedCount}` : '',
+              emptyModelIdCount > 0
+                ? ` (${emptyModelIdCount} could not get a valid id from filename)`
+                : '',
+            ].join(''),
           })
           resetForm()
           setOpen(false)
           onSuccess?.()
+        } else if (importedCount > 0 && failures.length > 0) {
+          toast.warning('Folder import partially completed', {
+            description: `Imported ${importedCount} model${importedCount > 1 ? 's' : ''}; ${failures.length} failed. First error: ${failures[0].message}`,
+          })
+          resetForm()
+          setOpen(false)
+          onSuccess?.()
+        } else if (failures.length > 0) {
+          toast.error('Failed to import models from folder', {
+            description: `${failures.length} error(s). First: ${failures[0].message}`,
+          })
+        } else if (emptyModelIdCount > 0) {
+          toast.warning('Some files were skipped', {
+            description: `${emptyModelIdCount} file(s) could not be assigned a valid model id from their names.`,
+          })
         } else {
           toast.error('No models imported', {
             description: 'All discovered models already exist or are invalid.',
@@ -313,6 +332,7 @@ export const ImportVisionModelDialog = ({
         })
       } finally {
         setImporting(false)
+        setFolderImportProgress(null)
       }
       return
     }
@@ -393,6 +413,7 @@ export const ImportVisionModelDialog = ({
     setImportMode('file')
     setModelDirectory(null)
     setDiscoveredModelFiles([])
+    setFolderImportProgress(null)
   }
 
   // Re-validate MMProj file when model name changes
@@ -556,20 +577,18 @@ export const ImportVisionModelDialog = ({
             )}
 
             {/* Model File Selection */}
-            <div
-              className="border  rounded-lg p-4 space-y-3"
-              style={{ display: importMode === 'file' ? 'block' : 'none' }}
-            >
-              <div className="flex items-center gap-2">
-                <h3 className="font-medium">
-                  Model File (GGUF)
-                </h3>
-                <span className="text-xs bg-secondary px-2 py-1 rounded-sm">
-                  Required
-                </span>
-              </div>
+            {importMode === 'file' && (
+              <div className="border  rounded-lg p-4 space-y-3">
+                <div className="flex items-center gap-2">
+                  <h3 className="font-medium">
+                    Model File (GGUF)
+                  </h3>
+                  <span className="text-xs bg-secondary px-2 py-1 rounded-sm">
+                    Required
+                  </span>
+                </div>
 
-              {modelFile ? (
+                {modelFile ? (
                 <div className="space-y-2">
                   <div className="border rounded-lg p-3">
                     <div className="flex items-center justify-between">
@@ -648,7 +667,8 @@ export const ImportVisionModelDialog = ({
                   Select GGUF File
                 </Button>
               )}
-            </div>
+              </div>
+            )}
 
             {/* MMPROJ File Selection - only show if vision model is enabled */}
             {isVisionModel && importMode === 'file' && (
@@ -772,7 +792,13 @@ export const ImportVisionModelDialog = ({
           >
             {importing && <IconLoader2 className="mr-2 size-4 animate-spin" />}
             {importing ? (
-              'Importing...'
+              importMode === 'directory' &&
+              folderImportProgress &&
+              folderImportProgress.total > 0 ? (
+                `Importing ${folderImportProgress.current} / ${folderImportProgress.total}...`
+              ) : (
+                'Importing...'
+              )
             ) : (
               <>
                 Import{' '}

--- a/web-app/src/containers/dialogs/ImportVisionModelDialog.tsx
+++ b/web-app/src/containers/dialogs/ImportVisionModelDialog.tsx
@@ -11,6 +11,8 @@ import { Switch } from '@/components/ui/switch'
 import { useServiceHub } from '@/hooks/useServiceHub'
 import { useState, useEffect, useCallback } from 'react'
 import { toast } from 'sonner'
+import { sanitizeModelId } from '@/lib/utils'
+import { fs } from '@janhq/core'
 import {
   IconLoader2,
   IconEye,
@@ -42,6 +44,9 @@ export const ImportVisionModelDialog = ({
     string | null
   >(null)
   const [isValidatingMmproj, setIsValidatingMmproj] = useState(false)
+  const [importMode, setImportMode] = useState<'file' | 'directory'>('file')
+  const [modelDirectory, setModelDirectory] = useState<string | null>(null)
+  const [discoveredModelFiles, setDiscoveredModelFiles] = useState<string[]>([])
 
   const validateGgufFile = useCallback(
     async (filePath: string, fileType: 'model' | 'mmproj'): Promise<void> => {
@@ -159,6 +164,9 @@ export const ImportVisionModelDialog = ({
   )
 
   const handleFileSelect = async (type: 'model' | 'mmproj') => {
+    setImportMode('file')
+    setModelDirectory(null)
+    setDiscoveredModelFiles([])
     const selectedFile = await serviceHub.dialog().open({
       multiple: false,
       directory: false,
@@ -186,7 +194,129 @@ export const ImportVisionModelDialog = ({
     }
   }
 
+  const listGgufFilesFromDirectory = useCallback(
+    async (dirPath: string): Promise<string[]> => {
+      const files: string[] = []
+      const entries = await fs.readdirSync(dirPath)
+
+      for (const entry of entries) {
+        const stat = await fs.fileStat(entry)
+        if (stat?.isDirectory) {
+          const nestedFiles = await listGgufFilesFromDirectory(entry)
+          files.push(...nestedFiles)
+          continue
+        }
+
+        const isGguf = entry.toLowerCase().endsWith('.gguf')
+        const isMmproj = entry.toLowerCase().includes('mmproj')
+        if (isGguf && !isMmproj) {
+          files.push(entry)
+        }
+      }
+
+      return files
+    },
+    []
+  )
+
+  const buildModelIdFromPath = (filePath: string): string => {
+    const fileName = filePath.split(/[\\/]/).pop() || ''
+    const baseName = fileName.replace(/\.(gguf|GGUF)$/, '')
+    return sanitizeModelId(baseName.replace(/\s/g, '-'))
+  }
+
+  const handleDirectorySelect = async () => {
+    setImportMode('directory')
+    setModelFile(null)
+    setMmProjFile(null)
+    setModelName('')
+    setValidationError(null)
+    setMmprojValidationError(null)
+    setIsValidating(false)
+    setIsValidatingMmproj(false)
+
+    const selectedDirectory = await serviceHub.dialog().open({
+      multiple: false,
+      directory: true,
+    })
+
+    if (!selectedDirectory || typeof selectedDirectory !== 'string') return
+
+    try {
+      const modelFiles = await listGgufFilesFromDirectory(selectedDirectory)
+      setModelDirectory(selectedDirectory)
+      setDiscoveredModelFiles(modelFiles)
+      if (modelFiles.length === 0) {
+        toast.error('No GGUF models found in folder')
+      }
+    } catch (error) {
+      setModelDirectory(selectedDirectory)
+      setDiscoveredModelFiles([])
+      toast.error('Failed to scan model folder', {
+        description:
+          error instanceof Error ? error.message : 'Unknown error occurred',
+      })
+    }
+  }
+
   const handleImport = async () => {
+    if (importMode === 'directory') {
+      if (!modelDirectory) {
+        toast.error('Please select a model folder')
+        return
+      }
+      if (discoveredModelFiles.length === 0) {
+        toast.error('No GGUF models found in selected folder')
+        return
+      }
+      if (isVisionModel) {
+        toast.error('Folder import only supports text GGUF models')
+        return
+      }
+
+      setImporting(true)
+      try {
+        const existingIds = new Set(provider.models.map((model) => model.id))
+        const seenIds = new Set<string>()
+        let importedCount = 0
+        let skippedCount = 0
+
+        for (const filePath of discoveredModelFiles) {
+          const modelId = buildModelIdFromPath(filePath)
+          if (!modelId || existingIds.has(modelId) || seenIds.has(modelId)) {
+            skippedCount += 1
+            continue
+          }
+
+          await serviceHub.models().pullModel(modelId, filePath)
+          seenIds.add(modelId)
+          importedCount += 1
+        }
+
+        if (importedCount > 0) {
+          toast.success('Folder import completed', {
+            description: `Imported ${importedCount} model${importedCount > 1 ? 's' : ''}${skippedCount > 0 ? `, skipped ${skippedCount}` : ''}.`,
+          })
+          resetForm()
+          setOpen(false)
+          onSuccess?.()
+        } else {
+          toast.error('No models imported', {
+            description: 'All discovered models already exist or are invalid.',
+          })
+        }
+      } catch (error) {
+        console.error('Folder import error:', error)
+        toast.error('Failed to import models from folder', {
+          description:
+            error instanceof Error ? error.message : 'Unknown error occurred',
+        })
+      } finally {
+        setImporting(false)
+      }
+      return
+    }
+
     if (!modelFile) {
       toast.error('Please select a model file')
       return
@@ -260,6 +390,9 @@ export const ImportVisionModelDialog = ({
     setIsValidating(false)
     setMmprojValidationError(null)
     setIsValidatingMmproj(false)
+    setImportMode('file')
+    setModelDirectory(null)
+    setDiscoveredModelFiles([])
   }
 
   // Re-validate MMProj file when model name changes
@@ -344,8 +477,89 @@ export const ImportVisionModelDialog = ({
 
           {/* File Selection Area */}
           <div className="space-y-4">
+            <div className="border rounded-lg p-4 space-y-3">
+              <div className="flex items-center justify-between gap-2">
+                <h3 className="font-medium">Import Mode</h3>
+                <div className="flex gap-2">
+                  <Button
+                    type="button"
+                    variant={importMode === 'file' ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={() => setImportMode('file')}
+                    disabled={importing}
+                  >
+                    Single File
+                  </Button>
+                  <Button
+                    type="button"
+                    variant={importMode === 'directory' ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={handleDirectorySelect}
+                    disabled={importing || isVisionModel}
+                  >
+                    Import Folder
+                  </Button>
+                </div>
+              </div>
+              {isVisionModel && (
+                <p className="text-xs text-muted-foreground">
+                  Folder import is disabled when Vision Model Support is enabled.
+                </p>
+              )}
+            </div>
+
+            {importMode === 'directory' && (
+              <div className="border rounded-lg p-4 space-y-3">
+                <div className="flex items-center gap-2">
+                  <h3 className="font-medium">Model Folder</h3>
+                  <span className="text-xs bg-secondary px-2 py-1 rounded-sm">
+                    Required
+                  </span>
+                </div>
+                {modelDirectory ? (
+                  <div className="space-y-2">
+                    <div className="border rounded-lg p-3">
+                      <div className="flex items-center justify-between gap-2">
+                        <div className="flex items-center gap-2">
+                          <IconCheck size={16} />
+                          <span className="text-sm font-medium truncate">
+                            {modelDirectory}
+                          </span>
+                        </div>
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          onClick={handleDirectorySelect}
+                          disabled={importing}
+                        >
+                          Change
+                        </Button>
+                      </div>
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Found {discoveredModelFiles.length} importable GGUF
+                      model{discoveredModelFiles.length === 1 ? '' : 's'}.
+                    </p>
+                  </div>
+                ) : (
+                  <Button
+                    type="button"
+                    variant="link"
+                    onClick={handleDirectorySelect}
+                    disabled={importing}
+                    className="w-full h-12 border border-dashed text-muted-foreground"
+                  >
+                    Select Model Folder
+                  </Button>
+                )}
+              </div>
+            )}
+
             {/* Model File Selection */}
-            <div className="border  rounded-lg p-4 space-y-3">
+            <div
+              className="border  rounded-lg p-4 space-y-3"
+              style={{ display: importMode === 'file' ? 'block' : 'none' }}
+            >
               <div className="flex items-center gap-2">
                 <h3 className="font-medium">
                   Model File (GGUF)
@@ -437,7 +651,7 @@ export const ImportVisionModelDialog = ({
             </div>
 
             {/* MMPROJ File Selection - only show if vision model is enabled */}
-            {isVisionModel && (
+            {isVisionModel && importMode === 'file' && (
               <div className="border rounded-lg p-4 space-y-3">
                 <div className="flex items-center gap-2">
                   <h3 className="font-medium">MMPROJ File</h3>
@@ -544,9 +758,12 @@ export const ImportVisionModelDialog = ({
             size="sm"
             disabled={
               importing ||
-              !modelFile ||
-              !modelName ||
-              (isVisionModel && !mmProjFile) ||
+              (importMode === 'file' &&
+                (!modelFile ||
+                  !modelName ||
+                  (isVisionModel && !mmProjFile))) ||
+              (importMode === 'directory' &&
+                (!modelDirectory || discoveredModelFiles.length === 0)) ||
               validationError !== null ||
               isValidating ||
               mmprojValidationError !== null ||
@@ -557,7 +774,12 @@ export const ImportVisionModelDialog = ({
             {importing ? (
               'Importing...'
             ) : (
-              <>Import {isVisionModel ? 'Vision ' : ''}Model</>
+              <>
+                Import{' '}
+                {importMode === 'directory'
+                  ? 'Folder'
+                  : `${isVisionModel ? 'Vision ' : ''}Model`}
+              </>
             )}
           </Button>
         </div>

--- a/web-app/src/containers/dialogs/__tests__/ImportVisionModelDialog.test.tsx
+++ b/web-app/src/containers/dialogs/__tests__/ImportVisionModelDialog.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import '@testing-library/jest-dom'
 
 const hoisted = vi.hoisted(() => ({
@@ -8,6 +9,7 @@ const hoisted = vi.hoisted(() => ({
   validateGgufFile: vi.fn(),
   basename: vi.fn((p: string) => p.split('/').pop() || p),
   invoke: vi.fn(),
+  mockGetGgufFiles: vi.fn(),
   toast: {
     success: vi.fn(),
     error: vi.fn(),
@@ -17,6 +19,17 @@ const hoisted = vi.hoisted(() => ({
 }))
 
 vi.mock('sonner', () => ({ toast: hoisted.toast }))
+
+vi.mock('@janhq/core', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@janhq/core')>()
+  return {
+    ...mod,
+    fs: {
+      ...mod.fs,
+      getGgufFiles: hoisted.mockGetGgufFiles,
+    },
+  }
+})
 
 // Override the global useServiceHub mock from setup.ts with a tailored one.
 vi.mock('@/hooks/useServiceHub', () => {
@@ -278,6 +291,120 @@ describe('ImportVisionModelDialog', () => {
     fireEvent.click(screen.getByText('Cancel'))
     await waitFor(() =>
       expect(screen.queryByText('Import Model')).not.toBeInTheDocument()
+    )
+  })
+})
+
+describe('ImportVisionModelDialog — directory import', () => {
+  const mockProvider = {
+    provider: 'llamacpp',
+    active: true,
+    models: [],
+    settings: [],
+  } as ModelProvider
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    hoisted.validateGgufFile.mockResolvedValue({
+      isValid: true,
+      metadata: { metadata: { 'general.architecture': 'llama' } },
+    })
+    hoisted.invoke.mockResolvedValue({
+      metadata: { 'general.architecture': 'clip' },
+    })
+    hoisted.dialogOpen.mockResolvedValue('/data/models-folder')
+    hoisted.mockGetGgufFiles.mockResolvedValue(['/data/models-folder/a.gguf'])
+  })
+
+  it('selecting a folder calls getGgufFiles with that path', async () => {
+    const user = userEvent.setup()
+    render(
+      <ImportVisionModelDialog
+        provider={mockProvider}
+        trigger={<button type="button">Open import</button>}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /Open import/i }))
+
+    const pickFolderButtons = screen.getAllByRole('button', {
+      name: /Import Folder/i,
+    })
+    await user.click(pickFolderButtons[0])
+
+    await waitFor(() => {
+      expect(hoisted.dialogOpen).toHaveBeenCalledWith({
+        multiple: false,
+        directory: true,
+      })
+    })
+    await waitFor(() => {
+      expect(hoisted.mockGetGgufFiles).toHaveBeenCalledWith([
+        '/data/models-folder',
+      ])
+    })
+    expect(
+      await screen.findByText(/Found 1 importable GGUF model/)
+    ).toBeInTheDocument()
+  })
+
+  it('shows an error toast when the folder has no gguf models', async () => {
+    hoisted.mockGetGgufFiles.mockResolvedValue([])
+    const user = userEvent.setup()
+    render(
+      <ImportVisionModelDialog
+        provider={mockProvider}
+        trigger={<button type="button">Open import</button>}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /Open import/i }))
+
+    await user.click(
+      screen.getAllByRole('button', { name: /Import Folder/i })[0]
+    )
+
+    await waitFor(() => {
+      expect(hoisted.toast.error).toHaveBeenCalledWith(
+        'No GGUF models found in folder'
+      )
+    })
+  })
+
+  it('folder import invokes pullModel per discovered file', async () => {
+    hoisted.mockGetGgufFiles.mockResolvedValue([
+      '/data/models-folder/m1.gguf',
+      '/data/models-folder/m2.gguf',
+    ])
+    hoisted.pullModel.mockResolvedValue(undefined)
+
+    const user = userEvent.setup()
+    render(
+      <ImportVisionModelDialog
+        provider={mockProvider}
+        trigger={<button type="button">Open import</button>}
+      />
+    )
+    await user.click(screen.getByRole('button', { name: /Open import/i }))
+
+    await user.click(
+      screen.getAllByRole('button', { name: /Import Folder/i })[0]
+    )
+    await screen.findByText(/Found 2 importable GGUF models/)
+
+    const importButtons = screen.getAllByRole('button', {
+      name: /Import Folder/i,
+    })
+    await user.click(importButtons[importButtons.length - 1])
+
+    await waitFor(() => {
+      expect(hoisted.pullModel).toHaveBeenCalledTimes(2)
+    })
+    expect(hoisted.pullModel).toHaveBeenCalledWith(
+      'm1',
+      '/data/models-folder/m1.gguf'
+    )
+    expect(hoisted.pullModel).toHaveBeenCalledWith(
+      'm2',
+      '/data/models-folder/m2.gguf'
     )
   })
 })

--- a/web-app/src/lib/__tests__/buildModelIdFromPath.test.ts
+++ b/web-app/src/lib/__tests__/buildModelIdFromPath.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest'
+import { buildModelIdFromPath } from '../buildModelIdFromPath'
+
+describe('buildModelIdFromPath', () => {
+  it('strips extension and normalizes spaces to hyphens before sanitize', () => {
+    expect(buildModelIdFromPath('/models/my model name.gguf')).toBe(
+      'my-model-name'
+    )
+  })
+
+  it('handles Windows-style paths', () => {
+    expect(
+      buildModelIdFromPath('C:\\Users\\dev\\models\\Qwen2-7B-Q4_K_M.gguf')
+    ).toBe('Qwen2-7B-Q4_K_M')
+  })
+
+  it('preserves allowed punctuation via sanitizeModelId (dots become underscores)', () => {
+    expect(buildModelIdFromPath('/x/model.name-v1.0.gguf')).toBe(
+      'model_name-v1_0'
+    )
+  })
+
+  it('strips characters not allowed in model ids', () => {
+    expect(buildModelIdFromPath('/m/weird@name#stuff.gguf')).toBe('weirdnamestuff')
+  })
+
+  it('returns empty string when filename sanitizes to nothing', () => {
+    expect(buildModelIdFromPath('/m/@@@.gguf')).toBe('')
+    expect(buildModelIdFromPath('/m/!!!.gguf')).toBe('')
+  })
+
+  it('handles empty basename edge case', () => {
+    expect(buildModelIdFromPath('/')).toBe('')
+  })
+})

--- a/web-app/src/lib/__tests__/ggufFolderScan.test.ts
+++ b/web-app/src/lib/__tests__/ggufFolderScan.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest'
+
+/**
+ * Reference recursive walk (mirrors folder-import rules: .gguf, exclude mmproj).
+ * Used to validate mocked `readdirSync` / `fileStat` layouts when hosts return
+ * bare filenames or full paths. Production scanning uses `get_gguf_files` / `fs.getGgufFiles`.
+ */
+function joinDirEntry(dirPath: string, entry: string): string {
+  if (entry.includes('/') || entry.includes('\\')) {
+    return entry
+  }
+  const trim = dirPath.replace(/[/\\]$/, '')
+  const sep = dirPath.includes('\\') ? '\\' : '/'
+  return `${trim}${sep}${entry}`
+}
+
+async function listGgufFilesFromDirectory(
+  dirPath: string,
+  fsApi: {
+    readdirSync: (p: string) => Promise<string[]>
+    fileStat: (p: string) => Promise<{ isDirectory?: boolean } | undefined>
+  }
+): Promise<string[]> {
+  const files: string[] = []
+  const entries = await fsApi.readdirSync(dirPath)
+  for (const entry of entries) {
+    const fullPath = joinDirEntry(dirPath, entry)
+    const stat = await fsApi.fileStat(fullPath)
+    if (stat?.isDirectory) {
+      files.push(...(await listGgufFilesFromDirectory(fullPath, fsApi)))
+      continue
+    }
+    const lower = fullPath.toLowerCase()
+    if (lower.endsWith('.gguf') && !lower.includes('mmproj')) {
+      files.push(fullPath)
+    }
+  }
+  return files
+}
+
+describe('listGgufFilesFromDirectory (reference walk with mocked fs)', () => {
+  it('recurses into subdirs and collects gguf paths when readdir returns basenames', async () => {
+    const fsApi = {
+      readdirSync: vi.fn(async (dir: string) => {
+        if (dir === '/root') {
+          return ['sub', 'a.gguf']
+        }
+        if (dir === '/root/sub') {
+          return ['b.gguf']
+        }
+        return []
+      }),
+      fileStat: vi.fn(async (p: string) => {
+        if (p === '/root/sub') {
+          return { isDirectory: true }
+        }
+        return { isDirectory: false }
+      }),
+    }
+
+    const result = await listGgufFilesFromDirectory('/root', fsApi)
+    expect(result.sort()).toEqual(['/root/a.gguf', '/root/sub/b.gguf'])
+  })
+
+  it('excludes mmproj gguf files', async () => {
+    const fsApi = {
+      readdirSync: vi.fn(async () => ['ok.gguf', 'vision-mmproj.gguf']),
+      fileStat: vi.fn(async () => ({ isDirectory: false })),
+    }
+
+    const result = await listGgufFilesFromDirectory('/m', fsApi)
+    expect(result).toEqual(['/m/ok.gguf'])
+  })
+
+  it('works when readdir returns full paths (host-native)', async () => {
+    const fsApi = {
+      readdirSync: vi.fn(async () => ['/m/nested/c.gguf']),
+      fileStat: vi.fn(async () => ({ isDirectory: false })),
+    }
+
+    const result = await listGgufFilesFromDirectory('/m', fsApi)
+    expect(result).toEqual(['/m/nested/c.gguf'])
+  })
+})

--- a/web-app/src/lib/buildModelIdFromPath.ts
+++ b/web-app/src/lib/buildModelIdFromPath.ts
@@ -1,0 +1,10 @@
+import { sanitizeModelId } from '@/lib/utils'
+
+/**
+ * Derives a local model id from a GGUF file path (folder import).
+ */
+export function buildModelIdFromPath(filePath: string): string {
+  const fileName = filePath.split(/[\\/]/).pop() || ''
+  const baseName = fileName.replace(/\.(gguf|GGUF)$/, '')
+  return sanitizeModelId(baseName.replace(/\s/g, '-'))
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -50,6 +50,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ai-sdk/google@npm:^2.0.0":
+  version: 2.0.68
+  resolution: "@ai-sdk/google@npm:2.0.68"
+  dependencies:
+    "@ai-sdk/provider": "npm:2.0.1"
+    "@ai-sdk/provider-utils": "npm:3.0.23"
+  peerDependencies:
+    zod: ^3.25.76 || ^4.1.8
+  checksum: 10c0/6e146e8bedebe85c59da401d38b4df6859440620b973b09bd2578327981bfd26417b2ed97b939886dacf13734568ae992976effa62937f732f0f2b1004efe637
+  languageName: node
+  linkType: hard
+
 "@ai-sdk/openai-compatible@npm:1.0.33, @ai-sdk/openai-compatible@npm:^1.0.28":
   version: 1.0.33
   resolution: "@ai-sdk/openai-compatible@npm:1.0.33"
@@ -97,6 +109,19 @@ __metadata:
   peerDependencies:
     zod: ^3.25.76 || ^4.1.8
   checksum: 10c0/272645109b4990c1367d46fd8982ee3436f88f4f5ec96d78f98c928052dcee6e9a7df326558d908d73901a5c0a84b3374c31722bb78579c2efd3417afb2100fb
+  languageName: node
+  linkType: hard
+
+"@ai-sdk/provider-utils@npm:3.0.23":
+  version: 3.0.23
+  resolution: "@ai-sdk/provider-utils@npm:3.0.23"
+  dependencies:
+    "@ai-sdk/provider": "npm:2.0.1"
+    "@standard-schema/spec": "npm:^1.0.0"
+    eventsource-parser: "npm:^3.0.6"
+  peerDependencies:
+    zod: ^3.25.76 || ^4.1.8
+  checksum: 10c0/7b2adcbea13a09f7c8c0c6c5a77cde5c9973689acea2c3a7f79742d7edf463d1cbc90df38911e0235efeae89e37af43cfea2d856dedea4acdc5b0c3e65bf7d1b
   languageName: node
   linkType: hard
 
@@ -2702,6 +2727,7 @@ __metadata:
   resolution: "@janhq/core@workspace:core"
   dependencies:
     "@npmcli/arborist": "npm:^7.1.0"
+    "@tauri-apps/api": "npm:2.8.0"
     "@types/node": "npm:^22.10.0"
     "@types/react": "npm:19.1.2"
     "@vitest/coverage-v8": "npm:^2.1.8"
@@ -2720,7 +2746,11 @@ __metadata:
     ulidx: "npm:^2.3.0"
     vitest: "npm:^2.1.8"
   peerDependencies:
+    "@tauri-apps/api": ^2.8.0
     react: 19.0.0
+  peerDependenciesMeta:
+    "@tauri-apps/api":
+      optional: true
   languageName: unknown
   linkType: soft
 
@@ -2774,6 +2804,7 @@ __metadata:
   resolution: "@janhq/web-app@workspace:web-app"
   dependencies:
     "@ai-sdk/anthropic": "npm:^2.0.0"
+    "@ai-sdk/google": "npm:^2.0.0"
     "@ai-sdk/openai": "npm:^2.0.0"
     "@ai-sdk/openai-compatible": "npm:^1.0.28"
     "@ai-sdk/react": "npm:^2.0.109"


### PR DESCRIPTION
## Describe Your Changes
Adds a new “Import Folder” mode in the Llamacpp import dialog to recursively discover and batch import .gguf models (excluding mmproj), while skipping duplicates and existing models.


## Fixes Issues

- Closes #7953

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

## Screenshot
<img width="827" height="619" alt="image" src="https://github.com/user-attachments/assets/f191b359-666c-4d00-b7c0-0dd5f4a62462" />
