### PR TITLE
chore: remove unused isProd export from lib/version.ts

### DIFF
--- a/web-app/src/lib/__tests__/version.test.ts
+++ b/web-app/src/lib/__tests__/version.test.ts
@@ -23,20 +23,4 @@ describe('version', () => {
     const mod = await import('../version')
     expect(mod.isBeta).toBe(true)
   })
-
-  it('isProd is true when VERSION has no hyphen, no beta, and not dev', async () => {
-    ;(globalThis as any).VERSION = '1.0.0'
-    vi.doMock('../utils', () => ({ isDev: vi.fn(() => false) }))
-    const mod = await import('../version')
-    expect(mod.isProd).toBe(true)
-    expect(mod.isNightly).toBe(false)
-    expect(mod.isBeta).toBe(false)
-  })
-
-  it('isProd is false when isDev returns true', async () => {
-    ;(globalThis as any).VERSION = '1.0.0'
-    vi.doMock('../utils', () => ({ isDev: vi.fn(() => true) }))
-    const mod = await import('../version')
-    expect(mod.isProd).toBe(false)
-  })
 })

--- a/web-app/src/lib/version.ts
+++ b/web-app/src/lib/version.ts
@@ -1,5 +1,2 @@
-import { isDev } from './utils'
-
 export const isNightly = VERSION.includes('-')
 export const isBeta = VERSION.includes('beta')
-export const isProd = !isNightly && !isBeta && !isDev()


### PR DESCRIPTION
## Describe Your Changes

- Removed the `isProd` export from `web-app/src/lib/version.ts` (plus the now-unused `import { isDev } from './utils'`).
- Removed the two `it('isProd ...')` blocks from `web-app/src/lib/__tests__/version.test.ts`.
- Net diff: 19 lines deleted, 0 added, 2 files changed.

### Why this is safe

- `grep -rn "\bisProd\b"` across `web-app` and `core/src` returned zero hits after the edit (the only references before were the export itself and its own test blocks).
- `isNightly` and `isBeta` remain exported and are still consumed by `containers/dialogs/AppUpdater.tsx`; their two tests still pass.
- `vitest web-app/src/lib/__tests__/version.test.ts` — 2/2 tests pass after the edit.
- Pure deletion — nothing user-visible to capture in a screenshot or recording.

## Fixes Issues

- Closes #8056

## Self Checklist

- [x] Added relevant comments, esp in complex areas — n/a, pure deletion
- [x] Updated docs (for bug fixes / features) — n/a, helper was not documented externally
- [x] Created issues for follow-up changes or refactoring needed — parallel dead-export removals tracked in issues #31, #32, #54, #55, #60
