### PR TITLE
chore: remove unused find_memory_pattern and is_memory_pattern from jan_utils

### DIFF
--- a/src-tauri/utils/src/string.rs
+++ b/src-tauri/utils/src/string.rs
@@ -27,53 +27,6 @@ pub fn err_to_string<E: std::fmt::Display>(e: E) -> String {
     format!("Error: {}", e)
 }
 
-/// Finds memory patterns in text using parentheses parsing
-pub fn find_memory_pattern(text: &str) -> Option<(usize, &str)> {
-    // Find the last parenthesis that contains the memory pattern
-    let mut last_match = None;
-    let mut chars = text.char_indices().peekable();
-
-    while let Some((start_idx, ch)) = chars.next() {
-        if ch == '(' {
-            // Find the closing parenthesis
-            let remaining = &text[start_idx + 1..];
-            if let Some(close_pos) = remaining.find(')') {
-                let content = &remaining[..close_pos];
-
-                // Check if this looks like memory info
-                if is_memory_pattern(content) {
-                    last_match = Some((start_idx, content));
-                }
-            }
-        }
-    }
-
-    last_match
-}
-
-/// Validates if content matches memory pattern format
-pub fn is_memory_pattern(content: &str) -> bool {
-    // Check if content matches pattern like "8128 MiB, 8128 MiB free"
-    // Must contain: numbers, "MiB", comma, "free"
-    if !(content.contains("MiB") && content.contains("free") && content.contains(',')) {
-        return false;
-    }
-
-    let parts: Vec<&str> = content.split(',').collect();
-    if parts.len() != 2 {
-        return false;
-    }
-
-    parts.iter().all(|part| {
-        let part = part.trim();
-        // Each part should start with a number and contain "MiB"
-        part.split_whitespace()
-            .next()
-            .map_or(false, |first_word| first_word.parse::<i32>().is_ok())
-            && part.contains("MiB")
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -144,59 +97,5 @@ mod tests {
         let result = err_to_string(io_error);
         assert!(result.starts_with("Error: "));
         assert!(result.contains("File not found"));
-    }
-
-    #[test]
-    fn test_is_memory_pattern_valid() {
-        assert!(is_memory_pattern("8128 MiB, 8128 MiB free"));
-        assert!(is_memory_pattern("1024 MiB, 512 MiB free"));
-        assert!(is_memory_pattern("16384 MiB, 12000 MiB free"));
-        assert!(is_memory_pattern("0 MiB, 0 MiB free"));
-    }
-
-    #[test]
-    fn test_is_memory_pattern_invalid() {
-        assert!(!is_memory_pattern("8128 MB, 8128 MB free")); // Wrong unit
-        assert!(!is_memory_pattern("8128 MiB 8128 MiB free")); // Missing comma
-        assert!(!is_memory_pattern("8128 MiB, 8128 MiB used")); // Wrong second part
-        assert!(!is_memory_pattern("not_a_number MiB, 8128 MiB free")); // Invalid number
-        assert!(!is_memory_pattern("8128 MiB")); // Missing second part
-        assert!(!is_memory_pattern("")); // Empty string
-        assert!(!is_memory_pattern("8128 MiB, free")); // Missing number in second part
-    }
-
-    #[test]
-    fn test_find_memory_pattern() {
-        let text = "Loading model... (8128 MiB, 4096 MiB free) completed";
-        let result = find_memory_pattern(text);
-        assert!(result.is_some());
-        let (start_idx, content) = result.unwrap();
-        assert!(start_idx > 0);
-        assert_eq!(content, "8128 MiB, 4096 MiB free");
-    }
-
-    #[test]
-    fn test_find_memory_pattern_multiple_parentheses() {
-        let text = "Start (not memory) then (1024 MiB, 512 MiB free) and (2048 MiB, 1024 MiB free) end";
-        let result = find_memory_pattern(text);
-        assert!(result.is_some());
-        let (_, content) = result.unwrap();
-        // Should return the LAST valid memory pattern
-        assert_eq!(content, "2048 MiB, 1024 MiB free");
-    }
-
-    #[test]
-    fn test_find_memory_pattern_no_match() {
-        let text = "No memory info here";
-        assert!(find_memory_pattern(text).is_none());
-        
-        let text_with_invalid = "Some text (invalid memory info) here";
-        assert!(find_memory_pattern(text_with_invalid).is_none());
-    }
-
-    #[test]
-    fn test_find_memory_pattern_unclosed_parenthesis() {
-        let text = "Unclosed (8128 MiB, 4096 MiB free";
-        assert!(find_memory_pattern(text).is_none());
     }
 }


### PR DESCRIPTION
## Describe Your Changes

- `find_memory_pattern` and `is_memory_pattern` in `src-tauri/utils/src/string.rs`  were `pub` but had no callers in `jan_utils`. The only real callers — the  llamacpp plugin's `device.rs` — define their **own private copies** of both  functions, so the `jan_utils` versions were dead code.
- Grep confirms: `grep -rn "find_memory_pattern\|is_memory_pattern" src-tauri`  outside `utils/src/string.rs` and `plugins/tauri-plugin-llamacpp/` returns nothing.
- Remove both functions and their six associated tests  (`test_is_memory_pattern_valid`, `test_is_memory_pattern_invalid`,
  `test_find_memory_pattern`, `test_find_memory_pattern_multiple_parentheses`,  `test_find_memory_pattern_no_match`, `test_find_memory_pattern_unclosed_parenthesis`).
- The llamacpp plugin's private copies at `src-tauri/plugins/tauri-plugin-llamacpp/src/device.rs:166` and `:189` are
  left untouched — they are correct and still covered by their own tests.
- Unifying the two implementations is a separate concern and intentionally left as a follow-up.
- Verified: `cargo check` clean, `cargo test` passes 26/26 from `src-tauri/utils/` (down from 32 — exactly the six removed tests).

## Fixes Issues

- Closes #8074 

## Self Checklist

- [x] Added relevant comments, esp in complex areas (n/a — pure deletion)
- [x] Updated docs (for bug fixes / features) (n/a — internal helpers, no docs referenced them)
- [x] Created issues for follow-up changes or refactoring needed (suggest filing one for unifying with the llamacpp plugin's private copies)
