### PR TITLE
chore: remove commented-out toast notification code in chat-session-store

### DIFF
--- a/web-app/src/stores/chat-session-store.ts
+++ b/web-app/src/stores/chat-session-store.ts
@@ -4,7 +4,6 @@ import type { Chat, UIMessage } from "@ai-sdk/react";
 import type { ChatStatus } from "ai";
 import { CustomChatTransport } from "@/lib/custom-chat-transport";
 import { useMessageQueue } from "@/stores/message-queue-store";
-// import { showChatCompletionToast } from "@/components/toasts/chat-completion-toast";
 
 export type SessionData = {
   tools: any[];
@@ -64,7 +63,6 @@ export const useChatSessions = create<ChatSessionState>((set, get) => ({
   setActiveConversationId: (conversationId) =>
     set({ activeConversationId: conversationId }),
   ensureSession: (sessionId, transport, createChat, title) => {
-    // Set active immediately - prevents toast for this session during status sync
     // Only update activeConversationId if it changed (avoid unnecessary state updates during render)
     if (get().activeConversationId !== sessionId) {
       set({ activeConversationId: sessionId });
@@ -143,25 +141,6 @@ export const useChatSessions = create<ChatSessionState>((set, get) => ({
         return state;
       }
 
-      // Only notify if:
-      // 1. Was streaming and now stopped
-      // 2. Not the active conversation
-      // 3. Chat has messages (not a brand new session)
-      // 4. No pending tool calls (tools are still being executed)
-      // const hasMessages = existing.chat.messages.length > 0;
-      // const hasPendingTools = existing.data.tools.length > 0;
-      // const shouldNotify =
-      //   wasStreaming &&
-      //   !isStreaming &&
-      //   hasMessages &&
-      //   !hasPendingTools &&
-      //   state.activeConversationId !== sessionId;
-
-      // if (shouldNotify) {
-      //   const title = existing.title ?? "Conversation";
-      //   showChatCompletionToast(title, existing.chat.messages, sessionId);
-      // }
-
       return {
         sessions: {
           ...state.sessions,
@@ -201,7 +180,7 @@ export const useChatSessions = create<ChatSessionState>((set, get) => ({
     // Clear any pending queued messages for this session
     useMessageQueue.getState().clearQueue(sessionId);
 
-    // Remove from store FIRST - prevents updateStatus from showing toast during cleanup
+    // Remove from store FIRST so updateStatus callbacks during cleanup find nothing to update
     set((state) => {
       if (!state.sessions[sessionId]) {
         return state;


### PR DESCRIPTION
## Describe Your Changes

- `web-app/src/stores/chat-session-store.ts` carried a commented-out import of `showChatCompletionToast` and a commented-out "should-notify" block in `updateStatus` with no rationale or follow-up issue. Per Option A in the
  issue, delete both — git history preserves the content if anyone needs to resurrect it.
- Two surrounding active-code comments still referenced the now-deleted toast behavior ("prevents toast for this session during status sync" and "prevents updateStatus from showing toast during cleanup"). Trim those references so they don't recreate the same "is this being worked on?" confusion the issue calls out:
  - `ensureSession`: drop the misleading first line; keep the still-accurate   ordering rationale.
  - `removeSession`: rephrase to describe what removing-first actually does   for cleanup callbacks now that toast suppression is gone.
- No behavior change: the deleted code was inert (commented out), and the active-code edits are pure comment changes.
- Verified: `tsc --noEmit` clean; existing `src/stores/__tests__/chat-session-store.test.ts` passes 22/22.

## Fixes Issues

- Closes #8078


## Self Checklist

- [x] Added relevant comments, esp in complex areas (n/a — pure deletion)
- [x] Updated docs (for bug fixes / features) (n/a — internal store, no docs referenced the toast)
- [x] Created issues for follow-up changes or refactoring needed
