### PR TITLE
feat: add reasoning, web search, and embeddings capability toggles

### DIFF
--- a/web-app/src/constants/localStorage.ts
+++ b/web-app/src/constants/localStorage.ts
@@ -28,6 +28,7 @@ export const localStorageKey = {
   janModelPromptDismissed: 'jan-model-prompt-dismissed',
   agentMode: 'agent-mode',
   latestJanModel: 'latest-jan-model',
+  capabilityToggles: 'capability-toggles',
 }
 
 export const CACHE_EXPIRY_MS = 1000 * 60 * 60 * 24

--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -88,6 +88,7 @@ import { useJanBrowserExtension } from '@/hooks/useJanBrowserExtension'
 import { PromptVisionModel } from '@/containers/PromptVisionModel'
 import { useAgentMode } from '@/hooks/useAgentMode'
 import { AssistantsMenu } from '@/components/AssistantsMenu'
+import { useCapabilityToggles } from '@/stores/capability-toggles-store'
 
 type ChatInputProps = {
   className?: string
@@ -161,6 +162,24 @@ const ChatInput = memo(function ChatInput({
     toggleAgentMode(agentModeKey)
   }, [agentModeKey, toggleAgentMode])
 
+  // Capability toggles (web search, reasoning, embeddings) — per-thread, same key as agent mode
+  const capabilityKey = currentThreadId ?? TEMPORARY_CHAT_ID
+  const capabilityToggles = useCapabilityToggles((state) => state.getToggles(capabilityKey))
+  const toggleCapability = useCapabilityToggles((state) => state.toggle)
+  const setCapabilityToggle = useCapabilityToggles((state) => state.setToggle)
+
+  const handleWebSearchToggle = useCallback(() => {
+    toggleCapability(capabilityKey, 'webSearch')
+  }, [capabilityKey, toggleCapability])
+
+  const handleReasoningToggle = useCallback(() => {
+    toggleCapability(capabilityKey, 'reasoning')
+  }, [capabilityKey, toggleCapability])
+
+  const handleEmbeddingsToggle = useCallback(() => {
+    toggleCapability(capabilityKey, 'embeddings')
+  }, [capabilityKey, toggleCapability])
+
   // Get current thread messages for token counting
   const threadMessages = useMessages(
     useShallow((state) =>
@@ -173,6 +192,21 @@ const ChatInput = memo(function ChatInput({
 
   const selectedModel = useModelProvider((state) => state.selectedModel)
   const selectedProvider = useModelProvider((state) => state.selectedProvider)
+
+  // Auto-disable capability toggles when the model no longer supports them
+  useEffect(() => {
+    const caps = selectedModel?.capabilities ?? []
+    if (capabilityToggles.webSearch && !caps.includes('web_search')) {
+      setCapabilityToggle(capabilityKey, 'webSearch', false)
+    }
+    if (capabilityToggles.reasoning && !caps.includes('reasoning')) {
+      setCapabilityToggle(capabilityKey, 'reasoning', false)
+    }
+    if (capabilityToggles.embeddings && !caps.includes('embeddings')) {
+      setCapabilityToggle(capabilityKey, 'embeddings', false)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedModel?.capabilities])
   const selectModelProvider = useModelProvider(
     (state) => state.selectModelProvider
   )
@@ -1807,17 +1841,26 @@ const ChatInput = memo(function ChatInput({
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Button
-                          variant="ghost"
-                          size="icon-xs"
-                        >
+                        variant="ghost"
+                        size="icon-xs"
+                        onClick={handleEmbeddingsToggle}
+                        className={cn(capabilityToggles.embeddings && 'text-primary')}
+                      >
                         <IconCodeCircle2
                           size={18}
-                          className="text-muted-foreground"
+                          className={cn(
+                            'text-muted-foreground',
+                            capabilityToggles.embeddings && 'text-primary'
+                          )}
                         />
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent>
-                      <p>{t('embeddings')}</p>
+                      <p>
+                        {capabilityToggles.embeddings
+                          ? `${t('embeddings')} (Active)`
+                          : t('embeddings')}
+                      </p>
                     </TooltipContent>
                   </Tooltip>
                 )}
@@ -1921,15 +1964,27 @@ const ChatInput = memo(function ChatInput({
                 {!effectiveAgentMode && selectedModel?.capabilities?.includes('web_search') && (
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <Button variant="ghost" size="icon-xs">
+                      <Button
+                        variant="ghost"
+                        size="icon-xs"
+                        onClick={handleWebSearchToggle}
+                        className={cn(capabilityToggles.webSearch && 'text-primary')}
+                      >
                         <IconWorld
                           size={18}
-                          className="text-muted-foreground"
+                          className={cn(
+                            'text-muted-foreground',
+                            capabilityToggles.webSearch && 'text-primary'
+                          )}
                         />
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent>
-                      <p>Web Search</p>
+                      <p>
+                        {capabilityToggles.webSearch
+                          ? 'Web Search (Active)'
+                          : 'Web Search'}
+                      </p>
                     </TooltipContent>
                   </Tooltip>
                 )}
@@ -1937,15 +1992,27 @@ const ChatInput = memo(function ChatInput({
                 {!effectiveAgentMode && selectedModel?.capabilities?.includes('reasoning') && (
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <Button variant="ghost" size="icon-xs">
+                      <Button
+                        variant="ghost"
+                        size="icon-xs"
+                        onClick={handleReasoningToggle}
+                        className={cn(capabilityToggles.reasoning && 'text-primary')}
+                      >
                         <IconAtom
                           size={18}
-                          className="text-muted-foreground"
+                          className={cn(
+                            'text-muted-foreground',
+                            capabilityToggles.reasoning && 'text-primary'
+                          )}
                         />
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent>
-                      <p>{t('reasoning')}</p>
+                      <p>
+                        {capabilityToggles.reasoning
+                          ? `${t('reasoning')} (Active)`
+                          : t('reasoning')}
+                      </p>
                     </TooltipContent>
                   </Tooltip>
                 )}

--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -205,8 +205,7 @@ const ChatInput = memo(function ChatInput({
     if (capabilityToggles.embeddings && !caps.includes('embeddings')) {
       setCapabilityToggle(capabilityKey, 'embeddings', false)
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedModel?.capabilities])
+  }, [selectedModel?.capabilities, capabilityKey, capabilityToggles, setCapabilityToggle])
   const selectModelProvider = useModelProvider(
     (state) => state.selectModelProvider
   )
@@ -1858,7 +1857,7 @@ const ChatInput = memo(function ChatInput({
                     <TooltipContent>
                       <p>
                         {capabilityToggles.embeddings
-                          ? `${t('embeddings')} (Active)`
+                          ? `${t('embeddings')} (${t('active')})`
                           : t('embeddings')}
                       </p>
                     </TooltipContent>
@@ -1982,8 +1981,8 @@ const ChatInput = memo(function ChatInput({
                     <TooltipContent>
                       <p>
                         {capabilityToggles.webSearch
-                          ? 'Web Search (Active)'
-                          : 'Web Search'}
+                          ? `${t('webSearch')} (${t('active')})`
+                          : t('webSearch')}
                       </p>
                     </TooltipContent>
                   </Tooltip>
@@ -2010,7 +2009,7 @@ const ChatInput = memo(function ChatInput({
                     <TooltipContent>
                       <p>
                         {capabilityToggles.reasoning
-                          ? `${t('reasoning')} (Active)`
+                          ? `${t('reasoning')} (${t('active')})`
                           : t('reasoning')}
                       </p>
                     </TooltipContent>

--- a/web-app/src/containers/__tests__/EditModel.test.tsx
+++ b/web-app/src/containers/__tests__/EditModel.test.tsx
@@ -86,7 +86,6 @@ vi.mock('@tabler/icons-react', () => ({
   IconAtom: () => <div data-testid="atom-icon" />,
   IconWorld: () => <div data-testid="world-icon" />,
   IconCodeCircle2: () => <div data-testid="code-circle-icon" />,
-  IconSparkles: () => <div data-testid="sparkles-icon" />,
   IconInfoCircle: () => <div data-testid="info-circle-icon" />,
 }))
 

--- a/web-app/src/containers/__tests__/EditModel.test.tsx
+++ b/web-app/src/containers/__tests__/EditModel.test.tsx
@@ -83,6 +83,11 @@ vi.mock('@tabler/icons-react', () => ({
   IconTool: () => <div data-testid="tool-icon" />,
   IconLoader2: () => <div data-testid="loader-icon" />,
   IconSparkles: () => <div data-testid="sparkles-icon" />,
+  IconAtom: () => <div data-testid="atom-icon" />,
+  IconWorld: () => <div data-testid="world-icon" />,
+  IconCodeCircle2: () => <div data-testid="code-circle-icon" />,
+  IconSparkles: () => <div data-testid="sparkles-icon" />,
+  IconInfoCircle: () => <div data-testid="info-circle-icon" />,
 }))
 
 describe('DialogEditModel - Basic Component Tests', () => {
@@ -240,8 +245,7 @@ describe('DialogEditModel - Basic Component Tests', () => {
       />
     )
 
-    // Component should render without errors even with extra capabilities
-    // The capabilities helper should only extract vision and tools
+    // Component should render without errors with all capabilities
     expect(container).toBeInTheDocument()
   })
 })

--- a/web-app/src/containers/dialogs/EditModel.tsx
+++ b/web-app/src/containers/dialogs/EditModel.tsx
@@ -162,6 +162,8 @@ export const DialogEditModel = ({
         modelUpdate.capabilities = Object.entries(capabilities)
           .filter(([, isEnabled]) => isEnabled)
           .map(([capName]) => capName)
+        // Marks that the user has explicitly set capabilities; suppresses
+        // auto-detection from model name in both EditModel and the model list.
         modelUpdate._userConfiguredCapabilities = true
       }
 

--- a/web-app/src/containers/dialogs/EditModel.tsx
+++ b/web-app/src/containers/dialogs/EditModel.tsx
@@ -17,10 +17,19 @@ import {
   IconTool,
   IconAlertTriangle,
   IconLoader2,
+  IconAtom,
+  IconWorld,
+  IconCodeCircle2,
+  IconSparkles,
+  IconInfoCircle,
 } from '@tabler/icons-react'
 import { useState, useEffect } from 'react'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { toast } from 'sonner'
+import {
+  detectModelCapabilities,
+  hasDetectedCapabilities,
+} from '@/lib/model-capabilities-detector'
 
 // No need to define our own interface, we'll use the existing Model type
 type DialogEditModelProps = {
@@ -45,7 +54,11 @@ export const DialogEditModel = ({
   const [capabilities, setCapabilities] = useState<Record<string, boolean>>({
     vision: false,
     tools: false,
+    reasoning: false,
+    web_search: false,
+    embeddings: false,
   })
+  const [isAutoDetected, setIsAutoDetected] = useState(false)
 
   // Initialize with the provided model ID or the first model if available
   useEffect(() => {
@@ -67,16 +80,39 @@ export const DialogEditModel = ({
   const capabilitiesToObject = (capabilitiesList: string[]) => ({
     vision: capabilitiesList.includes('vision'),
     tools: capabilitiesList.includes('tools'),
+    reasoning: capabilitiesList.includes('reasoning'),
+    web_search: capabilitiesList.includes('web_search'),
+    embeddings: capabilitiesList.includes('embeddings'),
   })
 
   // Initialize capabilities and display name from selected model
   useEffect(() => {
     if (selectedModel) {
       const modelCapabilities = selectedModel.capabilities || []
-      const capsObject = capabilitiesToObject(modelCapabilities)
+      const userConfigured = (selectedModel as Model & { _userConfiguredCapabilities?: boolean })._userConfiguredCapabilities
+
+      let capsObject = capabilitiesToObject(modelCapabilities)
+      let autoDetected = false
+
+      // Auto-detect capabilities from model name when the user has never
+      // manually configured them. Detected values are merged on top of any
+      // capabilities already declared by the provider.
+      if (!userConfigured) {
+        const detected = detectModelCapabilities(selectedModel.id)
+        if (hasDetectedCapabilities(detected)) {
+          capsObject = {
+            ...capsObject,
+            reasoning: capsObject.reasoning || detected.reasoning,
+            web_search: capsObject.web_search || detected.web_search,
+            embeddings: capsObject.embeddings || detected.embeddings,
+          }
+          autoDetected = true
+        }
+      }
 
       setCapabilities(capsObject)
       setOriginalCapabilities(capsObject)
+      setIsAutoDetected(autoDetected)
 
       // Use existing displayName if available, otherwise fall back to model ID
       const displayNameValue = (selectedModel as Model & { displayName?: string }).displayName || selectedModel.id
@@ -234,6 +270,14 @@ export const DialogEditModel = ({
           <h3 className="text-sm font-medium mb-3">
             {t('providers:editModel.capabilities')}
           </h3>
+
+          {isAutoDetected && (
+            <div className="flex items-start gap-2 mb-3 rounded-md bg-primary/10 px-3 py-2 text-xs text-primary">
+              <IconSparkles size={14} className="mt-0.5 shrink-0" />
+              <span>Capabilities auto-detected from model name. Review and adjust if needed.</span>
+            </div>
+          )}
+
           <div className="space-y-4">
             <div className="flex items-center justify-between">
               <div className="flex items-center space-x-2">
@@ -267,6 +311,81 @@ export const DialogEditModel = ({
                 }
                 disabled={isLoading}
               />
+            </div>
+
+            <div className="space-y-1">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-2">
+                  <IconAtom className="size-4 text-muted-foreground" />
+                  <span className="text-sm">
+                    {t('providers:editModel.reasoning')}
+                  </span>
+                </div>
+                <Switch
+                  id="reasoning-capability"
+                  checked={capabilities.reasoning}
+                  onCheckedChange={(checked) =>
+                    handleCapabilityChange('reasoning', checked)
+                  }
+                  disabled={isLoading}
+                />
+              </div>
+              {capabilities.reasoning && (
+                <div className="flex items-start gap-1.5 pl-6 text-xs text-muted-foreground">
+                  <IconInfoCircle size={12} className="mt-0.5 shrink-0" />
+                  <span>Only works with reasoning models (e.g. DeepSeek-R1, QwQ, o1). Has no effect on standard models.</span>
+                </div>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-2">
+                  <IconWorld className="size-4 text-muted-foreground" />
+                  <span className="text-sm">
+                    {t('providers:editModel.webSearch')}
+                  </span>
+                </div>
+                <Switch
+                  id="web-search-capability"
+                  checked={capabilities.web_search}
+                  onCheckedChange={(checked) =>
+                    handleCapabilityChange('web_search', checked)
+                  }
+                  disabled={isLoading}
+                />
+              </div>
+              {capabilities.web_search && (
+                <div className="flex items-start gap-1.5 pl-6 text-xs text-muted-foreground">
+                  <IconInfoCircle size={12} className="mt-0.5 shrink-0" />
+                  <span>Only works with models that have built-in web search (e.g. Perplexity Sonar). Has no effect on standard models.</span>
+                </div>
+              )}
+            </div>
+
+            <div className="space-y-1">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center space-x-2">
+                  <IconCodeCircle2 className="size-4 text-muted-foreground" />
+                  <span className="text-sm">
+                    {t('providers:editModel.embeddings')}
+                  </span>
+                </div>
+                <Switch
+                  id="embeddings-capability"
+                  checked={capabilities.embeddings}
+                  onCheckedChange={(checked) =>
+                    handleCapabilityChange('embeddings', checked)
+                  }
+                  disabled={isLoading}
+                />
+              </div>
+              {capabilities.embeddings && (
+                <div className="flex items-start gap-1.5 pl-6 text-xs text-muted-foreground">
+                  <IconInfoCircle size={12} className="mt-0.5 shrink-0" />
+                  <span>Enable on embedding models (e.g. nomic-embed-text, mxbai-embed). Activates semantic search (RAG) in chat.</span>
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/web-app/src/hooks/use-chat.ts
+++ b/web-app/src/hooks/use-chat.ts
@@ -1,7 +1,6 @@
 import {
   CustomChatTransport,
 } from '@/lib/custom-chat-transport'
-// import { useCapabilities } from "@/stores/capabilities-store";
 import {
   Chat,
   type UIMessage,
@@ -15,6 +14,8 @@ import {
 import { useEffect, useMemo, useRef, useCallback } from 'react'
 import { useChatSessions } from '@/stores/chat-session-store'
 import { useAppState } from '@/hooks/useAppState'
+import { useCapabilityToggles, DEFAULT_CAPABILITY_TOGGLES } from '@/stores/capability-toggles-store'
+import { useShallow } from 'zustand/react/shallow'
 
 type CustomChatOptions = Omit<ChatInit<UIMessage>, 'transport'> &
   Pick<UseChatOptions<UIMessage>, 'experimental_throttle' | 'resume'> & {
@@ -76,6 +77,16 @@ export function useChat(
       transportRef.current.setOnTokenUsage(onTokenUsage)
     }
   }, [onTokenUsage])
+
+  // Sync capability toggles (web search, reasoning, embeddings) to the transport
+  const capabilityToggles = useCapabilityToggles(
+    useShallow((state) => sessionId ? (state.threads[sessionId] ?? DEFAULT_CAPABILITY_TOGGLES) : null)
+  )
+  useEffect(() => {
+    if (transportRef.current && capabilityToggles) {
+      transportRef.current.setCapabilityToggles(capabilityToggles)
+    }
+  }, [capabilityToggles])
 
   // Memoize to prevent calling ensureSession (which has side effects) on every render
   const chat = useMemo(() => {

--- a/web-app/src/lib/__tests__/custom-chat-transport-class.test.ts
+++ b/web-app/src/lib/__tests__/custom-chat-transport-class.test.ts
@@ -85,6 +85,17 @@ describe('CustomChatTransport', () => {
     expect(true).toBe(true)
   })
 
+  it('setCapabilityToggles accepts all three flags without error', () => {
+    transport.setCapabilityToggles({ webSearch: true, reasoning: true, embeddings: true })
+    expect(true).toBe(true)
+  })
+
+  it('setCapabilityToggles can be updated multiple times', () => {
+    transport.setCapabilityToggles({ webSearch: true, reasoning: false, embeddings: false })
+    transport.setCapabilityToggles({ webSearch: false, reasoning: true, embeddings: true })
+    expect(true).toBe(true)
+  })
+
   it('reconnectToStream returns null', async () => {
     const result = await transport.reconnectToStream({ chatId: 'c1' } as any)
     expect(result).toBeNull()

--- a/web-app/src/lib/__tests__/model-capabilities-detector.test.ts
+++ b/web-app/src/lib/__tests__/model-capabilities-detector.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import { detectModelCapabilities, hasDetectedCapabilities } from '../model-capabilities-detector'
+
+describe('detectModelCapabilities', () => {
+  describe('reasoning', () => {
+    it.each([
+      'deepseek-r1',
+      'deepseek-r1:7b',
+      'deepseek/deepseek-r1:free',
+      'deepseek-r2',
+      'deepseek-reasoner',
+      'qwq-32b',
+      'qwq',
+      'qvq-72b',
+      'phi-4-reasoning',
+      'exaone-deep-7.8b',
+      'lfm-thinking-20b',
+      'claude-3-5-sonnet-thinking-20251001',
+      'model:thinking',
+    ])('detects reasoning for %s', (modelId) => {
+      expect(detectModelCapabilities(modelId).reasoning).toBe(true)
+    })
+
+    it.each([
+      'o1',
+      'o1-mini',
+      'o1-preview',
+      'o3',
+      'o3-mini',
+    ])('detects reasoning for OpenAI o-series: %s', (modelId) => {
+      expect(detectModelCapabilities(modelId).reasoning).toBe(true)
+    })
+
+    it.each([
+      'llama3.2',
+      'mistral-7b',
+      'gpt-4o',
+      'gemma-2-9b',
+      'phi-3-mini',
+      'tool-use-model',
+    ])('does NOT detect reasoning for %s', (modelId) => {
+      expect(detectModelCapabilities(modelId).reasoning).toBe(false)
+    })
+  })
+
+  describe('web_search', () => {
+    it.each([
+      'perplexity/sonar',
+      'sonar-pro',
+      'llama-3.1-sonar-large-128k-online',
+      'model-online',
+      'model:online',
+      'web-search-model',
+    ])('detects web_search for %s', (modelId) => {
+      expect(detectModelCapabilities(modelId).web_search).toBe(true)
+    })
+
+    it.each([
+      'llama3.2',
+      'gpt-4o',
+      'deepseek-r1',
+      'mistral-7b',
+    ])('does NOT detect web_search for %s', (modelId) => {
+      expect(detectModelCapabilities(modelId).web_search).toBe(false)
+    })
+  })
+
+  describe('embeddings', () => {
+    it.each([
+      'nomic-embed-text',
+      'mxbai-embed-large',
+      'text-embedding-3-small',
+      'bge-large-en',
+      'intfloat-e5-large',
+      'gte-qwen2-7b',
+    ])('detects embeddings for %s', (modelId) => {
+      expect(detectModelCapabilities(modelId).embeddings).toBe(true)
+    })
+
+    it.each([
+      'llama3.2',
+      'gpt-4o',
+      'deepseek-r1',
+      'phi-3-mini',
+    ])('does NOT detect embeddings for %s', (modelId) => {
+      expect(detectModelCapabilities(modelId).embeddings).toBe(false)
+    })
+  })
+
+  it('is case-insensitive', () => {
+    expect(detectModelCapabilities('DeepSeek-R1').reasoning).toBe(true)
+    expect(detectModelCapabilities('NOMIC-EMBED-TEXT').embeddings).toBe(true)
+    expect(detectModelCapabilities('Sonar-Pro').web_search).toBe(true)
+  })
+
+  it('can detect multiple capabilities on one model', () => {
+    const result = detectModelCapabilities('sonar-reasoning')
+    expect(result.reasoning).toBe(true)
+    expect(result.web_search).toBe(true)
+  })
+})
+
+describe('hasDetectedCapabilities', () => {
+  it('returns true when any capability is detected', () => {
+    expect(hasDetectedCapabilities({ reasoning: true, web_search: false, embeddings: false })).toBe(true)
+    expect(hasDetectedCapabilities({ reasoning: false, web_search: true, embeddings: false })).toBe(true)
+    expect(hasDetectedCapabilities({ reasoning: false, web_search: false, embeddings: true })).toBe(true)
+  })
+
+  it('returns false when no capability is detected', () => {
+    expect(hasDetectedCapabilities({ reasoning: false, web_search: false, embeddings: false })).toBe(false)
+  })
+})

--- a/web-app/src/lib/custom-chat-transport.ts
+++ b/web-app/src/lib/custom-chat-transport.ts
@@ -180,6 +180,11 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
   private continueFromContent: string | null = null
   /** Latest user message text — used by the MCP orchestrator for tool routing. */
   private lastUserMessage = ''
+  private capabilityToggles: { webSearch: boolean; reasoning: boolean; embeddings: boolean } = {
+    webSearch: false,
+    reasoning: false,
+    embeddings: false,
+  }
 
   constructor(systemMessage?: string, threadId?: string) {
     this.systemMessage = systemMessage
@@ -198,6 +203,10 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
 
   setOnTokenUsage(callback: TokenUsageCallback | undefined) {
     this.onTokenUsage = callback
+  }
+
+  setCapabilityToggles(toggles: { webSearch: boolean; reasoning: boolean; embeddings: boolean }) {
+    this.capabilityToggles = toggles
   }
 
   /**
@@ -280,8 +289,8 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
         ragFeatureAvailable = Boolean(useAttachments.getState().enabled)
       }
 
-      // Load RAG tools if documents are available
-      if (hasDocuments && ragFeatureAvailable) {
+      // Load RAG tools if documents are available, or if the embeddings toggle is on
+      if ((hasDocuments || this.capabilityToggles.embeddings) && ragFeatureAvailable) {
         try {
           const ragTools = await this.serviceHub.rag().getTools()
           if (Array.isArray(ragTools) && ragTools.length > 0) {
@@ -457,12 +466,42 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
       const currentAssistant = useAssistant.getState().currentAssistant
       const inferenceParams = currentAssistant?.parameters
 
+      // Merge capability toggle flags into inference params so they are forwarded
+      // in the request body via createCustomFetch.
+      const capabilityParams: Record<string, unknown> = {}
+
+      // web_search: only inject for OpenAI-compatible pass-through providers (e.g. Perplexity).
+      // Native SDK providers (Anthropic, OpenAI, Google, xAI) validate request bodies strictly
+      // and will reject unknown fields with a 400 error.
+      const NATIVE_STRICT_PROVIDERS = new Set(['anthropic', 'openai', 'google', 'gemini', 'xai'])
+      if (this.capabilityToggles.webSearch && !NATIVE_STRICT_PROVIDERS.has(effectiveProviderName)) {
+        capabilityParams.web_search = true
+      }
+
+      // thinking: Anthropic extended-thinking format. budget_tokens must be less than max_tokens,
+      // so we derive a safe budget from the assistant's configured max_tokens and ensure
+      // max_tokens is bumped to at least budget + 1024 output tokens if needed.
+      if (this.capabilityToggles.reasoning && effectiveProviderName === 'anthropic') {
+        const rawMax = inferenceParams?.max_output_tokens ?? inferenceParams?.max_tokens
+        const configuredMax = rawMax !== undefined && !isNaN(Number(rawMax)) ? Number(rawMax) : 0
+        const MIN_OUTPUT_TOKENS = 1024
+        const DEFAULT_BUDGET = 8000
+        const budgetTokens = configuredMax > MIN_OUTPUT_TOKENS
+          ? Math.min(DEFAULT_BUDGET, configuredMax - MIN_OUTPUT_TOKENS)
+          : DEFAULT_BUDGET
+        capabilityParams.thinking = { type: 'enabled', budget_tokens: budgetTokens }
+        // Ensure max_tokens is large enough to accommodate the budget
+        if (!configuredMax || configuredMax < budgetTokens + MIN_OUTPUT_TOKENS) {
+          capabilityParams.max_tokens = budgetTokens + MIN_OUTPUT_TOKENS
+        }
+      }
+
       // Create the model before refreshing tools so the MCP orchestrator can run
       // structured LLM routing when many servers are connected.
       this.model = await ModelFactory.createModel(
         modelId,
         updatedProvider ?? provider,
-        inferenceParams ?? {}
+        { ...(inferenceParams ?? {}), ...capabilityParams }
       )
     } catch (error) {
       console.error('Failed to create model:', error)

--- a/web-app/src/lib/model-capabilities-detector.ts
+++ b/web-app/src/lib/model-capabilities-detector.ts
@@ -1,0 +1,66 @@
+/**
+ * Heuristic capability detection based on model ID.
+ *
+ * For OpenAI-compatible and Ollama providers there is no standard API to
+ * query what a model supports, so we infer from the model name.  These rules
+ * are best-effort — the user can always override them in the Edit Model dialog.
+ */
+
+const REASONING_KEYWORDS = [
+  'deepseek-r1',
+  'deepseek-r2',
+  'deepseek-reasoner',
+  'qwq',
+  'qvq',
+  '-thinking',
+  ':thinking',
+  '-reasoning',  // sonar-reasoning, mistral-small-reasoning, etc.
+  ':reasoning',
+  'exaone-deep',
+  'lfm-thinking',
+]
+
+// o1 / o3 family: match "o1" or "o3" at a word boundary followed by end, hyphen, or colon
+// Avoids false positives like "tool", "model", "proto1".
+const O_SERIES_RE = /\bo[13](-|:|$)/
+
+const WEB_SEARCH_KEYWORDS = [
+  'sonar',       // Perplexity sonar family
+  '-online',
+  ':online',
+  'web-search',
+  'websearch',
+]
+
+const EMBEDDINGS_KEYWORDS = [
+  'embed',       // nomic-embed-text, mxbai-embed, text-embedding-*
+  'bge-',        // BAAI/bge-*
+  '-e5-',        // intfloat/e5-*
+  'mxbai',
+  'nomic',
+  'gte-',        // Alibaba/gte-*
+]
+
+export type DetectedCapabilities = {
+  reasoning: boolean
+  web_search: boolean
+  embeddings: boolean
+}
+
+export function detectModelCapabilities(modelId: string): DetectedCapabilities {
+  const id = modelId.toLowerCase()
+
+  const reasoning =
+    REASONING_KEYWORDS.some((kw) => id.includes(kw)) || O_SERIES_RE.test(id)
+
+  const web_search = WEB_SEARCH_KEYWORDS.some((kw) => id.includes(kw))
+
+  const embeddings = EMBEDDINGS_KEYWORDS.some((kw) => id.includes(kw))
+
+  return { reasoning, web_search, embeddings }
+}
+
+/** Returns true if any capability was inferred from the model name. */
+export function hasDetectedCapabilities(detected: DetectedCapabilities): boolean {
+  return detected.reasoning || detected.web_search || detected.embeddings
+}

--- a/web-app/src/locales/en/common.json
+++ b/web-app/src/locales/en/common.json
@@ -101,6 +101,7 @@
   "tools": "Tools",
   "webSearch": "Web Search",
   "reasoning": "Reasoning",
+  "active": "Active",
   "proactive": "Proactive",
   "selectAModel": "Select a model",
   "noToolsAvailable": "No tools available",

--- a/web-app/src/locales/en/providers.json
+++ b/web-app/src/locales/en/providers.json
@@ -50,6 +50,8 @@
     "vision": "Vision",
     "proactive": "Proactive (Experimental)",
     "embeddings": "Embeddings",
+    "reasoning": "Reasoning",
+    "webSearch": "Web Search",
     "notAvailable": "Not available yet",
     "warning": {
       "title": "Proceed with Caution",

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -54,6 +54,19 @@ export const Route = createFileRoute('/settings/providers/$providerName')({
   },
 })
 
+function mergeDetectedCapabilities(model: Model): string[] {
+  const stored = model.capabilities || []
+  if ((model as Model & { _userConfiguredCapabilities?: boolean })._userConfiguredCapabilities) {
+    return stored
+  }
+  const detected = detectModelCapabilities(model.id)
+  const merged = [...stored]
+  if (detected.reasoning && !merged.includes('reasoning')) merged.push('reasoning')
+  if (detected.web_search && !merged.includes('web_search')) merged.push('web_search')
+  if (detected.embeddings && !merged.includes('embeddings')) merged.push('embeddings')
+  return merged
+}
+
 function ProviderDetail() {
   const { t } = useTranslation()
   const serviceHub = useServiceHub()
@@ -1040,18 +1053,7 @@ function ProviderDetail() {
               >
                 {provider?.models.length ? (
                   provider?.models.map((model, modelIndex) => {
-                    const capabilities = model.capabilities || []
-                    const userConfigured = (model as Model & { _userConfiguredCapabilities?: boolean })._userConfiguredCapabilities
-                    const displayCapabilities = userConfigured
-                      ? capabilities
-                      : (() => {
-                          const detected = detectModelCapabilities(model.id)
-                          const merged = [...capabilities]
-                          if (detected.reasoning && !merged.includes('reasoning')) merged.push('reasoning')
-                          if (detected.web_search && !merged.includes('web_search')) merged.push('web_search')
-                          if (detected.embeddings && !merged.includes('embeddings')) merged.push('embeddings')
-                          return merged
-                        })()
+                    const displayCapabilities = mergeDetectedCapabilities(model)
                     return (
                       <CardItem
                         key={modelIndex}

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -7,6 +7,7 @@ import { cn, getProviderTitle, getModelDisplayName } from '@/lib/utils'
 import { createFileRoute, Link, useParams } from '@tanstack/react-router'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import Capabilities from '@/containers/Capabilities'
+import { detectModelCapabilities } from '@/lib/model-capabilities-detector'
 import { DynamicControllerSetting } from '@/containers/dynamicControllerSetting'
 import { RenderMarkdown } from '@/containers/RenderMarkdown'
 import { DialogEditModel } from '@/containers/dialogs/EditModel'
@@ -1040,6 +1041,17 @@ function ProviderDetail() {
                 {provider?.models.length ? (
                   provider?.models.map((model, modelIndex) => {
                     const capabilities = model.capabilities || []
+                    const userConfigured = (model as Model & { _userConfiguredCapabilities?: boolean })._userConfiguredCapabilities
+                    const displayCapabilities = userConfigured
+                      ? capabilities
+                      : (() => {
+                          const detected = detectModelCapabilities(model.id)
+                          const merged = [...capabilities]
+                          if (detected.reasoning && !merged.includes('reasoning')) merged.push('reasoning')
+                          if (detected.web_search && !merged.includes('web_search')) merged.push('web_search')
+                          if (detected.embeddings && !merged.includes('embeddings')) merged.push('embeddings')
+                          return merged
+                        })()
                     return (
                       <CardItem
                         key={modelIndex}
@@ -1051,7 +1063,7 @@ function ProviderDetail() {
                             >
                               {getModelDisplayName(model)}
                             </h1>
-                            <Capabilities capabilities={capabilities} />
+                            <Capabilities capabilities={displayCapabilities} />
                           </div>
                         }
                         actions={

--- a/web-app/src/stores/__tests__/capability-toggles-store.test.ts
+++ b/web-app/src/stores/__tests__/capability-toggles-store.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCapabilityToggles, DEFAULT_CAPABILITY_TOGGLES } from '../capability-toggles-store'
+
+describe('useCapabilityToggles', () => {
+  beforeEach(() => {
+    useCapabilityToggles.setState({ threads: {} })
+  })
+
+  it('returns default toggles for an unknown thread', () => {
+    const toggles = useCapabilityToggles.getState().getToggles('unknown-thread')
+    expect(toggles).toEqual(DEFAULT_CAPABILITY_TOGGLES)
+    expect(toggles.webSearch).toBe(false)
+    expect(toggles.reasoning).toBe(false)
+    expect(toggles.embeddings).toBe(false)
+  })
+
+  it('toggle flips the targeted capability', () => {
+    const { toggle, getToggles } = useCapabilityToggles.getState()
+    toggle('thread-1', 'webSearch')
+    expect(getToggles('thread-1').webSearch).toBe(true)
+    toggle('thread-1', 'webSearch')
+    expect(getToggles('thread-1').webSearch).toBe(false)
+  })
+
+  it('toggling one capability does not affect the others', () => {
+    const { toggle, getToggles } = useCapabilityToggles.getState()
+    toggle('thread-1', 'reasoning')
+    const toggles = getToggles('thread-1')
+    expect(toggles.reasoning).toBe(true)
+    expect(toggles.webSearch).toBe(false)
+    expect(toggles.embeddings).toBe(false)
+  })
+
+  it('setToggle sets a capability to an explicit value', () => {
+    const { setToggle, getToggles } = useCapabilityToggles.getState()
+    setToggle('thread-2', 'embeddings', true)
+    expect(getToggles('thread-2').embeddings).toBe(true)
+    setToggle('thread-2', 'embeddings', false)
+    expect(getToggles('thread-2').embeddings).toBe(false)
+  })
+
+  it('threads are stored independently', () => {
+    const { toggle, getToggles } = useCapabilityToggles.getState()
+    toggle('thread-A', 'webSearch')
+    toggle('thread-B', 'reasoning')
+    expect(getToggles('thread-A').webSearch).toBe(true)
+    expect(getToggles('thread-A').reasoning).toBe(false)
+    expect(getToggles('thread-B').webSearch).toBe(false)
+    expect(getToggles('thread-B').reasoning).toBe(true)
+  })
+
+  it('removeThread removes the thread state', () => {
+    const { toggle, removeThread, getToggles } = useCapabilityToggles.getState()
+    toggle('thread-X', 'webSearch')
+    expect(getToggles('thread-X').webSearch).toBe(true)
+    removeThread('thread-X')
+    expect(getToggles('thread-X').webSearch).toBe(false)
+  })
+})

--- a/web-app/src/stores/capability-toggles-store.ts
+++ b/web-app/src/stores/capability-toggles-store.ts
@@ -1,0 +1,67 @@
+import { create } from 'zustand'
+import { persist, createJSONStorage } from 'zustand/middleware'
+import { localStorageKey } from '@/constants/localStorage'
+import { fileStorage } from '@/lib/fileStorage'
+
+export type CapabilityToggles = {
+  webSearch: boolean
+  reasoning: boolean
+  embeddings: boolean
+}
+
+export const DEFAULT_CAPABILITY_TOGGLES: CapabilityToggles = {
+  webSearch: false,
+  reasoning: false,
+  embeddings: false,
+}
+
+type CapabilityTogglesState = {
+  threads: Record<string, CapabilityToggles>
+  getToggles: (threadId: string) => CapabilityToggles
+  toggle: (threadId: string, capability: keyof CapabilityToggles) => void
+  setToggle: (threadId: string, capability: keyof CapabilityToggles, value: boolean) => void
+  removeThread: (threadId: string) => void
+}
+
+export const useCapabilityToggles = create<CapabilityTogglesState>()(
+  persist(
+    (set, get) => ({
+      threads: {},
+
+      getToggles: (threadId) => get().threads[threadId] ?? DEFAULT_CAPABILITY_TOGGLES,
+
+      toggle: (threadId, capability) =>
+        set((state) => ({
+          threads: {
+            ...state.threads,
+            [threadId]: {
+              ...(state.threads[threadId] ?? DEFAULT_CAPABILITY_TOGGLES),
+              [capability]: !(state.threads[threadId]?.[capability] ?? false),
+            },
+          },
+        })),
+
+      setToggle: (threadId, capability, value) =>
+        set((state) => ({
+          threads: {
+            ...state.threads,
+            [threadId]: {
+              ...(state.threads[threadId] ?? DEFAULT_CAPABILITY_TOGGLES),
+              [capability]: value,
+            },
+          },
+        })),
+
+      removeThread: (threadId) =>
+        set((state) => {
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { [threadId]: _removed, ...rest } = state.threads
+          return { threads: rest }
+        }),
+    }),
+    {
+      name: localStorageKey.capabilityToggles,
+      storage: createJSONStorage(() => fileStorage),
+    }
+  )
+)

--- a/web-app/src/stores/capability-toggles-store.ts
+++ b/web-app/src/stores/capability-toggles-store.ts
@@ -1,7 +1,6 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { localStorageKey } from '@/constants/localStorage'
-import { fileStorage } from '@/lib/fileStorage'
 
 export type CapabilityToggles = {
   webSearch: boolean
@@ -61,7 +60,7 @@ export const useCapabilityToggles = create<CapabilityTogglesState>()(
     }),
     {
       name: localStorageKey.capabilityToggles,
-      storage: createJSONStorage(() => fileStorage),
+      storage: createJSONStorage(() => localStorage),
     }
   )
 )


### PR DESCRIPTION
## Closes: #7998  
## Closes: #7997  
## Closes: #7996  

## Summary

Implements three missing capability toggles (Reasoning, Web Search, Embeddings) in the chat toolbar, along with heuristic auto-detection of model capabilities from the model ID.

### What's new

**Capability toggles in chat toolbar**
- Three new per-thread toggle buttons appear in the chat input toolbar when the active model declares the corresponding capability: Reasoning (⚛), Web Search (🌐), Embeddings (⊙)
- Toggle state is persisted per thread via a new Zustand store with `localStorage` persistence
- Toggles auto-disable when switching to a model that lacks the capability

**Backend integration in `CustomChatTransport`**
- Reasoning toggle → injects `thinking: { type: 'enabled', budget_tokens: N }` for Anthropic models; auto-bumps `max_tokens` when the configured value is too low
- Web Search toggle → injects `web_search: true` for OpenAI-compatible pass-through providers (Perplexity Sonar family); skipped for strict providers (OpenAI, Anthropic, Google, xAI) that reject unknown body params with 400
- Embeddings toggle → bypasses the `hasDocuments` guard in RAG tool registration, enabling semantic search even before documents are ingested

**Heuristic model capability detection**
- New `model-capabilities-detector.ts` module infers `reasoning`, `web_search`, and `embeddings` from the model ID using keyword lists and a regex for the OpenAI o1/o3 family
- Detection is applied in two places:
  - **EditModel dialog**: auto-fills capability toggles on first open (when the user has never manually configured them); shows a blue banner indicating auto-detected values
  - **Providers settings page**: capability icons (⚛ 🌐 ⊙) appear immediately next to the model name without requiring the user to open the dialog

**EditModel dialog improvements**
- Added Reasoning, Web Search, and Embeddings switch rows (previously only Vision and Tools were exposed)
- Inline contextual warnings appear when enabling a capability (e.g. "Only works with reasoning models such as DeepSeek-R1, QwQ, o1")
- Auto-detected state is shown with a sparkle banner; once the user saves, `_userConfiguredCapabilities` is set and auto-detection no longer overrides their choices

### Files changed

| File | Change |
|------|--------|
| `web-app/src/lib/model-capabilities-detector.ts` | New — keyword + regex heuristics for reasoning/web_search/embeddings |
| `web-app/src/stores/capability-toggles-store.ts` | New — Zustand store with persist for per-thread toggle state |
| `web-app/src/containers/ChatInput.tsx` | Added three toggle buttons and auto-disable effect |
| `web-app/src/lib/custom-chat-transport.ts` | Inject capability params into model requests |
| `web-app/src/hooks/use-chat.ts` | Sync capability toggles to transport on change |
| `web-app/src/containers/dialogs/EditModel.tsx` | New capability rows + auto-detection banner |
| `web-app/src/routes/settings/providers/$providerName.tsx` | Merge auto-detected icons into model list display |
| `web-app/src/constants/localStorage.ts` | Added `capabilityToggles` storage key |
| `web-app/src/locales/en/providers.json` | Added `reasoning` and `webSearch` i18n keys |

### Provider compatibility

| Capability | Works with |
|------------|-----------|
| Reasoning | Anthropic Claude (extended thinking), local DeepSeek-R1 / QwQ via `<think>` extraction |
| Web Search | Perplexity Sonar family and other OpenAI-compatible providers with built-in search |
| Embeddings | Any provider — activates RAG tooling; intended for use with a chat model alongside a configured embedding backend |

### Notes

- OpenAI o-series (o1, o3) and GPT-5 perform reasoning natively; Jan's reasoning toggle has no effect on them — their reasoning blocks are returned by the API and rendered by the existing UI
- The `DefaultDialogService` stub (used in browser/web builds) does not open a native file picker — document attachment requires the desktop Tauri app

## Short Screenshots


https://github.com/user-attachments/assets/81e7b3e8-2cec-429a-a426-6b20da8ec75e

