### PR TITLE
fix: add xhtml to supported file extensions for upload

### DIFF
--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -648,6 +648,7 @@ const ChatInput = memo(function ChatInput({
               'pptx',
               'html',
               'htm',
+              'xhtml',
               // JavaScript / TypeScript
               'js',
               'mjs',

--- a/web-app/src/containers/ProjectFiles.tsx
+++ b/web-app/src/containers/ProjectFiles.tsx
@@ -56,6 +56,7 @@ const SUPPORTED_EXTENSIONS = [
   'pptx',
   'html',
   'htm',
+  'xhtml',
   // JavaScript / TypeScript
   'js',
   'mjs',


### PR DESCRIPTION
Fixes #8030

## Problem

`.xhtml` files were rejected by Jan's file picker with a brief error in the top-left corner. Both `.html` and `.xml` were already accepted, but `.xhtml` was missing from the allowed extension lists.

The issue existed in two places:
- `web-app/src/containers/ChatInput.tsx` — the inline extensions list used for the document attachment file picker
- `web-app/src/containers/ProjectFiles.tsx` — the `SUPPORTED_EXTENSIONS` constant used for project file uploads

## Solution

Added `'xhtml'` to the extensions list in both files, grouped alongside `'html'` and `'htm'` under the Documents section.

## Testing

Verified that `xhtml` now appears next to `html` and `htm` in both extension lists. The fix is a minimal two-line addition with no logic changes.