### PR TITLE
chore: remove unused thread-scroll default constant and type guard

### DIFF
--- a/web-app/src/constants/threadScroll.ts
+++ b/web-app/src/constants/threadScroll.ts
@@ -8,9 +8,6 @@ export const THREAD_SCROLL_BEHAVIOR = {
 export type ThreadScrollBehavior =
   (typeof THREAD_SCROLL_BEHAVIOR)[keyof typeof THREAD_SCROLL_BEHAVIOR]
 
-export const DEFAULT_THREAD_SCROLL_BEHAVIOR =
-  THREAD_SCROLL_BEHAVIOR.FLOW
-
 export const threadScrollBehaviorOptions: Array<{
   value: ThreadScrollBehavior
   translationKey: string
@@ -24,10 +21,4 @@ export const threadScrollBehaviorOptions: Array<{
     translationKey: 'settings:interface.threadScrollStickyTitle',
   },
 ]
-
-export const isThreadScrollBehavior = (
-  value: unknown
-): value is ThreadScrollBehavior =>
-  value === THREAD_SCROLL_BEHAVIOR.FLOW ||
-  value === THREAD_SCROLL_BEHAVIOR.STICKY
 


### PR DESCRIPTION
## Describe Your Changes

- Remove `DEFAULT_THREAD_SCROLL_BEHAVIOR` and `isThreadScrollBehavior`  from `web-app/src/constants/threadScroll.ts` — both had zero call sites.
- Verified via:
  - `grep -rn "DEFAULT_THREAD_SCROLL_BEHAVIOR" .` — definition only.
  - `grep -rn "isThreadScrollBehavior" .` — definition only.
- Kept `THREAD_SCROLL_BEHAVIOR`, `ThreadScrollBehavior`, and  `threadScrollBehaviorOptions`, which remain in active use (settings  UI + type unions).
- No user-visible behavior change — pure dead-code cleanup.

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [x] Updated docs (for bug fixes / features)    
- [x] Created issues for follow-up changes or refactoring needed

