### PR TITLE
fix: manual install backend

### DIFF
--- a/src-tauri/src/core/filesystem/commands.rs
+++ b/src-tauri/src/core/filesystem/commands.rs
@@ -180,7 +180,7 @@ pub fn decompress<R: Runtime>(
     path: &str,
     output_dir: &str,
 ) -> Result<(), String> {
-    let (_jan_data_folder, path_buf) = resolve_app_path_within_jan_data_folder(app.clone(), path)?;
+    let path_buf = std::path::PathBuf::from(path);
     let (_jan_data_folder, output_dir_buf) =
         resolve_app_path_within_jan_data_folder(app, output_dir)?;
 


### PR DESCRIPTION
## Describe Your Changes

- The decompress Tauri command validated both the archive path and the output directory against the Jan data folder, preventing extraction of archives located elsewhere. Only the output directory needs that restriction; the input path is read-only.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
