### PR TITLE
fix: restore pre-CoT reasoning duration + prevent action flicker during tool calls

### DIFF
--- a/web-app/src/components/ai-elements/__tests__/chain-of-thought.test.tsx
+++ b/web-app/src/components/ai-elements/__tests__/chain-of-thought.test.tsx
@@ -129,7 +129,7 @@ describe('ChainOfThoughtHeader', () => {
       </ChainOfThought>
     )
     expect(
-      screen.getByText('Reasoned through the problem')
+      screen.getByText('Thought for a few seconds')
     ).toBeInTheDocument()
   })
 
@@ -143,7 +143,7 @@ describe('ChainOfThoughtHeader', () => {
     )
     expect(screen.getByText('Custom header')).toBeInTheDocument()
     expect(
-      screen.queryByText('Reasoned through the problem')
+      screen.queryByText(/Thought for/)
     ).not.toBeInTheDocument()
   })
 })

--- a/web-app/src/components/ai-elements/chain-of-thought.tsx
+++ b/web-app/src/components/ai-elements/chain-of-thought.tsx
@@ -22,6 +22,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useState,
 } from 'react'
 import { Streamdown } from 'streamdown'
 import { Shimmer } from './shimmer'
@@ -36,7 +37,10 @@ type ChainOfThoughtContextValue = {
   isOpen: boolean
   setIsOpen: (open: boolean) => void
   isStreaming: boolean
+  duration: number | undefined
 }
+
+const MS_IN_S = 1000
 
 const ChainOfThoughtContext = createContext<ChainOfThoughtContextValue | null>(
   null
@@ -91,9 +95,23 @@ export const ChainOfThought = memo(
       setIsOpen(newOpen)
     }
 
+    const [startTime, setStartTime] = useState<number | null>(null)
+    const [duration, setDuration] = useState<number | undefined>(undefined)
+
+    useEffect(() => {
+      if (isStreaming) {
+        if (startTime === null) {
+          setStartTime(Date.now())
+        }
+      } else if (startTime !== null) {
+        setDuration(Math.ceil((Date.now() - startTime) / MS_IN_S))
+        setStartTime(null)
+      }
+    }, [isStreaming, startTime])
+
     const contextValue = useMemo(
-      () => ({ isStreaming, isOpen, setIsOpen }),
-      [isStreaming, isOpen, setIsOpen]
+      () => ({ isStreaming, isOpen, setIsOpen, duration }),
+      [isStreaming, isOpen, setIsOpen, duration]
     )
 
     return (
@@ -121,7 +139,7 @@ export type ChainOfThoughtHeaderProps = ComponentProps<
 
 export const ChainOfThoughtHeader = memo(
   ({ className, title, children, ...props }: ChainOfThoughtHeaderProps) => {
-    const { isStreaming, isOpen } = useChainOfThought()
+    const { isStreaming, isOpen, duration } = useChainOfThought()
 
     return (
       <CollapsibleTrigger
@@ -134,10 +152,14 @@ export const ChainOfThoughtHeader = memo(
         {children ?? (
           <>
             <SparklesIcon className="size-4" />
-            {isStreaming ? (
+            {isStreaming || duration === 0 ? (
               <Shimmer duration={1}>Reasoning...</Shimmer>
+            ) : title ? (
+              <p>{title}</p>
+            ) : duration === undefined ? (
+              <p>Thought for a few seconds</p>
             ) : (
-              <p>{title ?? 'Reasoned through the problem'}</p>
+              <p>Thought for {duration} seconds</p>
             )}
             <ChevronDownIcon
               className={cn(

--- a/web-app/src/containers/MessageItem.tsx
+++ b/web-app/src/containers/MessageItem.tsx
@@ -107,9 +107,25 @@ export const MessageItem = memo(
         .map((part) => (part as { url: string }).url)
     }, [message.parts])
 
+    // A tool part is "pending" until it reaches a terminal state. While any
+    // tool on the last assistant message is still pending the turn isn't
+    // done — the model will resume once the tool result arrives, even if the
+    // SDK briefly reports status as 'ready' between the tool-call stream and
+    // the follow-up request.
+    const hasPendingToolCall = useMemo(() => {
+      if (!isLastMessage || message.role !== 'assistant') return false
+      return message.parts.some((part) => {
+        if (!part.type?.startsWith('tool-')) return false
+        const state = (part as { state?: string }).state
+        return state !== 'output-available' && state !== 'output-error'
+      })
+    }, [isLastMessage, message.role, message.parts])
+
     const isStreaming =
-      isLastMessage &&
-      (status === CHAT_STATUS.STREAMING || status === CHAT_STATUS.SUBMITTED)
+      (isLastMessage &&
+        (status === CHAT_STATUS.STREAMING ||
+          status === CHAT_STATUS.SUBMITTED)) ||
+      hasPendingToolCall
 
     // Extract file metadata from message text (for user messages with attachments)
     const attachedFiles = useMemo(() => {

--- a/web-app/src/containers/MessageItem.tsx
+++ b/web-app/src/containers/MessageItem.tsx
@@ -107,7 +107,9 @@ export const MessageItem = memo(
         .map((part) => (part as { url: string }).url)
     }, [message.parts])
 
-    const isStreaming = isLastMessage && status === CHAT_STATUS.STREAMING
+    const isStreaming =
+      isLastMessage &&
+      (status === CHAT_STATUS.STREAMING || status === CHAT_STATUS.SUBMITTED)
 
     // Extract file metadata from message text (for user messages with attachments)
     const attachedFiles = useMemo(() => {
@@ -460,7 +462,8 @@ export const MessageItem = memo(
             </span>
             <CopyButton text={getFullTextContent()} />
 
-            {onEdit && status !== CHAT_STATUS.STREAMING && (
+            {onEdit && status !== CHAT_STATUS.STREAMING &&
+              status !== CHAT_STATUS.SUBMITTED && (
               <EditMessageDialog
                 message={getFullTextContent()}
                 imageUrls={imageUrls.length > 0 ? imageUrls : undefined}
@@ -468,7 +471,8 @@ export const MessageItem = memo(
               />
             )}
 
-            {onDelete && status !== CHAT_STATUS.STREAMING && (
+            {onDelete && status !== CHAT_STATUS.STREAMING &&
+              status !== CHAT_STATUS.SUBMITTED && (
               <DeleteMessageDialog onDelete={handleDelete} />
             )}
           </div>
@@ -538,8 +542,12 @@ export const MessageItem = memo(
     )
   },
   (prevProps, nextProps) => {
-    // Always re-render if streaming and this is the last message
-    if (nextProps.isLastMessage && nextProps.status === CHAT_STATUS.STREAMING) {
+    // Always re-render if the last message is in-flight (streaming or submitted)
+    if (
+      nextProps.isLastMessage &&
+      (nextProps.status === CHAT_STATUS.STREAMING ||
+        nextProps.status === CHAT_STATUS.SUBMITTED)
+    ) {
       return false
     }
 


### PR DESCRIPTION
## Describe Your Changes

- Restore pre-Chain-of-Thought behavior: show elapsed reasoning time in the collapsed CoT header once the model stops thinking (captures start time on streaming→idle, computes elapsed seconds, exposes via context).
- Prevent message-action flicker while tool calls are in-flight:
  - Hide actions when the last assistant message has any tool part whose state is not 'output-available' or 'output-error'.
  - Also treat both 'submitted' and 'streaming' statuses as busy (align MessageItem with ChatInput and chat-session store) to avoid actions briefly appearing during the submitted gap.
- Minor: unify reasoning-duration wording to "restore" the original behavior.


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
