### PR TITLE
fix: ship mlx-swift Cmlx bundle with default.metallib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,11 +149,18 @@ ifeq ($(DETECTED_OS),Darwin)
 	mkdir -p src-tauri/resources/bin; \
 	echo "Copying mlx-server from $$BUILD_DIR..."; \
 	cp "$$BUILD_DIR/mlx-server" src-tauri/resources/bin/mlx-server; \
-	if [ -d "$$BUILD_DIR/mlx-swift_Cmlx.bundle" ]; then \
-		cp -r "$$BUILD_DIR/mlx-swift_Cmlx.bundle" src-tauri/resources/bin/; \
-	else \
-		mkdir -p src-tauri/resources/bin/mlx-swift_Cmlx.bundle; \
+	CMLX_BUNDLE=$$(find "$$BUILD_DIR" -maxdepth 4 -type d -name '*Cmlx*.bundle' -print -quit); \
+	if [ -z "$$CMLX_BUNDLE" ]; then \
+		CMLX_BUNDLE=$$(find "$$BUILD_DIR" -maxdepth 5 -type f -name 'default.metallib' -print -quit | xargs -I{} dirname {}); \
 	fi; \
+	if [ -z "$$CMLX_BUNDLE" ] || [ ! -f "$$CMLX_BUNDLE/default.metallib" ]; then \
+		echo "Error: mlx-swift Cmlx resource bundle with default.metallib not found under $$BUILD_DIR"; \
+		find "$$BUILD_DIR" -maxdepth 5 -name '*.bundle' -o -name 'default.metallib' 2>/dev/null; \
+		exit 1; \
+	fi; \
+	echo "Copying Cmlx bundle from $$CMLX_BUNDLE..."; \
+	rm -rf src-tauri/resources/bin/mlx-swift_Cmlx.bundle; \
+	cp -r "$$CMLX_BUNDLE" src-tauri/resources/bin/mlx-swift_Cmlx.bundle; \
 	chmod +x src-tauri/resources/bin/mlx-server; \
 	echo "MLX server built and copied successfully"; \
 	echo "Checking for code signing identity..."; \
@@ -161,10 +168,12 @@ ifeq ($(DETECTED_OS),Darwin)
 	if [ -n "$$SIGNING_IDENTITY" ]; then \
 		echo "Signing mlx-server with identity: $$SIGNING_IDENTITY"; \
 		codesign --force --options runtime --timestamp --sign "$$SIGNING_IDENTITY" src-tauri/resources/bin/mlx-server; \
-		if [ -d "src-tauri/resources/bin/mlx-swift_Cmlx.bundle" ]; then \
-			echo "Signing mlx-swift_Cmlx.bundle..."; \
-			codesign --force --options runtime --timestamp --sign "$$SIGNING_IDENTITY" --deep src-tauri/resources/bin/mlx-swift_Cmlx.bundle; \
+		if [ ! -f "src-tauri/resources/bin/mlx-swift_Cmlx.bundle/default.metallib" ]; then \
+			echo "Error: mlx-swift_Cmlx.bundle is missing default.metallib; refusing to sign an empty bundle"; \
+			exit 1; \
 		fi; \
+		echo "Signing mlx-swift_Cmlx.bundle..."; \
+		codesign --force --options runtime --timestamp --sign "$$SIGNING_IDENTITY" --deep src-tauri/resources/bin/mlx-swift_Cmlx.bundle; \
 		echo "Code signing completed successfully"; \
 	else \
 		echo "Warning: No Developer ID Application identity found. Skipping code signing (notarization will fail)."; \

--- a/Makefile
+++ b/Makefile
@@ -149,15 +149,19 @@ ifeq ($(DETECTED_OS),Darwin)
 	mkdir -p src-tauri/resources/bin; \
 	echo "Copying mlx-server from $$BUILD_DIR..."; \
 	cp "$$BUILD_DIR/mlx-server" src-tauri/resources/bin/mlx-server; \
