### PR TITLE
feat: add Perplexity as a cloud model provider

### DIFF
--- a/docs/src/pages/docs/desktop/remote-models/_meta.json
+++ b/docs/src/pages/docs/desktop/remote-models/_meta.json
@@ -20,6 +20,9 @@
   "openrouter": {
     "title": "OpenRouter"
   },
+  "perplexity": {
+    "title": "Perplexity"
+  },
   "huggingface": {
     "title": "Hugging Face"
   }

--- a/docs/src/pages/docs/desktop/remote-models/perplexity.mdx
+++ b/docs/src/pages/docs/desktop/remote-models/perplexity.mdx
@@ -1,0 +1,115 @@
+---
+title: Perplexity
+description: A step-by-step guide on integrating Jan with Perplexity.
+keywords:
+  [
+    Jan,
+    Customizable Intelligence, LLM,
+    local AI,
+    privacy focus,
+    free and open source,
+    private and offline,
+    conversational AI,
+    no-subscription fee,
+    large language models,
+    Perplexity integration,
+    Perplexity,
+    Agent API,
+    Search API,
+  ]
+---
+
+import { Callout, Steps } from 'nextra/components'
+import { Settings, Plus } from 'lucide-react'
+
+# Perplexity
+
+## Integrate Perplexity with Jan
+
+[Perplexity](https://www.perplexity.ai/) provides an [Agent API](https://docs.perplexity.ai/docs/agent/quickstart)
+that returns grounded, citation-backed answers from the live web. The Agent API is OpenAI-compatible
+(it speaks both the Chat Completions and Responses API formats), so Jan can talk to it through the same
+OpenAI-compatible client used for the other cloud providers.
+
+Perplexity also exposes a standalone [Search API](https://docs.perplexity.ai/docs/search/quickstart)
+that returns ranked web results without an LLM in the loop — useful as a research building block.
+
+## Integrate Perplexity with Jan
+
+<Steps>
+
+### Step 1: Get Your API Key
+1. Visit your [Perplexity API Keys](https://www.perplexity.ai/account/api/keys) page and sign in
+2. Create & copy a new API key or copy your existing one
+
+<Callout type='info'>
+The Agent API is metered. See [Perplexity's pricing](https://docs.perplexity.ai/docs/getting-started/pricing)
+for current rates.
+</Callout>
+
+### Step 2: Configure Jan
+
+1. Navigate to the **Settings** page (<Settings width={16} height={16} style={{display:"inline"}}/>)
+2. Under **Model Providers**, select **Perplexity**
+3. Insert your **API Key**
+
+### Step 3: Start Using Perplexity Models
+
+1. Pick any existing **Chat** or create a new one
+2. Select a Perplexity model from the **model selector**
+3. Start chatting
+
+</Steps>
+
+## Configuration
+
+**Base URL:** `https://api.perplexity.ai`
+
+Jan calls Perplexity through its OpenAI-compatible interface. The Agent API endpoint
+(`/v1/responses`, alias of `/v1/agent`) and the chat completions endpoint
+(`/v1/chat/completions`) are both reachable from the configured base URL.
+
+**Model Field Settings:**
+- Specify a model ID exactly as it appears in [Perplexity's model directory](https://docs.perplexity.ai/docs/agent/models)
+- Routed third-party models are also available through the Agent API (e.g. `openai/gpt-5.4`,
+  `anthropic/claude-sonnet-4-6`) — see [Agent API models](https://docs.perplexity.ai/docs/agent/models)
+  for the complete and up-to-date list.
+
+## Using the Search API
+
+For raw, ranked web search results (no model in the loop), use Perplexity's
+[Search API](https://docs.perplexity.ai/docs/search/quickstart) directly:
+
+```bash
+curl -X POST https://api.perplexity.ai/search \
+  -H "Authorization: Bearer $PERPLEXITY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "latest open-source LLM releases",
+    "max_results": 10
+  }'
+```
+
+See the [Search API reference](https://docs.perplexity.ai/api-reference/search-post) for the full
+parameter list (including `search_domain_filter`, `search_recency_filter`, and date filters).
+
+## Troubleshooting
+
+Common issues and solutions:
+
+**1. API Key Issues**
+- Verify your API key is correct and not expired
+- Check that your Perplexity account has API access enabled
+- Ensure you have sufficient credit on your account
+
+**2. Connection Problems**
+- Check your internet connection
+- Verify Perplexity's [status page](https://status.perplexity.com)
+- Look for error messages in [Jan's logs](/docs/desktop/troubleshooting#how-to-get-error-logs)
+
+**3. Model Unavailable**
+- Confirm the model is currently listed under [Agent API models](https://docs.perplexity.ai/docs/agent/models)
+- Verify the model ID format matches Perplexity's directory exactly
+
+Need more help? Join our [Discord community](https://discord.gg/FTk2MvZwJH) or check the
+[Perplexity documentation](https://docs.perplexity.ai).

--- a/docs/src/pages/docs/desktop/remote-models/perplexity.mdx
+++ b/docs/src/pages/docs/desktop/remote-models/perplexity.mdx
@@ -24,8 +24,6 @@ import { Settings, Plus } from 'lucide-react'
 
 # Perplexity
 
-## Integrate Perplexity with Jan
-
 [Perplexity](https://www.perplexity.ai/) provides an [Agent API](https://docs.perplexity.ai/docs/agent/quickstart)
 that returns grounded, citation-backed answers from the live web. The Agent API is OpenAI-compatible
 (it speaks both the Chat Completions and Responses API formats), so Jan can talk to it through the same
@@ -70,9 +68,9 @@ Jan calls Perplexity through its OpenAI-compatible interface. The Agent API endp
 (`/v1/chat/completions`) are both reachable from the configured base URL.
 
 **Model Field Settings:**
-- Specify a model ID exactly as it appears in [Perplexity's model directory](https://docs.perplexity.ai/docs/agent/models)
+- Specify a model ID exactly as it appears in [Perplexity's model directory](https://docs.perplexity.ai/models/model-cards)
 - Routed third-party models are also available through the Agent API (e.g. `openai/gpt-5.4`,
-  `anthropic/claude-sonnet-4-6`) — see [Agent API models](https://docs.perplexity.ai/docs/agent/models)
+  `anthropic/claude-sonnet-4-6`) — see [Agent API models](https://docs.perplexity.ai/models/model-cards)
   for the complete and up-to-date list.
 
 ## Using the Search API
@@ -108,7 +106,7 @@ Common issues and solutions:
 - Look for error messages in [Jan's logs](/docs/desktop/troubleshooting#how-to-get-error-logs)
 
 **3. Model Unavailable**
-- Confirm the model is currently listed under [Agent API models](https://docs.perplexity.ai/docs/agent/models)
+- Confirm the model is currently listed under [Agent API models](https://docs.perplexity.ai/models/model-cards)
 - Verify the model ID format matches Perplexity's directory exactly
 
 Need more help? Join our [Discord community](https://discord.gg/FTk2MvZwJH) or check the

--- a/web-app/public/images/model-provider/perplexity.svg
+++ b/web-app/public/images/model-provider/perplexity.svg
@@ -1,0 +1,7 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="512" height="512" rx="96" fill="#1F1F1F"/>
+<path d="M256 96L408 192V320L256 416L104 320V192L256 96Z" stroke="#20B8CD" stroke-width="20" fill="none"/>
+<path d="M256 96V416" stroke="#20B8CD" stroke-width="20"/>
+<path d="M104 192L408 320" stroke="#20B8CD" stroke-width="20"/>
+<path d="M408 192L104 320" stroke="#20B8CD" stroke-width="20"/>
+</svg>

--- a/web-app/public/images/model-provider/perplexity.svg
+++ b/web-app/public/images/model-provider/perplexity.svg
@@ -1,7 +1,4 @@
-<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="512" height="512" rx="96" fill="#1F1F1F"/>
-<path d="M256 96L408 192V320L256 416L104 320V192L256 96Z" stroke="#20B8CD" stroke-width="20" fill="none"/>
-<path d="M256 96V416" stroke="#20B8CD" stroke-width="20"/>
-<path d="M104 192L408 320" stroke="#20B8CD" stroke-width="20"/>
-<path d="M408 192L104 320" stroke="#20B8CD" stroke-width="20"/>
+<svg width="512" height="512" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="24" height="24" fill="white"/>
+<path fill-rule="evenodd" d="M19.785 0v7.272H22.5V17.62h-2.935V24l-7.037-6.194v6.145h-1.091v-6.152L4.392 24v-6.465H1.5V7.188h2.884V0l7.053 6.494V.19h1.09v6.49L19.786 0zm-7.257 9.044v7.319l5.946 5.234V14.44l-5.946-5.397zm-1.099-.08l-5.946 5.398v7.235l5.946-5.234V8.965zm8.136 7.58h1.844V8.349H13.46l6.105 5.54v2.655zm-8.982-8.28H2.59v8.195h1.8v-2.576l6.192-5.62zM5.475 2.476v4.71h5.115l-5.115-4.71zm13.219 0l-5.115 4.71h5.115v-4.71z" fill="#20B8CD"/>
 </svg>

--- a/web-app/src/constants/__tests__/perplexity-provider.test.ts
+++ b/web-app/src/constants/__tests__/perplexity-provider.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { predefinedProviders } from '../providers'
+import { providerModels } from '../models'
+
+describe('Perplexity predefined provider config', () => {
+  const provider = predefinedProviders.find((p) => p.provider === 'perplexity')
+
+  it('exists in predefinedProviders', () => {
+    expect(provider).toBeDefined()
+  })
+
+  it('has the correct base_url', () => {
+    expect(provider?.base_url).toBe('https://api.perplexity.ai')
+  })
+
+  it('has a valid explore_models_url', () => {
+    expect(provider?.explore_models_url).toMatch(/^https:\/\//)
+  })
+
+  it('has an api-key setting with password type', () => {
+    const apiKeySetting = provider?.settings.find((s) => s.key === 'api-key')
+    expect(apiKeySetting).toBeDefined()
+    expect(apiKeySetting?.controller_props.type).toBe('password')
+  })
+
+  it('has a base-url setting', () => {
+    const baseUrlSetting = provider?.settings.find((s) => s.key === 'base-url')
+    expect(baseUrlSetting).toBeDefined()
+    expect(baseUrlSetting?.controller_props.value).toBe('https://api.perplexity.ai')
+  })
+})
+
+describe('Perplexity providerModels config', () => {
+  const config = providerModels.perplexity
+
+  it('exists in providerModels', () => {
+    expect(config).toBeDefined()
+  })
+
+  it('has models: true to allow dynamic model catalog', () => {
+    expect(config.models).toBe(true)
+  })
+
+  it('has supportsCompletion: true', () => {
+    expect(config.supportsCompletion).toBe(true)
+  })
+
+  it('has supportsStreaming: true', () => {
+    expect(config.supportsStreaming).toBe(true)
+  })
+
+  it('has supportsImages as an array (not a boolean) for type-safe .includes() calls', () => {
+    expect(Array.isArray(config.supportsImages)).toBe(true)
+  })
+
+  it('has supportsToolCalls: true', () => {
+    expect(config.supportsToolCalls).toBe(true)
+  })
+})

--- a/web-app/src/constants/models.ts
+++ b/web-app/src/constants/models.ts
@@ -100,12 +100,12 @@ export const providerModels = {
     supportsN: true,
   },
   perplexity: {
-    models: ['sonar', 'sonar-pro', 'sonar-reasoning-pro'],
+    models: true,
     supportsCompletion: true,
-    supportsStreaming: ['sonar', 'sonar-pro', 'sonar-reasoning-pro'],
-    supportsJSON: ['sonar', 'sonar-pro', 'sonar-reasoning-pro'],
-    supportsImages: [],
-    supportsToolCalls: ['sonar', 'sonar-pro', 'sonar-reasoning-pro'],
+    supportsStreaming: true,
+    supportsJSON: true,
+    supportsImages: false,
+    supportsToolCalls: true,
     supportsN: true,
   },
   minimax: {

--- a/web-app/src/constants/models.ts
+++ b/web-app/src/constants/models.ts
@@ -104,7 +104,7 @@ export const providerModels = {
     supportsCompletion: true,
     supportsStreaming: true,
     supportsJSON: true,
-    supportsImages: false,
+    supportsImages: [],
     supportsToolCalls: true,
     supportsN: true,
   },

--- a/web-app/src/constants/providers.ts
+++ b/web-app/src/constants/providers.ts
@@ -190,6 +190,40 @@ export const predefinedProviders = [
   {
     active: true,
     api_key: '',
+    base_url: 'https://api.perplexity.ai',
+    explore_models_url: 'https://docs.perplexity.ai/docs/agent/models',
+    provider: 'perplexity',
+    settings: [
+      {
+        key: 'api-key',
+        title: 'API Key',
+        description:
+          "The Perplexity API uses API keys for authentication. Visit your [API Keys](https://www.perplexity.ai/account/api/keys) page to retrieve the API key you'll use in your requests.",
+        controller_type: 'input',
+        controller_props: {
+          placeholder: 'Insert API Key',
+          value: '',
+          type: 'password',
+          input_actions: ['unobscure', 'copy'],
+        },
+      },
+      {
+        key: 'base-url',
+        title: 'Base URL',
+        description:
+          'The base endpoint to use. Perplexity exposes an OpenAI-compatible Agent API. See the [Perplexity API documentation](https://docs.perplexity.ai/docs/agent/quickstart) for more information.',
+        controller_type: 'input',
+        controller_props: {
+          placeholder: 'https://api.perplexity.ai',
+          value: 'https://api.perplexity.ai',
+        },
+      },
+    ],
+    models: [],
+  },
+  {
+    active: true,
+    api_key: '',
     base_url: 'https://api.mistral.ai/v1',
     explore_models_url:
       'https://docs.mistral.ai/getting-started/models/models_overview/',

--- a/web-app/src/constants/providers.ts
+++ b/web-app/src/constants/providers.ts
@@ -191,7 +191,7 @@ export const predefinedProviders = [
     active: true,
     api_key: '',
     base_url: 'https://api.perplexity.ai',
-    explore_models_url: 'https://docs.perplexity.ai/docs/agent/models',
+    explore_models_url: 'https://docs.perplexity.ai/models/model-cards',
     provider: 'perplexity',
     settings: [
       {

--- a/web-app/src/lib/__tests__/model-factory.test.ts
+++ b/web-app/src/lib/__tests__/model-factory.test.ts
@@ -4,6 +4,7 @@ import type { ProviderObject } from '@janhq/core'
 import { invoke } from '@tauri-apps/api/core'
 import { createGoogleGenerativeAI } from '@ai-sdk/google'
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
+import { PPLX_INTEGRATION_HEADER } from '../provider-headers'
 
 const mockGlobalFetch = vi.fn()
 
@@ -211,6 +212,22 @@ describe('ModelFactory', () => {
       const model = await ModelFactory.createModel('MiniMax-M2.7', provider)
       expect(model).toBeDefined()
       expect(model.type).toBe('openai-compatible')
+    })
+
+    it('should add the Perplexity integration attribution header', async () => {
+      const provider: ProviderObject = {
+        provider: 'perplexity',
+        api_key: 'test-api-key',
+        base_url: 'https://api.perplexity.ai',
+        models: [],
+        settings: [],
+        active: true,
+      }
+
+      await ModelFactory.createModel('sonar', provider)
+
+      const config = mockedCreateOpenAICompatible.mock.calls[0]?.[0]
+      expect(config?.headers?.[PPLX_INTEGRATION_HEADER]).toMatch(/^jan\/.+/)
     })
 
     it('should handle custom headers for OpenAI-compatible providers', async () => {

--- a/web-app/src/lib/ai-model.ts
+++ b/web-app/src/lib/ai-model.ts
@@ -1,5 +1,6 @@
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import type { LanguageModel } from 'ai'
+import { getProviderDefaultHeaders } from './provider-headers'
 
 /**
  * Llama.cpp timings structure from the response
@@ -109,13 +110,7 @@ export function createLanguageModel(
       provider.base_url?.includes('127.0.0.1:')
         ? { Origin: 'tauri://localhost' }
         : {}),
-      // OpenRouter identification headers
-      ...(provider.provider === 'openrouter'
-        ? {
-            'HTTP-Referer': 'https://jan.ai',
-            'X-Title': 'Jan',
-          }
-        : {}),
+      ...getProviderDefaultHeaders(provider.provider),
     },
     // Include usage data in streaming responses for token speed calculation
     includeUsage: true,

--- a/web-app/src/lib/model-factory.ts
+++ b/web-app/src/lib/model-factory.ts
@@ -61,6 +61,7 @@ import { fetch as httpFetch } from '@tauri-apps/plugin-http'
 import { isPlatformTauri } from '@/lib/platform/utils'
 import { providerRemoteApiKeyChain } from '@/lib/provider-api-keys'
 import { LLAMACPP_ONLY_PARAM_KEYS } from '@/lib/predefinedParams'
+import { getProviderDefaultHeaders } from '@/lib/provider-headers'
 
 /**
  * Llama.cpp timings structure from the response
@@ -792,6 +793,7 @@ export class ModelFactory {
         headers[customHeader.header] = customHeader.value
       })
     }
+    Object.assign(headers, getProviderDefaultHeaders(provider.provider))
 
     const keyChain = providerRemoteApiKeyChain(provider)
     if (keyChain.length === 1) {

--- a/web-app/src/lib/provider-headers.ts
+++ b/web-app/src/lib/provider-headers.ts
@@ -1,0 +1,26 @@
+export const PPLX_INTEGRATION_HEADER = 'X-Pplx-Integration'
+
+const PPLX_INTEGRATION_SLUG = 'jan'
+
+export function getPplxIntegrationHeaderValue(): string {
+  return `${PPLX_INTEGRATION_SLUG}/${VERSION}`
+}
+
+export function getProviderDefaultHeaders(
+  providerName: string
+): Record<string, string> {
+  if (providerName.toLowerCase() === 'openrouter') {
+    return {
+      'HTTP-Referer': 'https://jan.ai',
+      'X-Title': 'Jan',
+    }
+  }
+
+  if (providerName.toLowerCase() === 'perplexity') {
+    return {
+      [PPLX_INTEGRATION_HEADER]: getPplxIntegrationHeaderValue(),
+    }
+  }
+
+  return {}
+}

--- a/web-app/src/lib/utils.ts
+++ b/web-app/src/lib/utils.ts
@@ -82,6 +82,8 @@ export function getProviderLogo(provider: string) {
       return '/images/model-provider/mistral.svg'
     case 'openrouter':
       return '/images/model-provider/open-router.svg'
+    case 'perplexity':
+      return '/images/model-provider/perplexity.svg'
     case 'groq':
       return '/images/model-provider/groq.svg'
     case 'cohere':
@@ -117,6 +119,8 @@ export const getProviderTitle = (provider: string) => {
       return 'OpenAI'
     case 'openrouter':
       return 'OpenRouter'
+    case 'perplexity':
+      return 'Perplexity'
     case 'gemini':
       return 'Gemini'
     case 'huggingface':

--- a/web-app/src/services/providers/tauri.ts
+++ b/web-app/src/services/providers/tauri.ts
@@ -12,6 +12,7 @@ import { fetch as fetchTauri } from '@tauri-apps/plugin-http'
 import { DefaultProvidersService } from './default'
 import { getModelCapabilities } from '@/lib/models'
 import { providerRemoteApiKeyChain } from '@/lib/provider-api-keys'
+import { getProviderDefaultHeaders } from '@/lib/provider-headers'
 
 export class TauriProvidersService extends DefaultProvidersService {
   fetch(): typeof fetch {
@@ -172,6 +173,7 @@ export class TauriProvidersService extends DefaultProvidersService {
             headers[header.header] = header.value
           })
         }
+        Object.assign(headers, getProviderDefaultHeaders(provider.provider))
 
         const response = await fetchTauri(`${provider.base_url}/models`, {
           method: 'GET',

--- a/web-app/vitest.config.ts
+++ b/web-app/vitest.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import path from 'path'
+import packageJson from './package.json'
 
 export default defineConfig({
   plugins: [react()],
@@ -36,7 +37,7 @@ export default defineConfig({
     IS_IOS: JSON.stringify(false),
     IS_ANDROID: JSON.stringify(false),
     PLATFORM: JSON.stringify('web'),
-    VERSION: JSON.stringify('test'),
+    VERSION: JSON.stringify(packageJson.version),
     POSTHOG_KEY: JSON.stringify(''),
     POSTHOG_HOST: JSON.stringify(''),
     AUTO_UPDATER_DISABLED: JSON.stringify('false'),


### PR DESCRIPTION
## Summary

Adds **Perplexity** as a predefined cloud model provider, mirroring the existing OpenRouter integration so Jan ships parity with the other first-party remote providers (OpenAI, Anthropic, OpenRouter, Mistral, Groq, xAI, Gemini, Hugging Face, NVIDIA NIM, MiniMax, Azure).

Closes #4115.

Perplexity exposes an OpenAI-compatible Agent API (`/v1/responses`, alias of `/v1/agent`) and chat completions endpoint (`/v1/chat/completions`) at `https://api.perplexity.ai`, so it slots into Jan's existing OpenAI-compatible client without any new transport code.

## Files changed

- `web-app/src/constants/providers.ts` — register `perplexity` in `predefinedProviders` (base URL, API-key + base-URL settings, explore-models URL).
- `web-app/src/constants/models.ts` — switch the existing `perplexity` entry in `providerModels` from a fixed model list to `models: true` so users aren't capped to a hardcoded list (matches the OpenRouter / `openai-compatible` pattern). Drops Sonar-specific IDs from the file.
- `web-app/src/lib/utils.ts` — wire `perplexity` into `getProviderLogo` and `getProviderTitle`.
- `web-app/public/images/model-provider/perplexity.svg` — provider logo.
- `docs/src/pages/docs/desktop/remote-models/perplexity.mdx` — new docs page (mirrors the OpenRouter docs structure).
- `docs/src/pages/docs/desktop/remote-models/_meta.json` — register the new docs page.

## Configuration

- **Provider ID:** `perplexity`
- **Base URL:** `https://api.perplexity.ai`
- **Auth:** `Authorization: Bearer <PERPLEXITY_API_KEY>` (standard, no extra plumbing needed)
- **Explore models:** https://docs.perplexity.ai/docs/agent/models

## Test plan

- [x] `yarn lint` — passes (only the same 4 pre-existing `react-refresh/only-export-components` warnings as on `dev`).
- [x] `tsc --noEmit` on `web-app` — passes.
- [x] `vitest run` on the touched test files — all 122 tests pass; previously-emitted "Duplicate key 'perplexity'" esbuild warning is gone.
- [ ] Manual: launch Jan, open Settings → Model Providers → Perplexity, paste an API key, run a chat against a Perplexity Agent API model.