### PR TITLE
CI: Add Rust coverage job to CI workflows

### DIFF
--- a/.github/workflows/jan-linter-and-test.yml
+++ b/.github/workflows/jan-linter-and-test.yml
@@ -93,7 +93,13 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Run Rust test coverage
-        run: ./scripts/rust-coverage.sh
+        run: |
+          cargo llvm-cov clean --workspace --manifest-path src-tauri/Cargo.toml
+          cargo llvm-cov --no-report --manifest-path src-tauri/Cargo.toml --no-default-features --features test-tauri -- --test-threads=1
+          cargo llvm-cov --no-report --manifest-path src-tauri/plugins/tauri-plugin-hardware/Cargo.toml
+          cargo llvm-cov --no-report --manifest-path src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
+          cargo llvm-cov --no-report --manifest-path src-tauri/utils/Cargo.toml
+          cargo llvm-cov report --lcov --output-path rust-lcov.info --manifest-path src-tauri/Cargo.toml
 
       - name: Upload Rust code coverage for ref branch
         uses: actions/upload-artifact@v4

--- a/.github/workflows/jan-linter-and-test.yml
+++ b/.github/workflows/jan-linter-and-test.yml
@@ -75,6 +75,38 @@ jobs:
           name: ref-lcov.info
           path: coverage/lcov.info
 
+  base_branch_rust_cov:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.base_ref }}
+
+      - name: Install Tauri dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libglib2.0-dev libatk1.0-dev libpango1.0-dev libgtk-3-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev librsvg2-dev
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Run Rust test coverage
+        run: |
+          cargo llvm-cov clean --workspace --manifest-path src-tauri/Cargo.toml
+          cargo llvm-cov --no-report --manifest-path src-tauri/Cargo.toml --no-default-features --features test-tauri -- --test-threads=1
+          cargo llvm-cov --no-report --manifest-path src-tauri/plugins/tauri-plugin-hardware/Cargo.toml
+          cargo llvm-cov --no-report --manifest-path src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
+          cargo llvm-cov --no-report --manifest-path src-tauri/utils/Cargo.toml
+          cargo llvm-cov report --lcov --output-path rust-lcov.info --manifest-path src-tauri/Cargo.toml
+
+      - name: Upload Rust code coverage for ref branch
+        uses: actions/upload-artifact@v4
+        with:
+          name: ref-rust-lcov.info
+          path: rust-lcov.info
+
   test-on-macos:
     runs-on: 'macos-latest'
     if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
@@ -263,7 +295,7 @@ jobs:
   coverage-check:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-    needs: base_branch_cov
+    needs: [base_branch_cov, base_branch_rust_cov]
     continue-on-error: true
     steps:
       - name: Getting the repo
@@ -292,20 +324,52 @@ jobs:
         run: |
           make lint
 
-      - name: Run test coverage
+      - name: Run TypeScript test coverage
         run: |
           yarn test:coverage
+
+      - name: Install Tauri dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libglib2.0-dev libatk1.0-dev libpango1.0-dev libgtk-3-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev librsvg2-dev
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Run Rust test coverage
+        run: |
+          cargo llvm-cov clean --workspace --manifest-path src-tauri/Cargo.toml
+          cargo llvm-cov --no-report --manifest-path src-tauri/Cargo.toml --no-default-features --features test-tauri -- --test-threads=1
+          cargo llvm-cov --no-report --manifest-path src-tauri/plugins/tauri-plugin-hardware/Cargo.toml
+          cargo llvm-cov --no-report --manifest-path src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
+          cargo llvm-cov --no-report --manifest-path src-tauri/utils/Cargo.toml
+          cargo llvm-cov report --lcov --output-path rust-lcov.info --manifest-path src-tauri/Cargo.toml
+
+      - name: Merge coverage reports
+        run: |
+          cat ./coverage/lcov.info rust-lcov.info > merged-lcov.info
 
       - name: Download code coverage report from base branch
         uses: actions/download-artifact@v4
         with:
           name: ref-lcov.info