-	CMLX_BUNDLE=$$(find "$$BUILD_DIR" -maxdepth 4 -type d -name '*Cmlx*.bundle' -print -quit); \
-	if [ -z "$$CMLX_BUNDLE" ]; then \
-		CMLX_BUNDLE=$$(find "$$BUILD_DIR" -maxdepth 5 -type f -name 'default.metallib' -print -quit | xargs -I{} dirname {}); \
-	fi; \
-	if [ -z "$$CMLX_BUNDLE" ] || [ ! -f "$$CMLX_BUNDLE/default.metallib" ]; then \
-		echo "Error: mlx-swift Cmlx resource bundle with default.metallib not found under $$BUILD_DIR"; \
-		find "$$BUILD_DIR" -maxdepth 5 -name '*.bundle' -o -name 'default.metallib' 2>/dev/null; \
+	BUILD_ROOT="$$(cd mlx-server && pwd)/.build"; \
+	METALLIB=$$(find "$$BUILD_ROOT" -type f -name 'default.metallib' -print 2>/dev/null | head -1); \
+	if [ -z "$$METALLIB" ]; then \
+		echo "Error: default.metallib not found anywhere under $$BUILD_ROOT"; \
+		echo "--- *.bundle under $$BUILD_ROOT ---"; \
+		find "$$BUILD_ROOT" -name '*.bundle' 2>/dev/null; \
+		echo "--- *.metallib under $$BUILD_ROOT ---"; \
+		find "$$BUILD_ROOT" -name '*.metallib' 2>/dev/null; \
+		echo "--- top-level .build layout ---"; \
+		ls -la "$$BUILD_ROOT" 2>/dev/null; \
 		exit 1; \
 	fi; \
+	CMLX_BUNDLE=$$(dirname "$$METALLIB"); \
 	echo "Copying Cmlx bundle from $$CMLX_BUNDLE..."; \
 	rm -rf src-tauri/resources/bin/mlx-swift_Cmlx.bundle; \
 	cp -r "$$CMLX_BUNDLE" src-tauri/resources/bin/mlx-swift_Cmlx.bundle; \

--- a/Makefile
+++ b/Makefile
@@ -139,32 +139,28 @@ endif
 build-mlx-server:
 ifeq ($(DETECTED_OS),Darwin)
 	@echo "Building MLX server for Apple Silicon..."
-	cd mlx-server && swift build -c release
-	@echo "Copying build products..."
-	@BUILD_DIR=$$(cd mlx-server && swift build -c release --show-bin-path); \
-	if [ -z "$$BUILD_DIR" ]; then \
-		echo "Error: Could not find build products"; \
+	# mlx-swift's Metal shaders are compiled by the PrepareMetalShaders
+	# plugin, which only runs under Xcode -- `swift build` produces a
+	# binary with no default.metallib and the app fails at runtime. See
+	# https://github.com/ml-explore/mlx-swift README ("SwiftPM (command
+	# line) cannot build the Metal shaders").
+	cd mlx-server && xcodebuild build -scheme mlx-server -destination 'platform=OS X' -configuration Release OTHER_LDFLAGS="-dead_strip"
+	@echo "Finding build products..."
+	@DERIVED_DATA=$$(find ~/Library/Developer/Xcode/DerivedData/mlx-server-*/Build/Products/Release -maxdepth 0 2>/dev/null | head -1); \
+	if [ -z "$$DERIVED_DATA" ] || [ ! -f "$$DERIVED_DATA/mlx-server" ]; then \
+		echo "Error: Could not find xcodebuild products under DerivedData"; \
+		exit 1; \
+	fi; \
+	if [ ! -f "$$DERIVED_DATA/mlx-swift_Cmlx.bundle/default.metallib" ]; then \
+		echo "Error: $$DERIVED_DATA/mlx-swift_Cmlx.bundle/default.metallib missing -- PrepareMetalShaders did not run"; \
+		ls -la "$$DERIVED_DATA" 2>/dev/null; \
 		exit 1; \
 	fi; \
 	mkdir -p src-tauri/resources/bin; \
-	echo "Copying mlx-server from $$BUILD_DIR..."; \
-	cp "$$BUILD_DIR/mlx-server" src-tauri/resources/bin/mlx-server; \
-	BUILD_ROOT="$$(cd mlx-server && pwd)/.build"; \
-	METALLIB=$$(find "$$BUILD_ROOT" -type f -name 'default.metallib' -print 2>/dev/null | head -1); \
-	if [ -z "$$METALLIB" ]; then \
-		echo "Error: default.metallib not found anywhere under $$BUILD_ROOT"; \
-		echo "--- *.bundle under $$BUILD_ROOT ---"; \
-		find "$$BUILD_ROOT" -name '*.bundle' 2>/dev/null; \
-		echo "--- *.metallib under $$BUILD_ROOT ---"; \
-		find "$$BUILD_ROOT" -name '*.metallib' 2>/dev/null; \
-		echo "--- top-level .build layout ---"; \
-		ls -la "$$BUILD_ROOT" 2>/dev/null; \
-		exit 1; \
-	fi; \
-	CMLX_BUNDLE=$$(dirname "$$METALLIB"); \
-	echo "Copying Cmlx bundle from $$CMLX_BUNDLE..."; \
+	echo "Copying mlx-server from $$DERIVED_DATA..."; \
+	cp "$$DERIVED_DATA/mlx-server" src-tauri/resources/bin/mlx-server; \
 	rm -rf src-tauri/resources/bin/mlx-swift_Cmlx.bundle; \
