### PR TITLE
feat(llamacpp): expand server flags + wire llamacpp-only sampling params

### DIFF
--- a/extensions/llamacpp-extension/settings.json
+++ b/extensions/llamacpp-extension/settings.json
@@ -344,67 +344,49 @@
     }
   },
   {
-    "key": "mirostat",
-    "title": "Mirostat Mode",
-    "description": "Use Mirostat sampling (0: disabled, 1: Mirostat V1, 2: Mirostat V2).",
-    "controllerType": "dropdown",
+    "key": "cache_ram",
+    "title": "Prompt Cache RAM (MiB)",
+    "description": "Maximum prompt cache size in MiB (--cache-ram). -1 = unlimited, 0 = disabled.",
+    "controllerType": "input",
+    "controllerProps": {
+      "value": -1,
+      "placeholder": "-1",
+      "type": "number",
+      "textAlign": "right"
+    }
+  },
+  {
+    "key": "cache_reuse",
+    "title": "Cache Reuse",
+    "description": "Min chunk size of matching prefix tokens to reuse from cache (--cache-reuse). 0 = disabled.",
+    "controllerType": "input",
     "controllerProps": {
       "value": 0,
-      "options": [
-        { "value": 0, "name": "Disabled" },
-        { "value": 1, "name": "Mirostat V1" },
-        { "value": 2, "name": "Mirostat V2" }
-      ]
-    }
-  },
-  {
-    "key": "mirostat_lr",
-    "title": "Mirostat Learning Rate",
-    "description": "Mirostat learning rate (eta).",
-    "controllerType": "input",
-    "controllerProps": {
-      "value": 0.1,
-      "placeholder": "0.1",
+      "placeholder": "0",
       "type": "number",
       "textAlign": "right",
-      "min": 0,
-      "step": 0.01
+      "min": 0
     }
   },
   {
-    "key": "mirostat_ent",
-    "title": "Mirostat Target Entropy",
-    "description": "Mirostat target entropy (tau).",
+    "key": "swa_full",
+    "title": "Full SWA Cache",
+    "description": "Use full-size SWA cache (--swa-full). May improve quality at the cost of memory.",
+    "controllerType": "checkbox",
+    "controllerProps": {
+      "value": false
+    }
+  },
+  {
+    "key": "keep",
+    "title": "Keep First N Tokens",
+    "description": "Number of tokens from the initial prompt to keep when context is shifted (--keep). -1 = keep all.",
     "controllerType": "input",
     "controllerProps": {
-      "value": 5.0,
-      "placeholder": "5.0",
+      "value": 0,
+      "placeholder": "0",
       "type": "number",
-      "textAlign": "right",
-      "min": 0,
-      "step": 0.01
-    }
-  },
-  {
-    "key": "grammar_file",
-    "title": "Grammar File",
-    "description": "Path to a BNF-like grammar file to constrain generations.",
-    "controllerType": "input",
-    "controllerProps": {
-      "value": "",
-      "placeholder": "path/to/grammar.gbnf",
-      "type": "text"
-    }
-  },
-  {
-    "key": "json_schema_file",
-    "title": "JSON Schema File",
-    "description": "Path to a JSON schema file to constrain generations.",
-    "controllerType": "input",
-    "controllerProps": {
-      "value": "",
-      "placeholder": "path/to/schema.json",
-      "type": "text"
+      "textAlign": "right"
     }
   }
 ]

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -135,6 +135,11 @@ export default class llamacpp_extension extends AIEngine {
 
     let settings = structuredClone(SETTINGS) // Clone to modify settings definition before registration
 
+    if (!IS_MAC) {
+      const fitItem = settings.find((s) => s.key === 'fit')
+      if (fitItem) fitItem.controllerProps.value = true
+    }
+
     // This makes the settings (including the backend options and initial value) available to the Jan UI.
     this.registerSettings(settings)
 
@@ -154,6 +159,9 @@ export default class llamacpp_extension extends AIEngine {
 
     // Migration v2: disable fit by default
     await this.migrateFitDefault()
+
+    // Migration v3: enable fit on Windows/Linux with a discrete GPU
+    await this.migrateFitPlatformDefault()
 
     this.autoUnload = this.config.auto_unload
     this.timeout = this.config.timeout
@@ -251,6 +259,47 @@ export default class llamacpp_extension extends AIEngine {
       )
       this.config.fit = false
       logger.info('Migrated fit setting: disabled by default')
+    }
+
+    localStorage.setItem(MIGRATION_KEY, '1')
+  }
+
+  private async migrateFitPlatformDefault(): Promise<void> {
+    const MIGRATION_KEY = 'llamacpp_fit_platform_v2'
+    if (localStorage.getItem(MIGRATION_KEY)) return
+
+    if (IS_MAC) {
+      localStorage.setItem(MIGRATION_KEY, '1')
+      return
+    }
+
+    let hasDiscreteGpu = false
+    try {
+      const sysInfo = await getSystemInfo()
+      hasDiscreteGpu = (sysInfo?.gpus ?? []).some(
+        (g: any) =>
+          g?.nvidia_info != null ||
+          g?.vulkan_info?.device_type === 'DiscreteGpu'
+      )
+    } catch (error) {
+      // Skip writing the migration key so a transient probe failure retries.
+      logger.warn('Failed to probe GPU info for fit migration:', error)
+      return
+    }
+
+    // Only upgrade the v1 auto-default; preserve any explicit user override.
+    if (this.config.fit === false && hasDiscreteGpu) {
+      const settings = await this.getSettings()
+      await this.updateSettings(
+        settings.map((item) => {
+          if (item.key === 'fit') {
+            item.controllerProps.value = true
+          }
+          return item
+        })
+      )
+      this.config.fit = true
+      logger.info('Migrated fit setting: enabled (discrete GPU detected)')
     }
 
     localStorage.setItem(MIGRATION_KEY, '1')

--- a/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/index.ts
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/index.ts
@@ -31,8 +31,8 @@ function asI32(v: any, defaultValue = 0): number {
   return n
 }
 
-function asBool(v: any): boolean {
-  if (v === '' || v === null || v === undefined) return false
+function asBool(v: any, defaultValue = false): boolean {
+  if (v === '' || v === null || v === undefined) return defaultValue
   return v === true || v === 'true' || v === 1 || v === '1'
 }
 
@@ -92,6 +92,12 @@ export function normalizeLlamacppConfig(config: any): LlamacppConfig {
 
     ctx_shift: asBool(config.ctx_shift),
     parallel: asI32(config.parallel, 1),
+
+    reasoning: asString(config.reasoning, 'auto'),
+    cache_ram: asI32(config.cache_ram, -1),
+    cache_reuse: asI32(config.cache_reuse, 0),
+    swa_full: asBool(config.swa_full),
+    keep: asI32(config.keep, 0),
   }
 }
 

--- a/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/types.ts
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/types.ts
@@ -66,6 +66,11 @@ export type LlamacppConfig = {
   rope_freq_scale: number
   ctx_shift: boolean
   parallel: number
+  reasoning: string
+  cache_ram: number
+  cache_reuse: number
+  swa_full: boolean
+  keep: number
 }
 
 export type ModelPlan = {

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/args.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/args.rs
@@ -3,6 +3,18 @@ use serde::{Deserialize, Serialize};
 fn default_parallel() -> i32 {
      1
  }
+fn default_reasoning() -> String {
+    "auto".to_string()
+}
+fn default_cache_ram() -> i32 {
+    -1
+}
+fn default_cache_reuse() -> i32 {
+    0
+}
+fn default_keep() -> i32 {
+    0
+}
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LlamacppConfig {
     pub version_backend: String,
@@ -45,6 +57,16 @@ pub struct LlamacppConfig {
     pub ctx_shift: bool,
     #[serde(default = "default_parallel")]
     pub parallel: i32,
+    #[serde(default = "default_reasoning")]
+    pub reasoning: String,
+    #[serde(default = "default_cache_ram")]
+    pub cache_ram: i32,
+    #[serde(default = "default_cache_reuse")]
+    pub cache_reuse: i32,
+    #[serde(default)]
+    pub swa_full: bool,
+    #[serde(default = "default_keep")]
+    pub keep: i32,
 }
 
 /// Minimum llama.cpp build number that changed --flash-attn from a boolean
@@ -101,8 +123,34 @@ impl ArgumentBuilder {
             self.args.push("--no-webui".to_string());
         }
 
-        // Jinja template support
         self.args.push("--jinja".to_string());
+
+        match self.config.reasoning.as_str() {
+            "on" | "off" => {
+                self.args.push("--reasoning".to_string());
+                self.args.push(self.config.reasoning.clone());
+            }
+            _ => {}
+        }
+
+        if self.config.cache_ram >= 0 {
+            self.args.push("--cache-ram".to_string());
+            self.args.push(self.config.cache_ram.to_string());
+        }
+
+        if self.config.cache_reuse > 0 {
+            self.args.push("--cache-reuse".to_string());
+            self.args.push(self.config.cache_reuse.to_string());
+        }
+
+        if self.config.swa_full {
+            self.args.push("--swa-full".to_string());
+        }
+
+        if self.config.keep != 0 {
+            self.args.push("--keep".to_string());
+            self.args.push(self.config.keep.to_string());
+        }
 
         // Model path (required)
         self.args.push("-m".to_string());
@@ -321,9 +369,17 @@ impl ArgumentBuilder {
     }
 
     fn add_text_generation_args(&mut self) {
-        if self.config.ctx_size > 0 && !self.config.fit {
+        // With fit on, llama.cpp's fit code handles sizing. With fit off and
+        // no --ctx-size, it would load at n_ctx_train and OOM on small GPUs;
+        // fall back to 4096.
+        if !self.config.fit {
+            let ctx = if self.config.ctx_size > 0 {
+                self.config.ctx_size
+            } else {
+                4096
+            };
             self.args.push("--ctx-size".to_string());
-            self.args.push(self.config.ctx_size.to_string());
+            self.args.push(ctx.to_string());
         }
 
         if self.config.n_predict > 0 {
@@ -444,6 +500,11 @@ mod tests {
             rope_freq_scale: 1.0,
             ctx_shift: false,
             parallel: 1,
+            reasoning: "auto".to_string(),
+            cache_ram: -1,
+            cache_reuse: 0,
+            swa_full: false,
+            keep: 0,
         }
     }
 
@@ -840,6 +901,30 @@ mod tests {
     }
 
     #[test]
+    fn test_ctx_size_falls_back_to_4096_when_fit_off_and_unset() {
+        let mut config = default_config();
+        config.fit = false;
+        config.ctx_size = 0;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--ctx-size", "4096");
+    }
+
+    #[test]
+    fn test_ctx_size_omitted_when_fit_on() {
+        let mut config = default_config();
+        config.fit = true;
+        config.ctx_size = 8192;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--ctx-size");
+    }
+
+    #[test]
     fn test_n_predict() {
         let mut config = default_config();
         config.n_predict = 512;
@@ -1146,6 +1231,139 @@ mod tests {
 
         assert_arg_pair(&args, "--parallel", "1");
         assert_has_flag(&args, "-kvu");
+    }
+
+    #[test]
+    fn test_reasoning_auto_default_not_added() {
+        let config = default_config();
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--reasoning");
+    }
+
+    #[test]
+    fn test_reasoning_on_passes_value() {
+        let mut config = default_config();
+        config.reasoning = "on".to_string();
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--reasoning", "on");
+    }
+
+    #[test]
+    fn test_reasoning_off_passes_value() {
+        let mut config = default_config();
+        config.reasoning = "off".to_string();
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--reasoning", "off");
+    }
+
+    #[test]
+    fn test_cache_ram_default_unlimited_not_added() {
+        let config = default_config();
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--cache-ram");
+    }
+
+    #[test]
+    fn test_cache_ram_zero_disables() {
+        let mut config = default_config();
+        config.cache_ram = 0;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--cache-ram", "0");
+    }
+
+    #[test]
+    fn test_cache_ram_custom_value() {
+        let mut config = default_config();
+        config.cache_ram = 4096;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--cache-ram", "4096");
+    }
+
+    #[test]
+    fn test_cache_reuse_default_not_added() {
+        let config = default_config();
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--cache-reuse");
+    }
+
+    #[test]
+    fn test_cache_reuse_custom_value() {
+        let mut config = default_config();
+        config.cache_reuse = 256;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--cache-reuse", "256");
+    }
+
+    #[test]
+    fn test_swa_full_default_not_added() {
+        let config = default_config();
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--swa-full");
+    }
+
+    #[test]
+    fn test_swa_full_enabled() {
+        let mut config = default_config();
+        config.swa_full = true;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_has_flag(&args, "--swa-full");
+    }
+
+    #[test]
+    fn test_keep_default_not_added() {
+        let config = default_config();
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_no_flag(&args, "--keep");
+    }
+
+    #[test]
+    fn test_keep_custom_value() {
+        let mut config = default_config();
+        config.keep = 32;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--keep", "32");
+    }
+
+    #[test]
+    fn test_keep_negative_keep_all() {
+        let mut config = default_config();
+        config.keep = -1;
+
+        let builder = ArgumentBuilder::new(config, false).unwrap();
+        let args = builder.build("test", "/path", 8080, None);
+
+        assert_arg_pair(&args, "--keep", "-1");
     }
 
     #[test]

--- a/src-tauri/src/bin/jan-cli.rs
+++ b/src-tauri/src/bin/jan-cli.rs
@@ -1339,6 +1339,11 @@ fn build_llamacpp_config(n_gpu_layers: i32, ctx_size: i32, timeout: i32, fit: bo
         rope_freq_base: 0.0,
         rope_freq_scale: 0.0,
         ctx_shift: false,
-        parallel: 1
+        parallel: 1,
+        reasoning: "auto".to_string(),
+        cache_ram: -1,
+        cache_reuse: 0,
+        swa_full: false,
+        keep: 0,
     }
 }

--- a/web-app/src/containers/ModelSetting.tsx
+++ b/web-app/src/containers/ModelSetting.tsx
@@ -81,7 +81,7 @@ export function ModelSetting({
         models: updatedModels,
       })
 
-      // Call debounced stopModel only when updating ctx_len, ngl, chat_template, or offload_mmproj
+      // Call debounced stopModel only when updating settings that require restart,
       // and only if the model is currently running
       if (
         key === 'ctx_len' ||
@@ -90,7 +90,8 @@ export function ModelSetting({
         key === 'offload_mmproj' ||
         key === 'batch_size' ||
         key === 'cpu_moe' ||
-        key === 'n_cpu_moe'
+        key === 'n_cpu_moe' ||
+        key === 'reasoning'
       ) {
         // Check if model is running before stopping it
         serviceHub
@@ -128,12 +129,21 @@ export function ModelSetting({
           {Object.entries(model.settings || {})
           .reduce<[string, unknown][]>((acc, entry) => {
             if (entry[0] === 'auto_increase_ctx_len') return acc
+            if (entry[0] === 'reasoning') return acc
             if (entry[0] === 'ctx_len') {
               const autoIncrease = Object.entries(model.settings || {}).find(
                 ([k]) => k === 'auto_increase_ctx_len'
               )
               if (autoIncrease) acc.push(autoIncrease)
             }
+            acc.push(entry)
+            return acc
+          }, [])
+          .reduce<[string, unknown][]>((acc, entry) => {
+            const reasoning = Object.entries(model.settings || {}).find(
+              ([k]) => k === 'reasoning'
+            )
+            if (reasoning && acc.length === 0) acc.push(reasoning)
             acc.push(entry)
             return acc
           }, [])
@@ -152,7 +162,8 @@ export function ModelSetting({
                   className={cn(
                     'flex items-start justify-between gap-8',
                     (key === 'chat_template' ||
-                      key === 'override_tensor_buffer_t') &&
+                      key === 'override_tensor_buffer_t' ||
+                      config.controller_type === 'dropdown') &&
                       'flex-col gap-1 w-full'
                   )}
                 >

--- a/web-app/src/hooks/useModelProvider.ts
+++ b/web-app/src/hooks/useModelProvider.ts
@@ -538,9 +538,55 @@ export const useModelProvider = create<ModelProviderState>()(
             }
           })
         }
+
+        if (version <= 11 && state?.providers) {
+          state.providers.forEach((provider) => {
+            if (provider.provider !== 'llamacpp') return
+
+            // Reasoning moved from extension-level to per-model settings —
+            // strip any stale entry from the provider settings panel.
+            if (provider.settings) {
+              provider.settings = provider.settings.filter(
+                (s) => s.key !== 'reasoning'
+              )
+            }
+
+            if (provider.models) {
+              provider.models.forEach((model) => {
+                if (!model.settings) model.settings = {}
+
+                if (!model.settings.reasoning) {
+                  model.settings.reasoning = {
+                    ...modelSettings.reasoning,
+                    controller_props: {
+                      ...modelSettings.reasoning.controller_props,
+                    },
+                  }
+                }
+              })
+            }
+          })
+        }
+
+        if (version <= 12 && state?.providers) {
+          // Reset ctx_len from the prior 8192 default to '' so llama.cpp picks
+          // (auto-fit when enabled, model default otherwise). Preserve any
+          // user-customised value.
+          state.providers.forEach((provider) => {
+            if (provider.provider !== 'llamacpp' || !provider.models) return
+            provider.models.forEach((model) => {
+              const ctx = model.settings?.ctx_len as
+                | { controller_props?: { value?: unknown } }
+                | undefined
+              if (ctx?.controller_props?.value === 8192) {
+                ctx.controller_props.value = ''
+              }
+            })
+          })
+        }
         return state
       },
-      version: 11,
+      version: 13,
     }
   )
 )

--- a/web-app/src/lib/model-factory.ts
+++ b/web-app/src/lib/model-factory.ts
@@ -60,6 +60,7 @@ import { SessionInfo } from '@janhq/core'
 import { fetch as httpFetch } from '@tauri-apps/plugin-http'
 import { isPlatformTauri } from '@/lib/platform/utils'
 import { providerRemoteApiKeyChain } from '@/lib/provider-api-keys'
+import { LLAMACPP_ONLY_PARAM_KEYS } from '@/lib/predefinedParams'
 
 /**
  * Llama.cpp timings structure from the response
@@ -132,6 +133,19 @@ const CLIENT_SIDE_PARAM_KEYS: ReadonlySet<string> = new Set([
   'auto_compact',
 ])
 
+function filterParameters(
+  parameters: Record<string, unknown>,
+  keepLlamacppOnly: boolean
+): Record<string, unknown> {
+  if (keepLlamacppOnly) return parameters
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(parameters)) {
+    if (LLAMACPP_ONLY_PARAM_KEYS.has(k)) continue
+    out[k] = v
+  }
+  return out
+}
+
 /**
  * Create a custom fetch function that injects additional parameters into the
  * request body, normalising key names for OpenAI-compatible APIs:
@@ -140,7 +154,8 @@ const CLIENT_SIDE_PARAM_KEYS: ReadonlySet<string> = new Set([
  */
 function createCustomFetch(
   baseFetch: typeof globalThis.fetch,
-  parameters: Record<string, unknown>
+  parameters: Record<string, unknown>,
+  keepLlamacppOnly = false
 ): typeof globalThis.fetch {
   return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     if (init?.method === 'POST' || !init?.method) {
@@ -150,6 +165,7 @@ function createCustomFetch(
       const normalised: Record<string, unknown> = {}
       for (const [key, value] of Object.entries(parameters)) {
         if (CLIENT_SIDE_PARAM_KEYS.has(key)) continue
+        if (!keepLlamacppOnly && LLAMACPP_ONLY_PARAM_KEYS.has(key)) continue
         // max_output_tokens → max_tokens (OpenAI-compatible field name)
         const targetKey = key === 'max_output_tokens' ? 'max_tokens' : key
         normalised[targetKey] = value
@@ -416,7 +432,7 @@ export class ModelFactory {
       throw new Error(`No running session found for model: ${modelId}`)
     }
 
-    const customFetch = createCustomFetch(httpFetch, parameters)
+    const customFetch = createCustomFetch(httpFetch, parameters, true)
 
     const model = new OpenAICompatibleChatLanguageModel(modelId, {
       provider: 'llamacpp',
@@ -451,6 +467,7 @@ export class ModelFactory {
     provider?: ProviderObject,
     parameters: Record<string, unknown> = {}
   ): Promise<LanguageModel> {
+    parameters = filterParameters(parameters, false)
     // Start the model first if provider is available
     if (provider) {
       try {
@@ -541,6 +558,7 @@ export class ModelFactory {
     provider?: ProviderObject,
     parameters: Record<string, unknown> = {}
   ): Promise<LanguageModel> {
+    parameters = filterParameters(parameters, false)
     const availability = await invoke<string>(
       'plugin:foundation-models|check_foundation_models_availability',
       {}

--- a/web-app/src/lib/predefined.ts
+++ b/web-app/src/lib/predefined.ts
@@ -12,11 +12,12 @@ export const modelSettings = {
   ctx_len: {
     key: 'ctx_len',
     title: 'Context Size',
-    description: 'Size of the prompt context (0 = loaded from model).',
+    description:
+      'Size of the prompt context. Leave empty to auto-fit when --fit is on, or fall back to 4096 when off.',
     controller_type: 'input',
     controller_props: {
-      value: 8192,
-      placeholder: '8192',
+      value: '',
+      placeholder: 'auto',
       type: 'number',
     },
   },
@@ -195,6 +196,21 @@ export const modelSettings = {
       placeholder: '2048',
       type: 'number',
       textAlign: 'right',
+    },
+  },
+  reasoning: {
+    key: 'reasoning',
+    title: 'Reasoning',
+    description:
+      "Use reasoning/thinking in the chat. 'auto' detects from the chat template.",
+    controller_type: 'dropdown',
+    controller_props: {
+      value: 'auto',
+      options: [
+        { value: 'auto', name: 'Auto' },
+        { value: 'on', name: 'On' },
+        { value: 'off', name: 'Off' },
+      ],
     },
   },
 }

--- a/web-app/src/lib/predefinedParams.ts
+++ b/web-app/src/lib/predefinedParams.ts
@@ -55,4 +55,42 @@ export const paramsSettings = {
     description:
       'Number of most relevant documents to retrieve. Higher values return more results.',
   },
+  mirostat: {
+    key: 'mirostat',
+    value: 0,
+    title: 'Mirostat',
+    description: `Mirostat sampling mode (llama.cpp only). 0 = disabled, 1 = Mirostat v1, 2 = Mirostat v2.`,
+  },
+  mirostat_tau: {
+    key: 'mirostat_tau',
+    value: 5.0,
+    title: 'Mirostat Tau',
+    description: `Mirostat target entropy (llama.cpp only). Lower values produce more focused output.`,
+  },
+  mirostat_eta: {
+    key: 'mirostat_eta',
+    value: 0.1,
+    title: 'Mirostat Eta',
+    description: `Mirostat learning rate (llama.cpp only).`,
+  },
+  grammar: {
+    key: 'grammar',
+    value: '',
+    title: 'Grammar (GBNF)',
+    description: `GBNF grammar string to constrain generations (llama.cpp only). Paste the grammar contents directly.`,
+  },
+  json_schema: {
+    key: 'json_schema',
+    value: '',
+    title: 'JSON Schema',
+    description: `JSON schema string to constrain generations as valid JSON (llama.cpp only).`,
+  },
 }
+
+export const LLAMACPP_ONLY_PARAM_KEYS: ReadonlySet<string> = new Set([
+  'mirostat',
+  'mirostat_tau',
+  'mirostat_eta',
+  'grammar',
+  'json_schema',
+])


### PR DESCRIPTION
## Describe Your Changes

- Extension-level (settings.json + LlamacppConfig + args.rs):
- Adds --cache-ram, --cache-reuse, --swa-full, --keep flags
- Removes dead mirostat/grammar_file/json_schema_file entries that had no readers anywhere

Per-model (predefined.ts modelSettings):
- Adds reasoning dropdown (auto/on/off) → --reasoning, restart-on-change
- ctx_len defaults to empty (auto-fit when --fit is on, fall back to 4096 in args.rs when fit is off to avoid OOM at n_ctx_train)
- v11→v13 storage migrations backfill reasoning, strip the stale provider-level entry, and reset the prior 8192 ctx_len default

llamacpp-only sampling (predefinedParams.ts assistant params):
- Adds mirostat, mirostat_tau, mirostat_eta, grammar, json_schema
- Gates LLAMACPP_ONLY_PARAM_KEYS in createCustomFetch / MLX / Foundation Models so they only reach the local llama-server

Platform-aware --fit default:
- Synchronous default flips fit on for non-macOS in onLoad
- migrateFitPlatformDefault probes GPUs via getSystemInfo and only upgrades the v1 auto-default (false → true) when a discrete GPU is present (NVIDIA or Vulkan DiscreteGpu); explicit user values are preserved, probe failure retries on next launch

Misc:
- guest-js types/normalizer kept in sync with the Rust struct; asBool gains an optional default
- ModelSetting renders dropdown rows full-width so titles aren't squeezed; reasoning is hoisted to the top of the panel
- jan-cli's LlamacppConfig literal updated for the new fields
- New args.rs unit tests covering each flag's default-omits and custom-value paths plus ctx_size fit interactions


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
