### PR TITLE
chore: remove unused emptyThreadContent export from lib/completion

### DIFF
--- a/web-app/src/lib/completion.ts
+++ b/web-app/src/lib/completion.ts
@@ -123,19 +123,3 @@ export const newAssistantThreadContent = (
   completed_at: 0,
   metadata,
 })
-
-/**
- * Empty thread content object.
- * @returns
- */
-export const emptyThreadContent: ThreadMessage = {
-  type: 'text',
-  role: ChatCompletionRole.Assistant,
-  id: ulid(),
-  object: 'thread.message',
-  thread_id: '',
-  content: [],
-  status: MessageStatus.Ready,
-  created_at: 0,
-  completed_at: 0,
-}


### PR DESCRIPTION
## Describe Your Changes

- Removed the unused `emptyThreadContent` export from `web-app/src/lib/completion.ts` (no production or test references).

## Fixes Issues

- #8060 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas (N/A — dead code removal)
- [ ] Updated docs (for bug fixes / features) (N/A)
- [ ] Created issues for follow-up changes or refactoring needed (N/A)