### PR TITLE
Re-read assistant definition from disk on editing

### DIFF
--- a/web-app/src/hooks/__tests__/useAssistant.coverage.test.ts
+++ b/web-app/src/hooks/__tests__/useAssistant.coverage.test.ts
@@ -1,15 +1,24 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { act, renderHook } from '@testing-library/react'
 import { useAssistant, defaultAssistant } from '../useAssistant'
 
+const mockToast = vi.fn()
+vi.mock('sonner', () => ({
+  toast: {
+    error: mockToast,
+  },
+}))
+
 const mockCreateAssistant = vi.fn().mockResolvedValue(undefined)
 const mockDeleteAssistant = vi.fn().mockResolvedValue(undefined)
+const mockGetAssistants = vi.fn().mockResolvedValue([defaultAssistant])
 
 vi.mock('@/hooks/useServiceHub', () => ({
   getServiceHub: () => ({
     assistants: () => ({
       createAssistant: mockCreateAssistant,
       deleteAssistant: mockDeleteAssistant,
+      getAssistants: mockGetAssistants,
     }),
   }),
 }))
@@ -218,5 +227,52 @@ describe('useAssistant - coverage', () => {
 
     // currentAssistant should still be jan
     expect(result.current.currentAssistant?.id).toBe('jan')
+  })
+
+  it('refreshAssistants should fetch fresh data and update state', async () => {
+    const freshAssistants = [
+      { ...defaultAssistant, name: 'Fresh Jan' },
+      { id: 'a2', name: 'A2', avatar: '', description: '', instructions: '', created_at: 2, parameters: {} },
+    ]
+    mockGetAssistants.mockResolvedValue(freshAssistants as any)
+
+    const { result } = renderHook(() => useAssistant())
+
+    expect(result.current.loading).toBe(true)
+
+    await act(async () => {
+      await result.current.refreshAssistants()
+    })
+
+    expect(result.current.assistants).toEqual(freshAssistants)
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('refreshAssistants should set loading:true before fetch starts', async () => {
+    const deferred = vi.fn().mockReturnValue(new Promise((resolve) => setTimeout(resolve, 100)))
+    mockGetAssistants.mockReturnValue(deferred())
+
+    const { result } = renderHook(() => useAssistant())
+
+    expect(result.current.loading).toBe(true)
+  })
+
+  it('refreshAssistants should show toast error on failure', async () => {
+    mockGetAssistants.mockRejectedValue(new Error('Network error'))
+
+    const { result } = renderHook(() => useAssistant())
+
+    await act(async () => {
+      await result.current.refreshAssistants()
+    })
+
+    expect(mockToast).toHaveBeenCalledWith('Failed to refresh assistants', {
+      description: 'Network error',
+    })
+    expect(result.current.loading).toBe(false)
+  })
+
+  afterEach(() => {
+    mockToast.mockClear()
   })
 })

--- a/web-app/src/hooks/__tests__/useAssistant.coverage.test.ts
+++ b/web-app/src/hooks/__tests__/useAssistant.coverage.test.ts
@@ -2,16 +2,22 @@ import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { act, renderHook } from '@testing-library/react'
 import { useAssistant, defaultAssistant } from '../useAssistant'
 
-const mockToast = vi.fn()
+const mocks = vi.hoisted(() => ({
+  mockToast: vi.fn(),
+  mockCreateAssistant: vi.fn().mockResolvedValue(undefined),
+  mockDeleteAssistant: vi.fn().mockResolvedValue(undefined),
+  mockGetAssistants: vi.fn().mockResolvedValue([]),
+}))
 vi.mock('sonner', () => ({
   toast: {
-    error: mockToast,
+    error: mocks.mockToast,
   },
 }))
 