+
+      - name: Download Rust code coverage report from base branch
+        uses: actions/download-artifact@v4
+        with:
+          name: ref-rust-lcov.info
+          path: base-rust-cov
+
+      - name: Merge base branch coverage reports
+        run: |
+          cat ./lcov.info ./base-rust-cov/rust-lcov.info > base-merged-lcov.info
+
       - name: Generate Code Coverage report
         id: code-coverage
         uses: barecheck/code-coverage-action@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          lcov-file: './coverage/lcov.info'
-          base-lcov-file: './lcov.info'
+          lcov-file: './merged-lcov.info'
+          base-lcov-file: './base-merged-lcov.info'
           send-summary-comment: true
           show-annotations: 'warning'

--- a/.github/workflows/jan-linter-and-test.yml
+++ b/.github/workflows/jan-linter-and-test.yml
@@ -92,6 +92,14 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
+      - name: Create Tauri externalBin stubs
+        run: |
+          TRIPLE=$(rustc -vV | awk '/^host:/ { print $2 }')
+          mkdir -p src-tauri/resources/bin
+          for bin in uv bun; do
+            touch "src-tauri/resources/bin/${bin}-${TRIPLE}"
+          done
+
       - name: Run Rust test coverage
         run: |
           cargo llvm-cov clean --workspace --manifest-path src-tauri/Cargo.toml

--- a/.github/workflows/jan-linter-and-test.yml
+++ b/.github/workflows/jan-linter-and-test.yml
@@ -92,10 +92,13 @@ jobs:
       - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@cargo-llvm-cov
 
-      - name: Create Tauri externalBin stubs
+      - name: Create Tauri resource stubs for CI
         run: |
           TRIPLE=$(rustc -vV | awk '/^host:/ { print $2 }')
-          mkdir -p src-tauri/resources/bin
+          mkdir -p src-tauri/resources/bin src-tauri/resources/pre-install
+          touch src-tauri/resources/pre-install/.gitkeep
+          touch src-tauri/resources/LICENSE
+          touch src-tauri/resources/bin/jan-cli
           for bin in uv bun; do
             touch "src-tauri/resources/bin/${bin}-${TRIPLE}"
           done

--- a/.github/workflows/jan-linter-and-test.yml
+++ b/.github/workflows/jan-linter-and-test.yml
@@ -40,11 +40,11 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref }}
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ github.base_ref }}
 
@@ -93,13 +93,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Run Rust test coverage
-        run: |
-          cargo llvm-cov clean --workspace --manifest-path src-tauri/Cargo.toml
-          cargo llvm-cov --no-report --manifest-path src-tauri/Cargo.toml --no-default-features --features test-tauri -- --test-threads=1
-          cargo llvm-cov --no-report --manifest-path src-tauri/plugins/tauri-plugin-hardware/Cargo.toml
-          cargo llvm-cov --no-report --manifest-path src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
-          cargo llvm-cov --no-report --manifest-path src-tauri/utils/Cargo.toml
-          cargo llvm-cov report --lcov --output-path rust-lcov.info --manifest-path src-tauri/Cargo.toml
+        run: ./scripts/rust-coverage.sh
 
       - name: Upload Rust code coverage for ref branch
         uses: actions/upload-artifact@v4
@@ -112,12 +106,12 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Getting the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Installing node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -152,12 +146,12 @@ jobs:
     runs-on: windows-desktop-${{ matrix.antivirus-tools }}
     steps:
       - name: Getting the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Installing node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -191,7 +185,7 @@ jobs:
     runs-on: 'windows-latest'
     steps:
       - name: Getting the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -200,7 +194,7 @@ jobs:
           choco install --yes --no-progress make
 
       - name: Installing node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -241,7 +235,7 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Getting the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -257,7 +251,7 @@ jobs:
           swap-storage: true
 
       - name: Installing node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -299,12 +293,12 @@ jobs:
     continue-on-error: true
     steps:
       - name: Getting the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Installing node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: 'Cleanup cache'
