### PR TITLE
fix: tool-call schemas, predefined provider base_url, i18n

### DIFF
--- a/src-tauri/src/core/server/proxy.rs
+++ b/src-tauri/src/core/server/proxy.rs
@@ -23,6 +23,22 @@ const SCHEMA_PRIMITIVE_TYPES: &[&str] = &[
     "string", "number", "integer", "boolean", "null", "array", "object",
 ];
 
+// llama.cpp's json-schema-to-grammar emits PCRE `\d` for these formats,
+// which GBNF rejects; the failed grammar silently disables tool-call JSON.
+const LLAMACPP_BROKEN_STRING_FORMATS: &[&str] = &["date", "time", "date-time"];
+
+fn pattern_has_pcre_shorthand(pattern: &str) -> bool {
+    let bytes = pattern.as_bytes();
+    let mut i = 0;
+    while i + 1 < bytes.len() {
+        if bytes[i] == b'\\' && matches!(bytes[i + 1], b'd' | b'D' | b'w' | b'W' | b's' | b'S') {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
 /// If `value` is a bare string naming a JSON-schema primitive type (e.g.
 /// `"string"`), expand it to `{ "type": <that> }`. Some tool generators emit
 /// shorthand like `{ "properties": { "foo": "string" } }`; llama.cpp's
@@ -75,6 +91,24 @@ pub(crate) fn normalize_openai_tool_parameters_schema(schema: &mut serde_json::V
                     "type".to_string(),
                     serde_json::Value::String("string".to_string()),
                 );
+            }
+
+            let drop_format = map
+                .get("format")
+                .and_then(|v| v.as_str())
+                .map(|f| LLAMACPP_BROKEN_STRING_FORMATS.contains(&f))
+                .unwrap_or(false);
+            if drop_format {
+                map.remove("format");
+            }
+
+            let drop_pattern = map
+                .get("pattern")
+                .and_then(|v| v.as_str())
+                .map(pattern_has_pcre_shorthand)
+                .unwrap_or(false);
+            if drop_pattern {
+                map.remove("pattern");
             }
 
             // Recurse, with shorthand expansion for keys whose direct children

--- a/src-tauri/src/core/server/tests.rs
+++ b/src-tauri/src/core/server/tests.rs
@@ -502,6 +502,74 @@ mod tests {
         assert_eq!(schema["properties"]["metadata"]["properties"], json!({}));
     }
 
+    #[test]
+    fn strips_broken_string_formats_for_llamacpp_grammar() {
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "start": { "type": "string", "format": "date-time" },
+                "stop":  { "type": "string", "format": "date" },
+                "at":    { "type": "string", "format": "time" }
+            }
+        });
+
+        proxy::normalize_openai_tool_parameters_schema(&mut schema);
+
+        assert!(schema["properties"]["start"].get("format").is_none());
+        assert!(schema["properties"]["stop"].get("format").is_none());
+        assert!(schema["properties"]["at"].get("format").is_none());
+        assert_eq!(schema["properties"]["start"]["type"], json!("string"));
+    }
+
+    #[test]
+    fn preserves_harmless_string_formats() {
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "id":  { "type": "string", "format": "uuid" },
+                "url": { "type": "string", "format": "uri" }
+            }
+        });
+
+        proxy::normalize_openai_tool_parameters_schema(&mut schema);
+
+        assert_eq!(schema["properties"]["id"]["format"], json!("uuid"));
+        assert_eq!(schema["properties"]["url"]["format"], json!("uri"));
+    }
+
+    #[test]
+    fn strips_pcre_shorthand_patterns() {
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "when":  { "type": "string", "pattern": "^\\d{4}-\\d{2}-\\d{2}$" },
+                "alpha": { "type": "string", "pattern": "^[A-Z]+$" }
+            }
+        });
+
+        proxy::normalize_openai_tool_parameters_schema(&mut schema);
+
+        assert!(schema["properties"]["when"].get("pattern").is_none());
+        assert_eq!(schema["properties"]["alpha"]["pattern"], json!("^[A-Z]+$"));
+    }
+
+    #[test]
+    fn strips_broken_format_when_type_missing_or_non_string() {
+        let mut schema = json!({
+            "type": "object",
+            "properties": {
+                "until":    { "format": "date-time", "description": "iso end" },
+                "nullable": { "type": ["string", "null"], "format": "date" }
+            }
+        });
+
+        proxy::normalize_openai_tool_parameters_schema(&mut schema);
+
+        assert!(schema["properties"]["until"].get("format").is_none());
+        assert_eq!(schema["properties"]["until"]["type"], json!("string"));
+        assert!(schema["properties"]["nullable"].get("format").is_none());
+    }
+
     // ── Pure helper coverage ───────────────────────────────────────────────
 
     #[test]

