### PR TITLE
chore: drop unnecessary export on AppRoutes and Routes in lib/service.ts

### DIFF
--- a/web-app/src/lib/service.ts
+++ b/web-app/src/lib/service.ts
@@ -3,7 +3,7 @@ import { getServiceHub } from '@/hooks/useServiceHub'
 import { isPlatformTauri } from '@/lib/platform'
 import type { InvokeArgs } from '@/services/core/types'
 
-export const AppRoutes = [
+const AppRoutes = [
   'installExtensions',
   'getTools',
   'callTool',
@@ -27,7 +27,7 @@ export const AppRoutes = [
   'changeAppDataFolder',
 ]
 // Define API routes based on different route types
-export const Routes = [...CoreRoutes, ...APIRoutes, ...AppRoutes].map((r) => ({
+const Routes = [...CoreRoutes, ...APIRoutes, ...AppRoutes].map((r) => ({
   path: `app`,
   route: r,
 }))


### PR DESCRIPTION
## Describe Your Changes

- `AppRoutes` and `Routes` in `web-app/src/lib/service.ts` were exported but
  never imported outside the file. A repo-wide grep confirms no external
  references in `web-app/src` or `core/src`.
- Drop the `export` keyword on both so they remain module-internal helpers
  and aren't accidentally part of the public API surface.
- No behavior change — `Routes` is still composed from `CoreRoutes`,
  `APIRoutes`, and `AppRoutes` and consumed by the exported `APIs` object.

## Fixes Issues
- Closes #8069 

## Self Checklist

- [x] Added relevant comments, esp in complex areas (n/a — pure visibility change)
- [x] Updated docs (for bug fixes / features) (n/a — internal refactor)
- [x] Created issues for follow-up changes or refactoring needed