-	cp -r "$$CMLX_BUNDLE" src-tauri/resources/bin/mlx-swift_Cmlx.bundle; \
+	cp -r "$$DERIVED_DATA/mlx-swift_Cmlx.bundle" src-tauri/resources/bin/; \
 	chmod +x src-tauri/resources/bin/mlx-server; \
 	echo "MLX server built and copied successfully"; \
 	echo "Checking for code signing identity..."; \

--- a/Makefile
+++ b/Makefile
@@ -151,9 +151,10 @@ ifeq ($(DETECTED_OS),Darwin)
 		echo "Error: Could not find xcodebuild products under DerivedData"; \
 		exit 1; \
 	fi; \
-	if [ ! -f "$$DERIVED_DATA/mlx-swift_Cmlx.bundle/default.metallib" ]; then \
-		echo "Error: $$DERIVED_DATA/mlx-swift_Cmlx.bundle/default.metallib missing -- PrepareMetalShaders did not run"; \
-		ls -la "$$DERIVED_DATA" 2>/dev/null; \
+	METALLIB=$$(find "$$DERIVED_DATA/mlx-swift_Cmlx.bundle" -name 'default.metallib' -print -quit 2>/dev/null); \
+	if [ -z "$$METALLIB" ]; then \
+		echo "Error: default.metallib missing under $$DERIVED_DATA/mlx-swift_Cmlx.bundle -- PrepareMetalShaders did not run"; \
+		find "$$DERIVED_DATA/mlx-swift_Cmlx.bundle" -maxdepth 4 2>/dev/null; \
 		exit 1; \
 	fi; \
 	mkdir -p src-tauri/resources/bin; \
@@ -168,8 +169,8 @@ ifeq ($(DETECTED_OS),Darwin)
 	if [ -n "$$SIGNING_IDENTITY" ]; then \
 		echo "Signing mlx-server with identity: $$SIGNING_IDENTITY"; \
 		codesign --force --options runtime --timestamp --sign "$$SIGNING_IDENTITY" src-tauri/resources/bin/mlx-server; \
-		if [ ! -f "src-tauri/resources/bin/mlx-swift_Cmlx.bundle/default.metallib" ]; then \
-			echo "Error: mlx-swift_Cmlx.bundle is missing default.metallib; refusing to sign an empty bundle"; \
+		if ! find src-tauri/resources/bin/mlx-swift_Cmlx.bundle -name 'default.metallib' -print -quit 2>/dev/null | grep -q .; then \
+			echo "Error: staged mlx-swift_Cmlx.bundle is missing default.metallib; refusing to sign an empty bundle"; \
 			exit 1; \
 		fi; \
 		echo "Signing mlx-swift_Cmlx.bundle..."; \

--- a/web-app/src/hooks/useModelProvider.ts
+++ b/web-app/src/hooks/useModelProvider.ts
@@ -38,7 +38,13 @@ export const useModelProvider = create<ModelProviderState>()(
       },
       setProviders: (providers) =>
         set((state) => {
+          // MLX is Apple-Silicon only; drop it on every other platform so it
+          // can't be reactivated, queried, or shown anywhere in the UI.
+          providers = IS_MACOS
+            ? providers
+            : providers.filter((e) => e.provider !== 'mlx')
           const existingProviders = state.providers
+            .filter((e) => IS_MACOS || e.provider !== 'mlx')
             // Filter out legacy llama.cpp provider for migration
             // Can remove after a couple of releases
             .filter((e) => e.provider !== 'llama.cpp')


### PR DESCRIPTION
## Describe Your Changes

- The build-mlx-server target hardcoded $BUILD_DIR/mlx-swift_Cmlx.bundle and
silently fell back to creating an empty placeholder directory when the
bundle wasn't found there. SwiftPM doesn't always place resource bundles
flat in --show-bin-path output, so the empty bundle shipped into the app
and mlx-c aborted at runtime with "Failed to load the default metallib"
on every model load.

Locate the Cmlx bundle by globbing for *Cmlx*.bundle under $BUILD_DIR,
fall back to the parent dir of any default.metallib, and hard-fail with
a directory listing if neither is found. The signing block also refuses
to sign a bundle missing default.metallib so a broken staged tree can't
slip past codesign and into a release.

## Fixes Issues

- Closes #7804
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
