### PR TITLE
fix(filesystem): prevent path traversal in mv, mkdir, and write_file_sync

### DIFF
--- a/src-tauri/src/core/filesystem/commands.rs
+++ b/src-tauri/src/core/filesystem/commands.rs
@@ -39,7 +39,8 @@ pub fn mkdir<R: Runtime>(app_handle: tauri::AppHandle<R>, args: Vec<String>) -> 
         return Err("mkdir error: Invalid argument".to_string());
     }
 
-    let path = resolve_path(app_handle, &args[0]);
+    let (_jan_data_folder, path) = resolve_app_path_within_jan_data_folder(app_handle, &args[0])
+        .map_err(|_| format!("mkdir error: path {} is not under jan data folder", args[0]))?;
     fs::create_dir_all(&path).map_err(|e| e.to_string())
 }
 
@@ -49,8 +50,15 @@ pub fn mv<R: Runtime>(app_handle: tauri::AppHandle<R>, args: Vec<String>) -> Res
         return Err("mv error: Invalid argument - source and destination required".to_string());
     }
 
-    let source = resolve_path(app_handle.clone(), &args[0]);
-    let destination = resolve_path(app_handle, &args[1]);
+    let (_jan_data_folder, source) =
+        resolve_app_path_within_jan_data_folder(app_handle.clone(), &args[0]).map_err(|_| {
+            format!("mv error: source {} is not under jan data folder", args[0])
+        })?;
+    let (_jan_data_folder, destination) = resolve_app_path_within_jan_data_folder(
+        app_handle,
+        &args[1],
+    )
+    .map_err(|_| format!("mv error: destination {} is not under jan data folder", args[1]))?;
 
     if !source.exists() {
         return Err("mv error: Source path does not exist".to_string());
@@ -125,7 +133,13 @@ pub fn write_file_sync<R: Runtime>(
         return Err("write_file_sync error: Invalid argument".to_string());
     }
 
-    let path = resolve_path(app_handle, &args[0]);
+    let (_jan_data_folder, path) = resolve_app_path_within_jan_data_folder(app_handle, &args[0])
+        .map_err(|_| {
+            format!(
+                "write_file_sync error: path {} is not under jan data folder",
+                args[0]
+            )
+        })?;
     let content = &args[1];
     fs::write(&path, content).map_err(|e| e.to_string())
 }

--- a/src-tauri/src/core/filesystem/tests.rs
+++ b/src-tauri/src/core/filesystem/tests.rs
@@ -34,6 +34,79 @@ fn test_mkdir() {
 }
 
 #[test]
+fn test_mkdir_rejects_path_outside_jan_data_folder() {
+    let app = mock_app();
+    let outside = unique_test_dir("mkdir-outside");
+    let args = vec![outside.to_string_lossy().to_string()];
+    let result = mkdir(app.handle().clone(), args);
+    assert!(result.is_err());
+    assert!(!outside.exists());
+}
+
+#[test]
+fn test_mv_rejects_source_outside_jan_data_folder() {
+    let app = mock_app();
+    let outside_dir = unique_test_dir("mv-outside-src");
+    fs::create_dir_all(&outside_dir).unwrap();
+    let outside_file = outside_dir.join("source.txt");
+    File::create(&outside_file).unwrap();
+
+    let destination = get_jan_data_folder_path(app.handle().clone()).join("moved.txt");
+    let args = vec![
+        outside_file.to_string_lossy().to_string(),
+        destination.to_string_lossy().to_string(),
+    ];
+    let result = mv(app.handle().clone(), args);
+    assert!(result.is_err());
+    assert!(outside_file.exists());
+    assert!(!destination.exists());
+
+    let _ = fs::remove_dir_all(&outside_dir);
+}
+
+#[test]
+fn test_mv_rejects_destination_outside_jan_data_folder() {
+    let app = mock_app();
+    let source = get_jan_data_folder_path(app.handle().clone()).join("mv_src.txt");
+    fs::create_dir_all(source.parent().unwrap()).unwrap();
+    File::create(&source).unwrap();
+
+    let outside_dir = unique_test_dir("mv-outside-dest");
+    fs::create_dir_all(&outside_dir).unwrap();
+    let outside_dest = outside_dir.join("moved.txt");
+
+    let args = vec![
+        source.to_string_lossy().to_string(),
+        outside_dest.to_string_lossy().to_string(),
+    ];
+    let result = mv(app.handle().clone(), args);
+    assert!(result.is_err());
+    assert!(source.exists());
+    assert!(!outside_dest.exists());
+
+    let _ = fs::remove_file(&source);
+    let _ = fs::remove_dir_all(&outside_dir);
+}
+
+#[test]
+fn test_write_file_sync_rejects_path_outside_jan_data_folder() {
+    let app = mock_app();
+    let outside = unique_test_dir("write-outside");
+    fs::create_dir_all(&outside).unwrap();
+    let outside_file = outside.join("forbidden.txt");
+
+    let args = vec![
+        outside_file.to_string_lossy().to_string(),
+        "malicious content".to_string(),
+    ];
+    let result = write_file_sync(app.handle().clone(), args);
+    assert!(result.is_err());
+    assert!(!outside_file.exists());
+
+    let _ = fs::remove_dir_all(&outside);
+}
+
+#[test]
 fn test_join_path() {
     let app = mock_app();
     let path = "file://test_dir";


### PR DESCRIPTION
## Summary

Three Tauri filesystem commands (`mv`, `mkdir`, `write_file_sync`) in `src-tauri/src/core/filesystem/commands.rs` used the unscoped `resolve_path` helper and never verified the result stayed inside the Jan data folder. A caller (malicious extension, compromised renderer, or crafted IPC payload) could:

- overwrite arbitrary files (`write_file_sync` → `~/.bashrc`, SSH keys, …)
- move files in/out of any writable location (`mv`)
- create directories anywhere the process can write (`mkdir`)

Severity is highest on desktop, where Jan runs with the user's full filesystem permissions. The sibling `rm` command and the newer `write_yaml` / `read_yaml` / `decompress` commands already use the scoped helper - this PR brings the three outliers in line.

## Changes

- `mkdir`, `mv`, `write_file_sync` now call `resolve_app_path_within_jan_data_folder`, which canonicalizes and rejects anything outside the Jan data folder.
- `mv` validates **both** source and destination.
- Added 4 regression tests covering the rejection paths.

Read-only commands in the same file (`read_file_sync`, `readdir_sync`, `exists_sync`, `file_stat`, `join_path`) still use the unscoped helper. The information-disclosure risk is lower, and the file header notes the whole legacy API surface is slated for removal - happy to scope them in a follow-up if preferred.

## Test plan

- [x] `cargo test --lib core::filesystem::` - all 14 tests pass, including the 4 new rejection tests:
  - `test_mkdir_rejects_path_outside_jan_data_folder`
  - `test_mv_rejects_source_outside_jan_data_folder`
  - `test_mv_rejects_destination_outside_jan_data_folder`
  - `test_write_file_sync_rejects_path_outside_jan_data_folder`
- [x] Existing `test_mkdir`, `test_rm`, and sibling tests still pass (no regression on legal paths inside the Jan data folder).

## Before / after

Backend-only fix - no UI. Before/after is shown via tests rather than screenshots:

**Before:** `mkdir`, `mv`, and `write_file_sync` accept any absolute path. New rejection tests fail against `main`.

**After:** Same commands return `"... is not under jan data folder"` for out-of-scope paths. All 14 filesystem tests pass.

## Related

Closes #8067 
