### PR TITLE
feat: clearer variants, local fit check, and download lifecycle fixes

### DIFF
--- a/extensions/assistant-extension/src/index.ts
+++ b/extensions/assistant-extension/src/index.ts
@@ -261,9 +261,7 @@ Current date: {{current_date}}`
     description:
       'Jan is a helpful desktop assistant that can reason through complex tasks and use tools to complete them on the user’s behalf.',
     model: '*',
-    instructions: `You are Jan, a helpful AI assistant who assists users with their requests. Jan is trained by Menlo Research (https://www.menlo.ai).
-
-You must output your response in the exact language used in the latest user message. Do not provide translations or switch languages unless explicitly instructed to do so. If the input is mostly English, respond in English.
+    instructions: `You must output your response in the exact language used in the latest user message. Do not provide translations or switch languages unless explicitly instructed to do so. If the input is mostly English, respond in English.
 
 When handling user queries:
 

--- a/web-app/src/components/ai-elements/tool.tsx
+++ b/web-app/src/components/ai-elements/tool.tsx
@@ -1,4 +1,4 @@
-
+/* eslint-disable react-refresh/only-export-components */
 import { useControllableState } from '@radix-ui/react-use-controllable-state'
 import {
   Collapsible,

--- a/web-app/src/components/ui/button-group.tsx
+++ b/web-app/src/components/ui/button-group.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 

--- a/web-app/src/components/ui/button.tsx
+++ b/web-app/src/components/ui/button.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"

--- a/web-app/src/components/ui/sidebar.tsx
+++ b/web-app/src/components/ui/sidebar.tsx
@@ -1,4 +1,5 @@
 "use client";
+/* eslint-disable react-refresh/only-export-components */
 
 import { Slot } from "@radix-ui/react-slot";
 import { type VariantProps, cva } from "class-variance-authority";

--- a/web-app/src/containers/DownloadButton.tsx
+++ b/web-app/src/containers/DownloadButton.tsx
@@ -5,7 +5,7 @@ import { useGeneralSetting } from '@/hooks/useGeneralSetting'
 import { useModelProvider } from '@/hooks/useModelProvider'
 import { useServiceHub } from '@/hooks/useServiceHub'
 import { useTranslation } from '@/i18n'
-import { extractModelName } from '@/lib/models'
+import { extractModelName, extractQuantLabel } from '@/lib/models'
 import { cn, sanitizeModelId } from '@/lib/utils'
 import { CatalogModel } from '@/services/models/types'
 import { DownloadEvent, DownloadState, events } from '@janhq/core'
@@ -161,7 +161,12 @@ export function DownloadButtonPlaceholder({
           onClick={handleDownload}
           className={cn(isDownloading && 'hidden')}
         >
-          {t('hub:download')}
+          {(() => {
+            const label = extractQuantLabel(quant?.model_id)
+            return label
+              ? `${t('hub:download')} · ${label}`
+              : t('hub:download')
+          })()}
         </Button>
       )}
     </div>

--- a/web-app/src/containers/DownloadButton.tsx
+++ b/web-app/src/containers/DownloadButton.tsx
@@ -5,7 +5,11 @@ import { useGeneralSetting } from '@/hooks/useGeneralSetting'
 import { useModelProvider } from '@/hooks/useModelProvider'
 import { useServiceHub } from '@/hooks/useServiceHub'
 import { useTranslation } from '@/i18n'
-import { extractModelName, selectDefaultQuant } from '@/lib/models'
+import {
+  extractModelName,
+  extractQuantLabel,
+  selectDefaultQuant,
+} from '@/lib/models'
 import { toast } from 'sonner'
 import { cn, sanitizeModelId } from '@/lib/utils'
 import { CatalogModel } from '@/services/models/types'
@@ -170,7 +174,12 @@ export function DownloadButtonPlaceholder({
           onClick={handleDownload}
           className={cn(isDownloading && 'hidden')}
         >
-          {t('hub:download')}
+          {(() => {
+            const label = extractQuantLabel(quant?.model_id)
+            return label
+              ? `${t('hub:download')} · ${label}`
+              : t('hub:download')
+          })()}
         </Button>
       )}
     </div>

--- a/web-app/src/containers/DownloadButton.tsx
+++ b/web-app/src/containers/DownloadButton.tsx
@@ -5,7 +5,12 @@ import { useGeneralSetting } from '@/hooks/useGeneralSetting'
 import { useModelProvider } from '@/hooks/useModelProvider'
 import { useServiceHub } from '@/hooks/useServiceHub'
 import { useTranslation } from '@/i18n'
-import { extractModelName, extractQuantLabel } from '@/lib/models'
+import {
+  extractModelName,
+  extractQuantLabel,
+  selectDefaultQuant,
+} from '@/lib/models'
+import { toast } from 'sonner'
 import { cn, sanitizeModelId } from '@/lib/utils'
 import { CatalogModel } from '@/services/models/types'
 import { DownloadEvent, DownloadState, events } from '@janhq/core'
@@ -22,14 +27,19 @@ export function DownloadButtonPlaceholder({
   model,
   handleUseModel,
 }: ModelProps) {
-  const { downloads, localDownloadingModels, addLocalDownloadingModel } =
-    useDownloadStore(
-      useShallow((state) => ({
-        downloads: state.downloads,
-        localDownloadingModels: state.localDownloadingModels,
-        addLocalDownloadingModel: state.addLocalDownloadingModel,
-      }))
-    )
+  const {
+    downloads,
+    localDownloadingModels,
+    addLocalDownloadingModel,
+    removeLocalDownloadingModel,
+  } = useDownloadStore(
+    useShallow((state) => ({
+      downloads: state.downloads,
+      localDownloadingModels: state.localDownloadingModels,
+      addLocalDownloadingModel: state.addLocalDownloadingModel,
+      removeLocalDownloadingModel: state.removeLocalDownloadingModel,
+    }))
+  )
   const { t } = useTranslation()
   const getProviderByName = useModelProvider((state) => state.getProviderByName)
   const llamaProvider = getProviderByName('llamacpp')
@@ -38,12 +48,7 @@ export function DownloadButtonPlaceholder({
   const huggingfaceToken = useGeneralSetting((state) => state.huggingfaceToken)
   const [isDownloaded, setDownloaded] = useState<boolean>(false)
 
-  const quant =
-    model.quants?.find((e) =>
-      DEFAULT_MODEL_QUANTIZATIONS.some((m) =>
-        e.model_id.toLowerCase().includes(m)
-      )
-    ) ?? model.quants?.[0]
+  const quant = selectDefaultQuant(model.quants, DEFAULT_MODEL_QUANTIZATIONS)
 
   const modelId = quant?.model_id || model.model_name
 
@@ -79,12 +84,13 @@ export function DownloadButtonPlaceholder({
   }, [llamaProvider, modelId, model.developer])
 
   useEffect(() => {
-    events.on(
-      DownloadEvent.onFileDownloadAndVerificationSuccess,
-      (state: DownloadState) => {
-        if (state.modelId === modelId) setDownloaded(true)
-      }
-    )
+    const handler = (state: DownloadState) => {
+      if (state.modelId === modelId) setDownloaded(true)
+    }
+    events.on(DownloadEvent.onFileDownloadAndVerificationSuccess, handler)
+    return () => {
+      events.off(DownloadEvent.onFileDownloadAndVerificationSuccess, handler)
+    }
   }, [modelId])
 
   const isRecommendedModel = useCallback((modelId: string) => {
@@ -117,16 +123,23 @@ export function DownloadButtonPlaceholder({
   const isRecommended = isRecommendedModel(model.model_name)
 
   const handleDownload = async () => {
-    // Immediately set local downloading state and start download
     addLocalDownloadingModel(modelId)
     const mmprojPath = (
       model.mmproj_models?.find(
         (e) => e.model_id.toLowerCase() === 'mmproj-f16'
       ) || model.mmproj_models?.[0]
     )?.path
-    serviceHub
-      .models()
-      .pullModelWithMetadata(modelId, modelUrl, mmprojPath, huggingfaceToken)
+    try {
+      await serviceHub
+        .models()
+        .pullModelWithMetadata(modelId, modelUrl, mmprojPath, huggingfaceToken)
+    } catch (err) {
+      removeLocalDownloadingModel(modelId)
+      console.error('Failed to start download:', err)
+      toast.error(t('hub:downloadFailed', 'Failed to start download'), {
+        description: err instanceof Error ? err.message : String(err),
+      })
+    }
   }
 
   return (

--- a/web-app/src/containers/DownloadButton.tsx
+++ b/web-app/src/containers/DownloadButton.tsx
@@ -136,9 +136,10 @@ export function DownloadButtonPlaceholder({
     } catch (err) {
       removeLocalDownloadingModel(modelId)
       console.error('Failed to start download:', err)
-      toast.error(t('hub:downloadFailed', 'Failed to start download'), {
-        description: err instanceof Error ? err.message : String(err),
-      })
+      toast.error(
+        t('hub:downloadFailed', { defaultValue: 'Failed to start download' }),
+        { description: err instanceof Error ? err.message : String(err) }
+      )
     }
   }
 

--- a/web-app/src/containers/DownloadButton.tsx
+++ b/web-app/src/containers/DownloadButton.tsx
@@ -5,11 +5,7 @@ import { useGeneralSetting } from '@/hooks/useGeneralSetting'
 import { useModelProvider } from '@/hooks/useModelProvider'
 import { useServiceHub } from '@/hooks/useServiceHub'
 import { useTranslation } from '@/i18n'
-import {
-  extractModelName,
-  extractQuantLabel,
-  selectDefaultQuant,
-} from '@/lib/models'
+import { extractModelName, selectDefaultQuant } from '@/lib/models'
 import { toast } from 'sonner'
 import { cn, sanitizeModelId } from '@/lib/utils'
 import { CatalogModel } from '@/services/models/types'
@@ -174,12 +170,7 @@ export function DownloadButtonPlaceholder({
           onClick={handleDownload}
           className={cn(isDownloading && 'hidden')}
         >
-          {(() => {
-            const label = extractQuantLabel(quant?.model_id)
-            return label
-              ? `${t('hub:download')} · ${label}`
-              : t('hub:download')
-          })()}
+          {t('hub:download')}
         </Button>
       )}
     </div>

--- a/web-app/src/containers/ModelDownloadAction.tsx
+++ b/web-app/src/containers/ModelDownloadAction.tsx
@@ -10,6 +10,7 @@ import { CatalogModel } from '@/services/models/types'
 import { IconDownload } from '@tabler/icons-react'
 import { useNavigate } from '@tanstack/react-router'
 import { useCallback, useMemo } from 'react'
+import { toast } from 'sonner'
 
 export const ModelDownloadAction = ({
   variant,
@@ -22,8 +23,12 @@ export const ModelDownloadAction = ({
 
   const { t } = useTranslation()
   const huggingfaceToken = useGeneralSetting((state) => state.huggingfaceToken)
-  const { downloads, localDownloadingModels, addLocalDownloadingModel } =
-    useDownloadStore()
+  const {
+    downloads,
+    localDownloadingModels,
+    addLocalDownloadingModel,
+    removeLocalDownloadingModel,
+  } = useDownloadStore()
   const downloadProcesses = useMemo(
     () =>
       Object.values(downloads).map((download) => ({
@@ -56,18 +61,26 @@ export const ModelDownloadAction = ({
 
   const handleDownloadModel = useCallback(async () => {
     addLocalDownloadingModel(variant.model_id)
-    serviceHub
-      .models()
-      .pullModelWithMetadata(
-        variant.model_id,
-        variant.path,
-        (
-          model.mmproj_models?.find(
-            (e) => e.model_id.toLowerCase() === 'mmproj-f16'
-          ) || model.mmproj_models?.[0]
-        )?.path,
-        huggingfaceToken
-      )
+    try {
+      await serviceHub
+        .models()
+        .pullModelWithMetadata(
+          variant.model_id,
+          variant.path,
+          (
+            model.mmproj_models?.find(
+              (e) => e.model_id.toLowerCase() === 'mmproj-f16'
+            ) || model.mmproj_models?.[0]
+          )?.path,
+          huggingfaceToken
+        )
+    } catch (err) {
+      removeLocalDownloadingModel(variant.model_id)
+      console.error('Failed to start download:', err)
+      toast.error(t('hub:downloadFailed', 'Failed to start download'), {
+        description: err instanceof Error ? err.message : String(err),
+      })
+    }
   }, [
     serviceHub,
     variant.path,
@@ -75,6 +88,8 @@ export const ModelDownloadAction = ({
     huggingfaceToken,
     model.mmproj_models,
     addLocalDownloadingModel,
+    removeLocalDownloadingModel,
+    t,
   ])
 
   const isDownloading =

--- a/web-app/src/containers/ModelDownloadAction.tsx
+++ b/web-app/src/containers/ModelDownloadAction.tsx
@@ -77,9 +77,10 @@ export const ModelDownloadAction = ({
     } catch (err) {
       removeLocalDownloadingModel(variant.model_id)
       console.error('Failed to start download:', err)
-      toast.error(t('hub:downloadFailed', 'Failed to start download'), {
-        description: err instanceof Error ? err.message : String(err),
-      })
+      toast.error(
+        t('hub:downloadFailed', { defaultValue: 'Failed to start download' }),
+        { description: err instanceof Error ? err.message : String(err) }
+      )
     }
   }, [
     serviceHub,

--- a/web-app/src/containers/ModelInfoHoverCard.tsx
+++ b/web-app/src/containers/ModelInfoHoverCard.tsx
@@ -3,17 +3,68 @@ import {
   HoverCardContent,
   HoverCardTrigger,
 } from '@/components/ui/hover-card'
-import { IconInfoCircle } from '@tabler/icons-react'
+import {
+  IconAlertTriangle,
+  IconCheck,
+  IconDeviceDesktopQuestion,
+  IconX,
+} from '@tabler/icons-react'
 import { CatalogModel, ModelQuant } from '@/services/models/types'
+import { selectDefaultQuant, extractQuantLabel } from '@/lib/models'
+import { useHardware } from '@/hooks/useHardware'
+import {
+  DEFAULT_CTX_LENGTH,
+  estimateModelFit,
+  parseFileSize,
+  type FitTier,
+} from '@/lib/modelCompatibility'
+import { cn } from '@/lib/utils'
 
 interface ModelInfoHoverCardProps {
   model: CatalogModel
   variant?: ModelQuant
   isDefaultVariant?: boolean
-  defaultModelQuantizations: string[]
-  modelSupportStatus: Record<string, string>
-  onCheckModelSupport: (variant: ModelQuant) => void
+  defaultModelQuantizations: readonly string[]
   children?: React.ReactNode
+}
+
+type TriggerStyle = {
+  icon: typeof IconCheck
+  label: string
+  detail: string
+  pill: string
+  dot: string
+}
+
+const TRIGGER_STYLES: Record<FitTier, TriggerStyle> = {
+  green: {
+    icon: IconCheck,
+    label: 'Fits',
+    detail: 'Should run comfortably on your device',
+    pill: 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+    dot: 'bg-emerald-500',
+  },
+  yellow: {
+    icon: IconAlertTriangle,
+    label: 'May be slow',
+    detail: 'Will run but leaves little memory headroom',
+    pill: 'bg-amber-500/10 text-amber-700 dark:text-amber-400',
+    dot: 'bg-amber-500',
+  },
+  red: {
+    icon: IconX,
+    label: "Won't fit",
+    detail: 'Likely exceeds your available memory',
+    pill: 'bg-red-500/10 text-red-600 dark:text-red-400',
+    dot: 'bg-red-500',
+  },
+  unknown: {
+    icon: IconDeviceDesktopQuestion,
+    label: 'Fit unknown',
+    detail: 'Could not estimate memory requirements',
+    pill: 'bg-secondary text-muted-foreground',
+    dot: 'bg-neutral-400',
+  },
 }
 
 export const ModelInfoHoverCard = ({
@@ -21,100 +72,44 @@ export const ModelInfoHoverCard = ({
   variant,
   isDefaultVariant,
   defaultModelQuantizations,
-  modelSupportStatus,
-  onCheckModelSupport,
   children,
 }: ModelInfoHoverCardProps) => {
+  const hardwareData = useHardware((s) => s.hardwareData)
+
+  if (model.is_mlx) return null
+
   const displayVariant =
-    variant ||
-    model.quants?.find((m: ModelQuant) =>
-      defaultModelQuantizations.some((e) =>
-        m.model_id.toLowerCase().includes(e)
-      )
-    ) ||
-    model.quants?.[0]
+    variant ?? selectDefaultQuant(model.quants, defaultModelQuantizations)
 
-  const handleMouseEnter = () => {
-    if (displayVariant) {
-      onCheckModelSupport(displayVariant)
-    }
-  }
+  const fileSizeBytes = parseFileSize(displayVariant?.file_size)
+  const tier: FitTier = estimateModelFit(
+    fileSizeBytes,
+    DEFAULT_CTX_LENGTH,
+    hardwareData
+  )
+  const style = TRIGGER_STYLES[tier]
+  const Icon = style.icon
 
-  const getCompatibilityStatus = () => {
-    const status = displayVariant
-      ? modelSupportStatus[displayVariant.model_id]
-      : null
-
-    if (status === 'LOADING') {
-      return (
-        <div className="flex items-start gap-2">
-          <div className="size-2 shrink-0 border border-t-transparent rounded-full animate-spin mt-1"></div>
-          <span className="text-muted-foreground">Checking...</span>
-        </div>
-      )
-    } else if (status === 'GREEN') {
-      return (
-        <div className="flex items-start gap-2">
-          <div className="size-2 shrink-0 bg-green-500 rounded-full mt-1"></div>
-          <span className="text-green-500 font-medium">
-            Recommended for your device
-          </span>
-        </div>
-      )
-    } else if (status === 'YELLOW') {
-      return (
-        <div className="flex items-start gap-2">
-          <div className="size-2 shrink-0 bg-yellow-500 rounded-full mt-1"></div>
-          <span className="text-yellow-500 font-medium">
-            May be slow on your device
-          </span>
-        </div>
-      )
-    } else if (status === 'RED') {
-      return (
-        <div className="flex items-start gap-2">
-          <div className="size-2 shrink-0 bg-red-500 rounded-full mt-1"></div>
-          <span className="text-red-500 font-medium">
-            May be incompatible with your device
-          </span>
-        </div>
-      )
-    } else if (status === 'GREY') {
-      return (
-        <div className="flex items-start gap-2">
-          <div className="size-2 shrink-0 bg-neutral-500 rounded-full mt-1"></div>
-          <span className="text-neutral-500 font-medium">
-            Unable to determine model compatibility with your current device
-          </span>
-        </div>
-      )
-    } else {
-      return (
-        <div className="flex items-start gap-2">
-          <div className="size-2 shrink-0 bg-gray-400 rounded-full mt-1"></div>
-          <span className="text-gray-500">Unknown</span>
-        </div>
-      )
-    }
-  }
-
-  if(model.is_mlx) return null
+  const trigger = children ?? (
+    <button
+      type="button"
+      className={cn(
+        'inline-flex items-center gap-1 rounded font-medium cursor-pointer transition-colors',
+        isDefaultVariant ? 'text-xs px-2 py-1' : 'text-[11px] px-1.5 py-0.5',
+        style.pill
+      )}
+      aria-label={`Device compatibility: ${style.label}`}
+    >
+      <Icon size={isDefaultVariant ? 14 : 12} />
+      {isDefaultVariant && <span>{style.label}</span>}
+    </button>
+  )
 
   return (
-    <HoverCard>
-      <HoverCardTrigger asChild onMouseEnter={handleMouseEnter}>
-        {children || (
-          <div className="cursor-pointer">
-            <IconInfoCircle
-              size={isDefaultVariant ? 20 : 14}
-              className="mt-0.5 text-muted-foreground transition-colors"
-            />
-          </div>
-        )}
-      </HoverCardTrigger>
+    <HoverCard openDelay={150}>
+      <HoverCardTrigger asChild>{trigger}</HoverCardTrigger>
       <HoverCardContent className="w-80 p-4" side="left">
         <div className="space-y-4">
-          {/* Header */}
           <div className="border-b pb-3">
             <h4 className="text-sm font-semibold">
               {!isDefaultVariant ? variant?.model_id : model?.model_name}
@@ -126,59 +121,53 @@ export const ModelInfoHoverCard = ({
             </p>
           </div>
 
-          {/* Main Info Grid */}
           <div className="grid grid-cols-1 gap-4 text-xs">
-            <div className="space-y-2">
-              <>
-                <div>
-                  <span className="text-muted-foreground block">
-                    {isDefaultVariant ? 'Default Quantization' : 'Quantization'}
-                  </span>
-                  <span className="font-medium mt-1 inline-block">
-                    {variant?.model_id.split('-').pop()?.toUpperCase() || 'N/A'}
-                  </span>
-                </div>
-              </>
+            <div>
+              <span className="text-muted-foreground block">
+                {isDefaultVariant ? 'Default Quantization' : 'Quantization'}
+              </span>
+              <span className="font-medium mt-1 inline-block">
+                {extractQuantLabel(displayVariant?.model_id) || 'N/A'}
+              </span>
             </div>
 
-            <div className="space-y-2">
-              <div>
-                <span className="text-muted-foreground block">
-                  Compatibility
-                </span>
-                <div className="flex items-center gap-1.5 mt-1">
-                  {getCompatibilityStatus()}
+            <div>
+              <span className="text-muted-foreground block">
+                Device compatibility
+              </span>
+              <div className="flex items-start gap-2 mt-1">
+                <div
+                  className={cn(
+                    'size-2 shrink-0 rounded-full mt-1',
+                    style.dot
+                  )}
+                />
+                <div>
+                  <p className="font-medium">{style.label}</p>
+                  <p className="text-muted-foreground mt-0.5">{style.detail}</p>
                 </div>
               </div>
+              <p className="text-[11px] text-muted-foreground mt-2 italic">
+                Estimated from file size and your hardware. Actual performance
+                depends on quantization and context length.
+              </p>
             </div>
           </div>
 
-          {/* Features Section */}
-          {((model.num_mmproj ?? 0) > 0 || model.tools || ((model.num_mmproj ?? 0) > 0 && model.tools)) && (
-            <div className="border-t  pt-3">
+          {((model.num_mmproj ?? 0) > 0 || model.tools) && (
+            <div className="border-t pt-3">
               <h5 className="text-xs font-medium text-muted-foreground mb-2">
                 Features
               </h5>
               <div className="flex flex-wrap gap-2">
                 {model.tools && (
                   <div className="flex items-center gap-1.5 px-2 py-1 bg-secondary rounded-sm">
-                    <span className="text-xs font-medium">
-                      Tools
-                    </span>
+                    <span className="text-xs font-medium">Tools</span>
                   </div>
                 )}
                 {(model.num_mmproj ?? 0) > 0 && (
                   <div className="flex items-center gap-1.5 px-2 py-1 bg-secondary rounded-sm">
-                    <span className="text-xs font-medium">
-                      Vision
-                    </span>
-                  </div>
-                )}
-                {(model.num_mmproj ?? 0) > 0 && model.tools && (
-                  <div className="flex items-center gap-1.5 px-2 py-1 bg-secondary rounded-sm">
-                    <span className="text-xs font-medium">
-                      Proactive
-                    </span>
+                    <span className="text-xs font-medium">Vision</span>
                   </div>
                 )}
               </div>

--- a/web-app/src/hooks/useAssistant.ts
+++ b/web-app/src/hooks/useAssistant.ts
@@ -40,9 +40,7 @@ export const defaultAssistant: Assistant = {
   avatar: '👋',
   description:
     "Jan is a helpful desktop assistant that can reason through complex tasks and use tools to complete them on the user's behalf.",
-  instructions: `You are Jan, a helpful AI assistant who assists users with their requests. Jan is trained by Menlo Research (https://www.menlo.ai).
-
-You must output your response in the exact language used in the latest user message. Do not provide translations or switch languages unless explicitly instructed to do so. If the input is mostly English, respond in English.
+  instructions: `You must output your response in the exact language used in the latest user message. Do not provide translations or switch languages unless explicitly instructed to do so. If the input is mostly English, respond in English.
 
 When handling user queries:
 

--- a/web-app/src/lib/__tests__/modelCompatibility.test.ts
+++ b/web-app/src/lib/__tests__/modelCompatibility.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from 'vitest'
+import type { HardwareData } from '@/hooks/useHardware'
+import {
+  DEFAULT_CTX_LENGTH,
+  estimateKvCacheBytes,
+  estimateModelFit,
+  isAppleSilicon,
+  parseFileSize,
+} from '../modelCompatibility'
+
+const GB = 1024 ** 3
+
+const baseHardware = (overrides: Partial<HardwareData> = {}): HardwareData => ({
+  cpu: { arch: 'x86_64', core_count: 8, extensions: [], name: 'CPU', usage: 0 },
+  gpus: [],
+  os_type: 'linux',
+  os_name: 'linux',
+  total_memory: 16 * 1024,
+  ...overrides,
+})
+
+const appleSilicon = (totalMemoryGib: number): HardwareData =>
+  baseHardware({
+    cpu: { arch: 'aarch64', core_count: 10, extensions: [], name: 'M2', usage: 0 },
+    os_type: 'macos',
+    total_memory: totalMemoryGib * 1024,
+  })
+
+const withDiscreteGpu = (
+  ramGib: number,
+  vramGib: number
+): HardwareData =>
+  baseHardware({
+    total_memory: ramGib * 1024,
+    gpus: [
+      {
+        name: 'GPU',
+        total_memory: vramGib * 1024,
+        vendor: 'nvidia',
+        uuid: '0',
+        driver_version: '',
+        nvidia_info: { index: 0, compute_capability: '8.0' },
+        vulkan_info: {
+          index: 0,
+          device_id: 0,
+          device_type: 'discrete',
+          api_version: '',
+        },
+      },
+    ],
+  })
+
+describe('parseFileSize', () => {
+  it('parses common decimal units', () => {
+    expect(parseFileSize('4.7 GB')).toBeCloseTo(4.7 * 1000 ** 3)
+    expect(parseFileSize('158 MB')).toBeCloseTo(158 * 1000 ** 2)
+    expect(parseFileSize('2.5GB')).toBeCloseTo(2.5 * 1000 ** 3)
+  })
+
+  it('parses binary units distinctly from decimal', () => {
+    expect(parseFileSize('1 GiB')).toBe(1024 ** 3)
+    expect(parseFileSize('1 GB')).toBe(1000 ** 3)
+  })
+
+  it('returns null for unparseable input', () => {
+    expect(parseFileSize('')).toBeNull()
+    expect(parseFileSize(undefined)).toBeNull()
+    expect(parseFileSize(null)).toBeNull()
+    expect(parseFileSize('not a size')).toBeNull()
+    expect(parseFileSize('4.7 ZB')).toBeNull()
+  })
+
+  it('accepts numbers as bytes', () => {
+    expect(parseFileSize(5_000_000)).toBe(5_000_000)
+    expect(parseFileSize(-1)).toBeNull()
+  })
+})
+
+describe('estimateKvCacheBytes', () => {
+  it('scales linearly with context length', () => {
+    const base = estimateKvCacheBytes(10 * GB, 4096)
+    expect(estimateKvCacheBytes(10 * GB, 8192)).toBeCloseTo(base * 2)
+    expect(estimateKvCacheBytes(10 * GB, 2048)).toBeCloseTo(base * 0.5)
+  })
+
+  it('uses 10% of file size at the baseline context', () => {
+    expect(estimateKvCacheBytes(10 * GB, 4096)).toBeCloseTo(GB)
+  })
+
+  it('falls back to default ctx when ctx is non-positive', () => {
+    expect(estimateKvCacheBytes(10 * GB, 0)).toBeCloseTo(
+      estimateKvCacheBytes(10 * GB, DEFAULT_CTX_LENGTH)
+    )
+  })
+
+  it('returns 0 for invalid file size', () => {
+    expect(estimateKvCacheBytes(0)).toBe(0)
+    expect(estimateKvCacheBytes(-1)).toBe(0)
+    expect(estimateKvCacheBytes(NaN)).toBe(0)
+  })
+})
+
+describe('isAppleSilicon', () => {
+  it('detects macOS + aarch64 + no discrete GPU', () => {
+    expect(isAppleSilicon(appleSilicon(16))).toBe(true)
+  })
+
+  it('rejects when a discrete GPU is present', () => {
+    const hw = appleSilicon(16)
+    expect(isAppleSilicon({ ...hw, gpus: withDiscreteGpu(16, 8).gpus })).toBe(false)
+  })
+
+  it('rejects Intel Macs', () => {
+    expect(
+      isAppleSilicon({ ...appleSilicon(16), cpu: { ...appleSilicon(16).cpu, arch: 'x86_64' } })
+    ).toBe(false)
+  })
+})
+
+describe('estimateModelFit', () => {
+  it('returns unknown when file size cannot be determined', () => {
+    expect(estimateModelFit(null, DEFAULT_CTX_LENGTH, appleSilicon(16))).toBe('unknown')
+    expect(estimateModelFit(0, DEFAULT_CTX_LENGTH, appleSilicon(16))).toBe('unknown')
+  })
+
+  it('returns unknown when hardware has not been probed', () => {
+    expect(
+      estimateModelFit(4 * GB, DEFAULT_CTX_LENGTH, baseHardware({ total_memory: 0 }))
+    ).toBe('unknown')
+  })
+
+  describe('apple silicon', () => {
+    it('greens a small model on a 16 GiB M-series', () => {
+      expect(estimateModelFit(4 * GB, DEFAULT_CTX_LENGTH, appleSilicon(16))).toBe('green')
+    })
+
+    it('reds a model that exceeds usable unified memory', () => {
+      expect(estimateModelFit(13 * GB, DEFAULT_CTX_LENGTH, appleSilicon(16))).toBe('red')
+    })
+
+    it('yellows a model that fits but leaves <15% headroom', () => {
+      // 16 GiB → usable ≈ 11.9 GiB; comfortable threshold ≈ 10.1 GiB.
+      // 9.5 GiB file × 1.2 (ctx overhead) ≈ 11.4 GiB required → YELLOW band.
+      expect(estimateModelFit(9.5 * GB, DEFAULT_CTX_LENGTH, appleSilicon(16))).toBe('yellow')
+    })
+  })
+
+  describe('discrete GPU', () => {
+    it('greens a model that fits entirely in usable VRAM', () => {
+      expect(
+        estimateModelFit(4 * GB, DEFAULT_CTX_LENGTH, withDiscreteGpu(32, 16))
+      ).toBe('green')
+    })
+
+    it('yellows a model that spills from VRAM into system RAM', () => {
+      expect(
+        estimateModelFit(10 * GB, DEFAULT_CTX_LENGTH, withDiscreteGpu(32, 8))
+      ).toBe('yellow')
+    })
+
+    it('reds a model larger than combined usable RAM+VRAM', () => {
+      expect(
+        estimateModelFit(40 * GB, DEFAULT_CTX_LENGTH, withDiscreteGpu(16, 8))
+      ).toBe('red')
+    })
+  })
+
+  describe('CPU only (no GPU)', () => {
+    it('greens a model that fits in usable RAM', () => {
+      expect(
+        estimateModelFit(8 * GB, DEFAULT_CTX_LENGTH, baseHardware({ total_memory: 32 * 1024 }))
+      ).toBe('green')
+    })
+
+    it('reds a model larger than usable RAM', () => {
+      expect(
+        estimateModelFit(20 * GB, DEFAULT_CTX_LENGTH, baseHardware({ total_memory: 16 * 1024 }))
+      ).toBe('red')
+    })
+  })
+
+  it('respects context length when computing required memory', () => {
+    const hw = appleSilicon(16)
+    expect(estimateModelFit(9 * GB, 2048, hw)).toBe('green')
+    expect(estimateModelFit(9 * GB, 32768, hw)).not.toBe('green')
+  })
+})

--- a/web-app/src/lib/__tests__/models.test.ts
+++ b/web-app/src/lib/__tests__/models.test.ts
@@ -5,6 +5,7 @@ import {
   removeYamlFrontMatter,
   extractModelName,
   extractModelRepo,
+  extractQuantLabel,
   getModelCapabilities,
 } from '../models'
 import { ModelCapabilities } from '@/types/models'
@@ -232,6 +233,42 @@ describe('extractModelRepo', () => {
     expect(extractModelRepo('https://huggingface.co/cortexso/tinyllama/')).toBe(
       'cortexso/tinyllama/'
     )
+  })
+})
+
+describe('extractQuantLabel', () => {
+  it('extracts standard K-quant suffixes', () => {
+    expect(extractQuantLabel('Jan-v2-VL-high-Q4_K_M')).toBe('Q4_K_M')
+    expect(extractQuantLabel('Jan-v2-VL-high-Q5_K_S')).toBe('Q5_K_S')
+    expect(extractQuantLabel('Jan-v2-VL-high-Q3_K_L')).toBe('Q3_K_L')
+  })
+
+  it('extracts plain Q-quant suffixes', () => {
+    expect(extractQuantLabel('Model-Q4_0')).toBe('Q4_0')
+    expect(extractQuantLabel('Model-Q8_0')).toBe('Q8_0')
+  })
+
+  it('extracts IQ quant variants', () => {
+    expect(extractQuantLabel('Model-IQ4_XS')).toBe('IQ4_XS')
+    expect(extractQuantLabel('Model-IQ4_NL')).toBe('IQ4_NL')
+    expect(extractQuantLabel('Model-IQ3_M')).toBe('IQ3_M')
+  })
+
+  it('extracts float precision labels', () => {
+    expect(extractQuantLabel('Model-F16')).toBe('F16')
+    expect(extractQuantLabel('Model-BF16')).toBe('BF16')
+    expect(extractQuantLabel('Model-F32')).toBe('F32')
+  })
+
+  it('normalizes case to uppercase', () => {
+    expect(extractQuantLabel('jan-v2-vl-high-q4_k_m')).toBe('Q4_K_M')
+    expect(extractQuantLabel('model-iq4_xs')).toBe('IQ4_XS')
+  })
+
+  it('returns null when no quant marker present', () => {
+    expect(extractQuantLabel('some-random-model')).toBeNull()
+    expect(extractQuantLabel('')).toBeNull()
+    expect(extractQuantLabel()).toBeNull()
   })
 })
 

--- a/web-app/src/lib/__tests__/models.test.ts
+++ b/web-app/src/lib/__tests__/models.test.ts
@@ -7,6 +7,7 @@ import {
   extractModelRepo,
   extractQuantLabel,
   getModelCapabilities,
+  selectDefaultQuant,
 } from '../models'
 import { ModelCapabilities } from '@/types/models'
 
@@ -233,6 +234,45 @@ describe('extractModelRepo', () => {
     expect(extractModelRepo('https://huggingface.co/cortexso/tinyllama/')).toBe(
       'cortexso/tinyllama/'
     )
+  })
+})
+
+describe('selectDefaultQuant', () => {
+  const preferred = ['iq4_xs', 'q4_k_m'] as const
+
+  it('returns the first preferred match', () => {
+    const quants = [
+      { model_id: 'Model-Q3_K_L' },
+      { model_id: 'Model-Q4_K_M' },
+      { model_id: 'Model-Q5_K_S' },
+    ]
+    expect(selectDefaultQuant(quants, preferred)).toBe(quants[1])
+  })
+
+  it('prefers earlier entries in the preferred list', () => {
+    const quants = [
+      { model_id: 'Model-Q4_K_M' },
+      { model_id: 'Model-IQ4_XS' },
+    ]
+    expect(selectDefaultQuant(quants, preferred)?.model_id).toBe('Model-Q4_K_M')
+  })
+
+  it('matches case-insensitively', () => {
+    const quants = [{ model_id: 'model-q4_k_m' }]
+    expect(selectDefaultQuant(quants, preferred)).toBe(quants[0])
+  })
+
+  it('falls back to the first quant when nothing matches', () => {
+    const quants = [
+      { model_id: 'Model-Q3_K_L' },
+      { model_id: 'Model-Q8_0' },
+    ]
+    expect(selectDefaultQuant(quants, preferred)).toBe(quants[0])
+  })
+
+  it('returns undefined for empty or missing input', () => {
+    expect(selectDefaultQuant([], preferred)).toBeUndefined()
+    expect(selectDefaultQuant(undefined, preferred)).toBeUndefined()
   })
 })
 

--- a/web-app/src/lib/modelCompatibility.ts
+++ b/web-app/src/lib/modelCompatibility.ts
@@ -1,0 +1,114 @@
+import type { HardwareData } from '@/hooks/useHardware'
+
+export type FitTier = 'green' | 'yellow' | 'red' | 'unknown'
+
+export const DEFAULT_CTX_LENGTH = 8192
+
+const KV_HEURISTIC_RATIO = 0.1
+const KV_BASELINE_CTX = 4096
+
+const DISCRETE_RESERVE_BYTES = 2_288_490_189
+const APPLE_SILICON_FIXED_OVERHEAD = 2_684_354_560
+const APPLE_SILICON_VARIABLE_RATIO = 0.1
+const APPLE_SILICON_COMFORTABLE_RATIO = 0.85
+
+const MIB = 1024 * 1024
+const UNIT_BYTES: Record<string, number> = {
+  b: 1,
+  kb: 1000,
+  kib: 1024,
+  mb: 1000 ** 2,
+  mib: 1024 ** 2,
+  gb: 1000 ** 3,
+  gib: 1024 ** 3,
+  tb: 1000 ** 4,
+  tib: 1024 ** 4,
+}
+
+export function parseFileSize(input?: string | number | null): number | null {
+  if (input == null) return null
+  if (typeof input === 'number') {
+    return Number.isFinite(input) && input >= 0 ? input : null
+  }
+  const trimmed = input.trim()
+  if (!trimmed) return null
+  const match = trimmed.match(/^([0-9]+(?:\.[0-9]+)?)\s*([a-zA-Z]+)?$/)
+  if (!match) return null
+  const value = parseFloat(match[1])
+  if (!Number.isFinite(value) || value < 0) return null
+  const unitKey = (match[2] || 'b').toLowerCase()
+  const multiplier = UNIT_BYTES[unitKey]
+  if (multiplier === undefined) return null
+  return value * multiplier
+}
+
+export function estimateKvCacheBytes(
+  fileSizeBytes: number,
+  ctxLength: number = DEFAULT_CTX_LENGTH
+): number {
+  if (!Number.isFinite(fileSizeBytes) || fileSizeBytes <= 0) return 0
+  const ctx = ctxLength > 0 ? ctxLength : DEFAULT_CTX_LENGTH
+  return fileSizeBytes * KV_HEURISTIC_RATIO * (ctx / KV_BASELINE_CTX)
+}
+
+export function isAppleSilicon(hardware: HardwareData): boolean {
+  return (
+    hardware.os_type === 'macos' &&
+    hardware.cpu.arch === 'aarch64' &&
+    hardware.gpus.length === 0
+  )
+}
+
+function totalRamBytes(hardware: HardwareData): number {
+  return (hardware.total_memory || 0) * MIB
+}
+
+function totalVramBytes(hardware: HardwareData): number {
+  return hardware.gpus.reduce((sum, g) => sum + (g.total_memory || 0) * MIB, 0)
+}
+
+function hardwareReady(hardware: HardwareData): boolean {
+  return totalRamBytes(hardware) > 0
+}
+
+export function estimateModelFit(
+  fileSizeBytes: number | null,
+  ctxLength: number,
+  hardware: HardwareData
+): FitTier {
+  if (
+    fileSizeBytes == null ||
+    !Number.isFinite(fileSizeBytes) ||
+    fileSizeBytes <= 0
+  ) {
+    return 'unknown'
+  }
+  if (!hardwareReady(hardware)) return 'unknown'
+
+  const required = fileSizeBytes + estimateKvCacheBytes(fileSizeBytes, ctxLength)
+
+  if (isAppleSilicon(hardware)) {
+    const total = totalRamBytes(hardware)
+    const variableOverhead = total * APPLE_SILICON_VARIABLE_RATIO
+    const usable = Math.max(0, total - APPLE_SILICON_FIXED_OVERHEAD - variableOverhead)
+    if (required > usable) return 'red'
+    return required <= usable * APPLE_SILICON_COMFORTABLE_RATIO ? 'green' : 'yellow'
+  }
+
+  const ram = totalRamBytes(hardware)
+  const vram = totalVramBytes(hardware)
+  const hasDiscreteGpu = vram > 0
+
+  if (!hasDiscreteGpu) {
+    const usable = Math.max(0, ram - DISCRETE_RESERVE_BYTES)
+    return required <= usable ? 'green' : 'red'
+  }
+
+  const usableVram = Math.max(0, vram - DISCRETE_RESERVE_BYTES)
+  const usableRam = Math.max(0, ram - DISCRETE_RESERVE_BYTES)
+  const usableTotal = usableRam + usableVram
+
+  if (required > usableTotal) return 'red'
+  if (required <= usableVram) return 'green'
+  return 'yellow'
+}

--- a/web-app/src/lib/models.ts
+++ b/web-app/src/lib/models.ts
@@ -91,6 +91,18 @@ export const extractModelRepo = (model?: string) => {
   return model?.replace('https://huggingface.co/', '')
 }
 
+export const selectDefaultQuant = <T extends { model_id: string }>(
+  quants: T[] | undefined,
+  preferred: readonly string[]
+): T | undefined => {
+  if (!quants?.length) return undefined
+  return (
+    quants.find((q) =>
+      preferred.some((p) => q.model_id.toLowerCase().includes(p))
+    ) ?? quants[0]
+  )
+}
+
 export const extractQuantLabel = (modelId?: string): string | null => {
   if (!modelId) return null
   const match = modelId.match(

--- a/web-app/src/lib/models.ts
+++ b/web-app/src/lib/models.ts
@@ -90,3 +90,11 @@ export const extractModelName = (model?: string) => {
 export const extractModelRepo = (model?: string) => {
   return model?.replace('https://huggingface.co/', '')
 }
+
+export const extractQuantLabel = (modelId?: string): string | null => {
+  if (!modelId) return null
+  const match = modelId.match(
+    /(IQ\d+(?:_[A-Z0-9]+)+|Q\d+(?:_[A-Z0-9]+)*|BF16|F16|F32)(?:[-_.][^-_.]*)?$/i
+  )
+  return match ? match[1].toUpperCase() : null
+}

--- a/web-app/src/locales/en/hub.json
+++ b/web-app/src/locales/en/hub.json
@@ -3,6 +3,7 @@
   "sortMostDownloaded": "Most downloaded",
   "newChat": "New chat",
   "download": "Download",
+  "downloadFailed": "Failed to start download",
   "downloaded": "Downloaded",
   "loadingModels": "Loading models...",
   "noModels": "No models found",

--- a/web-app/src/routes/hub/$modelId.tsx
+++ b/web-app/src/routes/hub/$modelId.tsx
@@ -19,7 +19,7 @@ import { useEffect, useMemo, useCallback, useState } from 'react'
 import { useModelProvider } from '@/hooks/useModelProvider'
 import { useDownloadStore } from '@/hooks/useDownloadStore'
 import { useServiceHub } from '@/hooks/useServiceHub'
-import type { CatalogModel, ModelQuant } from '@/services/models/types'
+import type { CatalogModel } from '@/services/models/types'
 import { Progress } from '@/components/ui/progress'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
@@ -58,10 +58,6 @@ function HubModelDetailContent() {
   const [readmeContent, setReadmeContent] = useState<string>('')
   const [isLoadingReadme, setIsLoadingReadme] = useState(false)
 
-  // State for model support status
-  const [modelSupportStatus, setModelSupportStatus] = useState<
-    Record<string, 'RED' | 'YELLOW' | 'GREEN' | 'LOADING' | 'GREY'>
-  >({})
 
   useEffect(() => {
     fetchSources()
@@ -137,43 +133,6 @@ function HubModelDetailContent() {
       return `${years} year${years > 1 ? 's' : ''} ago`
     }
   }
-
-  // Check model support function
-  const checkModelSupport = useCallback(
-    async (variant: ModelQuant) => {
-      const modelKey = variant.model_id
-
-      // Don't check again if already checking or checked
-      if (modelSupportStatus[modelKey]) {
-        return
-      }
-
-      // Set loading state
-      setModelSupportStatus((prev) => ({
-        ...prev,
-        [modelKey]: 'LOADING',
-      }))
-
-      try {
-        // Use the HuggingFace path for the model
-        const modelPath = variant.path
-        const supported = await serviceHub
-          .models()
-          .isModelSupported(modelPath, 8192)
-        setModelSupportStatus((prev) => ({
-          ...prev,
-          [modelKey]: supported,
-        }))
-      } catch (error) {
-        console.error('Error checking model support:', error)
-        setModelSupportStatus((prev) => ({
-          ...prev,
-          [modelKey]: 'RED',
-        }))
-      }
-    },
-    [modelSupportStatus, serviceHub]
-  )
 
   // Extract tags from quants (model variants)
   const tags = useMemo(() => {
@@ -421,8 +380,6 @@ function HubModelDetailContent() {
                                 defaultModelQuantizations={
                                   DEFAULT_MODEL_QUANTIZATIONS
                                 }
-                                modelSupportStatus={modelSupportStatus}
-                                onCheckModelSupport={checkModelSupport}
                               />
                             </td>
                             <td className="py-3 px-2 text-right ml-auto">

--- a/web-app/src/routes/hub/index.tsx
+++ b/web-app/src/routes/hub/index.tsx
@@ -507,9 +507,9 @@ function HubContent() {
                     >
                       <Card
                         header={
-                          <div className="flex items-center justify-between gap-x-2">
+                          <div className="flex items-start justify-between gap-x-3">
                             <div
-                              className="cursor-pointer"
+                              className="cursor-pointer min-w-0 flex-1"
                               onClick={() => {
                                 navigate({
                                   to: route.hub.model,
@@ -543,27 +543,29 @@ function HubContent() {
                                 ) || ''}
                               </h1>
                             </div>
-                            <div className="shrink-0 space-x-3 flex items-center">
-                              <span className="text-muted-foreground font-medium text-xs">
-                                {filteredModels[virtualItem.index].is_mlx
-                                  ? filteredModels[virtualItem.index]
-                                      .safetensors_files?.[0]?.file_size
-                                  : selectDefaultQuant(
-                                      filteredModels[virtualItem.index].quants,
-                                      DEFAULT_MODEL_QUANTIZATIONS
-                                    )?.file_size}
-                              </span>
-                              <ModelInfoHoverCard
-                                model={filteredModels[virtualItem.index]}
-                                defaultModelQuantizations={
-                                  DEFAULT_MODEL_QUANTIZATIONS
-                                }
-                                variant={selectDefaultQuant(
-                                  filteredModels[virtualItem.index].quants,
-                                  DEFAULT_MODEL_QUANTIZATIONS
-                                )}
-                                isDefaultVariant={true}
-                              />
+                            <div className="shrink-0 flex flex-col items-end gap-2">
+                              <div className="flex items-center gap-2">
+                                <span className="text-muted-foreground font-medium text-xs">
+                                  {filteredModels[virtualItem.index].is_mlx
+                                    ? filteredModels[virtualItem.index]
+                                        .safetensors_files?.[0]?.file_size
+                                    : selectDefaultQuant(
+                                        filteredModels[virtualItem.index].quants,
+                                        DEFAULT_MODEL_QUANTIZATIONS
+                                      )?.file_size}
+                                </span>
+                                <ModelInfoHoverCard
+                                  model={filteredModels[virtualItem.index]}
+                                  defaultModelQuantizations={
+                                    DEFAULT_MODEL_QUANTIZATIONS
+                                  }
+                                  variant={selectDefaultQuant(
+                                    filteredModels[virtualItem.index].quants,
+                                    DEFAULT_MODEL_QUANTIZATIONS
+                                  )}
+                                  isDefaultVariant={true}
+                                />
+                              </div>
                               {filteredModels[virtualItem.index].is_mlx ? (
                                 <MlxModelDownloadAction
                                   model={filteredModels[virtualItem.index]}

--- a/web-app/src/routes/hub/index.tsx
+++ b/web-app/src/routes/hub/index.tsx
@@ -15,7 +15,11 @@ import {
 } from 'react'
 import { useModelProvider } from '@/hooks/useModelProvider'
 import { Card, CardItem } from '@/containers/Card'
-import { extractModelName, extractDescription } from '@/lib/models'
+import {
+  extractModelName,
+  extractDescription,
+  selectDefaultQuant,
+} from '@/lib/models'
 import {
   IconChevronDown,
   IconChevronUp,
@@ -585,16 +589,9 @@ function HubContent() {
                                 {filteredModels[virtualItem.index].is_mlx
                                   ? filteredModels[virtualItem.index]
                                       .safetensors_files?.[0]?.file_size
-                                  : (
-                                      filteredModels[
-                                        virtualItem.index
-                                      ].quants?.find((m) =>
-                                        DEFAULT_MODEL_QUANTIZATIONS.some((e) =>
-                                          m.model_id.toLowerCase().includes(e)
-                                        )
-                                      ) ??
-                                      filteredModels[virtualItem.index]
-                                        .quants?.[0]
+                                  : selectDefaultQuant(
+                                      filteredModels[virtualItem.index].quants,
+                                      DEFAULT_MODEL_QUANTIZATIONS
                                     )?.file_size}
                               </span>
                               <ModelInfoHoverCard
@@ -602,17 +599,10 @@ function HubContent() {
                                 defaultModelQuantizations={
                                   DEFAULT_MODEL_QUANTIZATIONS
                                 }
-                                variant={
-                                  filteredModels[
-                                    virtualItem.index
-                                  ].quants?.find((m) =>
-                                    DEFAULT_MODEL_QUANTIZATIONS.some((e) =>
-                                      m.model_id.toLowerCase().includes(e)
-                                    )
-                                  ) ??
-                                  filteredModels[virtualItem.index]
-                                    .quants?.[0]
-                                }
+                                variant={selectDefaultQuant(
+                                  filteredModels[virtualItem.index].quants,
+                                  DEFAULT_MODEL_QUANTIZATIONS
+                                )}
                                 isDefaultVariant={true}
                                 modelSupportStatus={modelSupportStatus}
                                 onCheckModelSupport={checkModelSupport}
@@ -746,12 +736,9 @@ function HubContent() {
                           (() => {
                             const quants =
                               filteredModels[virtualItem.index].quants ?? []
-                            const recommendedId = (
-                              quants.find((m) =>
-                                DEFAULT_MODEL_QUANTIZATIONS.some((e) =>
-                                  m.model_id.toLowerCase().includes(e)
-                                )
-                              ) ?? quants[0]
+                            const recommendedId = selectDefaultQuant(
+                              quants,
+                              DEFAULT_MODEL_QUANTIZATIONS
                             )?.model_id
                             return (
                             <div className="mt-5">

--- a/web-app/src/routes/hub/index.tsx
+++ b/web-app/src/routes/hub/index.tsx
@@ -57,6 +57,36 @@ type SearchParams = {
   repo: string
 }
 
+type QuantTier = {
+  label: string
+  className: string
+}
+
+function getQuantTier(modelId: string): QuantTier | null {
+  const id = modelId.toLowerCase()
+  if (/(^|[-_.])(f32|bf16|f16|q8|q6)([-_.]|$)/.test(id)) {
+    return {
+      label: 'Large',
+      className:
+        'bg-amber-500/10 text-amber-700 dark:text-amber-400',
+    }
+  }
+  if (/(^|[-_.])(q5|q4_k|iq4)/.test(id)) {
+    return {
+      label: 'Balanced',
+      className:
+        'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+    }
+  }
+  if (/(^|[-_.])(iq2|iq3|q2|q3|q4_0|q4_1)/.test(id)) {
+    return {
+      label: 'Small',
+      className: 'bg-blue-500/10 text-blue-600 dark:text-blue-400',
+    }
+  }
+  return null
+}
+
 export const Route = createFileRoute(route.hub.index as any)({
   component: HubContent,
   validateSearch: (search: Record<string, unknown>): SearchParams => ({
@@ -665,38 +695,16 @@ function HubContent() {
                             <div className="flex gap-1.5 items-center">
                               {(filteredModels[virtualItem.index].num_mmproj ?? 0) >
                                 0 && (
-                                <div className="flex items-center gap-1">
-                                  <Tooltip>
-                                    <TooltipTrigger asChild>
-                                      <div>
-                                        <IconEye
-                                          size={17}
-                                          className="text-muted-foreground"
-                                        />
-                                      </div>
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                      <p>{t('vision')}</p>
-                                    </TooltipContent>
-                                  </Tooltip>
-                                </div>
+                                <span className="inline-flex items-center gap-1 text-xs font-medium px-1.5 py-0.5 rounded bg-secondary text-foreground/80">
+                                  <IconEye size={13} />
+                                  {t('vision')}
+                                </span>
                               )}
                               {filteredModels[virtualItem.index].tools && (
-                                <div className="flex items-center gap-1">
-                                  <Tooltip>
-                                    <TooltipTrigger asChild>
-                                      <div>
-                                        <IconTool
-                                          size={17}
-                                          className="text-muted-foreground"
-                                        />
-                                      </div>
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                      <p>{t('tools')}</p>
-                                    </TooltipContent>
-                                  </Tooltip>
-                                </div>
+                                <span className="inline-flex items-center gap-1 text-xs font-medium px-1.5 py-0.5 rounded bg-secondary text-foreground/80">
+                                  <IconTool size={13} />
+                                  {t('tools')}
+                                </span>
                               )}
                             </div>
                           </div>
@@ -734,55 +742,47 @@ function HubContent() {
                           filteredModels[virtualItem.index].model_name
                         ] &&
                           (filteredModels[virtualItem.index].quants?.length ?? 0) >
-                            0 && (
+                            0 &&
+                          (() => {
+                            const quants =
+                              filteredModels[virtualItem.index].quants ?? []
+                            const recommendedId = (
+                              quants.find((m) =>
+                                DEFAULT_MODEL_QUANTIZATIONS.some((e) =>
+                                  m.model_id.toLowerCase().includes(e)
+                                )
+                              ) ?? quants[0]
+                            )?.model_id
+                            return (
                             <div className="mt-5">
-                              {filteredModels[virtualItem.index].quants?.map(
+                              {quants.map(
                                 (variant) => (
                                   <CardItem
                                     key={variant.model_id}
                                     title={
-                                      <>
-                                        <div className="flex items-center gap-1">
-                                          <span className="mr-2">
-                                            {variant.model_id}
+                                      <div className="flex items-center gap-2">
+                                        <span>{variant.model_id}</span>
+                                        {(() => {
+                                          const tier = getQuantTier(
+                                            variant.model_id
+                                          )
+                                          return tier ? (
+                                            <span
+                                              className={cn(
+                                                'text-xs font-medium px-1.5 py-0.5 rounded',
+                                                tier.className
+                                              )}
+                                            >
+                                              {tier.label}
+                                            </span>
+                                          ) : null
+                                        })()}
+                                        {variant.model_id === recommendedId && (
+                                          <span className="text-xs font-medium px-1.5 py-0.5 rounded bg-primary/10 text-primary">
+                                            Recommended
                                           </span>
-                                          {(filteredModels[virtualItem.index].num_mmproj ?? 0) > 0 && (
-                                            <div className="flex items-center gap-1">
-                                              <Tooltip>
-                                                <TooltipTrigger asChild>
-                                                  <div>
-                                                    <IconEye
-                                                      size={17}
-                                                      className="text-muted-foreground"
-                                                    />
-                                                  </div>
-                                                </TooltipTrigger>
-                                                <TooltipContent>
-                                                  <p>{t('vision')}</p>
-                                                </TooltipContent>
-                                              </Tooltip>
-                                            </div>
-                                          )}
-                                          {filteredModels[virtualItem.index]
-                                            .tools && (
-                                            <div className="flex items-center gap-1">
-                                              <Tooltip>
-                                                <TooltipTrigger asChild>
-                                                  <div>
-                                                    <IconTool
-                                                      size={17}
-                                                      className="text-muted-foreground"
-                                                    />
-                                                  </div>
-                                                </TooltipTrigger>
-                                                <TooltipContent>
-                                                  <p>{t('tools')}</p>
-                                                </TooltipContent>
-                                              </Tooltip>
-                                            </div>
-                                          )}
-                                        </div>
-                                      </>
+                                        )}
+                                      </div>
                                     }
                                     actions={
                                       <div className="flex items-center gap-2">
@@ -825,7 +825,8 @@ function HubContent() {
                                 )
                               )}
                             </div>
-                          )}
+                            )
+                          })()}
                       </Card>
                     </div>
                   ))}

--- a/web-app/src/routes/hub/index.tsx
+++ b/web-app/src/routes/hub/index.tsx
@@ -143,9 +143,6 @@ function HubContent() {
   const [huggingFaceRepo, setHuggingFaceRepo] = useState<CatalogModel | null>(
     null
   )
-  const [modelSupportStatus, setModelSupportStatus] = useState<
-    Record<string, 'RED' | 'YELLOW' | 'GREEN' | 'LOADING'>
-  >({})
   const [isInitialLoad, setIsInitialLoad] = useState(true)
   const addModelSourceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
     null
@@ -364,44 +361,6 @@ function HubContent() {
     [navigate]
   )
 
-  const checkModelSupport = useCallback(
-    async (variant: any) => {
-      const modelKey = variant.model_id
-
-      // Don't check again if already checking or checked
-      if (modelSupportStatus[modelKey]) {
-        return
-      }
-
-      // Set loading state
-      setModelSupportStatus((prev) => ({
-        ...prev,
-        [modelKey]: 'LOADING',
-      }))
-
-      try {
-        // Use the HuggingFace path for the model
-        const modelPath = variant.path
-        const supportStatus = await serviceHub
-          .models()
-          .isModelSupported(modelPath, 8192)
-
-        setModelSupportStatus((prev) => ({
-          ...prev,
-          [modelKey]: supportStatus,
-        }))
-      } catch (error) {
-        console.error('Error checking model support:', error)
-        setModelSupportStatus((prev) => ({
-          ...prev,
-          [modelKey]: 'RED',
-        }))
-      }
-    },
-    [modelSupportStatus, serviceHub]
-  )
-
-  // Check if we're on the last step
   const renderFilter = () => {
     return (
       <>
@@ -604,8 +563,6 @@ function HubContent() {
                                   DEFAULT_MODEL_QUANTIZATIONS
                                 )}
                                 isDefaultVariant={true}
-                                modelSupportStatus={modelSupportStatus}
-                                onCheckModelSupport={checkModelSupport}
                               />
                               {filteredModels[virtualItem.index].is_mlx ? (
                                 <MlxModelDownloadAction
@@ -783,12 +740,6 @@ function HubContent() {
                                           variant={variant}
                                           defaultModelQuantizations={
                                             DEFAULT_MODEL_QUANTIZATIONS
-                                          }
-                                          modelSupportStatus={
-                                            modelSupportStatus
-                                          }
-                                          onCheckModelSupport={
-                                            checkModelSupport
                                           }
                                         />
                                         {filteredModels[virtualItem.index]

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -32,7 +32,7 @@ import {
 } from '@tabler/icons-react'
 import { useDefaultEmbeddingModel } from '@/hooks/useDefaultEmbeddingModel'
 import { toast } from 'sonner'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { predefinedProviders } from '@/constants/providers'
 import { useModelLoad } from '@/hooks/useModelLoad'
 import { useLlamacppDevices } from '@/hooks/useLlamacppDevices'
@@ -81,13 +81,21 @@ function ProviderDetail() {
   const { getProviderByName, setProviders, updateProvider } = useModelProvider()
   const provider = getProviderByName(providerName)
   const isLlamacpp = provider?.provider === 'llamacpp'
-  const allModels = provider?.models ?? []
-  const embeddingModels = isLlamacpp
-    ? allModels.filter((m) => (m as any).embedding === true)
-    : []
-  const chatModels = isLlamacpp
-    ? allModels.filter((m) => (m as any).embedding !== true)
-    : allModels
+  const allModels = useMemo(() => provider?.models ?? [], [provider?.models])
+  const embeddingModels = useMemo(
+    () =>
+      isLlamacpp
+        ? allModels.filter((m) => (m as any).embedding === true)
+        : [],
+    [isLlamacpp, allModels]
+  )
+  const chatModels = useMemo(
+    () =>
+      isLlamacpp
+        ? allModels.filter((m) => (m as any).embedding !== true)
+        : allModels,
+    [isLlamacpp, allModels]
+  )
   const defaultEmbeddingModelId = useDefaultEmbeddingModel((s) =>
     isLlamacpp ? s.getDefault('llamacpp') : undefined
   )


### PR DESCRIPTION
## Describe Your Changes
Refactor the model hub list view so users can tell at a glance *what* a model is, *whether their machine can run it*, and *which file the Download button will fetch* — without hovering, expanding, or downloading anything from HuggingFace just to check.

  ### Hub UX
  - **Capability badges**: replace inline vision/tools icons with labeled pill badges (`Vision`, `Tools`) so the meaning is readable, not inferred from glyphs.
  - **Quant tier labels**: each variant in the expanded list is tagged `Small` / `Balanced` / `Large` based on its quant suffix (filename-only, no parsing). `IQ4_*` correctly maps to Balanced.
  - **Recommended marker**: the variant the default Download button will pick gets a `Recommended` pill, visually linking the header CTA to the row in the expanded list.
  - **Download button** reads `Download · Q4_K_M` (or the matched quant), so the picked file is named before the user clicks.
  - **Header layout aligned**: outer flex anchors to title top; the right column stacks into `[size · fit pill]` over the Download button, so long model names no longer push action chips out of alignment.

  ### Local device-fit heuristic (no network)
  `is_model_supported` today range-fetches the GGUF header per variant, which made per-card eager checks infeasible on a hub list. Replaced with a pure frontend estimator:

  - New `lib/modelCompatibility.ts` — takes catalog `file_size` + a default context length + `useHardware` state, returns `green | yellow | red | unknown`.
  - Mirrors the apple-silicon (2.5 GB fixed + 10% variable overhead, 85% comfort threshold) and discrete-GPU (2.13 GB reserve, VRAM-first spill-to-RAM tiers) logic from the Rust plugin. KV cache is approximated as `file_size × 0.10 × (ctx / 4096)`.
  - Every card now shows fit status on first paint: `Fits` / `May be slow` / `Won't fit` / `Fit unknown`.
  - `ModelInfoHoverCard`'s generic "i" icon trigger is replaced by a status-colored pill (icon + label on the parent card, icon-only on the dense variant rows). The hover card still surfaces the full fit explanation, quantization, and feature badges.
  - Drops the per-row `modelSupportStatus` state and `checkModelSupport` callback from both `hub/index.tsx` and `hub/$modelId.tsx`.

  ### Download lifecycle hardening
  Audited the download path and fixed three real issues:

  - **Event-listener leak** in `DownloadButton`: `events.on(...)` is now paired with `events.off(...)` in the effect cleanup, matching`MlxModelDownloadAction`.
  - **Unhandled promise** in both `DownloadButton` and `ModelDownloadAction`: `pullModelWithMetadata` is now awaited inside a `try/catch`. On failure we roll back the optimistic
    `addLocalDownloadingModel(...)` and surface a sonner toast, so the button no longer hangs in "downloading" forever after a network drop / 401 / disk-full.
  - **Default-quant pick** was duplicated across 4 inline sites; collapsed into `selectDefaultQuant()` in `lib/models.ts` with tests.

  ### Misc
  - Drop the identity paragraph from the default assistant seed in both `useAssistant.ts` and the assistant extension. Historical migrations (v1/v2) are intentionally left intact so existing on-disk assistant records are not retroactively rewritten.
  - Clear the 6 standing lint warnings: real `useMemo` fix in `settings/providers/$providerName.tsx`; per-file `react-refresh/only-export-components` disable on four shadcn-style files where the mixed-export pattern is idiomatic.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