--- a/web-app/src/constants/providers.ts
+++ b/web-app/src/constants/providers.ts
@@ -45,17 +45,6 @@ export const predefinedProviders = [
           input_actions: ['unobscure', 'copy'],
         },
       },
-      {
-        key: 'base-url',
-        title: 'Base URL',
-        description:
-          'The base endpoint to use. See the [OpenAI API documentation](https://platform.openai.com/docs/api-reference/chat/create) for more information.',
-        controller_type: 'input',
-        controller_props: {
-          placeholder: 'https://api.openai.com/v1',
-          value: 'https://api.openai.com/v1',
-        },
-      },
     ],
     models: [],
   },
@@ -77,17 +66,6 @@ export const predefinedProviders = [
           value: '',
           type: 'password',
           input_actions: ['unobscure', 'copy'],
-        },
-      },
-      {
-        key: 'base-url',
-        title: 'Base URL',
-        description:
-          'Your Azure OpenAI resource endpoint. See the [Azure OpenAI documentation](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/latest) for more information.',
-        controller_type: 'input',
-        controller_props: {
-          placeholder: 'https://YOUR-RESOURCE-NAME.openai.azure.com/openai/v1',
-          value: 'https://YOUR-RESOURCE-NAME.openai.azure.com/openai/v1',
         },
       },
     ],
@@ -112,17 +90,6 @@ export const predefinedProviders = [
           value: '',
           type: 'password',
           input_actions: ['unobscure', 'copy'],
-        },
-      },
-      {
-        key: 'base-url',
-        title: 'Base URL',
-        description:
-          'The base endpoint to use. See the [Anthropic API documentation](https://docs.anthropic.com/en/api/messages) for more information.',
-        controller_type: 'input',
-        controller_props: {
-          placeholder: 'https://api.anthropic.com',
-          value: 'https://api.anthropic.com',
         },
       },
     ],
@@ -156,17 +123,6 @@ export const predefinedProviders = [
           value: '',
           type: 'password',
           input_actions: ['unobscure', 'copy'],
-        },
-      },
-      {
-        key: 'base-url',
-        title: 'Base URL',
-        description:
-          'The base endpoint to use. See the [OpenRouter API documentation](https://openrouter.ai/docs/api-reference/overview) for more information.',
-        controller_type: 'input',
-        controller_props: {
-          placeholder: 'https://openrouter.ai/api/v1',
-          value: 'https://openrouter.ai/api/v1',
         },
       },
     ],
@@ -208,17 +164,6 @@ export const predefinedProviders = [
           input_actions: ['unobscure', 'copy'],
         },
       },
-      {
-        key: 'base-url',
-        title: 'Base URL',
-        description:
-          'The base endpoint to use. See the [Mistral documentation](https://docs.mistral.ai/getting-started/models/models_overview/) for more information.',
-        controller_type: 'input',
-        controller_props: {
-          placeholder: 'https://api.mistral.ai/v1',
-          value: 'https://api.mistral.ai/v1',
-        },
-      },
     ],
     models: [],
   },