@@ -337,13 +331,7 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
 
       - name: Run Rust test coverage
-        run: |
-          cargo llvm-cov clean --workspace --manifest-path src-tauri/Cargo.toml
-          cargo llvm-cov --no-report --manifest-path src-tauri/Cargo.toml --no-default-features --features test-tauri -- --test-threads=1
-          cargo llvm-cov --no-report --manifest-path src-tauri/plugins/tauri-plugin-hardware/Cargo.toml
-          cargo llvm-cov --no-report --manifest-path src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
-          cargo llvm-cov --no-report --manifest-path src-tauri/utils/Cargo.toml
-          cargo llvm-cov report --lcov --output-path rust-lcov.info --manifest-path src-tauri/Cargo.toml
+        run: ./scripts/rust-coverage.sh
 
       - name: Merge coverage reports
         run: |
@@ -355,6 +343,8 @@ jobs:
           name: ref-lcov.info
 
       - name: Download Rust code coverage report from base branch
+        id: download-rust-cov
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: ref-rust-lcov.info
@@ -362,7 +352,12 @@ jobs:
 
       - name: Merge base branch coverage reports
         run: |
-          cat ./lcov.info ./base-rust-cov/rust-lcov.info > base-merged-lcov.info
+          if [ -f ./base-rust-cov/rust-lcov.info ]; then
+            cat ./lcov.info ./base-rust-cov/rust-lcov.info > base-merged-lcov.info
+          else
+            echo "Rust base coverage not available, using TS-only coverage"
+            cp ./lcov.info base-merged-lcov.info
+          fi
 
       - name: Generate Code Coverage report
         id: code-coverage

--- a/.github/workflows/jan-linter-and-test.yml
+++ b/.github/workflows/jan-linter-and-test.yml
@@ -95,12 +95,16 @@ jobs:
       - name: Create Tauri resource stubs for CI
         run: |
           TRIPLE=$(rustc -vV | awk '/^host:/ { print $2 }')
-          mkdir -p src-tauri/resources/bin src-tauri/resources/pre-install
+          mkdir -p src-tauri/resources/bin src-tauri/resources/pre-install src-tauri/icons
           touch src-tauri/resources/pre-install/.gitkeep
           touch src-tauri/resources/LICENSE
           touch src-tauri/resources/bin/jan-cli
           for bin in uv bun; do
             touch "src-tauri/resources/bin/${bin}-${TRIPLE}"
+          done
+          # Icons are gitignored; generate_context!() requires them at compile time
+          for icon in 32x32.png 128x128.png 128x128@2x.png icon.icns icon.ico; do
+            [ -f "src-tauri/icons/$icon" ] || cp src-tauri/icons/icon.png "src-tauri/icons/$icon"
           done
 
       - name: Run Rust test coverage

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ test-data
 llm-docs
 .claude/agents
 .claude
+CLAUDE.md

--- a/scripts/rust-coverage.sh
+++ b/scripts/rust-coverage.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Runs Rust test coverage using cargo-llvm-cov across all workspace crates.
+# Outputs: rust-lcov.info in the current directory.
+set -euo pipefail
+
+cargo llvm-cov clean --workspace --manifest-path src-tauri/Cargo.toml
+cargo llvm-cov --no-report --manifest-path src-tauri/Cargo.toml --no-default-features --features test-tauri -- --test-threads=1
+cargo llvm-cov --no-report --manifest-path src-tauri/plugins/tauri-plugin-hardware/Cargo.toml
+cargo llvm-cov --no-report --manifest-path src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
+cargo llvm-cov --no-report --manifest-path src-tauri/utils/Cargo.toml
+cargo llvm-cov report --lcov --output-path rust-lcov.info --manifest-path src-tauri/Cargo.toml

--- a/scripts/rust-coverage.sh
+++ b/scripts/rust-coverage.sh
@@ -3,16 +3,20 @@
 # Outputs: rust-lcov.info in the current directory.
 set -euo pipefail
 
