### PR TITLE
fix(web): detect real Tauri runtime on localhost

### DIFF
--- a/web-app/src/lib/platform/utils.ts
+++ b/web-app/src/lib/platform/utils.ts
@@ -11,6 +11,22 @@ export const isPlatformTauri = (): boolean => {
   if (IS_WEB_APP === true || (IS_WEB_APP as unknown as string) === 'true') {
     return false
   }
+
+  // In dev, web can be built with Tauri flags but still opened in a regular browser.
+  // Only treat as Tauri when a runtime bridge is actually present.
+  if (typeof window !== 'undefined') {
+    const w = window as Window & {
+      __TAURI__?: unknown
+      __TAURI_INTERNALS__?: unknown
+    }
+    const hasTauriBridge =
+      typeof w.__TAURI__ !== 'undefined' ||
+      typeof w.__TAURI_INTERNALS__ !== 'undefined'
+    if (!hasTauriBridge) {
+      return false
+    }
+  }
+
   return true
 }
 


### PR DESCRIPTION
## Describe Your Changes

- Fix platform detection for `localhost` browser sessions so Jan only runs Tauri-specific services when an actual Tauri runtime bridge (`window.__TAURI__ / window.__TAURI_INTERNALS__`) is present.
- Prevent the web app from being misclassified as desktop Tauri in dev scenarios where `IS_TAURI` flags are present but the app is opened in a normal browser.
- Add a runtime guard in `web-app/src/lib/platform/utils.ts` to fall back to web mode when no Tauri bridge exists, avoiding missing-thread/data behavior caused by wrong service initialization.

## Fixes Issues

- Closes #7957 

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