-const mockCreateAssistant = vi.fn().mockResolvedValue(undefined)
-const mockDeleteAssistant = vi.fn().mockResolvedValue(undefined)
-const mockGetAssistants = vi.fn().mockResolvedValue([defaultAssistant])
+const mockCreateAssistant = mocks.mockCreateAssistant
+const mockDeleteAssistant = mocks.mockDeleteAssistant
+const mockGetAssistants = mocks.mockGetAssistants
+const mockToast = mocks.mockToast
 
 vi.mock('@/hooks/useServiceHub', () => ({
   getServiceHub: () => ({
@@ -33,6 +39,7 @@ vi.mock('@/constants/localStorage', () => ({
 describe('useAssistant - coverage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mocks.mockGetAssistants.mockResolvedValue([defaultAssistant])
     localStorage.clear()
     act(() => {
       useAssistant.setState({

--- a/web-app/src/hooks/__tests__/useAssistant.coverage.test.ts
+++ b/web-app/src/hooks/__tests__/useAssistant.coverage.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { act, renderHook } from '@testing-library/react'
 import { useAssistant, defaultAssistant } from '../useAssistant'
 
@@ -276,9 +276,5 @@ describe('useAssistant - coverage', () => {
       description: 'Network error',
     })
     expect(result.current.loading).toBe(false)
-  })
-
-  afterEach(() => {
-    mockToast.mockClear()
   })
 })

--- a/web-app/src/hooks/__tests__/useAssistant.coverage.test.ts
+++ b/web-app/src/hooks/__tests__/useAssistant.coverage.test.ts
@@ -1,15 +1,24 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
 import { act, renderHook } from '@testing-library/react'
 import { useAssistant, defaultAssistant } from '../useAssistant'
 
+const mockToast = vi.fn()
+vi.mock('sonner', () => ({
+  toast: {
+    error: mockToast,
+  },
+}))
+
 const mockCreateAssistant = vi.fn().mockResolvedValue(undefined)
 const mockDeleteAssistant = vi.fn().mockResolvedValue(undefined)
+const mockGetAssistants = vi.fn().mockResolvedValue([defaultAssistant])
 
 vi.mock('@/hooks/useServiceHub', () => ({
   getServiceHub: () => ({
     assistants: () => ({
       createAssistant: mockCreateAssistant,
       deleteAssistant: mockDeleteAssistant,
+      getAssistants: mockGetAssistants,
     }),
   }),
 }))
@@ -217,5 +226,52 @@ describe('useAssistant - coverage', () => {
 
     // currentAssistant should still be jan
     expect(result.current.currentAssistant?.id).toBe('jan')
+  })
+
+  it('refreshAssistants should fetch fresh data and update state', async () => {
+    const freshAssistants = [
+      { ...defaultAssistant, name: 'Fresh Jan' },
+      { id: 'a2', name: 'A2', avatar: '', description: '', instructions: '', created_at: 2, parameters: {} },
+    ]
+    mockGetAssistants.mockResolvedValue(freshAssistants as any)
+
+    const { result } = renderHook(() => useAssistant())
+
+    expect(result.current.loading).toBe(true)
+
+    await act(async () => {
+      await result.current.refreshAssistants()
+    })
+
+    expect(result.current.assistants).toEqual(freshAssistants)
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('refreshAssistants should set loading:true before fetch starts', async () => {
+    const deferred = vi.fn().mockReturnValue(new Promise((resolve) => setTimeout(resolve, 100)))
+    mockGetAssistants.mockReturnValue(deferred())
+
+    const { result } = renderHook(() => useAssistant())
+
+    expect(result.current.loading).toBe(true)
+  })
+
+  it('refreshAssistants should show toast error on failure', async () => {
+    mockGetAssistants.mockRejectedValue(new Error('Network error'))
+
+    const { result } = renderHook(() => useAssistant())
+
+    await act(async () => {
+      await result.current.refreshAssistants()
+    })
+
+    expect(mockToast).toHaveBeenCalledWith('Failed to refresh assistants', {
+      description: 'Network error',
+    })
+    expect(result.current.loading).toBe(false)
+  })
+
+  afterEach(() => {
+    mockToast.mockClear()
   })
 })

--- a/web-app/src/hooks/useAssistant.ts
+++ b/web-app/src/hooks/useAssistant.ts
@@ -1,6 +1,7 @@
 import { getServiceHub } from '@/hooks/useServiceHub'
 import { Assistant as CoreAssistant } from '@janhq/core'
 import { create } from 'zustand'
+import { toast } from 'sonner'
 import { localStorageKey } from '@/constants/localStorage'
 
 interface AssistantState {
@@ -217,17 +218,19 @@ export const useAssistant = create<AssistantState>((set, get) => ({
     }
   },
   refreshAssistants: async () => {
+    set({ loading: true })
     try {
       const assistants = await getServiceHub().assistants().getAssistants()
       if (assistants) {
-        // Update the state with fresh assistants
         set({
           assistants,
           loading: false
         })
       }
     } catch (error) {
-      console.error('Failed to refresh assistants:', error)
+      toast.error('Failed to refresh assistants', {
+        description: error instanceof Error ? error.message : String(error),
+      })
       set({ loading: false })
     }
   },

--- a/web-app/src/hooks/useAssistant.ts
+++ b/web-app/src/hooks/useAssistant.ts
@@ -17,6 +17,7 @@ interface AssistantState {
   ) => void
   setDefaultAssistant: (id: string) => void
   setAssistants: (assistants: Assistant[] | null) => void
+  refreshAssistants: () => Promise<void>
 }
 
 const setLastUsedAssistantId = (assistantId: string) => {
@@ -212,6 +213,21 @@ export const useAssistant = create<AssistantState>((set, get) => ({
         loading: false
       })
     } else {
+      set({ loading: false })
+    }
+  },
+  refreshAssistants: async () => {
+    try {
+      const assistants = await getServiceHub().assistants().getAssistants()
+      if (assistants) {
+        // Update the state with fresh assistants
+        set({
+          assistants,
+          loading: false
+        })
+      }
+    } catch (error) {
+      console.error('Failed to refresh assistants:', error)
       set({ loading: false })
     }
   },

--- a/web-app/src/hooks/useAssistant.ts
+++ b/web-app/src/hooks/useAssistant.ts
@@ -17,6 +17,7 @@ interface AssistantState {
   ) => void
   setDefaultAssistant: (id: string) => void
   setAssistants: (assistants: Assistant[] | null) => void
+  refreshAssistants: () => Promise<void>
 }
 
 const setLastUsedAssistantId = (assistantId: string) => {
@@ -203,6 +204,21 @@ export const useAssistant = create<AssistantState>((set, get) => ({
         loading: false
       })
     } else {
+      set({ loading: false })
+    }
+  },
+  refreshAssistants: async () => {
+    try {
+      const assistants = await getServiceHub().assistants().getAssistants()
+      if (assistants) {
+        // Update the state with fresh assistants
+        set({
+          assistants,
+          loading: false
+        })
+      }
+    } catch (error) {
+      console.error('Failed to refresh assistants:', error)
       set({ loading: false })
     }
   },

--- a/web-app/src/hooks/useAssistant.ts
+++ b/web-app/src/hooks/useAssistant.ts
@@ -1,6 +1,7 @@
 import { getServiceHub } from '@/hooks/useServiceHub'
 import { Assistant as CoreAssistant } from '@janhq/core'
 import { create } from 'zustand'
+import { toast } from 'sonner'
 import { localStorageKey } from '@/constants/localStorage'
 
 interface AssistantState {
@@ -208,17 +209,19 @@ export const useAssistant = create<AssistantState>((set, get) => ({
     }
   },
   refreshAssistants: async () => {
+    set({ loading: true })
     try {
       const assistants = await getServiceHub().assistants().getAssistants()
       if (assistants) {
-        // Update the state with fresh assistants
         set({
           assistants,
           loading: false
         })
       }
     } catch (error) {
-      console.error('Failed to refresh assistants:', error)
+      toast.error('Failed to refresh assistants', {
+        description: error instanceof Error ? error.message : String(error),
+      })
       set({ loading: false })
     }
   },

--- a/web-app/src/hooks/useAssistant.ts
+++ b/web-app/src/hooks/useAssistant.ts
@@ -213,10 +213,9 @@ export const useAssistant = create<AssistantState>((set, get) => ({
     try {
       const assistants = await getServiceHub().assistants().getAssistants()
       if (assistants) {
-        set({
-          assistants,
-          loading: false
-        })
+        set({ assistants, loading: false })
+      } else {
+        set({ loading: false })
       }
     } catch (error) {
       toast.error('Failed to refresh assistants', {

--- a/web-app/src/routes/settings/assistant.tsx
+++ b/web-app/src/routes/settings/assistant.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { route } from '@/constants/routes'
-import { useState, useEffect } from 'react'
+import { useState, useCallback, useRef } from 'react'
 
 import { useAssistant } from '@/hooks/useAssistant'
 
@@ -43,7 +43,7 @@ function AssistantContent() {
   const [editingKey, setEditingKey] = useState<string | null>(null)
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
   const [deletingId, setDeletingId] = useState<string | null>(null)
-  const [editingAssistant, setEditingAssistant] = useState<Assistant | null>(null)
+  const refreshRequestRef = useRef(0)
 
   const handleDelete = (id: string) => {
     setDeletingId(id)
@@ -68,26 +68,19 @@ function AssistantContent() {
     setEditingKey(null)
   }
 
-  const handleEditClick = (assistantId: string) => {
+  const handleEditClick = useCallback((assistantId: string) => {
     // Before opening the edit dialog, refresh the assistants to get the latest data
-    refreshAssistants().then(() => {
-      setEditingKey(assistantId)
-      setOpen(true)
-    })
-  }
+    const requestId = ++refreshRequestRef.current
+    refreshAssistants()
+      .then(() => {
+        if (refreshRequestRef.current !== requestId) return
+        setEditingKey(assistantId)
+        setOpen(true)
+      })
+  }, [])
 
   const sortedAssistants = assistants.slice().sort((a, b) => a.created_at - b.created_at)
   const defaultAssistant = sortedAssistants.find((a) => a.id === defaultAssistantId)
-
-  // When editingKey changes, we need to get the latest assistant data
-  useEffect(() => {
-    if (editingKey) {
-      const assistant = assistants.find(a => a.id === editingKey)
-      setEditingAssistant(assistant || null)
-    } else {
-      setEditingAssistant(null)
-    }
-  }, [editingKey, assistants])
 
   return (
     <div className="flex flex-col h-svh w-full">
@@ -215,7 +208,7 @@ function AssistantContent() {
             open={open}
             onOpenChange={setOpen}
             editingKey={editingKey}
-            initialData={editingAssistant || undefined}
+            initialData={editingKey ? assistants.find(a => a.id === editingKey) : undefined}
             onSave={handleSave}
           />
           <DeleteAssistantDialog

--- a/web-app/src/routes/settings/assistant.tsx
+++ b/web-app/src/routes/settings/assistant.tsx
@@ -37,7 +37,6 @@ function AssistantContent() {
     deleteAssistant,
     defaultAssistantId,
     setDefaultAssistant,
-    refreshAssistants
   } = useAssistant()
   const [open, setOpen] = useState(false)
   const [editingKey, setEditingKey] = useState<string | null>(null)
@@ -71,7 +70,7 @@ function AssistantContent() {
   const handleEditClick = useCallback((assistantId: string) => {
     // Before opening the edit dialog, refresh the assistants to get the latest data
     const requestId = ++refreshRequestRef.current
-    refreshAssistants()
+    useAssistant.getState().refreshAssistants()
       .then(() => {
         if (refreshRequestRef.current !== requestId) return
         setEditingKey(assistantId)

--- a/web-app/src/routes/settings/assistant.tsx
+++ b/web-app/src/routes/settings/assistant.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { route } from '@/constants/routes'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 
 import { useAssistant } from '@/hooks/useAssistant'
 
@@ -30,18 +30,20 @@ export const Route = createFileRoute(route.settings.assistant as any)({
 
 function AssistantContent() {
   const { t } = useTranslation()
-  const { 
+  const {
     assistants,
     addAssistant,
     updateAssistant,
     deleteAssistant,
     defaultAssistantId,
-    setDefaultAssistant
+    setDefaultAssistant,
+    refreshAssistants
   } = useAssistant()
   const [open, setOpen] = useState(false)
   const [editingKey, setEditingKey] = useState<string | null>(null)
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)
   const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [editingAssistant, setEditingAssistant] = useState<Assistant | null>(null)
 
   const handleDelete = (id: string) => {
     setDeletingId(id)
@@ -66,8 +68,26 @@ function AssistantContent() {
     setEditingKey(null)
   }
 
+  const handleEditClick = (assistantId: string) => {
+    // Before opening the edit dialog, refresh the assistants to get the latest data
+    refreshAssistants().then(() => {
+      setEditingKey(assistantId)
+      setOpen(true)
+    })
+  }
+
   const sortedAssistants = assistants.slice().sort((a, b) => a.created_at - b.created_at)
   const defaultAssistant = sortedAssistants.find((a) => a.id === defaultAssistantId)
+
+  // When editingKey changes, we need to get the latest assistant data
+  useEffect(() => {
+    if (editingKey) {
+      const assistant = assistants.find(a => a.id === editingKey)
+      setEditingAssistant(assistant || null)
+    } else {
+      setEditingAssistant(null)
+    }
+  }, [editingKey, assistants])
 
   return (
     <div className="flex flex-col h-svh w-full">
@@ -174,10 +194,7 @@ function AssistantContent() {
                       variant="ghost"
                       size="icon-xs"
                       title={t('assistants:editAssistant')}
-                      onClick={() => {
-                        setEditingKey(assistant.id)
-                        setOpen(true)
-                      }}
+                      onClick={() => handleEditClick(assistant.id)}
                     >
                       <IconPencil className="text-muted-foreground size-4" />
                     </Button>
@@ -198,11 +215,7 @@ function AssistantContent() {
             open={open}
             onOpenChange={setOpen}
             editingKey={editingKey}
-            initialData={
-              editingKey
-                ? assistants.find((a) => a.id === editingKey)
-                : undefined
-            }
+            initialData={editingAssistant || undefined}
             onSave={handleSave}
           />
           <DeleteAssistantDialog


### PR DESCRIPTION
This helps avoid overwriting assistant definition changes if the file containing the definition was edited externally while the UI is open.

Code was AI generated - but human tested for function because it was created to scratch my own itch.

## Describe Your Changes

- Added refreshAssistants method to useAssistant hook to fetch fresh data from backend
- Modified assistant editing flow to refresh assistants before opening edit dialog
- Ensures latest assistant definitions are loaded when editing
- Addresses issue where edits might show stale data from previous cache

## Fixes Issues

N / A

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [x] Updated docs (for bug fixes / features)
- [x] Created issues for follow-up changes or refactoring needed