-# Tauri build script validates resources and externalBin paths exist.
+# Tauri build script validates resources, externalBin, and icons exist.
 # Create stubs so the build succeeds in CI where these aren't present.
 TRIPLE=$(rustc -vV | awk '/^host:/ { print $2 }')
-mkdir -p src-tauri/resources/bin src-tauri/resources/pre-install
+mkdir -p src-tauri/resources/bin src-tauri/resources/pre-install src-tauri/icons
 [ -f src-tauri/resources/LICENSE ] || touch src-tauri/resources/LICENSE
 [ -f src-tauri/resources/bin/jan-cli ] || touch src-tauri/resources/bin/jan-cli
 [ "$(ls -A src-tauri/resources/pre-install 2>/dev/null)" ] || touch src-tauri/resources/pre-install/.gitkeep
 for bin in uv bun; do
   stub="src-tauri/resources/bin/${bin}-${TRIPLE}"
   [ -f "$stub" ] || touch "$stub"
+done
+# Icons are gitignored; generate_context!() requires them at compile time
+for icon in 32x32.png 128x128.png 128x128@2x.png icon.icns icon.ico; do
+  [ -f "src-tauri/icons/$icon" ] || cp src-tauri/icons/icon.png "src-tauri/icons/$icon"
 done
 
 cargo llvm-cov clean --workspace --manifest-path src-tauri/Cargo.toml

--- a/scripts/rust-coverage.sh
+++ b/scripts/rust-coverage.sh
@@ -3,6 +3,15 @@
 # Outputs: rust-lcov.info in the current directory.
 set -euo pipefail
 
+# Tauri build script validates externalBin paths exist. Create stubs so
+# the build succeeds in CI where the real binaries aren't downloaded.
+TRIPLE=$(rustc -vV | awk '/^host:/ { print $2 }')
+mkdir -p src-tauri/resources/bin
+for bin in uv bun; do
+  stub="src-tauri/resources/bin/${bin}-${TRIPLE}"
+  [ -f "$stub" ] || touch "$stub"
+done
+
 cargo llvm-cov clean --workspace --manifest-path src-tauri/Cargo.toml
 cargo llvm-cov --no-report --manifest-path src-tauri/Cargo.toml --no-default-features --features test-tauri -- --test-threads=1
 cargo llvm-cov --no-report --manifest-path src-tauri/plugins/tauri-plugin-hardware/Cargo.toml

--- a/scripts/rust-coverage.sh
+++ b/scripts/rust-coverage.sh
@@ -3,10 +3,13 @@
 # Outputs: rust-lcov.info in the current directory.
 set -euo pipefail
 
-# Tauri build script validates externalBin paths exist. Create stubs so
-# the build succeeds in CI where the real binaries aren't downloaded.
+# Tauri build script validates resources and externalBin paths exist.
+# Create stubs so the build succeeds in CI where these aren't present.
 TRIPLE=$(rustc -vV | awk '/^host:/ { print $2 }')
-mkdir -p src-tauri/resources/bin
+mkdir -p src-tauri/resources/bin src-tauri/resources/pre-install
+[ -f src-tauri/resources/LICENSE ] || touch src-tauri/resources/LICENSE
+[ -f src-tauri/resources/bin/jan-cli ] || touch src-tauri/resources/bin/jan-cli
+[ "$(ls -A src-tauri/resources/pre-install 2>/dev/null)" ] || touch src-tauri/resources/pre-install/.gitkeep
 for bin in uv bun; do
   stub="src-tauri/resources/bin/${bin}-${TRIPLE}"
   [ -f "$stub" ] || touch "$stub"


### PR DESCRIPTION
## Describe Your Changes

- Introduces a dedicated job (`base_branch_rust_cov`) to run Rust test coverage checks against the base branch when a pull request is opened. This ensures that the Rust component's test coverage is available for comparison against the existing codebase coverage, providing a more comprehensive review pipeline.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