@@ -240,17 +185,6 @@ export const predefinedProviders = [
           value: '',
           type: 'password',
           input_actions: ['unobscure', 'copy'],
-        },
-      },
-      {
-        key: 'base-url',
-        title: 'Base URL',
-        description:
-          'The base OpenAI-compatible endpoint to use. See the [Groq documentation](https://console.groq.com/docs) for more information.',
-        controller_type: 'input',
-        controller_props: {
-          placeholder: 'https://api.groq.com/openai/v1',
-          value: 'https://api.groq.com/openai/v1',
         },
       },
     ],
@@ -276,17 +210,6 @@ export const predefinedProviders = [
           input_actions: ['unobscure', 'copy'],
         },
       },
-      {
-        key: 'base-url',
-        title: 'Base URL',
-        description:
-          'The base endpoint to use. See the [xAI API documentation](https://docs.x.ai/overview) for more information.',
-        controller_type: 'input',
-        controller_props: {
-          placeholder: 'https://api.x.ai/v1',
-          value: 'https://api.x.ai/v1',
-        },
-      },
     ],
     models: [],
   },
@@ -310,18 +233,6 @@ export const predefinedProviders = [
           input_actions: ['unobscure', 'copy'],
         },
       },
-      {
-        key: 'base-url',
-        title: 'Base URL',
-        description:
-          'The base OpenAI-compatible endpoint to use. See the [Gemini documentation](https://ai.google.dev/gemini-api/docs/openai) for more information.',
-        controller_type: 'input',
-        controller_props: {
-          placeholder:
-            'https://generativelanguage.googleapis.com/v1beta/openai',
-          value: 'https://generativelanguage.googleapis.com/v1beta/openai',
-        },
-      },
     ],
     models: [],
   },
@@ -343,17 +254,6 @@ export const predefinedProviders = [
           value: '',
           type: 'password',
           input_actions: ['unobscure', 'copy'],
-        },
-      },
-      {
-        key: 'base-url',
-        title: 'Base URL',
-        description:
-          'The base endpoint to use. Use `https://api.minimax.io/v1` for global access or `https://api.minimaxi.com/v1` for users in China. See the [MiniMax API documentation](https://platform.minimax.io/docs/api-reference/text-openai-api) for more information.',
-        controller_type: 'input',
-        controller_props: {
-          placeholder: 'https://api.minimax.io/v1',
-          value: 'https://api.minimax.io/v1',
         },
       },
     ],
@@ -409,17 +309,6 @@ export const predefinedProviders = [
           input_actions: ['unobscure', 'copy'],
         },
       },
-      {
-        key: 'base-url',
-        title: 'Base URL',
-        description:
-          'The base endpoint to use. See the [Hugging Face Inference Providers documentation](https://huggingface.co/docs/inference-providers) for more information.',
-        controller_type: 'input',
-        controller_props: {
-          placeholder: 'https://router.huggingface.co/v1',
-          value: 'https://router.huggingface.co/v1',
-        },
-      },
     ],
     models: [
       {
@@ -466,17 +355,6 @@ export const predefinedProviders = [
           value: '',
           type: 'password',
           input_actions: ['unobscure', 'copy'],
-        },
-      },
-      {
-        key: 'base-url',
-        title: 'Base URL',
-        description:
-          'The NVIDIA NIM OpenAI-compatible endpoint to use. See the [NVIDIA NIM API documentation](https://docs.api.nvidia.com/nim/reference/llm-apis) for more information.',
-        controller_type: 'input',
-        controller_props: {
-          placeholder: 'https://integrate.api.nvidia.com/v1',
-          value: 'https://integrate.api.nvidia.com/v1',
         },
       },
     ],

