### PR TITLE
feat: add tooltip and bulk delete for downloaded models

### DIFF
--- a/core/src/browser/extensions/engines/AIEngine.ts
+++ b/core/src/browser/extensions/engines/AIEngine.ts
@@ -172,6 +172,9 @@ export interface modelInfo {
   path?: string // Absolute path to the model file, if applicable
   // Additional provider-specific metadata can be added here
   embedding?: boolean
+  // True if the model was imported from a user-supplied local file
+  // (path lives outside the provider's managed models directory).
+  imported?: boolean
   [key: string]: any
 }
 

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -1042,6 +1042,9 @@ export default class llamacpp_extension extends AIEngine {
         capabilities.push('vision')
       }
 
+      const mp = modelConfig.model_path ?? ''
+      const isAbsolute = mp.startsWith('/') || /^[A-Za-z]:[\\/]/.test(mp)
+
       const modelInfo = {
         id: modelId,
         name: modelConfig.name ?? modelId,
@@ -1050,6 +1053,7 @@ export default class llamacpp_extension extends AIEngine {
         port: 0, // port is not known until the model is loaded
         sizeBytes: modelConfig.size_bytes ?? 0,
         embedding: isEmbedding,
+        imported: isAbsolute,
         capabilities: capabilities.length > 0 ? capabilities : undefined,
       } as modelInfo
       modelInfos.push(modelInfo)

--- a/src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
@@ -15,7 +15,6 @@ base64 = "0.22.1"
 byteorder = "1.5.0"
 hmac = "0.12.1"
 jan-utils = { path = "../../utils" }
-lddtree = "0.5"
 walkdir = "2"
 log = "0.4"
 rand = "0.8"
@@ -30,6 +29,10 @@ serde_json = "1.0.149"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 reqwest = { version = "0.11", features = ["json", "blocking", "stream", "native-tls"] }
+
+# lddtree's Mach-O handling has crashed in the field; we skip dep analysis on macOS.
+[target.'cfg(not(any(target_os = "macos", target_os = "ios", target_os = "android")))'.dependencies]
+lddtree = "0.5"
 
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
 reqwest = { version = "0.11", features = ["json", "blocking", "stream", "rustls-tls"], default-features = false }

--- a/src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
@@ -15,6 +15,7 @@ base64 = "0.22.1"
 byteorder = "1.5.0"
 hmac = "0.12.1"
 jan-utils = { path = "../../utils" }
+lddtree = "0.5"
 walkdir = "2"
 log = "0.4"
 rand = "0.8"
@@ -29,10 +30,6 @@ serde_json = "1.0.149"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 reqwest = { version = "0.11", features = ["json", "blocking", "stream", "native-tls"] }
-
-# lddtree's Mach-O handling has crashed in the field; we skip dep analysis on macOS.
-[target.'cfg(not(any(target_os = "macos", target_os = "ios", target_os = "android")))'.dependencies]
-lddtree = "0.5"
 
 [target.'cfg(any(target_os = "android", target_os = "ios"))'.dependencies]
 reqwest = { version = "0.11", features = ["json", "blocking", "stream", "rustls-tls"], default-features = false }

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/deps_analyzer.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/deps_analyzer.rs
@@ -3,8 +3,10 @@
 //! a crash from taking down the app.
 
 use serde::{Deserialize, Serialize};
+#[cfg(not(target_os = "macos"))]
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+#[cfg(not(target_os = "macos"))]
 use std::process::{Command, Stdio};
 
 pub const ANALYZE_FLAG: &str = "--internal-analyze-deps";
@@ -15,6 +17,11 @@ pub struct AnalyzeOutput {
     pub resolved: Vec<String>,
 }
 
+// On macOS we never spawn the analyzer subprocess, so this is a no-op.
+#[cfg(target_os = "macos")]
+pub fn run_deps_analyzer_if_requested() {}
+
+#[cfg(not(target_os = "macos"))]
 pub fn run_deps_analyzer_if_requested() {
     let mut args = std::env::args().skip(1);
     if args.next().as_deref() != Some(ANALYZE_FLAG) {
@@ -57,6 +64,7 @@ pub fn run_deps_analyzer_if_requested() {
     }
 }
 
+#[cfg(not(target_os = "macos"))]
 fn analyze(lib_dir: &Path, targets: &[PathBuf]) -> AnalyzeOutput {
     let analyzer =
         lddtree::DependencyAnalyzer::default().add_library_path(lib_dir.to_path_buf());
@@ -92,6 +100,14 @@ pub(crate) fn is_virtual_windows_dll(name: &str) -> bool {
     lower.starts_with("api-ms-win-") || lower.starts_with("ext-ms-win-")
 }
 
+// macOS resolves dynamic libraries via dyld at load time; lddtree's Mach-O
+// handling is unreliable and has crashed in the field, so skip the analyzer.
+#[cfg(target_os = "macos")]
+pub fn analyze_out_of_process(_lib_dir: &Path, _targets: &[PathBuf]) -> AnalyzeOutput {
+    AnalyzeOutput::default()
+}
+
+#[cfg(not(target_os = "macos"))]
 pub fn analyze_out_of_process(lib_dir: &Path, targets: &[PathBuf]) -> AnalyzeOutput {
     let exe = match std::env::current_exe() {
         Ok(p) => p,

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/deps_analyzer.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/deps_analyzer.rs
@@ -3,10 +3,8 @@
 //! a crash from taking down the app.
 
 use serde::{Deserialize, Serialize};
-#[cfg(not(target_os = "macos"))]
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-#[cfg(not(target_os = "macos"))]
 use std::process::{Command, Stdio};
 
 pub const ANALYZE_FLAG: &str = "--internal-analyze-deps";
@@ -17,11 +15,6 @@ pub struct AnalyzeOutput {
     pub resolved: Vec<String>,
 }
 
-// On macOS we never spawn the analyzer subprocess, so this is a no-op.
-#[cfg(target_os = "macos")]
-pub fn run_deps_analyzer_if_requested() {}
-
-#[cfg(not(target_os = "macos"))]
 pub fn run_deps_analyzer_if_requested() {
     let mut args = std::env::args().skip(1);
     if args.next().as_deref() != Some(ANALYZE_FLAG) {
@@ -64,7 +57,6 @@ pub fn run_deps_analyzer_if_requested() {
     }
 }
 
-#[cfg(not(target_os = "macos"))]
 fn analyze(lib_dir: &Path, targets: &[PathBuf]) -> AnalyzeOutput {
     let analyzer =
         lddtree::DependencyAnalyzer::default().add_library_path(lib_dir.to_path_buf());
@@ -100,14 +92,6 @@ pub(crate) fn is_virtual_windows_dll(name: &str) -> bool {
     lower.starts_with("api-ms-win-") || lower.starts_with("ext-ms-win-")
 }
 
-// macOS resolves dynamic libraries via dyld at load time; lddtree's Mach-O
-// handling is unreliable and has crashed in the field, so skip the analyzer.
-#[cfg(target_os = "macos")]
-pub fn analyze_out_of_process(_lib_dir: &Path, _targets: &[PathBuf]) -> AnalyzeOutput {
-    AnalyzeOutput::default()
-}
-
-#[cfg(not(target_os = "macos"))]
 pub fn analyze_out_of_process(lib_dir: &Path, targets: &[PathBuf]) -> AnalyzeOutput {
     let exe = match std::env::current_exe() {
         Ok(p) => p,

--- a/web-app/src/containers/dialogs/DeleteAllModels.tsx
+++ b/web-app/src/containers/dialogs/DeleteAllModels.tsx
@@ -38,7 +38,9 @@ export const DialogDeleteAllModels = ({
   const [totalBytes, setTotalBytes] = useState<number | undefined>(undefined)
   const [isDeleting, setIsDeleting] = useState(false)
 
-  const modelCount = provider.models.length
+  const downloadedModels = provider.models.filter((m) => !m.imported)
+  const importedCount = provider.models.length - downloadedModels.length
+  const modelCount = downloadedModels.length
 
   useEffect(() => {
     if (!open) return
@@ -49,7 +51,7 @@ export const DialogDeleteAllModels = ({
       .fetchModels()
       .then((infos) => {
         if (cancelled) return
-        const ids = new Set(provider.models.map((m) => m.id))
+        const ids = new Set(downloadedModels.map((m) => m.id))
         const total = infos
           .filter((i) => ids.has(i.id) && i.providerId === provider.provider)
           .reduce((sum, i) => sum + (i.sizeBytes || 0), 0)
@@ -61,12 +63,12 @@ export const DialogDeleteAllModels = ({
     return () => {
       cancelled = true
     }
-  }, [open, provider, serviceHub])
+  }, [open, provider, serviceHub, downloadedModels])
 
   const handleDeleteAll = async () => {
     if (isDeleting) return
     setIsDeleting(true)
-    const ids = provider.models.map((m) => m.id)
+    const ids = downloadedModels.map((m) => m.id)
     let failed = 0
 
     for (const id of ids) {
@@ -142,6 +144,14 @@ export const DialogDeleteAllModels = ({
               : formatBytes(totalBytes, { fallback: '—' })}
           </span>
         </div>
+
+        {importedCount > 0 && (
+          <p className="text-xs text-muted-foreground">
+            {t('providers:deleteAllModels.importedExcluded', {
+              count: importedCount,
+            })}
+          </p>
+        )}
 
         <DialogFooter className="mt-2">
           <DialogClose asChild>

--- a/web-app/src/containers/dialogs/DeleteAllModels.tsx
+++ b/web-app/src/containers/dialogs/DeleteAllModels.tsx
@@ -16,7 +16,7 @@ import { formatBytes } from '@/lib/utils'
 import { useAppState } from '@/hooks/useAppState'
 import { useShallow } from 'zustand/shallow'
 
-import { IconTrash, IconLoader } from '@tabler/icons-react'
+import { IconTrash } from '@tabler/icons-react'
 
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
@@ -126,27 +126,22 @@ export const DialogDeleteAllModels = ({
       <DialogContent>
         <DialogHeader>
           <DialogTitle>{t('providers:deleteAllModels.title')}</DialogTitle>
-          <DialogDescription asChild>
-            <div className="space-y-2">
-              <p>
-                {t('providers:deleteAllModels.description', {
-                  count: modelCount,
-                })}
-              </p>
-              <p className="text-sm">
-                {t('providers:deleteAllModels.sizeLabel')}{' '}
-                <span className="font-medium text-foreground">
-                  {totalBytes === undefined
-                    ? t('providers:deleteAllModels.calculating')
-                    : formatBytes(totalBytes, { fallback: '—' })}
-                </span>
-              </p>
-              <p className="text-sm text-destructive">
-                {t('providers:deleteAllModels.warning')}
-              </p>
-            </div>
+          <DialogDescription>
+            {t('providers:deleteAllModels.description', { count: modelCount })}{' '}
+            {t('providers:deleteAllModels.warning')}
           </DialogDescription>
         </DialogHeader>
+
+        <div className="flex items-center justify-between rounded-md bg-main-view-fg/5 px-3 py-2 text-sm">
+          <span className="text-muted-foreground">
+            {t('providers:deleteAllModels.sizeLabel')}
+          </span>
+          <span className="font-medium text-foreground">
+            {totalBytes === undefined
+              ? t('providers:deleteAllModels.calculating')
+              : formatBytes(totalBytes, { fallback: '—' })}
+          </span>
+        </div>
 
         <DialogFooter className="mt-2">
           <DialogClose asChild>
@@ -161,16 +156,9 @@ export const DialogDeleteAllModels = ({
             disabled={isDeleting}
             autoFocus
           >
-            {isDeleting ? (
-              <>
-                <IconLoader size={16} className="animate-spin" />
-                <span>{t('providers:deleteAllModels.deleting')}</span>
-              </>
-            ) : (
-              <span>
-                {t('providers:deleteAllModels.confirm', { count: modelCount })}
-              </span>
-            )}
+            {isDeleting
+              ? t('providers:deleteAllModels.deleting')
+              : t('providers:deleteAllModels.confirm', { count: modelCount })}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/web-app/src/containers/dialogs/DeleteAllModels.tsx
+++ b/web-app/src/containers/dialogs/DeleteAllModels.tsx
@@ -1,0 +1,179 @@
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import { useModelProvider } from '@/hooks/useModelProvider'
+import { useServiceHub } from '@/hooks/useServiceHub'
+import { useFavoriteModel } from '@/hooks/useFavoriteModel'
+import { formatBytes } from '@/lib/utils'
+import { useAppState } from '@/hooks/useAppState'
+import { useShallow } from 'zustand/shallow'
+
+import { IconTrash, IconLoader } from '@tabler/icons-react'
+
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { useTranslation } from '@/i18n/react-i18next-compat'
+
+type DialogDeleteAllModelsProps = {
+  provider: ModelProvider
+}
+
+export const DialogDeleteAllModels = ({
+  provider,
+}: DialogDeleteAllModelsProps) => {
+  const { t } = useTranslation()
+  const serviceHub = useServiceHub()
+  const { setProviders, deleteModel: deleteModelCache } = useModelProvider()
+  const { removeFavorite } = useFavoriteModel()
+  const [activeModels] = useAppState(useShallow((s) => [s.activeModels]))
+  const [open, setOpen] = useState(false)
+  const [totalBytes, setTotalBytes] = useState<number | undefined>(undefined)
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  const modelCount = provider.models.length
+
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    setTotalBytes(undefined)
+    serviceHub
+      .models()
+      .fetchModels()
+      .then((infos) => {
+        if (cancelled) return
+        const ids = new Set(provider.models.map((m) => m.id))
+        const total = infos
+          .filter((i) => ids.has(i.id) && i.providerId === provider.provider)
+          .reduce((sum, i) => sum + (i.sizeBytes || 0), 0)
+        setTotalBytes(total)
+      })
+      .catch(() => {
+        if (!cancelled) setTotalBytes(0)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [open, provider, serviceHub])
+
+  const handleDeleteAll = async () => {
+    if (isDeleting) return
+    setIsDeleting(true)
+    const ids = provider.models.map((m) => m.id)
+    let failed = 0
+
+    for (const id of ids) {
+      try {
+        if (activeModels.includes(id)) {
+          try {
+            await serviceHub.models().stopModel(id, provider.provider)
+          } catch {
+            // best-effort stop; continue with delete
+          }
+        }
+        removeFavorite(id)
+        deleteModelCache(id)
+        await serviceHub.models().deleteModel(id, provider.provider)
+      } catch (err) {
+        failed++
+        console.error(`Failed to delete model ${id}:`, err)
+      }
+    }
+
+    try {
+      const providers = await serviceHub.providers().getProviders()
+      const filtered = providers.map((p) =>
+        p.provider === provider.provider
+          ? { ...p, models: p.models.filter((m) => !ids.includes(m.id)) }
+          : p
+      )
+      setProviders(filtered)
+    } catch (err) {
+      console.error('Failed to refresh providers after bulk delete:', err)
+    }
+
+    const succeeded = ids.length - failed
+    if (succeeded > 0) {
+      toast.success(
+        t('providers:deleteAllModels.success', { count: succeeded })
+      )
+    }
+    if (failed > 0) {
+      toast.error(t('providers:deleteAllModels.partialFailure', { count: failed }))
+    }
+
+    setIsDeleting(false)
+    setOpen(false)
+  }
+
+  if (modelCount === 0) return null
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !isDeleting && setOpen(o)}>
+      <DialogTrigger asChild>
+        <Button variant="secondary" size="sm">
+          <IconTrash size={18} className="text-muted-foreground" />
+          <span>{t('providers:deleteAllModels.button')}</span>
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t('providers:deleteAllModels.title')}</DialogTitle>
+          <DialogDescription asChild>
+            <div className="space-y-2">
+              <p>
+                {t('providers:deleteAllModels.description', {
+                  count: modelCount,
+                })}
+              </p>
+              <p className="text-sm">
+                {t('providers:deleteAllModels.sizeLabel')}{' '}
+                <span className="font-medium text-foreground">
+                  {totalBytes === undefined
+                    ? t('providers:deleteAllModels.calculating')
+                    : formatBytes(totalBytes, { fallback: '—' })}
+                </span>
+              </p>
+              <p className="text-sm text-destructive">
+                {t('providers:deleteAllModels.warning')}
+              </p>
+            </div>
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogFooter className="mt-2">
+          <DialogClose asChild>
+            <Button variant="ghost" size="sm" disabled={isDeleting}>
+              {t('providers:deleteModel.cancel')}
+            </Button>
+          </DialogClose>
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={handleDeleteAll}
+            disabled={isDeleting}
+            autoFocus
+          >
+            {isDeleting ? (
+              <>
+                <IconLoader size={16} className="animate-spin" />
+                <span>{t('providers:deleteAllModels.deleting')}</span>
+              </>
+            ) : (
+              <span>
+                {t('providers:deleteAllModels.confirm', { count: modelCount })}
+              </span>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web-app/src/containers/dialogs/DeleteAllModels.tsx
+++ b/web-app/src/containers/dialogs/DeleteAllModels.tsx
@@ -18,7 +18,7 @@ import { useShallow } from 'zustand/shallow'
 
 import { IconTrash } from '@tabler/icons-react'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 
@@ -38,9 +38,17 @@ export const DialogDeleteAllModels = ({
   const [totalBytes, setTotalBytes] = useState<number | undefined>(undefined)
   const [isDeleting, setIsDeleting] = useState(false)
 
-  const downloadedModels = provider.models.filter((m) => !m.imported)
-  const importedCount = provider.models.length - downloadedModels.length
-  const modelCount = downloadedModels.length
+  const downloadedIdsKey = provider.models
+    .filter((m) => !m.imported)
+    .map((m) => m.id)
+    .sort()
+    .join('|')
+  const downloadedIds = useMemo(
+    () => (downloadedIdsKey ? downloadedIdsKey.split('|') : []),
+    [downloadedIdsKey]
+  )
+  const importedCount = provider.models.length - downloadedIds.length
+  const modelCount = downloadedIds.length
 
   useEffect(() => {
     if (!open) return
@@ -51,7 +59,7 @@ export const DialogDeleteAllModels = ({
       .fetchModels()
       .then((infos) => {
         if (cancelled) return
-        const ids = new Set(downloadedModels.map((m) => m.id))
+        const ids = new Set(downloadedIds)
         const total = infos
           .filter((i) => ids.has(i.id) && i.providerId === provider.provider)
           .reduce((sum, i) => sum + (i.sizeBytes || 0), 0)
@@ -63,12 +71,12 @@ export const DialogDeleteAllModels = ({
     return () => {
       cancelled = true
     }
-  }, [open, provider, serviceHub, downloadedModels])
+  }, [open, provider.provider, serviceHub, downloadedIds])
 
   const handleDeleteAll = async () => {
     if (isDeleting) return
     setIsDeleting(true)
-    const ids = downloadedModels.map((m) => m.id)
+    const ids = downloadedIds
     let failed = 0
 
     for (const id of ids) {

--- a/web-app/src/containers/dialogs/DeleteModel.tsx
+++ b/web-app/src/containers/dialogs/DeleteModel.tsx
@@ -117,7 +117,9 @@ export const DialogDeleteModel = ({
             {t('providers:deleteModel.title', { modelId: selectedModel.id })}
           </DialogTitle>
           <DialogDescription>
-            {t('providers:deleteModel.description')}
+            {selectedModel.imported
+              ? t('providers:deleteModel.importedDescription')
+              : t('providers:deleteModel.description')}
           </DialogDescription>
         </DialogHeader>
 
@@ -129,7 +131,9 @@ export const DialogDeleteModel = ({
           </DialogClose>
           <DialogClose asChild>
             <Button variant="destructive" size="sm" onClick={removeModel} autoFocus>
-              {t('providers:deleteModel.delete')}
+              {selectedModel.imported
+                ? t('providers:deleteModel.removeFromJan')
+                : t('providers:deleteModel.delete')}
             </Button>
           </DialogClose>
         </DialogFooter>

--- a/web-app/src/containers/dialogs/DeleteModel.tsx
+++ b/web-app/src/containers/dialogs/DeleteModel.tsx
@@ -9,6 +9,11 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { useModelProvider } from '@/hooks/useModelProvider'
 import { useServiceHub } from '@/hooks/useServiceHub'
 
@@ -90,9 +95,21 @@ export const DialogDeleteModel = ({
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <div className="size-6 cursor-pointer flex items-center justify-center rounded transition-all duration-200 ease-in-out">
-          <IconTrash size={18} className="text-muted-foreground" />
-        </div>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div
+              role="button"
+              tabIndex={0}
+              aria-label={t('providers:deleteModel.delete')}
+              className="size-6 cursor-pointer flex items-center justify-center rounded transition-all duration-200 ease-in-out hover:bg-main-view-fg/8"
+            >
+              <IconTrash size={18} className="text-muted-foreground" />
+            </div>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>{t('providers:deleteModel.delete')}</p>
+          </TooltipContent>
+        </Tooltip>
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>

--- a/web-app/src/locales/en/providers.json
+++ b/web-app/src/locales/en/providers.json
@@ -33,6 +33,18 @@
     "cancel": "Cancel",
     "delete": "Delete"
   },
+  "deleteAllModels": {
+    "button": "Delete All",
+    "title": "Delete all downloaded models?",
+    "description": "This will permanently remove {{count}} model(s) from disk.",
+    "sizeLabel": "Disk space to be freed:",
+    "calculating": "Calculating…",
+    "warning": "This action cannot be undone.",
+    "confirm": "Delete {{count}} model(s)",
+    "deleting": "Deleting…",
+    "success": "Deleted {{count}} model(s).",
+    "partialFailure": "Failed to delete {{count}} model(s). See console for details."
+  },
   "deleteProvider": {
     "title": "Delete Provider",
     "description": "Delete this provider and all its models. This action cannot be undone.",

--- a/web-app/src/locales/en/providers.json
+++ b/web-app/src/locales/en/providers.json
@@ -7,6 +7,8 @@
   "refreshing": "Refreshing...",
   "refresh": "Refresh",
   "import": "Import",
+  "imported": "Imported",
+  "importedTooltip": "Imported from a local file. Deleting will remove the file from disk.",
   "importModelSuccess": "Model {{provider}} has been imported successfully.",
   "importModelError": "Failed to import model:",
   "stop": "Stop",
@@ -29,6 +31,8 @@
   "deleteModel": {
     "title": "Delete Model: {{modelId}}",
     "description": "Are you sure you want to delete this model? This action cannot be undone.",
+    "importedDescription": "Remove this imported model from Jan? Your local file on disk will not be deleted.",
+    "removeFromJan": "Remove from Jan",
     "success": "Model {{modelId}} has been permanently deleted.",
     "cancel": "Cancel",
     "delete": "Delete"
@@ -40,6 +44,7 @@
     "sizeLabel": "Disk space to be freed:",
     "calculating": "Calculating…",
     "warning": "This action cannot be undone.",
+    "importedExcluded": "{{count}} imported model(s) will be kept (their files were not downloaded by Jan).",
     "confirm": "Delete {{count}} model(s)",
     "deleting": "Deleting…",
     "success": "Deleted {{count}} model(s).",

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -1058,6 +1058,14 @@ function ProviderDetail() {
                               {getModelDisplayName(model)}
                             </h1>
                             <Capabilities capabilities={capabilities} />
+                            {model.imported && (
+                              <span
+                                className="shrink-0 rounded-sm bg-main-view-fg/10 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground"
+                                title={t('providers:importedTooltip')}
+                              >
+                                {t('providers:imported')}
+                              </span>
+                            )}
                           </div>
                         }
                         actions={

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -14,6 +14,7 @@ import { ImportVisionModelDialog } from '@/containers/dialogs/ImportVisionModelD
 import { ImportMlxModelDialog } from '@/containers/dialogs/ImportMlxModelDialog'
 import { ModelSetting } from '@/containers/ModelSetting'
 import { DialogDeleteModel } from '@/containers/dialogs/DeleteModel'
+import { DialogDeleteAllModels } from '@/containers/dialogs/DeleteAllModels'
 import { FavoriteModelAction } from '@/containers/FavoriteModelAction'
 import { route } from '@/constants/routes'
 import DeleteProvider from '@/containers/dialogs/DeleteProvider'
@@ -998,6 +999,11 @@ function ProviderDetail() {
                           <DialogAddModel provider={provider} />
                         </>
                       )}
+                      {provider &&
+                        (provider.provider === 'llamacpp' ||
+                          provider.provider === 'mlx') && (
+                          <DialogDeleteAllModels provider={provider} />
+                        )}
                       {provider && provider.provider === 'llamacpp' && (
                         <ImportVisionModelDialog
                           provider={provider}

--- a/web-app/src/routes/settings/providers/__tests__/$providerName.test.tsx
+++ b/web-app/src/routes/settings/providers/__tests__/$providerName.test.tsx
@@ -275,6 +275,7 @@ vi.mock('@tabler/icons-react', () => ({
   IconLoader: () => <span />,
   IconRefresh: () => <span />,
   IconUpload: () => <span />,
+  IconTrash: () => <span />,
 }))
 
 vi.mock('@/lib/utils', () => ({

--- a/web-app/src/services/providers/tauri.ts
+++ b/web-app/src/services/providers/tauri.ts
@@ -101,6 +101,7 @@ export class TauriProvidersService extends DefaultProvidersService {
                 description: model.description,
                 capabilities,
                 embedding: model.embedding, // Preserve embedding flag for filtering in UI
+                imported: (model as { imported?: boolean }).imported,
                 provider: providerName,
                 settings: Object.values(modelSettings).reduce(
                   (acc, setting) => {

--- a/web-app/src/types/modelProviders.d.ts
+++ b/web-app/src/types/modelProviders.d.ts
@@ -39,6 +39,9 @@ type Model = {
   settings?: Record<string, ProviderSetting>
   /** Whether this model is an embedding model (e.g., BERT-based) */
   embedding?: boolean
+  /** Whether this model was imported from a user-supplied local file
+   *  (path lives outside the provider's managed models directory). */
+  imported?: boolean
 }
 
 /**


### PR DESCRIPTION
## Describe Your Changes

- Wrap the per-model delete trash icon in a Tooltip with an aria-label so the action is discoverable instead of an unlabeled icon.
- Add a DeleteAllModels dialog for llamacpp/mlx providers that sums sizeBytes from fetchModels() and shows total disk space to be freed before confirming, then stops/deletes each model and refreshes state.
<img width="1203" height="753" alt="Screenshot From 2026-05-06 10-58-00" src="https://github.com/user-attachments/assets/4ccfc6bf-c59d-4be1-8979-8fd17e9bcf9c" />

 

## Fixes Issues

- Closes #8092
- Closes #7642

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
