### PR TITLE
chore: remove debug console.log calls from TauriDialogService.open

### DIFF
--- a/web-app/src/services/dialog/tauri.ts
+++ b/web-app/src/services/dialog/tauri.ts
@@ -9,21 +9,7 @@ import { DefaultDialogService } from './default'
 export class TauriDialogService extends DefaultDialogService {
   async open(options?: DialogOpenOptions): Promise<string | string[] | null> {
     try {
-      console.log('TauriDialogService: Opening dialog with options:', options)
-      if (options?.filters) {
-        console.log('TauriDialogService: File filters:', options.filters)
-        options.filters.forEach((filter, index) => {
-          console.log(
-            `TauriDialogService: Filter ${index} - Name: "${filter.name}", Extensions:`,
-            filter.extensions
-          )
-        })
-      }
-      const result = await invoke<string | string[] | null>('open_dialog', {
-        options,
-      })
-      console.log('TauriDialogService: Dialog result:', result)
-      return result
+      return await invoke<string | string[] | null>('open_dialog', { options })
     } catch (error) {
       console.error('Error opening dialog in Tauri:', error)
       return null


### PR DESCRIPTION
## Describe Your Changes

- Removed the 4 debug `console.log` calls inside `TauriDialogService.open()` at `web-app/src/services/dialog/tauri.ts`:
  - `"TauriDialogService: Opening dialog with options:"`
  - `"TauriDialogService: File filters:"`
  - The `forEach` iteration log `"Filter ${index} - Name: ..."`
  - `"TauriDialogService: Dialog result:"`
- Collapsed the now-redundant `const result = await invoke(...)` + return pattern into a single `return await invoke(...)` line so `open` and `save` are symmetric.
- Kept both `console.error` blocks — those are real error signals, not debug noise.
- Net diff: 15 lines deleted, 1 inserted, 1 file changed.

### Why this is safe

- `grep` confirms no test anywhere in `web-app/src` asserted on the log output (the only other `TauriDialogService:` matches are class-name mock setups in `services/__tests__/*.test.ts`).
- `vitest web-app/src/services/dialog/__tests__/tauri.test.ts` — 5/5 tests pass after the edit.
- Behaviour unchanged beyond the removed noise: the open/save IPC call, the options passed to it, the return value, and the error path are all identical.

## Fixes Issues

- Closes #8054 

## Self Checklist

- [x] Added relevant comments, esp in complex areas — n/a, pure deletion
- [x] Updated docs (for bug fixes / features) — n/a, internal debug noise
- [x] Created issues for follow-up changes or refactoring needed — the parallel `console.log` noise in `services/theme/default.ts` and `services/dialog/default.ts` is tracked separately in issue #52