--- a/web-app/src/containers/SettingsMenu.tsx
+++ b/web-app/src/containers/SettingsMenu.tsx
@@ -184,7 +184,7 @@ const SettingsMenu = () => {
 
   const integrationSettings = [
     {
-      title: 'common:connectors',
+      title: 'common:mcp-servers',
       route: route.settings.mcp_servers,
       icon: IconTopologyStar3,
     },

--- a/web-app/src/containers/__tests__/SettingsMenu.test.tsx
+++ b/web-app/src/containers/__tests__/SettingsMenu.test.tsx
@@ -112,7 +112,7 @@ describe('SettingsMenu', () => {
 
   it('renders integrations links', () => {
     render(<SettingsMenu />)
-    expect(screen.getByText('common:connectors')).toBeInTheDocument()
+    expect(screen.getByText('common:mcp-servers')).toBeInTheDocument()
     expect(screen.getByText('common:claude_code')).toBeInTheDocument()
   })
 

--- a/web-app/src/hooks/__tests__/useModelProvider.test.ts
+++ b/web-app/src/hooks/__tests__/useModelProvider.test.ts
@@ -282,7 +282,7 @@ describe('useModelProvider migrations', () => {
     ])
   })
 
-  it('migrates Mistral provider base URL to add /v1 suffix', () => {
+  it('overwrites stale base_url and strips base-url setting for predefined providers', () => {
     const persistApi = (useModelProvider as any).persist
     const migrate = persistApi?.getOptions().migrate as
       | ((state: unknown, version: number) => any)
@@ -292,6 +292,21 @@ describe('useModelProvider migrations', () => {
 
     const persistedState = {
       providers: [
+        {
+          provider: 'anthropic',
+          models: [],
+          base_url: 'https://api.anthropic.com',
+          settings: [
+            { key: 'api-key', controller_props: { value: 'sk-x' } },
+            {
+              key: 'base-url',
+              controller_props: {
+                value: 'https://api.anthropic.com',
+                placeholder: 'https://api.anthropic.com',
+              },
+            },
+          ],
+        },
         {
           provider: 'mistral',
           models: [],
@@ -299,69 +314,48 @@ describe('useModelProvider migrations', () => {
           settings: [
             {
               key: 'base-url',
-              controller_props: {
-                value: 'https://api.mistral.ai',
-                placeholder: 'https://api.mistral.ai',
-              },
+              controller_props: { value: 'https://api.mistral.ai' },
             },
           ],
         },
-      ],
-      selectedProvider: 'mistral',
-      selectedModel: null,
-      deletedModels: [],
-    }
-
-    const migratedState = migrate!(persistedState, 8)
-    const mistralProvider = migratedState.providers[0]
-    const baseUrlSetting = mistralProvider.settings.find(
-      (setting: any) => setting.key === 'base-url'
-    )
-
-    expect(mistralProvider.base_url).toBe('https://api.mistral.ai/v1')
-    expect(baseUrlSetting.controller_props.value).toBe('https://api.mistral.ai/v1')
-    expect(baseUrlSetting.controller_props.placeholder).toBe('https://api.mistral.ai/v1')
-  })
-
-  it('does not migrate Mistral provider base URL if already has /v1', () => {
-    const persistApi = (useModelProvider as any).persist
-    const migrate = persistApi?.getOptions().migrate as
-      | ((state: unknown, version: number) => any)
-      | undefined
-
-    expect(migrate).toBeDefined()
-
-    const persistedState = {
-      providers: [
         {
-          provider: 'mistral',
+          provider: 'my-custom',
           models: [],
-          base_url: 'https://api.mistral.ai/v1',
+          base_url: 'https://example.com/v1',
           settings: [
             {
               key: 'base-url',
-              controller_props: {
-                value: 'https://api.mistral.ai/v1',
-                placeholder: 'https://api.mistral.ai/v1',
-              },
+              controller_props: { value: 'https://example.com/v1' },
             },
           ],
         },
       ],
-      selectedProvider: 'mistral',
+      selectedProvider: 'anthropic',
       selectedModel: null,
       deletedModels: [],
     }
 
-    const migratedState = migrate!(persistedState, 8)
-    const mistralProvider = migratedState.providers[0]
-    const baseUrlSetting = mistralProvider.settings.find(
-      (setting: any) => setting.key === 'base-url'
-    )
+    const migratedState = migrate!(persistedState, 13)
+    const [anthropic, mistral, custom] = migratedState.providers
 
-    expect(mistralProvider.base_url).toBe('https://api.mistral.ai/v1')
-    expect(baseUrlSetting.controller_props.value).toBe('https://api.mistral.ai/v1')
-    expect(baseUrlSetting.controller_props.placeholder).toBe('https://api.mistral.ai/v1')
+    expect(anthropic.base_url).toBe('https://api.anthropic.com/v1')
+    expect(
+      anthropic.settings.find((s: any) => s.key === 'base-url')
+    ).toBeUndefined()
+    expect(
+      anthropic.settings.find((s: any) => s.key === 'api-key')
+    ).toBeDefined()
+
+    expect(mistral.base_url).toBe('https://api.mistral.ai/v1')
+    expect(
+      mistral.settings.find((s: any) => s.key === 'base-url')
+    ).toBeUndefined()
+
+    // Custom providers (not in predefinedProviders) are left alone.
+    expect(custom.base_url).toBe('https://example.com/v1')
+    expect(
+      custom.settings.find((s: any) => s.key === 'base-url')
+    ).toBeDefined()
   })
 
   it('does not affect other providers during Mistral migration', () => {

--- a/web-app/src/hooks/useModelProvider.ts
+++ b/web-app/src/hooks/useModelProvider.ts
@@ -3,6 +3,7 @@ import { persist, createJSONStorage } from 'zustand/middleware'
 import { localStorageKey } from '@/constants/localStorage'
 import { getServiceHub } from '@/hooks/useServiceHub'
 import { modelSettings } from '@/lib/predefined'
+import { predefinedProviders } from '@/constants/providers'
 import {
   API_KEY_FALLBACKS_SETTING_KEY,
   parseApiKeyFallbacks,
@@ -685,6 +686,25 @@ export const useModelProvider = create<ModelProviderState>()(
           })
         }
 
+        if (version <= 13 && state?.providers) {
+          // Predefined providers no longer carry a user-editable base-url
+          // setting. Force their base_url back to the canonical constant and
+          // strip any leftover base-url entry from persisted settings[].
+          const canonicalByName = new Map(
+            predefinedProviders.map((p) => [p.provider, p.base_url])
+          )
+          state.providers.forEach((provider) => {
+            const canonical = canonicalByName.get(provider.provider)
+            if (!canonical) return
+            provider.base_url = canonical
+            if (provider.settings) {
+              provider.settings = provider.settings.filter(
+                (s) => s.key !== 'base-url'
+              )
+            }
+          })
+        }
+
         if (version <= 12 && state?.providers) {
           // Reset ctx_len from the prior 8192 default to '' so llama.cpp picks
           // (auto-fit when enabled, model default otherwise). Preserve any
@@ -703,7 +723,7 @@ export const useModelProvider = create<ModelProviderState>()(
         }
         return state
       },
-      version: 13,
+      version: 14,
     }
   )
 )

--- a/web-app/src/lib/__tests__/custom-chat-transport.test.ts
+++ b/web-app/src/lib/__tests__/custom-chat-transport.test.ts
@@ -172,6 +172,96 @@ describe('normalizeToolInputSchema', () => {
     expect(normalizeToolInputSchema(schema)).toEqual(schema)
   })
 
+  it('strips date/time/date-time format from string leaves', () => {
+    expect(
+      normalizeToolInputSchema({
+        type: 'object',
+        properties: {
+          start: { type: 'string', format: 'date-time' },
+          stop: { type: 'string', format: 'date' },
+          at: { type: 'string', format: 'time' },
+        },
+      })
+    ).toEqual({
+      type: 'object',
+      properties: {
+        start: { type: 'string' },
+        stop: { type: 'string' },
+        at: { type: 'string' },
+      },
+    })
+  })
+
+  it('preserves harmless string formats', () => {
+    expect(
+      normalizeToolInputSchema({
+        type: 'object',
+        properties: {
+          id: { type: 'string', format: 'uuid' },
+          url: { type: 'string', format: 'uri' },
+        },
+      })
+    ).toEqual({
+      type: 'object',
+      properties: {
+        id: { type: 'string', format: 'uuid' },
+        url: { type: 'string', format: 'uri' },
+      },
+    })
+  })
+
+  it('strips pattern that uses PCRE shorthand escapes', () => {
+    expect(
+      normalizeToolInputSchema({
+        type: 'object',
+        properties: {
+          when: { type: 'string', pattern: '^\\d{4}-\\d{2}-\\d{2}$' },
+          digit_class: { type: 'string', pattern: '[\\w]+' },
+        },
+      })
+    ).toEqual({
+      type: 'object',
+      properties: {
+        when: { type: 'string' },
+        digit_class: { type: 'string' },
+      },
+    })
+  })
+
+  it('preserves patterns without PCRE shorthand', () => {
+    expect(
+      normalizeToolInputSchema({
+        type: 'object',
+        properties: {
+          alpha: { type: 'string', pattern: '^[A-Z]+$' },
+        },
+      })
+    ).toEqual({
+      type: 'object',
+      properties: {
+        alpha: { type: 'string', pattern: '^[A-Z]+$' },
+      },
+    })
+  })
+
+  it('strips broken format even when type is missing or non-string', () => {
+    expect(
+      normalizeToolInputSchema({
+        type: 'object',
+        properties: {
+          until: { format: 'date-time', description: 'iso end' },
+          nullable: { type: ['string', 'null'], format: 'date' },
+        },
+      })
+    ).toEqual({
+      type: 'object',
+      properties: {
+        until: { type: 'string', description: 'iso end' },
+        nullable: { type: ['string', 'null'] },
+      },
+    })
+  })
+
   it('patches only underspecified nodes in mixed schemas', () => {
     expect(
       normalizeToolInputSchema({

--- a/web-app/src/lib/custom-chat-transport.ts
+++ b/web-app/src/lib/custom-chat-transport.ts
@@ -151,8 +151,30 @@ function normalizeToolInputSchemaValue(value: unknown): unknown {
     normalized.type = 'string'
   }
 
+  // llama.cpp's json-schema-to-grammar emits PCRE `\d` for these formats,
+  // which GBNF rejects; the failed grammar silently disables tool-call JSON.
+  if (
+    typeof normalized.format === 'string' &&
+    LLAMACPP_BROKEN_STRING_FORMATS.has(normalized.format as string)
+  ) {
+    delete normalized.format
+  }
+
+  // `pattern` is the same PCRE-to-GBNF trap as `format`: any pattern that
+  // uses `\d`, `\w`, or `\s` (extremely common in date/time/uuid regexes)
+  // fails GBNF compilation. The model still has `type` and `description`.
+  if (
+    typeof normalized.pattern === 'string' &&
+    PCRE_SHORTHAND.test(normalized.pattern as string)
+  ) {
+    delete normalized.pattern
+  }
+
   return normalized
 }
+
+const LLAMACPP_BROKEN_STRING_FORMATS = new Set(['date', 'time', 'date-time'])
+const PCRE_SHORTHAND = /\\[dDwWsS]/
 
 /**
  * Returns true when an assistant message carries no content the model would

--- a/web-app/src/locales/cs/common.json
+++ b/web-app/src/locales/cs/common.json
@@ -2,7 +2,6 @@
   "assistants": "Asistenti",
   "hardware": "Hardware",
   "mcp-servers": "MCP servery",
-  "connectors": "MCP servery",
   "local_api_server": "Lokální API server",
   "https_proxy": "HTTPS Proxy",
   "extensions": "Rozšíření",

--- a/web-app/src/locales/de-DE/common.json
+++ b/web-app/src/locales/de-DE/common.json
@@ -1,7 +1,7 @@
 {
   "assistants": "Assistenten",
   "hardware": "Hardware",
-  "mcp-servers": "Mcp Server",
+  "mcp-servers": "MCP-Server",
   "local_api_server": "Lokaler API Server",
   "https_proxy": "HTTPS Proxy",
   "extensions": "Erweiterungen",

--- a/web-app/src/locales/de-DE/common.json
+++ b/web-app/src/locales/de-DE/common.json
@@ -2,7 +2,6 @@
   "assistants": "Assistenten",
   "hardware": "Hardware",
   "mcp-servers": "Mcp Server",
-  "connectors": "Mcp Server",
   "local_api_server": "Lokaler API Server",
   "https_proxy": "HTTPS Proxy",
   "extensions": "Erweiterungen",

--- a/web-app/src/locales/en/common.json
+++ b/web-app/src/locales/en/common.json
@@ -2,7 +2,6 @@
   "assistants": "Assistants",
   "hardware": "Hardware",
   "mcp-servers": "MCP Servers",
-  "connectors": "Connectors",
   "local_api_server": "Local API Server",
   "remote_access": "Remote Access",
   "integrations": "Integrations",

--- a/web-app/src/locales/es/common.json
+++ b/web-app/src/locales/es/common.json
@@ -2,7 +2,6 @@
   "assistants": "Asistentes",
   "hardware": "Hardware",
   "mcp-servers": "Servidores MCP",
-  "connectors": "Servidores MCP",
   "local_api_server": "Servidor API local",
   "remote_access": "Acceso remoto",
   "integrations": "Integraciones",

--- a/web-app/src/locales/fr/common.json
+++ b/web-app/src/locales/fr/common.json
@@ -2,7 +2,6 @@
   "assistants": "Assistants",
   "hardware": "Matériel",
   "mcp-servers": "Serveurs MCP",
-  "connectors": "Serveurs MCP",
   "local_api_server": "Serveur Local API",
   "https_proxy": "Mandataire Proxy HTTPS",
   "extensions": "Extensions",

--- a/web-app/src/locales/hi/common.json
+++ b/web-app/src/locales/hi/common.json
@@ -2,7 +2,6 @@
   "assistants": "सहायक",
   "hardware": "हार्डवेयर",
   "mcp-servers": "MCP सर्वर",
-  "connectors": "MCP सर्वर",
   "local_api_server": "लोकल API सर्वर",
   "remote_access": "रिमोट एक्सेस",
   "integrations": "इंटीग्रेशन",

--- a/web-app/src/locales/id/common.json
+++ b/web-app/src/locales/id/common.json
@@ -2,7 +2,6 @@
   "assistants": "Asisten",
   "hardware": "Perangkat Keras",
   "mcp-servers": "Server MCP",
-  "connectors": "Server MCP",
   "local_api_server": "Server API Lokal",
   "https_proxy": "Proksi HTTPS",
   "extensions": "Ekstensi",

--- a/web-app/src/locales/ja/common.json
+++ b/web-app/src/locales/ja/common.json
@@ -2,7 +2,6 @@
   "assistants": "アシスタント",
   "hardware": "ハードウェア",
   "mcp-servers": "MCPサーバー",
-  "connectors": "MCPサーバー",
   "local_api_server": "ローカルAPIサーバー",
   "https_proxy": "HTTPSプロキシ",
   "extensions": "拡張機能",

--- a/web-app/src/locales/pl/common.json
+++ b/web-app/src/locales/pl/common.json
@@ -2,7 +2,6 @@
   "assistants": "Asystenci",
   "hardware": "Sprzęt",
   "mcp-servers": "Serwery MCP",
-  "connectors": "Serwery MCP",
   "local_api_server": "Lokalny Serwer API",
   "https_proxy": "Pośrednik HTTPS",
   "extensions": "Rozszerzenia",

--- a/web-app/src/locales/pt-BR/common.json
+++ b/web-app/src/locales/pt-BR/common.json
@@ -2,7 +2,6 @@
   "assistants": "Assistentes",
   "hardware": "Hardware",
   "mcp-servers": "Servidores MCP",
-  "connectors": "Servidores MCP",
   "local_api_server": "Servidor de API Local",
   "https_proxy": "Proxy HTTPS",
   "extensions": "Extensões",

--- a/web-app/src/locales/ru/common.json
+++ b/web-app/src/locales/ru/common.json
@@ -2,7 +2,6 @@
   "assistants": "Ассистенты",
   "hardware": "Оборудование",
   "mcp-servers": "Серверы MCP",
-  "connectors": "Серверы MCP",
   "local_api_server": "Локальный API-сервер",
   "https_proxy": "HTTPS-прокси",
   "extensions": "Расширения",

--- a/web-app/src/locales/vn/common.json
+++ b/web-app/src/locales/vn/common.json
@@ -2,7 +2,6 @@
   "assistants": "Trợ lý",
   "hardware": "Phần cứng",
   "mcp-servers": "Máy chủ MCP",
-  "connectors": "Máy chủ MCP",
   "local_api_server": "Máy chủ API cục bộ",
   "https_proxy": "Proxy HTTPS",
   "extensions": "Tiện ích mở rộng",

--- a/web-app/src/locales/zh-CN/common.json
+++ b/web-app/src/locales/zh-CN/common.json
@@ -2,7 +2,6 @@
   "assistants": "助手",
   "hardware": "硬件",
   "mcp-servers": "MCP 服务",
-  "connectors": "MCP 服务",
   "local_api_server": "本地 API 服务",
   "https_proxy": "HTTPS 代理",
   "extensions": "扩展",

--- a/web-app/src/locales/zh-TW/common.json
+++ b/web-app/src/locales/zh-TW/common.json
@@ -2,7 +2,6 @@
   "assistants": "助理",
   "hardware": "硬體",
   "mcp-servers": "MCP 伺服器",
-  "connectors": "MCP 伺服器",
   "local_api_server": "本地 API 伺服器",
   "https_proxy": "HTTPS 代理",
   "extensions": "擴充功能",

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -876,10 +876,6 @@ function ProviderDetail() {
                     </div>
                   )
 
-                  if (isPredefinedProvider && setting.key === 'base-url') {
-                    return null
-                  }
-
                   return (
                     <CardItem
                       key={settingIndex}


### PR DESCRIPTION
## Describe Your Changes

- **Predefined providers no longer carry a user-editable `base-url` setting.** The settings card was already hidden from the UI for predefined providers, so the per-provider `base-url` entry was vestigial data with two sources of truth — and that mismatch had already shipped a bug (Anthropic's `base_url` was `…/v1` but the settings entry was `…` without `/v1`). Top-level `base_url` is now authoritative for all predefined providers; custom providers added via "+" keep their editable `base-url`. Migration v14 overwrites stale persisted `base_url`s with the canonical constant and strips any leftover `base-url` setting.

- **Strip GBNF-incompatible `format` and `pattern` from tool input schemas.** llama.cpp's `json-schema-to-grammar` emits PCRE shorthands (`\d`, `\w`, `\s`) when it sees `format: date-time|date|time` or any `pattern` using those escapes. GBNF rejects them ("error parsing grammar: unknown escape at \d\d"), grammar compilation fails, llama-server silently falls back to unconstrained generation, and tool-capable models (Qwen3 in particular) emit their native `<tool_call>` XML instead of OpenAI JSON. The downstream parser then reports a misleading "Failed to parse input at pos N". Fix is applied symmetrically in the TS client-side normalizer and the Rust proxy. Caught with `caldav-mcp`'s `create-event` / `update-event` tools, whose `recurrenceRule.until` / `start` / `end` ship both a `format` and a redundant `\d`-laden `pattern`.

- **Drop the duplicate `connectors` i18n key.** Every locale's `common.json` already carried `mcp-servers` with the right translation; the parallel `connectors` key was only used by the settings menu and was still rendering "Connectors" in English while every other locale had already been rewritten to "MCP Servers". Point `SettingsMenu` (and its test) at the canonical `mcp-servers` key and delete the redundant lines.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
