### PR TITLE
fix(sidebar): reduce left sidebar max width to prevent content cramping

### DIFF
--- a/web-app/src/components/ui/sidebar.tsx
+++ b/web-app/src/components/ui/sidebar.tsx
@@ -30,7 +30,7 @@ const SIDEBAR_KEYBOARD_SHORTCUT = "b";
 
 //* new constants for sidebar resizing
 const MIN_SIDEBAR_WIDTH = "14rem";
-const MAX_SIDEBAR_WIDTH = "40rem";
+const MAX_SIDEBAR_WIDTH = "20rem";
 
 type SidebarContext = {
 	state: "expanded" | "collapsed";


### PR DESCRIPTION
Fixes #7985

## Problem
The left sidebar could be dragged to a maximum width of 40rem (640px), which left the main content area (including the settings panel) extremely cramped and nearly unusable.

## Solution
Reduced `MAX_SIDEBAR_WIDTH` from `40rem` to `20rem` in `web-app/src/components/ui/sidebar.tsx`. This ensures that even at maximum sidebar width, the main content area always has sufficient space to render properly.

## Testing
- Manually verified that the sidebar can still be resized between its minimum (14rem) and new maximum (20rem).
- Confirmed the main content / settings panel remains usable at max sidebar width.