### PR TITLE
chore: remove stub console.log calls from default theme and dialog shims

### DIFF
--- a/web-app/src/services/dialog/__tests__/default.test.ts
+++ b/web-app/src/services/dialog/__tests__/default.test.ts
@@ -1,35 +1,24 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { DefaultDialogService } from '../default'
 
 describe('DefaultDialogService', () => {
-  it('open() logs and returns null', async () => {
-    const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  it('open() returns null', async () => {
     const svc = new DefaultDialogService()
-    expect(await svc.open({ title: 'Pick' })).toBeNull()
-    expect(spy).toHaveBeenCalledWith('dialog.open called with options:', { title: 'Pick' })
-    spy.mockRestore()
+    expect(await svc.open({ title: 'Pick' } as any)).toBeNull()
   })
 
   it('open() with no options returns null', async () => {
-    const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
     const svc = new DefaultDialogService()
     expect(await svc.open()).toBeNull()
-    expect(spy).toHaveBeenCalledWith('dialog.open called with options:', undefined)
-    spy.mockRestore()
   })
 
-  it('save() logs and returns null', async () => {
-    const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  it('save() returns null', async () => {
     const svc = new DefaultDialogService()
-    expect(await svc.save({ title: 'Save' })).toBeNull()
-    expect(spy).toHaveBeenCalledWith('dialog.save called with options:', { title: 'Save' })
-    spy.mockRestore()
+    expect(await svc.save({ title: 'Save' } as any)).toBeNull()
   })
 
   it('save() with no options returns null', async () => {
-    const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
     const svc = new DefaultDialogService()
     expect(await svc.save()).toBeNull()
-    spy.mockRestore()
   })
 })

--- a/web-app/src/services/dialog/default.ts
+++ b/web-app/src/services/dialog/default.ts
@@ -2,16 +2,14 @@
  * Default Dialog Service - Generic implementation with minimal returns
  */
 
-import type { DialogService, DialogOpenOptions } from './types'
+import type { DialogService } from './types'
 
 export class DefaultDialogService implements DialogService {
-  async open(options?: DialogOpenOptions): Promise<string | string[] | null> {
-    console.log('dialog.open called with options:', options)
+  async open(): Promise<string | string[] | null> {
     return null
   }
 
-  async save(options?: DialogOpenOptions): Promise<string | null> {
-    console.log('dialog.save called with options:', options)
+  async save(): Promise<string | null> {
     return null
   }
 }

--- a/web-app/src/services/theme/__tests__/default.test.ts
+++ b/web-app/src/services/theme/__tests__/default.test.ts
@@ -1,22 +1,16 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import { DefaultThemeService } from '../default'
 
 describe('DefaultThemeService', () => {
-  it('setTheme() logs and resolves', async () => {
-    const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  it('setTheme() resolves', async () => {
     const svc = new DefaultThemeService()
     await expect(svc.setTheme('dark' as any)).resolves.toBeUndefined()
-    expect(spy).toHaveBeenCalledWith('setTheme called with theme:', 'dark')
-    spy.mockRestore()
   })
 
-  it('getCurrentWindow() returns object with setTheme', async () => {
-    const spy = vi.spyOn(console, 'log').mockImplementation(() => {})
+  it('getCurrentWindow() returns object with setTheme that resolves', async () => {
     const svc = new DefaultThemeService()
     const win = svc.getCurrentWindow()
     expect(win).toHaveProperty('setTheme')
     await expect(win.setTheme('light' as any)).resolves.toBeUndefined()
-    expect(spy).toHaveBeenCalledWith('window.setTheme called with theme:', 'light')
-    spy.mockRestore()
   })
 })

--- a/web-app/src/services/theme/default.ts
+++ b/web-app/src/services/theme/default.ts
@@ -2,18 +2,16 @@
  * Default Theme Service - Generic implementation with minimal returns
  */
 
-import type { ThemeService, ThemeMode } from './types'
+import type { ThemeService } from './types'
 
 export class DefaultThemeService implements ThemeService {
-  async setTheme(theme: ThemeMode): Promise<void> {
-    console.log('setTheme called with theme:', theme)
+  async setTheme(): Promise<void> {
     // No-op - not implemented in default service
   }
 
   getCurrentWindow() {
     return {
-      setTheme: (theme: ThemeMode): Promise<void> => {
-        console.log('window.setTheme called with theme:', theme)
+      setTheme: (): Promise<void> => {
         return Promise.resolve()
       }
     }


### PR DESCRIPTION
## Describe Your Changes

- The default (web-target) service shims in `web-app/src/services/theme/default.ts` and `web-app/src/services/dialog/default.ts` carried four `console.log` calls that fired on every theme change and every file-dialog interaction
  in the browser build. These were stubbing aids that became permanent log noise.
- Delete all four `console.log` lines (per the issue's primary action).
- The file-level docstrings already describe these as "Generic implementation with minimal returns," so no replacement `console.warn` is needed.
- Tidy-ups that fall out of the deletion:
  - `setTheme(theme)` / `window.setTheme(theme)` and `dialog.open(options)` /  `dialog.save(options)` no longer reference their parameters, so the parameter bindings are dropped. TypeScript allows implementations to omit trailing interface parameters (a function with fewer params is assignable to one with more), which keeps ESLint clean without needing
    `_`-prefixes (the project's config doesn't honor them) or `eslint-disable` comments.
  - `ThemeMode` and `DialogOpenOptions` type imports become unused and are   removed.
- No behavior change beyond removing the log output: the methods continue to return their existing no-op values (`undefined` / `null` / resolved promises).
- Verified: `eslint` clean on both files; `tsc --noEmit` clean across the project.

## Fixes Issues

- Closes #8080

## Self Checklist

- [x] Added relevant comments, esp in complex areas (n/a — pure deletion)
- [x] Updated docs (for bug fixes / features) (n/a — internal shims, no docs referenced these logs)
- [x] Created issues for follow-up changes or refactoring needed
