### PR TITLE
chore: remove unused newAssistantThreadContent export from completion.ts

### DIFF
--- a/web-app/src/lib/completion.ts
+++ b/web-app/src/lib/completion.ts
@@ -91,40 +91,6 @@ export const newUserThreadContent = (
 }
 
 /**
- * @fileoverview Helper functions for creating thread content.
- * These functions are used to create thread content objects
- * for different types of content, such as text and image.
- * The functions return objects that conform to the `ThreadContent` type.
- * @param content - The content of the thread
- * @returns
- */
-export const newAssistantThreadContent = (
-  threadId: string,
-  content: string,
-  metadata: Record<string, unknown> = {},
-  id?: string,
-): ThreadMessage => ({
-  type: 'text',
-  role: ChatCompletionRole.Assistant,
-  content: [
-    {
-      type: ContentType.Text,
-      text: {
-        value: content,
-        annotations: [],
-      },
-    },
-  ],
-  id: id ?? ulid(),
-  object: 'thread.message',
-  thread_id: threadId,
-  status: MessageStatus.Ready,
-  created_at: 0,
-  completed_at: 0,
-  metadata,
-})
-
-/**
  * Empty thread content object.
  * @returns
  */


### PR DESCRIPTION
## Describe Your Changes

- Deleted the `export const newAssistantThreadContent` helper from `web-app/src/lib/completion.ts`, along with its immediate JSDoc block (which was labelled `@fileoverview` but was actually a per-function docstring — its `@param content` / `@returns` tags matched only this one function's signature).
- Net diff: 34 lines deleted, 0 added, 1 file changed.

### Why this is safe

- `grep -rn "newAssistantThreadContent" web-app` returned only the declaration itself — zero production callers, zero test callers.
- All imports at the top of `completion.ts` (`ContentType`, `ChatCompletionRole`, `ThreadMessage`, `MessageStatus`, `ulid`) are still consumed by the remaining `newUserThreadContent` and `emptyThreadContent` exports, so no orphan imports are left.
- Pure deletion — nothing user-visible to capture in a screenshot or recording.

## Fixes Issues

- Closes #8051 

## Self Checklist

- [x] Added relevant comments, esp in complex areas — n/a, pure deletion
- [x] Updated docs (for bug fixes / features) — n/a, helper was not documented externally
- [x] Created issues for follow-up changes or refactoring needed — related `emptyThreadContent` dead-export is tracked in issue #54
