### PR TITLE
fix: prevent long non-breaking URLs from overflowing project view (#7…

### DIFF
--- a/web-app/src/components/ui/sidebar.tsx
+++ b/web-app/src/components/ui/sidebar.tsx
@@ -418,6 +418,8 @@ const SidebarInset = React.forwardRef<
 		<main
 			ref={ref}
 			className={cn(
+				// min-w-0 prevents flex-1 children from expanding beyond the flex container
+				// when they contain non-breakable content (e.g. long URLs without whitespace).
 				"relative flex min-h-svh flex-1 flex-col bg-background min-w-0",
 				"peer-data-[variant=inset]:min-h-[calc(100svh-(--spacing(4)))] md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm",
 				className,

--- a/web-app/src/components/ui/sidebar.tsx
+++ b/web-app/src/components/ui/sidebar.tsx
@@ -418,7 +418,7 @@ const SidebarInset = React.forwardRef<
 		<main
 			ref={ref}
 			className={cn(
-				"relative flex min-h-svh flex-1 flex-col bg-background",
+				"relative flex min-h-svh flex-1 flex-col bg-background min-w-0",
 				"peer-data-[variant=inset]:min-h-[calc(100svh-(--spacing(4)))] md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm",
 				className,
 			)}

--- a/web-app/src/containers/ThreadList.tsx
+++ b/web-app/src/containers/ThreadList.tsx
@@ -136,9 +136,9 @@ const ThreadItem = memo(
 
     return (
       <SidebarMenuItem>
-        {currentProjectId ? 
-          <Link to="/threads/$threadId" params={{ threadId: thread.id }} className="bg-card dark:bg-secondary/20 mb-2 px-4 py-4 border hover:dark:bg-secondary/30 rounded-lg block">
-              <span>{thread.title || t('common:newThread')}</span>
+        {currentProjectId ?
+          <Link to="/threads/$threadId" params={{ threadId: thread.id }} className="bg-card dark:bg-secondary/20 mb-2 px-4 py-4 border hover:dark:bg-secondary/30 rounded-lg block max-w-full overflow-hidden">
+              <span className="block truncate">{thread.title || t('common:newThread')}</span>
               {currentProjectId && lastUserMessageText && (
                 <div className="text-muted-foreground text-xs mt-1 line-clamp-1 pr-10">
                   {lastUserMessageText}

--- a/web-app/src/containers/ThreadList.tsx
+++ b/web-app/src/containers/ThreadList.tsx
@@ -138,17 +138,17 @@ const ThreadItem = memo(
       <SidebarMenuItem>
         {currentProjectId ?
           <Link to="/threads/$threadId" params={{ threadId: thread.id }} className="bg-card dark:bg-secondary/20 mb-2 px-4 py-4 border hover:dark:bg-secondary/30 rounded-lg block max-w-full overflow-hidden">
-              <span className="block truncate">{thread.title || t('common:newThread')}</span>
+              <span className="block truncate" title={thread.title || t('common:newThread')}>{thread.title || t('common:newThread')}</span>
               {currentProjectId && lastUserMessageText && (
                 <div className="text-muted-foreground text-xs mt-1 line-clamp-1 pr-10">
                   {lastUserMessageText}
                 </div>
               )}
           </Link>
-          : 
+          :
           <SidebarMenuButton asChild>
             <Link to="/threads/$threadId" params={{ threadId: thread.id }}>
-              <span>{thread.title || t('common:newThread')}</span>
+              <span className="block truncate" title={thread.title || t('common:newThread')}>{thread.title || t('common:newThread')}</span>
             </Link>
           </SidebarMenuButton>
         }

--- a/web-app/src/containers/__tests__/ThreadList.test.tsx
+++ b/web-app/src/containers/__tests__/ThreadList.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from 'vitest'
+import { act, render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import ThreadList from '../ThreadList'
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, className, title }: any) => (
+    <a className={className} title={title}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock('@/i18n/react-i18next-compat', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+vi.mock('@/hooks/useThreads', () => ({
+  useThreads: (selector: any) =>
+    selector({
+      deleteThread: vi.fn(),
+      renameThread: vi.fn(),
+      updateThread: vi.fn(),
+    }),
+}))
+
+vi.mock('@/hooks/useMessages', () => ({
+  useMessages: (selector: any) =>
+    selector({
+      getMessages: () => [],
+      setMessages: vi.fn(),
+    }),
+}))
+
+vi.mock('@/hooks/useThreadManagement', () => ({
+  useThreadManagement: () => ({
+    folders: [],
+    getFolderById: vi.fn(),
+  }),
+}))
+
+vi.mock('@/components/ui/sidebar', () => ({
+  SidebarMenuItem: ({ children }: any) => <li>{children}</li>,
+  SidebarMenuButton: ({ children }: any) => <div>{children}</div>,
+  SidebarMenuAction: ({ children }: any) => <button>{children}</button>,
+  useSidebar: () => ({ isMobile: false }),
+}))
+
+vi.mock('@/components/ui/dropdown-menu', () => {
+  const Passthrough = ({ children }: any) => <>{children}</>
+  return {
+    DropdownMenu: Passthrough,
+    DropdownMenuContent: Passthrough,
+    DropdownMenuItem: Passthrough,
+    DropdownMenuSeparator: () => null,
+    DropdownMenuTrigger: Passthrough,
+    DropdownMenuSub: Passthrough,
+    DropdownMenuSubContent: Passthrough,
+    DropdownMenuSubTrigger: Passthrough,
+  }
+})
+
+vi.mock('@/containers/dialogs', () => ({
+  RenameThreadDialog: () => null,
+  DeleteThreadDialog: () => null,
+}))
+
+const longUrl = 'https://example.com/' + 'a'.repeat(300)
+
+const makeThread = (overrides: Partial<Thread> = {}): Thread =>
+  ({
+    id: 't1',
+    title: longUrl,
+    updated: 0,
+    metadata: {},
+    ...overrides,
+  }) as Thread
+
+const flushEffects = () => act(() => Promise.resolve())
+
+describe('ThreadList — long-URL overflow guard (#7959)', () => {
+  it('truncates non-project thread titles and exposes full text via title attribute', async () => {
+    render(<ThreadList threads={[makeThread()]} />)
+    await flushEffects()
+
+    const titleSpans = screen
+      .getAllByText(longUrl)
+      .filter((el) => el.tagName === 'SPAN')
+    expect(titleSpans.length).toBeGreaterThan(0)
+
+    const titleEl = titleSpans[0]
+    expect(titleEl).toHaveClass('block', 'truncate')
+    expect(titleEl).toHaveAttribute('title', longUrl)
+  })
+
+  it('applies overflow guard on the project-view thread link wrapper', async () => {
+    render(
+      <ThreadList
+        threads={[makeThread()]}
+        currentProjectId="project-1"
+      />
+    )
+    await flushEffects()
+
+    const link = screen.getByText(longUrl).closest('a')
+    expect(link).not.toBeNull()
+    expect(link).toHaveClass('max-w-full', 'overflow-hidden')
+  })
+
+  it('falls back to the new-thread label when the title is empty and still truncates', async () => {
+    render(<ThreadList threads={[makeThread({ title: '' })]} />)
+    await flushEffects()
+
+    const titleEl = screen
+      .getAllByText('common:newThread')
+      .find((el) => el.tagName === 'SPAN')
+    expect(titleEl).toBeDefined()
+    expect(titleEl).toHaveClass('block', 'truncate')
+    expect(titleEl).toHaveAttribute('title', 'common:newThread')
+  })
+})


### PR DESCRIPTION
## Describe Your Changes

- Add `min-w-0` to `SidebarInset` to prevent flex item from expanding beyond viewport when content contains long non-breaking text
- Add `max-w-full overflow-hidden` to thread card `Link` in project view to constrain width
- Add `block truncate` to thread title `span` to truncate long titles with ellipsis

## Fixes Issues

- Closes #7959

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

## Screenshots

### After fix
![thread-title-truncated]
<img width="904" height="702" alt="screenshot" src="https://github.com/user-attachments/assets/7c0e52d7-3127-4e26-8b04-e194bf3f6867" />
(screenshot.png)

Thread titles with long non-breaking text are now properly truncated with ellipsis instead of breaking the container layout.
