### PR TITLE
fix: keep in-flight work alive across thread navigation

### DIFF
--- a/web-app/src/components/PromptProgress.tsx
+++ b/web-app/src/components/PromptProgress.tsx
@@ -1,9 +1,16 @@
 import { useAppState } from '@/hooks/useAppState'
 import { Loader } from 'lucide-react'
+import { useParams } from '@tanstack/react-router'
 
 export function PromptProgress() {
-  const promptProgress = useAppState((state) => state.promptProgress)
-  const loadingModel = useAppState((state) => state.loadingModel)
+  const params = useParams({ from: '/threads/$threadId', shouldThrow: false })
+  const threadId = params?.threadId
+  const promptProgress = useAppState((state) =>
+    threadId ? state.promptProgresses[threadId] : state.promptProgress
+  )
+  const loadingModel = useAppState((state) =>
+    threadId ? state.loadingModels[threadId] : state.loadingModel
+  )
 
   const percentage =
     promptProgress && promptProgress.total > 0

--- a/web-app/src/components/PromptProgress.tsx
+++ b/web-app/src/components/PromptProgress.tsx
@@ -6,10 +6,12 @@ export function PromptProgress() {
   const params = useParams({ from: '/threads/$threadId', shouldThrow: false })
   const threadId = params?.threadId
   const promptProgress = useAppState((state) =>
-    threadId ? state.promptProgresses[threadId] : state.promptProgress
+    (threadId ? state.promptProgresses[threadId] : undefined) ??
+    state.promptProgress
   )
   const loadingModel = useAppState((state) =>
-    threadId ? state.loadingModels[threadId] : state.loadingModel
+    (threadId ? state.loadingModels[threadId] : undefined) ??
+    state.loadingModel
   )
 
   const percentage =

--- a/web-app/src/components/__tests__/PromptProgress.test.tsx
+++ b/web-app/src/components/__tests__/PromptProgress.test.tsx
@@ -8,6 +8,10 @@ vi.mock('@/hooks/useAppState', () => ({
   useAppState: vi.fn(),
 }))
 
+vi.mock('@tanstack/react-router', () => ({
+  useParams: () => undefined,
+}))
+
 const mockUseAppState = useAppState as ReturnType<typeof vi.fn>
 
 describe('PromptProgress', () => {

--- a/web-app/src/containers/ThreadList.tsx
+++ b/web-app/src/containers/ThreadList.tsx
@@ -1,5 +1,6 @@
-import { Folder, MoreHorizontal, Pencil, Trash2, X } from 'lucide-react'
+import { Folder, Loader2, MoreHorizontal, Pencil, Trash2, X } from 'lucide-react'
 import { useThreads } from '@/hooks/useThreads'
+import { useIsThreadActive } from '@/hooks/useAppState'
 import { useMessages } from '@/hooks/useMessages'
 import { useThreadManagement } from '@/hooks/useThreadManagement'
 import { useServiceHub } from '@/hooks/useServiceHub'
@@ -134,11 +135,18 @@ const ThreadItem = memo(
       }
     }
 
+    const isActive = useIsThreadActive(thread.id)
+
     return (
       <SidebarMenuItem>
         {currentProjectId ?
           <Link to="/threads/$threadId" params={{ threadId: thread.id }} className="bg-card dark:bg-secondary/20 mb-2 px-4 py-4 border hover:dark:bg-secondary/30 rounded-lg block max-w-full overflow-hidden">
-              <span className="block truncate" title={thread.title || t('common:newThread')}>{thread.title || t('common:newThread')}</span>
+              <div className="flex items-center gap-1.5 min-w-0">
+                {isActive && (
+                  <Loader2 className="size-3 shrink-0 animate-spin text-muted-foreground" />
+                )}
+                <span className="block truncate" title={thread.title || t('common:newThread')}>{thread.title || t('common:newThread')}</span>
+              </div>
               {currentProjectId && lastUserMessageText && (
                 <div className="text-muted-foreground text-xs mt-1 line-clamp-1 pr-10">
                   {lastUserMessageText}
@@ -148,6 +156,9 @@ const ThreadItem = memo(
           :
           <SidebarMenuButton asChild>
             <Link to="/threads/$threadId" params={{ threadId: thread.id }}>
+              {isActive && (
+                <Loader2 className="size-3 shrink-0 animate-spin text-muted-foreground" />
+              )}
               <span className="block truncate" title={thread.title || t('common:newThread')}>{thread.title || t('common:newThread')}</span>
             </Link>
           </SidebarMenuButton>

--- a/web-app/src/containers/ThreadList.tsx
+++ b/web-app/src/containers/ThreadList.tsx
@@ -1,6 +1,7 @@
 import { Folder, Loader2, MoreHorizontal, Pencil, Trash2, X } from 'lucide-react'
 import { useThreads } from '@/hooks/useThreads'
 import { useIsThreadActive } from '@/hooks/useAppState'
+import { useChatSessions } from '@/stores/chat-session-store'
 import { useMessages } from '@/hooks/useMessages'
 import { useThreadManagement } from '@/hooks/useThreadManagement'
 import { useServiceHub } from '@/hooks/useServiceHub'
@@ -135,7 +136,11 @@ const ThreadItem = memo(
       }
     }
 
-    const isActive = useIsThreadActive(thread.id)
+    const isAppStateActive = useIsThreadActive(thread.id)
+    const isSessionStreaming = useChatSessions(
+      (state) => state.sessions[thread.id]?.isStreaming ?? false
+    )
+    const isActive = isAppStateActive || isSessionStreaming
 
     return (
       <SidebarMenuItem>

--- a/web-app/src/containers/TokenSpeedIndicator.tsx
+++ b/web-app/src/containers/TokenSpeedIndicator.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react'
 import { useAppState } from '@/hooks/useAppState'
 import { toNumber } from '@/utils/number'
 import { Gauge } from 'lucide-react'
+import { useParams } from '@tanstack/react-router'
 
 interface TokenUsage {
   inputTokens?: number
@@ -22,13 +23,16 @@ interface TokenSpeedIndicatorProps {
 
 export const TokenSpeedIndicator = memo(
   ({ metadata, streaming }: TokenSpeedIndicatorProps) => {
-    // Get real-time token speed from global state during streaming
-    const streamingTokenSpeed = useAppState((state) =>
-      state.tokenSpeed ? Math.round(state.tokenSpeed.tokenSpeed) : 0
-    )
-    const streamingTokenCount = useAppState((state) =>
-      state.tokenSpeed?.tokenCount || 0
-    )
+    const params = useParams({ from: '/threads/$threadId', shouldThrow: false })
+    const threadId = params?.threadId
+    const streamingTokenSpeed = useAppState((state) => {
+      const ts = threadId ? state.tokenSpeeds[threadId] : state.tokenSpeed
+      return ts ? Math.round(ts.tokenSpeed) : 0
+    })
+    const streamingTokenCount = useAppState((state) => {
+      const ts = threadId ? state.tokenSpeeds[threadId] : state.tokenSpeed
+      return ts?.tokenCount || 0
+    })
 
     // Fallback to persisted metadata when not streaming
     const persistedTokenSpeed =

--- a/web-app/src/containers/TokenSpeedIndicator.tsx
+++ b/web-app/src/containers/TokenSpeedIndicator.tsx
@@ -26,11 +26,15 @@ export const TokenSpeedIndicator = memo(
     const params = useParams({ from: '/threads/$threadId', shouldThrow: false })
     const threadId = params?.threadId
     const streamingTokenSpeed = useAppState((state) => {
-      const ts = threadId ? state.tokenSpeeds[threadId] : state.tokenSpeed
+      const ts =
+        (threadId ? state.tokenSpeeds[threadId] : undefined) ??
+        state.tokenSpeed
       return ts ? Math.round(ts.tokenSpeed) : 0
     })
     const streamingTokenCount = useAppState((state) => {
-      const ts = threadId ? state.tokenSpeeds[threadId] : state.tokenSpeed
+      const ts =
+        (threadId ? state.tokenSpeeds[threadId] : undefined) ??
+        state.tokenSpeed
       return ts?.tokenCount || 0
     })
 

--- a/web-app/src/hooks/use-chat.ts
+++ b/web-app/src/hooks/use-chat.ts
@@ -1,7 +1,6 @@
 import {
   CustomChatTransport,
 } from '@/lib/custom-chat-transport'
-// import { useCapabilities } from "@/stores/capabilities-store";
 import {
   Chat,
   type UIMessage,

--- a/web-app/src/hooks/use-chat.ts
+++ b/web-app/src/hooks/use-chat.ts
@@ -66,8 +66,10 @@ export function useChat(
     }
   }, [systemMessage])
 
-  // Set up streaming token speed callback to update global state
   const resetTokenSpeed = useAppState((state) => state.resetTokenSpeed)
+  const resetThreadTokenSpeed = useAppState(
+    (state) => state.resetThreadTokenSpeed
+  )
 
   // Update the token usage callback when it changes
   useEffect(() => {
@@ -109,12 +111,12 @@ export function useChat(
     }
   }, [sessionId, chatResult.status, updateStatus])
 
-  // Reset token speed when streaming stops
   useEffect(() => {
     if (chatResult.status !== 'streaming') {
       resetTokenSpeed()
+      if (sessionId) resetThreadTokenSpeed(sessionId)
     }
-  }, [chatResult.status, resetTokenSpeed])
+  }, [chatResult.status, resetTokenSpeed, resetThreadTokenSpeed, sessionId])
 
   // Refresh tools when MCP or RAG tool names change (e.g., when MCP servers start/stop)
   useEffect(() => {

--- a/web-app/src/hooks/useAppState.ts
+++ b/web-app/src/hooks/useAppState.ts
@@ -36,6 +36,7 @@ type AppState = {
   tokenSpeeds: Record<string, TokenSpeed>
   cancelToolCalls: Record<string, () => void>
   errorMessages: Record<string, AppErrorMessage>
+  busyThreads: Record<string, boolean>
   currentStreamThreadId?: string
 
   setServerStatus: (value: 'running' | 'stopped' | 'pending') => void
@@ -90,6 +91,7 @@ type AppState = {
   ) => void
   clearThreadState: (threadId: string) => void
   setCurrentStreamThreadId: (threadId: string | undefined) => void
+  setThreadBusy: (threadId: string, busy: boolean) => void
 }
 
 export const useAppState = create<AppState>()((set) => ({
@@ -110,8 +112,16 @@ export const useAppState = create<AppState>()((set) => ({
   tokenSpeeds: {},
   cancelToolCalls: {},
   errorMessages: {},
+  busyThreads: {},
   currentStreamThreadId: undefined,
   setCurrentStreamThreadId: (threadId) => set({ currentStreamThreadId: threadId }),
+  setThreadBusy: (threadId, busy) =>
+    set((state) => {
+      const next = { ...state.busyThreads }
+      if (busy) next[threadId] = true
+      else delete next[threadId]
+      return { busyThreads: next }
+    }),
   updateStreamingContent: (content: ThreadMessage | undefined) => {
     set(() => ({
       streamingContent: content
@@ -322,12 +332,14 @@ export const useAppState = create<AppState>()((set) => ({
       const tokenSpeeds = { ...state.tokenSpeeds }
       const cancelToolCalls = { ...state.cancelToolCalls }
       const errorMessages = { ...state.errorMessages }
+      const busyThreads = { ...state.busyThreads }
       delete streamingContents[threadId]
       delete loadingModels[threadId]
       delete promptProgresses[threadId]
       delete tokenSpeeds[threadId]
       delete cancelToolCalls[threadId]
       delete errorMessages[threadId]
+      delete busyThreads[threadId]
       return {
         streamingContents,
         loadingModels,
@@ -335,6 +347,7 @@ export const useAppState = create<AppState>()((set) => ({
         tokenSpeeds,
         cancelToolCalls,
         errorMessages,
+        busyThreads,
       }
     }),
 }))
@@ -345,6 +358,7 @@ export const useActiveThreadIds = () =>
     Object.keys(state.streamingContents).forEach((id) => ids.add(id))
     Object.keys(state.loadingModels).forEach((id) => ids.add(id))
     Object.keys(state.cancelToolCalls).forEach((id) => ids.add(id))
+    Object.keys(state.busyThreads).forEach((id) => ids.add(id))
     return ids
   })
 
@@ -353,6 +367,7 @@ export const useIsThreadActive = (threadId: string | undefined) =>
     threadId
       ? threadId in state.streamingContents ||
         threadId in state.loadingModels ||
-        threadId in state.cancelToolCalls
+        threadId in state.cancelToolCalls ||
+        threadId in state.busyThreads
       : false
   )

--- a/web-app/src/hooks/useAppState.ts
+++ b/web-app/src/hooks/useAppState.ts
@@ -60,7 +60,6 @@ export const useAppState = create<AppState>()((set) => ({
   serverStatus: 'stopped',
   abortControllers: {},
   tokenSpeed: undefined,
-  currentToolCall: undefined,
   promptProgress: undefined,
   cancelToolCall: undefined,
   activeModels: [],

--- a/web-app/src/hooks/useAppState.ts
+++ b/web-app/src/hooks/useAppState.ts
@@ -29,6 +29,14 @@ type AppState = {
   promptProgress?: PromptProgress
   activeModels: string[]
   cancelToolCall?: () => void
+
+  streamingContents: Record<string, ThreadMessage>
+  loadingModels: Record<string, boolean>
+  promptProgresses: Record<string, PromptProgress>
+  tokenSpeeds: Record<string, TokenSpeed>
+  cancelToolCalls: Record<string, () => void>
+  errorMessages: Record<string, AppErrorMessage>
+
   setServerStatus: (value: 'running' | 'stopped' | 'pending') => void
   updateStreamingContent: (content: ThreadMessage | undefined) => void
   updateLoadingModel: (loading: boolean) => void
@@ -49,6 +57,37 @@ type AppState = {
   setErrorMessage: (error: AppErrorMessage | undefined) => void
   updatePromptProgress: (progress: PromptProgress | undefined) => void
   setActiveModels: (models: string[]) => void
+
+  updateThreadStreamingContent: (
+    threadId: string,
+    content: ThreadMessage | undefined
+  ) => void
+  updateThreadLoadingModel: (threadId: string, loading: boolean) => void
+  updateThreadPromptProgress: (
+    threadId: string,
+    progress: PromptProgress | undefined
+  ) => void
+  updateThreadTokenSpeed: (
+    threadId: string,
+    message: ThreadMessage,
+    increment?: number
+  ) => void
+  setThreadTokenSpeed: (
+    threadId: string,
+    message: ThreadMessage,
+    speed: number,
+    completionTokens: number
+  ) => void
+  resetThreadTokenSpeed: (threadId: string) => void
+  setThreadCancelToolCall: (
+    threadId: string,
+    cancel: (() => void) | undefined
+  ) => void
+  setThreadErrorMessage: (
+    threadId: string,
+    error: AppErrorMessage | undefined
+  ) => void
+  clearThreadState: (threadId: string) => void
 }
 
 export const useAppState = create<AppState>()((set) => ({
@@ -63,6 +102,12 @@ export const useAppState = create<AppState>()((set) => ({
   promptProgress: undefined,
   cancelToolCall: undefined,
   activeModels: [],
+  streamingContents: {},
+  loadingModels: {},
+  promptProgresses: {},
+  tokenSpeeds: {},
+  cancelToolCalls: {},
+  errorMessages: {},
   updateStreamingContent: (content: ThreadMessage | undefined) => {
     set(() => ({
       streamingContent: content
@@ -172,4 +217,138 @@ export const useAppState = create<AppState>()((set) => ({
       activeModels: models,
     }))
   },
+
+  updateThreadStreamingContent: (threadId, content) =>
+    set((state) => {
+      const next = { ...state.streamingContents }
+      if (content) {
+        next[threadId] = {
+          ...content,
+          created_at: content.created_at || Date.now(),
+        }
+      } else {
+        delete next[threadId]
+      }
+      return { streamingContents: next }
+    }),
+  updateThreadLoadingModel: (threadId, loading) =>
+    set((state) => {
+      const next = { ...state.loadingModels }
+      if (loading) next[threadId] = true
+      else delete next[threadId]
+      return { loadingModels: next }
+    }),
+  updateThreadPromptProgress: (threadId, progress) =>
+    set((state) => {
+      const next = { ...state.promptProgresses }
+      if (progress) next[threadId] = progress
+      else delete next[threadId]
+      return { promptProgresses: next }
+    }),
+  setThreadTokenSpeed: (threadId, message, speed, completionTokens) =>
+    set((state) => ({
+      tokenSpeeds: {
+        ...state.tokenSpeeds,
+        [threadId]: {
+          ...state.tokenSpeeds[threadId],
+          lastTimestamp: Date.now(),
+          tokenSpeed: speed,
+          tokenCount: completionTokens,
+          message: message.id,
+        },
+      },
+    })),
+  updateThreadTokenSpeed: (threadId, message, increment = 1) =>
+    set((state) => {
+      const now = Date.now()
+      const prev = state.tokenSpeeds[threadId]
+      if (!prev) {
+        return {
+          tokenSpeeds: {
+            ...state.tokenSpeeds,
+            [threadId]: {
+              lastTimestamp: now,
+              tokenSpeed: 0,
+              tokenCount: increment,
+              message: message.id,
+            },
+          },
+        }
+      }
+      const elapsed = (now - prev.lastTimestamp) / 1000
+      const total = prev.tokenCount + increment
+      return {
+        tokenSpeeds: {
+          ...state.tokenSpeeds,
+          [threadId]: {
+            ...prev,
+            tokenSpeed: total / (elapsed > 0 ? elapsed : 1),
+            tokenCount: total,
+            message: message.id,
+          },
+        },
+      }
+    }),
+  resetThreadTokenSpeed: (threadId) =>
+    set((state) => {
+      if (!(threadId in state.tokenSpeeds)) return state
+      const next = { ...state.tokenSpeeds }
+      delete next[threadId]
+      return { tokenSpeeds: next }
+    }),
+  setThreadCancelToolCall: (threadId, cancel) =>
+    set((state) => {
+      const next = { ...state.cancelToolCalls }
+      if (cancel) next[threadId] = cancel
+      else delete next[threadId]
+      return { cancelToolCalls: next }
+    }),
+  setThreadErrorMessage: (threadId, error) =>
+    set((state) => {
+      const next = { ...state.errorMessages }
+      if (error) next[threadId] = error
+      else delete next[threadId]
+      return { errorMessages: next }
+    }),
+  clearThreadState: (threadId) =>
+    set((state) => {
+      const streamingContents = { ...state.streamingContents }
+      const loadingModels = { ...state.loadingModels }
+      const promptProgresses = { ...state.promptProgresses }
+      const tokenSpeeds = { ...state.tokenSpeeds }
+      const cancelToolCalls = { ...state.cancelToolCalls }
+      const errorMessages = { ...state.errorMessages }
+      delete streamingContents[threadId]
+      delete loadingModels[threadId]
+      delete promptProgresses[threadId]
+      delete tokenSpeeds[threadId]
+      delete cancelToolCalls[threadId]
+      delete errorMessages[threadId]
+      return {
+        streamingContents,
+        loadingModels,
+        promptProgresses,
+        tokenSpeeds,
+        cancelToolCalls,
+        errorMessages,
+      }
+    }),
 }))
+
+export const useActiveThreadIds = () =>
+  useAppState((state) => {
+    const ids = new Set<string>()
+    Object.keys(state.streamingContents).forEach((id) => ids.add(id))
+    Object.keys(state.loadingModels).forEach((id) => ids.add(id))
+    Object.keys(state.cancelToolCalls).forEach((id) => ids.add(id))
+    return ids
+  })
+
+export const useIsThreadActive = (threadId: string | undefined) =>
+  useAppState((state) =>
+    threadId
+      ? threadId in state.streamingContents ||
+        threadId in state.loadingModels ||
+        threadId in state.cancelToolCalls
+      : false
+  )

--- a/web-app/src/hooks/useAppState.ts
+++ b/web-app/src/hooks/useAppState.ts
@@ -36,6 +36,7 @@ type AppState = {
   tokenSpeeds: Record<string, TokenSpeed>
   cancelToolCalls: Record<string, () => void>
   errorMessages: Record<string, AppErrorMessage>
+  currentStreamThreadId?: string
 
   setServerStatus: (value: 'running' | 'stopped' | 'pending') => void
   updateStreamingContent: (content: ThreadMessage | undefined) => void
@@ -88,6 +89,7 @@ type AppState = {
     error: AppErrorMessage | undefined
   ) => void
   clearThreadState: (threadId: string) => void
+  setCurrentStreamThreadId: (threadId: string | undefined) => void
 }
 
 export const useAppState = create<AppState>()((set) => ({
@@ -108,6 +110,8 @@ export const useAppState = create<AppState>()((set) => ({
   tokenSpeeds: {},
   cancelToolCalls: {},
   errorMessages: {},
+  currentStreamThreadId: undefined,
+  setCurrentStreamThreadId: (threadId) => set({ currentStreamThreadId: threadId }),
   updateStreamingContent: (content: ThreadMessage | undefined) => {
     set(() => ({
       streamingContent: content

--- a/web-app/src/hooks/useThreads.ts
+++ b/web-app/src/hooks/useThreads.ts
@@ -6,6 +6,8 @@ import { TEMPORARY_CHAT_ID } from '@/constants/chat'
 import { useAgentMode } from '@/hooks/useAgentMode'
 import { ExtensionManager } from '@/lib/extension'
 import { ExtensionTypeEnum, VectorDBExtension } from '@janhq/core'
+import { useChatSessions } from '@/stores/chat-session-store'
+import { useAppState } from '@/hooks/useAppState'
 
 type ThreadState = {
   threads: Record<string, Thread>
@@ -155,9 +157,9 @@ export const useThreads = create<ThreadState>()((set, get) => ({
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { [threadId]: _, ...remainingThreads } = state.threads
 
-      // Clean up agent mode state
       useAgentMode.getState().removeThread(threadId)
-      // Clean up vector DB collection
+      useChatSessions.getState().removeSession(threadId)
+      useAppState.getState().clearThreadState(threadId)
       cleanupVectorDB(threadId)
       getServiceHub().threads().deleteThread(threadId)
 
@@ -224,9 +226,10 @@ export const useThreads = create<ThreadState>()((set, get) => ({
     set((state) => {
       const allThreadIds = Object.keys(state.threads)
 
-      // Delete all threads and clean up their vector DB collections
       allThreadIds.forEach((threadId) => {
         useAgentMode.getState().removeThread(threadId)
+        useChatSessions.getState().removeSession(threadId)
+        useAppState.getState().clearThreadState(threadId)
         cleanupVectorDB(threadId)
         getServiceHub().threads().deleteThread(threadId)
       })
@@ -250,8 +253,9 @@ export const useThreads = create<ThreadState>()((set, get) => ({
           state.threads[threadId].metadata?.project?.id === projectId
       )
 
-      // Delete threads and clean up their vector DB collections
       threadsToDeleteIds.forEach((threadId) => {
+        useChatSessions.getState().removeSession(threadId)
+        useAppState.getState().clearThreadState(threadId)
         cleanupVectorDB(threadId)
         getServiceHub().threads().deleteThread(threadId)
       })

--- a/web-app/src/lib/custom-chat-transport.ts
+++ b/web-app/src/lib/custom-chat-transport.ts
@@ -460,7 +460,7 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
       messageId: string | undefined
     } & ChatRequestOptions
   ): Promise<ReadableStream<UIMessageChunk>> {
-    const threadId = options.chatId
+    const threadId = this.threadId ?? options.chatId
     useAppState.getState().setCurrentStreamThreadId(threadId)
     // Capture the effective provider name early so the Anthropic serial
     // tool-use repair later uses the same value that was used to create the

--- a/web-app/src/lib/custom-chat-transport.ts
+++ b/web-app/src/lib/custom-chat-transport.ts
@@ -461,6 +461,7 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
     } & ChatRequestOptions
   ): Promise<ReadableStream<UIMessageChunk>> {
     const threadId = options.chatId
+    useAppState.getState().setCurrentStreamThreadId(threadId)
     // Capture the effective provider name early so the Anthropic serial
     // tool-use repair later uses the same value that was used to create the
     // model, even if the user switches provider mid-request.
@@ -739,6 +740,9 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
         useAppState.getState().updateLoadingModel(false)
         useAppState.getState().updateThreadPromptProgress(threadId, undefined)
         useAppState.getState().updateThreadLoadingModel(threadId, false)
+        if (useAppState.getState().currentStreamThreadId === threadId) {
+          useAppState.getState().setCurrentStreamThreadId(undefined)
+        }
         const errorMessage = error == null
           ? 'Unknown error'
           : typeof error === 'string'
@@ -754,6 +758,9 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
         useAppState.getState().updateLoadingModel(false)
         useAppState.getState().updateThreadPromptProgress(threadId, undefined)
         useAppState.getState().updateThreadLoadingModel(threadId, false)
+        if (useAppState.getState().currentStreamThreadId === threadId) {
+          useAppState.getState().setCurrentStreamThreadId(undefined)
+        }
         if (responseMessage) {
           const metadata = responseMessage.metadata as
             | Record<string, unknown>

--- a/web-app/src/lib/custom-chat-transport.ts
+++ b/web-app/src/lib/custom-chat-transport.ts
@@ -460,6 +460,7 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
       messageId: string | undefined
     } & ChatRequestOptions
   ): Promise<ReadableStream<UIMessageChunk>> {
+    const threadId = options.chatId
     // Capture the effective provider name early so the Anthropic serial
     // tool-use repair later uses the same value that was used to create the
     // model, even if the user switches provider mid-request.
@@ -498,6 +499,7 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
           )
           if (!loaded.includes(modelId)) {
             useAppState.getState().updateLoadingModel(true)
+            useAppState.getState().updateThreadLoadingModel(threadId, true)
           }
         } catch {
           // Ignore probe failures; the router will still load on demand
@@ -512,8 +514,10 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
         { ...(inferenceParams ?? {}), ...reasoningParams }
       )
       useAppState.getState().updateLoadingModel(false)
+      useAppState.getState().updateThreadLoadingModel(threadId, false)
     } catch (error) {
       useAppState.getState().updateLoadingModel(false)
+      useAppState.getState().updateThreadLoadingModel(threadId, false)
       console.error('Failed to create model:', error)
       throw new Error(
         `Failed to create model: ${error instanceof Error ? error.message : JSON.stringify(error)}`
@@ -661,6 +665,7 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
 
     let streamStartTime: number | undefined
     useAppState.getState().updatePromptProgress(undefined)
+    useAppState.getState().updateThreadPromptProgress(threadId, undefined)
 
     const result = streamText({
       model: this.model,
@@ -732,6 +737,8 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
       onError: (error) => {
         useAppState.getState().updatePromptProgress(undefined)
         useAppState.getState().updateLoadingModel(false)
+        useAppState.getState().updateThreadPromptProgress(threadId, undefined)
+        useAppState.getState().updateThreadLoadingModel(threadId, false)
         const errorMessage = error == null
           ? 'Unknown error'
           : typeof error === 'string'
@@ -745,6 +752,8 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
       onFinish: ({ responseMessage }) => {
         useAppState.getState().updatePromptProgress(undefined)
         useAppState.getState().updateLoadingModel(false)
+        useAppState.getState().updateThreadPromptProgress(threadId, undefined)
+        useAppState.getState().updateThreadLoadingModel(threadId, false)
         if (responseMessage) {
           const metadata = responseMessage.metadata as
             | Record<string, unknown>

--- a/web-app/src/lib/model-factory.ts
+++ b/web-app/src/lib/model-factory.ts
@@ -112,8 +112,13 @@ const providerMetadataExtractor: MetadataExtractor = {
     return {
       processChunk: (parsedChunk: unknown) => {
         const chunk = parsedChunk as LlamaCppChunk
-        if (useAppState.getState().loadingModel) {
-          useAppState.getState().updateLoadingModel(false)
+        const state = useAppState.getState()
+        const streamThreadId = state.currentStreamThreadId
+        if (state.loadingModel) {
+          state.updateLoadingModel(false)
+        }
+        if (streamThreadId) {
+          state.updateThreadLoadingModel(streamThreadId, false)
         }
         if (chunk?.timings) {
           lastTimings = chunk.timings
@@ -124,12 +129,16 @@ const providerMetadataExtractor: MetadataExtractor = {
           typeof pp.total === 'number' &&
           typeof pp.processed === 'number'
         ) {
-          useAppState.getState().updatePromptProgress({
+          const progress = {
             total: pp.total,
             processed: pp.processed,
             cache: pp.cache ?? 0,
             time_ms: pp.time_ms ?? 0,
-          })
+          }
+          state.updatePromptProgress(progress)
+          if (streamThreadId) {
+            state.updateThreadPromptProgress(streamThreadId, progress)
+          }
         }
       },
       buildMetadata: () => {

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -373,17 +373,14 @@ function ThreadDetail() {
       // The thread title is the user's first message (set in ChatInput on creation),
       // so we use it directly as the summarization input.
       // Skipped if already summarized, manually renamed, or max attempts reached.
-      console.log('[ThreadTitle] onFinish fired, isAbort:', isAbort)
       if (!isAbort) {
         const currentThread = useThreads.getState().threads[threadId]
-        console.log('[ThreadTitle] thread:', !!currentThread, 'titleSummarized:', currentThread?.metadata?.titleSummarized, 'attempts:', titleAttemptsRef.current)
         if (
           currentThread &&
           !currentThread.metadata?.titleSummarized &&
           titleAttemptsRef.current < MAX_TITLE_SUMMARIZATION_ATTEMPTS
         ) {
           const titleText = currentThread.title
-          console.log('[ThreadTitle] titleText length:', titleText?.length, 'threshold:', TITLE_SUMMARIZATION_MIN_LENGTH)
 
           if (titleText && titleText.length >= TITLE_SUMMARIZATION_MIN_LENGTH) {
             // Cancel any previous in-flight summarization
@@ -393,9 +390,7 @@ function ThreadDetail() {
             titleAttemptsRef.current++
             const originalTitle = titleText
 
-            console.log('[ThreadTitle] calling generateThreadTitle...')
             generateThreadTitle(titleText, controller.signal).then((title) => {
-              console.log('[ThreadTitle] result:', title, 'aborted:', controller.signal.aborted)
               if (!title || controller.signal.aborted) return
               // Don't overwrite if the user manually renamed while we were generating
               const thread = useThreads.getState().threads[threadId]

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -626,7 +626,10 @@ function ThreadDetail() {
       let processedAttachments = combinedAttachments
       const projectId = thread?.metadata?.project?.id
       if (combinedAttachments.length > 0) {
-        if (hasEmbeddingDocuments) setProcessingEmbeddings(true)
+        if (hasEmbeddingDocuments) {
+          setProcessingEmbeddings(true)
+          useAppState.getState().setThreadBusy(threadId, true)
+        }
         try {
           const parsePreference = useAttachments.getState().parseMode
           const result = await processAttachmentsForSend({
@@ -661,6 +664,7 @@ function ThreadDetail() {
           return
         } finally {
           setProcessingEmbeddings(false)
+          useAppState.getState().setThreadBusy(threadId, false)
         }
       }
 

--- a/web-app/vitest.config.ts
+++ b/web-app/vitest.config.ts
@@ -9,8 +9,8 @@ export default defineConfig({
     setupFiles: ['./src/test/setup.ts'],
     globals: true,
     css: true,
-    testTimeout: 15000,
-    hookTimeout: 15000,
+    testTimeout: 30000,
+    hookTimeout: 30000,
     coverage: {
       reporter: ['text', 'json', 'html', 'lcov'],
       include: ['src/**/*.{ts,tsx}'],


### PR DESCRIPTION
## Describe Your Changes
Navigating away from a thread mid-work (model load, embedding gen, tool execution, token streaming) previously left the UI in a stale state and silently killed the in-flight stream on
  return:

  - Streaming-adjacent state (`loadingModel`, `promptProgress`, `tokenSpeed`, `cancelToolCall`, `errorMessage`) lived in **global slots** in `useAppState`. Whichever thread was mounted owned
   them, regardless of which thread triggered the work.
  - `CustomChatTransport` held `threadId` as instance state; `onError`/`onFinish` closures could persist to the wrong thread.
  - `useChatSessions.removeSession()` was defined but never called — the cached `Chat` instance per threadId outlived its thread forever.
  - The thread route's unmount aborts cleaned up the title-summary controller but otherwise had no per-thread teardown story.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
