### PR TITLE
fix(mcp): guard backoff multiplier and delay against non-finite floats

### DIFF
--- a/src-tauri/src/core/mcp/helpers.rs
+++ b/src-tauri/src/core/mcp/helpers.rs
@@ -263,10 +263,19 @@ pub async fn monitor_mcp_server_handle<R: Runtime>(
         let base_delay_ms = settings.base_restart_delay_ms;
         let max_delay_ms = settings.max_restart_delay_ms;
         let multiplier = settings.backoff_multiplier;
-        let delay_ms = (base_delay_ms as f64
-            * multiplier.powi((consecutive_failures - 1) as i32))
-            as u64;
-        let capped_delay_ms = delay_ms.min(max_delay_ms);
+        let safe_multiplier = if multiplier.is_finite() && multiplier >= 1.0 {
+            multiplier
+        } else {
+            1.0
+        };
+        let raw_delay =
+            base_delay_ms as f64 * safe_multiplier.powi((consecutive_failures - 1) as i32);
+        let delay_ms = if raw_delay.is_finite() {
+            raw_delay as u64
+        } else {
+            max_delay_ms
+        };
+        let capped_delay_ms = delay_ms.min(max_delay_ms).max(base_delay_ms);
 
         log::info!(
             "MCP server {name} reconnect attempt {} in {}ms",

--- a/src-tauri/src/core/mcp/helpers.rs
+++ b/src-tauri/src/core/mcp/helpers.rs
@@ -159,6 +159,31 @@ pub async fn run_mcp_commands<R: Runtime>(
     Ok(())
 }
 
+/// Computes the clamped exponential backoff delay in milliseconds.
+///
+/// `attempt` is 0-indexed (0 = first failure). Invalid multipliers (NaN, negative,
+/// zero, < 1.0) fall back to 1.0 so the delay never decreases. Overflow to
+/// infinity caps at `max_delay_ms`. Result is always >= `base_delay_ms`.
+pub(super) fn compute_backoff_delay(
+    base_delay_ms: u64,
+    max_delay_ms: u64,
+    multiplier: f64,
+    attempt: u32,
+) -> u64 {
+    let safe_multiplier = if multiplier.is_finite() && multiplier >= 1.0 {
+        multiplier
+    } else {
+        1.0
+    };
+    let raw_delay = base_delay_ms as f64 * safe_multiplier.powi(attempt as i32);
+    let delay_ms = if raw_delay.is_finite() {
+        raw_delay as u64
+    } else {
+        max_delay_ms
+    };
+    delay_ms.min(max_delay_ms).max(base_delay_ms)
+}
+
 /// Monitor MCP server health and auto-reconnect on failure with exponential backoff
 pub async fn monitor_mcp_server_handle<R: Runtime>(
     app: AppHandle<R>,
@@ -263,19 +288,12 @@ pub async fn monitor_mcp_server_handle<R: Runtime>(
         let base_delay_ms = settings.base_restart_delay_ms;
         let max_delay_ms = settings.max_restart_delay_ms;
         let multiplier = settings.backoff_multiplier;
-        let safe_multiplier = if multiplier.is_finite() && multiplier >= 1.0 {
-            multiplier
-        } else {
-            1.0
-        };
-        let raw_delay =
-            base_delay_ms as f64 * safe_multiplier.powi((consecutive_failures - 1) as i32);
-        let delay_ms = if raw_delay.is_finite() {
-            raw_delay as u64
-        } else {
-            max_delay_ms
-        };
-        let capped_delay_ms = delay_ms.min(max_delay_ms).max(base_delay_ms);
+        let capped_delay_ms = compute_backoff_delay(
+            base_delay_ms,
+            max_delay_ms,
+            multiplier,
+            consecutive_failures - 1,
+        );
 
         log::info!(
             "MCP server {name} reconnect attempt {} in {}ms",

--- a/src-tauri/src/core/mcp/tests.rs
+++ b/src-tauri/src/core/mcp/tests.rs
@@ -778,6 +778,87 @@ fn test_extract_active_status_variants() {
 }
 
 // ============================================================================
+// helpers.rs Tests: compute_backoff_delay
+// ============================================================================
+
+#[test]
+fn test_compute_backoff_delay_normal_exponential_growth() {
+    use super::helpers::compute_backoff_delay;
+    // Default settings: base=1000ms, max=30000ms, multiplier=2.0
+    assert_eq!(compute_backoff_delay(1000, 30000, 2.0, 0), 1000);
+    assert_eq!(compute_backoff_delay(1000, 30000, 2.0, 1), 2000);
+    assert_eq!(compute_backoff_delay(1000, 30000, 2.0, 2), 4000);
+    assert_eq!(compute_backoff_delay(1000, 30000, 2.0, 4), 16000);
+}
+
+#[test]
+fn test_compute_backoff_delay_caps_at_max() {
+    use super::helpers::compute_backoff_delay;
+    // 1000 * 2^5 = 32000 > 30000 → capped
+    assert_eq!(compute_backoff_delay(1000, 30000, 2.0, 5), 30000);
+    // Very high attempt still caps
+    assert_eq!(compute_backoff_delay(1000, 30000, 2.0, 100), 30000);
+}
+
+#[test]
+fn test_compute_backoff_delay_invalid_multiplier_zero() {
+    use super::helpers::compute_backoff_delay;
+    // multiplier=0 falls back to 1.0 → constant base delay, no spin loop
+    assert_eq!(compute_backoff_delay(1000, 30000, 0.0, 0), 1000);
+    assert_eq!(compute_backoff_delay(1000, 30000, 0.0, 5), 1000);
+}
+
+#[test]
+fn test_compute_backoff_delay_invalid_multiplier_nan() {
+    use super::helpers::compute_backoff_delay;
+    assert_eq!(compute_backoff_delay(1000, 30000, f64::NAN, 0), 1000);
+    assert_eq!(compute_backoff_delay(1000, 30000, f64::NAN, 5), 1000);
+}
+
+#[test]
+fn test_compute_backoff_delay_invalid_multiplier_infinity() {
+    use super::helpers::compute_backoff_delay;
+    assert_eq!(compute_backoff_delay(1000, 30000, f64::INFINITY, 0), 1000);
+    assert_eq!(compute_backoff_delay(1000, 30000, f64::INFINITY, 5), 1000);
+}
+
+#[test]
+fn test_compute_backoff_delay_invalid_multiplier_negative() {
+    use super::helpers::compute_backoff_delay;
+    assert_eq!(compute_backoff_delay(1000, 30000, -2.0, 0), 1000);
+    assert_eq!(compute_backoff_delay(1000, 30000, -2.0, 5), 1000);
+}
+
+#[test]
+fn test_compute_backoff_delay_invalid_multiplier_less_than_one() {
+    use super::helpers::compute_backoff_delay;
+    // multiplier=0.5 < 1.0 → falls back to 1.0
+    assert_eq!(compute_backoff_delay(1000, 30000, 0.5, 3), 1000);
+}
+
+#[test]
+fn test_compute_backoff_delay_large_multiplier_overflows_to_max() {
+    use super::helpers::compute_backoff_delay;
+    // base=1000, multiplier=1e200 at attempt=5 → raw overflows to infinity → max
+    assert_eq!(compute_backoff_delay(1000, 30000, 1e200, 5), 30000);
+}
+
+#[test]
+fn test_compute_backoff_delay_floor_is_base_delay() {
+    use super::helpers::compute_backoff_delay;
+    // With multiplier=1.0, delay stays exactly at base for any attempt
+    assert_eq!(compute_backoff_delay(5000, 30000, 1.0, 0), 5000);
+    assert_eq!(compute_backoff_delay(5000, 30000, 1.0, 10), 5000);
+}
+
+#[test]
+fn test_compute_backoff_delay_base_zero_documents_no_floor() {
+    use super::helpers::compute_backoff_delay;
+    // base_delay_ms=0 is a misconfiguration not guarded here; result is 0
+    assert_eq!(compute_backoff_delay(0, 30000, 2.0, 0), 0);
+}
+
+// ============================================================================
 // lockfile.rs Tests
 // ============================================================================
 


### PR DESCRIPTION
## Describe Your Changes

- Clamp `backoff_multiplier` to `>= 1.0` before use; NaN, negative, and zero values fall back to `1.0` to prevent a zero-delay reconnect spin loop
- Guard the `f64 → u64` cast: if the product overflows to `f64::INFINITY`, cap directly at `max_delay_ms` instead of casting undefined behavior
- Add `.max(base_delay_ms)` floor so the delay never drops below the configured base regardless of multiplier value

## Fixes Issues

- Closes #8014

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
