### PR TITLE
feat: add NEAR AI Cloud provider

### DIFF
--- a/docs/src/pages/docs/desktop/remote-models/_meta.json
+++ b/docs/src/pages/docs/desktop/remote-models/_meta.json
@@ -20,6 +20,9 @@
   "openrouter": {
     "title": "OpenRouter"
   },
+  "nearai": {
+    "title": "NEAR AI Cloud"
+  },
   "huggingface": {
     "title": "Hugging Face"
   }

--- a/docs/src/pages/docs/desktop/remote-models/nearai.mdx
+++ b/docs/src/pages/docs/desktop/remote-models/nearai.mdx
@@ -1,0 +1,69 @@
+---
+title: NEAR AI Cloud
+description: A step-by-step guide on integrating Jan with NEAR AI Cloud.
+keywords:
+  [
+    Jan,
+    local AI,
+    privacy focus,
+    conversational AI,
+    large language models,
+    NEAR AI,
+    NEAR AI Cloud,
+    TEE inference,
+  ]
+---
+
+import { Callout, Steps } from 'nextra/components'
+import { Settings } from 'lucide-react'
+
+# NEAR AI Cloud
+
+Jan supports [NEAR AI Cloud](https://cloud.near.ai) through its OpenAI-compatible API, allowing you to use NEAR-hosted models with TEE-backed private inference from Jan.
+
+## Integrate NEAR AI Cloud with Jan
+
+<Steps>
+
+### Step 1: Get Your API Key
+1. Visit [NEAR AI Cloud](https://cloud.near.ai) and sign in
+2. Create or copy an API key for your account
+
+<Callout type='info'>
+NEAR AI Cloud model availability and TEE attestation support can vary by model. Check the public model catalog before selecting a model ID.
+</Callout>
+
+### Step 2: Configure Jan
+
+1. Navigate to the **Settings** page (<Settings width={16} height={16} style={{display:"inline"}}/>)
+2. Under **Model Providers**, select **NEAR AI**
+3. Insert your **API Key**
+4. Keep the default base URL: `https://cloud-api.near.ai/v1`
+
+### Step 3: Start Using NEAR AI Cloud Models
+
+1. Open any existing **Chat** or create a new one
+2. Select a NEAR AI Cloud model from the **model selector**
+3. Start chatting
+</Steps>
+
+## Available Models Through NEAR AI Cloud
+
+Jan refreshes NEAR AI Cloud models from the public catalog at `https://cloud-api.near.ai/v1/model/list`. Use the `modelId` value from that catalog when adding a model manually.
+
+## Troubleshooting
+
+**1. API Key Issues**
+- Verify your API key is correct and not expired
+- Confirm your account has access to the model you selected
+
+**2. Connection Problems**
+- Check your internet connection
+- Verify the base URL is `https://cloud-api.near.ai/v1`
+- Look for error messages in [Jan's logs](/docs/desktop/troubleshooting#how-to-get-error-logs)
+
+**3. Model Unavailable**
+- Confirm the model appears in the [NEAR AI Cloud model catalog](https://cloud-api.near.ai/v1/model/list)
+- Check whether the model supports chat-style text output
+
+Need more help? Join our [Discord community](https://discord.gg/FTk2MvZwJH).

--- a/web-app/src/constants/__tests__/nearai-provider.test.ts
+++ b/web-app/src/constants/__tests__/nearai-provider.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { providerModels } from '../models'
+import { predefinedProviders } from '../providers'
+
+describe('NEAR AI predefined provider', () => {
+  it('registers NEAR AI Cloud as an OpenAI-compatible remote provider', () => {
+    const provider = predefinedProviders.find((p) => p.provider === 'nearai')
+
+    expect(provider).toBeDefined()
+    expect(provider?.base_url).toBe('https://cloud-api.near.ai/v1')
+    expect(provider?.explore_models_url).toBe(
+      'https://cloud-api.near.ai/v1/model/list'
+    )
+    expect(provider?.settings.map((s) => s.key)).toEqual([
+      'api-key',
+      'base-url',
+    ])
+  })
+
+  it('uses the live model catalog instead of a static model list', () => {
+    expect(providerModels.nearai.models).toBe(true)
+    expect(providerModels.nearai.supportsStreaming).toBe(true)
+    expect(providerModels.nearai.supportsToolCalls).toBe(true)
+  })
+})

--- a/web-app/src/constants/models.ts
+++ b/web-app/src/constants/models.ts
@@ -126,6 +126,15 @@ export const providerModels = {
     supportsToolCalls: true,
     supportsN: true,
   },
+  nearai: {
+    models: true,
+    supportsCompletion: true,
+    supportsStreaming: true,
+    supportsJSON: true,
+    supportsImages: true,
+    supportsToolCalls: true,
+    supportsN: true,
+  },
   nvidia: {
     models: ['moonshotai/kimi-k2.5', 'minimaxai/minimax-m2.5', 'z-ai/glm5'],
     supportsCompletion: true,

--- a/web-app/src/constants/providers.ts
+++ b/web-app/src/constants/providers.ts
@@ -451,6 +451,40 @@ export const predefinedProviders = [
   {
     active: true,
     api_key: '',
+    base_url: 'https://cloud-api.near.ai/v1',
+    explore_models_url: 'https://cloud-api.near.ai/v1/model/list',
+    provider: 'nearai',
+    settings: [
+      {
+        key: 'api-key',
+        title: 'API Key',
+        description:
+          "The NEAR AI Cloud API uses API keys for authentication. Visit [NEAR AI Cloud](https://cloud.near.ai) to create the API key you'll use for TEE-backed private inference.",
+        controller_type: 'input',
+        controller_props: {
+          placeholder: 'Insert API Key',
+          value: '',
+          type: 'password',
+          input_actions: ['unobscure', 'copy'],
+        },
+      },
+      {
+        key: 'base-url',
+        title: 'Base URL',
+        description:
+          'The NEAR AI Cloud OpenAI-compatible endpoint to use. See the [NEAR AI Cloud model catalog](https://cloud-api.near.ai/v1/model/list) for available model IDs.',
+        controller_type: 'input',
+        controller_props: {
+          placeholder: 'https://cloud-api.near.ai/v1',
+          value: 'https://cloud-api.near.ai/v1',
+        },
+      },
+    ],
+    models: [],
+  },
+  {
+    active: true,
+    api_key: '',
     base_url: 'https://integrate.api.nvidia.com/v1',
     explore_models_url: 'https://build.nvidia.com/models',
     provider: 'nvidia',

--- a/web-app/src/lib/__tests__/model-factory.test.ts
+++ b/web-app/src/lib/__tests__/model-factory.test.ts
@@ -161,6 +161,30 @@ describe('ModelFactory', () => {
       expect(model.type).toBe('openai-compatible')
     })
 
+    it('should create an OpenAI-compatible model for NEAR AI provider', async () => {
+      const provider: ProviderObject = {
+        provider: 'nearai',
+        api_key: 'test-api-key',
+        base_url: 'https://cloud-api.near.ai/v1',
+        models: [],
+        settings: [],
+        active: true,
+      }
+
+      const model = await ModelFactory.createModel(
+        'Qwen/Qwen3.6-35B-A3B-FP8',
+        provider
+      )
+      expect(model).toBeDefined()
+      expect(model.type).toBe('openai-compatible')
+      expect(mockedCreateOpenAICompatible).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          name: 'nearai',
+          baseURL: 'https://cloud-api.near.ai/v1',
+        })
+      )
+    })
+
     it('should handle custom headers for OpenAI-compatible providers', async () => {
       const provider: ProviderObject = {
         provider: 'custom',

--- a/web-app/src/lib/__tests__/remoteModelCatalog.test.ts
+++ b/web-app/src/lib/__tests__/remoteModelCatalog.test.ts
@@ -38,11 +38,21 @@ function mkGeminiProvider(extra: Record<string, unknown> = {}) {
   } as any
 }
 
+function mkNearAIProvider(extra: Record<string, unknown> = {}) {
+  return {
+    provider: 'nearai',
+    base_url: 'https://cloud-api.near.ai/v1',
+    api_key: 'near-test',
+    ...extra,
+  } as any
+}
+
 describe('supportsRemoteCatalog', () => {
-  it('supports openai, anthropic and gemini', () => {
+  it('supports openai, anthropic, gemini and nearai', () => {
     expect(supportsRemoteCatalog('openai')).toBe(true)
     expect(supportsRemoteCatalog('anthropic')).toBe(true)
     expect(supportsRemoteCatalog('gemini')).toBe(true)
+    expect(supportsRemoteCatalog('nearai')).toBe(true)
     expect(supportsRemoteCatalog('groq')).toBe(false)
     expect(supportsRemoteCatalog('mistral')).toBe(false)
   })
@@ -170,6 +180,146 @@ describe('fetchTopRemoteModels openai', () => {
     await expect(
       fetchTopRemoteModels(mkOpenAIProvider(), fetchImpl)
     ).rejects.toThrow(/Failed to fetch models from openai/)
+  })
+})
+
+describe('fetchTopRemoteModels nearai', () => {
+  it('uses the NEAR model catalog and filters non-chat utility models', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      mkResponse({
+        models: [
+          {
+            modelId: 'anthropic/claude-haiku-4-5',
+            metadata: {
+              verifiable: false,
+              attestationSupported: false,
+              architecture: {
+                inputModalities: ['text', 'image'],
+                outputModalities: ['text'],
+              },
+            },
+          },
+          {
+            modelId: 'Qwen/Qwen3.6-35B-A3B-FP8',
+            metadata: {
+              verifiable: true,
+              attestationSupported: true,
+              architecture: {
+                inputModalities: ['text'],
+                outputModalities: ['text'],
+              },
+            },
+          },
+          {
+            modelId: 'Qwen/Qwen3-VL-30B-A3B-Instruct',
+            metadata: {
+              verifiable: true,
+              attestationSupported: true,
+              architecture: {
+                inputModalities: ['text', 'image'],
+                outputModalities: ['text'],
+              },
+            },
+          },
+          {
+            modelId: 'black-forest-labs/FLUX.2-klein-4B',
+            metadata: {
+              verifiable: true,
+              attestationSupported: true,
+              architecture: {
+                inputModalities: ['text'],
+                outputModalities: ['image'],
+              },
+            },
+          },
+          {
+            modelId: 'Qwen/Qwen3-Embedding-0.6B',
+            metadata: {
+              verifiable: true,
+              attestationSupported: true,
+              architecture: {
+                inputModalities: ['text'],
+                outputModalities: ['embedding'],
+              },
+            },
+          },
+          {
+            modelId: 'Qwen/Qwen3-Reranker-0.6B',
+            metadata: {
+              verifiable: true,
+              attestationSupported: true,
+              architecture: {
+                inputModalities: ['text'],
+                outputModalities: ['text'],
+              },
+            },
+          },
+          {
+            modelId: 'openai/privacy-filter',
+            metadata: {
+              verifiable: true,
+              attestationSupported: true,
+              architecture: {
+                inputModalities: ['text'],
+                outputModalities: ['text'],
+              },
+            },
+          },
+          {
+            modelId: 'openai/whisper-large-v3',
+            metadata: {
+              verifiable: true,
+              attestationSupported: true,
+              architecture: {
+                inputModalities: ['audio'],
+                outputModalities: ['text'],
+              },
+            },
+          },
+          {
+            modelId: 'missing-modalities',
+            metadata: {
+              verifiable: true,
+              attestationSupported: true,
+              architecture: {
+                inputModalities: [],
+                outputModalities: [],
+              },
+            },
+          },
+        ],
+      })
+    )
+
+    const result = await fetchTopRemoteModels(mkNearAIProvider(), fetchImpl)
+    const ids = result.map((m) => m.id)
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://cloud-api.near.ai/v1/model/list',
+      expect.objectContaining({
+        method: 'GET',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer near-test',
+        }),
+      })
+    )
+    expect(ids).toContain('Qwen/Qwen3.6-35B-A3B-FP8')
+    expect(ids).toContain('Qwen/Qwen3-VL-30B-A3B-Instruct')
+    expect(ids).toContain('anthropic/claude-haiku-4-5')
+    expect(ids).not.toContain('black-forest-labs/FLUX.2-klein-4B')
+    expect(ids).not.toContain('Qwen/Qwen3-Embedding-0.6B')
+    expect(ids).not.toContain('Qwen/Qwen3-Reranker-0.6B')
+    expect(ids).not.toContain('openai/privacy-filter')
+    expect(ids).not.toContain('openai/whisper-large-v3')
+    expect(ids).not.toContain('missing-modalities')
+
+    expect(
+      result.find((m) => m.id === 'Qwen/Qwen3-VL-30B-A3B-Instruct')
+        ?.capabilities
+    ).toEqual(['completion', 'tools', 'vision'])
+    expect(
+      result.find((m) => m.id === 'Qwen/Qwen3.6-35B-A3B-FP8')?.capabilities
+    ).toEqual(['completion', 'tools'])
   })
 })
 

--- a/web-app/src/lib/__tests__/utils.test.ts
+++ b/web-app/src/lib/__tests__/utils.test.ts
@@ -35,6 +35,7 @@ describe('getProviderTitle', () => {
     expect(getProviderTitle('openai')).toBe('OpenAI')
     expect(getProviderTitle('openrouter')).toBe('OpenRouter')
     expect(getProviderTitle('gemini')).toBe('Gemini')
+    expect(getProviderTitle('nearai')).toBe('NEAR AI')
     expect(getProviderTitle('nvidia')).toBe('NVIDIA NIM')
   })
 

--- a/web-app/src/lib/model-factory.ts
+++ b/web-app/src/lib/model-factory.ts
@@ -512,6 +512,8 @@ export class ModelFactory {
       case 'moonshot':
       case 'minimax':
         return this.createOpenAICompatibleModel(modelId, provider)
+      case 'nearai':
+        return this.createOpenAICompatibleModel(modelId, provider, parameters)
 
       case 'mistral':
         return this.createMistralModel(modelId, provider, parameters)

--- a/web-app/src/lib/remoteModelCatalog.ts
+++ b/web-app/src/lib/remoteModelCatalog.ts
@@ -22,7 +22,8 @@ export function supportsRemoteCatalog(providerName: string): boolean {
   return (
     providerName === 'openai' ||
     providerName === 'anthropic' ||
-    providerName === 'gemini'
+    providerName === 'gemini' ||
+    providerName === 'nearai'
   )
 }
 
@@ -148,9 +149,10 @@ export async function fetchTopRemoteModels(
   let lastStatus = 0
   let lastStatusText = ''
   for (let i = 0; i < attempts.length; i++) {
+    const catalogPath = provider.provider === 'nearai' ? 'model/list' : 'models'
     const result = await getJson(
       fetchImpl,
-      `${provider.base_url}/models`,
+      `${provider.base_url}/${catalogPath}`,
       buildHeaders(provider, attempts[i])
     )
     lastStatus = result.status
@@ -161,6 +163,13 @@ export async function fetchTopRemoteModels(
     }
 
     const body = result.body as { data?: unknown }
+    if (provider.provider === 'nearai') {
+      const nearBody = result.body as { models?: unknown }
+      const nearRows = Array.isArray(nearBody?.models)
+        ? (nearBody.models as unknown[])
+        : []
+      return normalizeNearAICatalog(nearRows)
+    }
     const rows = Array.isArray(body?.data) ? (body.data as unknown[]) : []
     return normalizeCatalog(provider.provider, rows)
   }
@@ -199,6 +208,60 @@ function normalizeCatalog(providerName: string, rows: unknown[]): RemoteCatalogM
     parsed.sort((a, b) => b.createdMs - a.createdMs || a.id.localeCompare(b.id))
   }
   return parsed.slice(0, TOP_N)
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : []
+}
+
+function normalizeNearAICatalog(rows: unknown[]): RemoteCatalogModel[] {
+  const parsed: (RemoteCatalogModel & { score: number })[] = []
+  for (const raw of rows) {
+    if (!raw || typeof raw !== 'object') continue
+    const row = raw as Record<string, unknown>
+    const id =
+      typeof row.modelId === 'string'
+        ? row.modelId
+        : typeof row.id === 'string'
+          ? row.id
+          : null
+    if (!id || id === 'openai/privacy-filter' || /reranker/i.test(id)) continue
+
+    const metadata =
+      row.metadata && typeof row.metadata === 'object'
+        ? (row.metadata as Record<string, unknown>)
+        : {}
+    const architecture =
+      metadata.architecture && typeof metadata.architecture === 'object'
+        ? (metadata.architecture as Record<string, unknown>)
+        : {}
+    const inputModalities = asStringArray(architecture.inputModalities)
+    const outputModalities = asStringArray(architecture.outputModalities)
+
+    if (inputModalities.length === 0 && outputModalities.length === 0) continue
+    if (!outputModalities.includes('text')) continue
+    if (!inputModalities.includes('text') && !inputModalities.includes('image')) continue
+
+    const capabilities = ['completion', 'tools']
+    if (inputModalities.includes('image')) capabilities.push('vision')
+    const score =
+      metadata.attestationSupported === true
+        ? 2
+        : metadata.verifiable === true
+          ? 1
+          : 0
+
+    parsed.push({ id, capabilities, createdMs: 0, score })
+  }
+
+  parsed.sort((a, b) => b.score - a.score || a.id.localeCompare(b.id))
+  return parsed.slice(0, TOP_N).map((model) => ({
+    id: model.id,
+    capabilities: model.capabilities,
+    createdMs: model.createdMs,
+  }))
 }
 
 function parseCreated(created: unknown, createdAt: unknown): number {

--- a/web-app/src/lib/utils.ts
+++ b/web-app/src/lib/utils.ts
@@ -121,6 +121,8 @@ export const getProviderTitle = (provider: string) => {
       return 'xAI'
     case 'minimax':
       return 'MiniMax'
+    case 'nearai':
+      return 'NEAR AI'
     case 'nvidia':
       return 'NVIDIA NIM'
     default:

--- a/web-app/src/services/providers/__tests__/tauri.test.ts
+++ b/web-app/src/services/providers/__tests__/tauri.test.ts
@@ -232,6 +232,27 @@ describe('TauriProvidersService', () => {
       expect(result).toEqual(['m1', 'm2'])
     })
 
+    it('fetches NEAR AI models from model/list and maps modelId values', async () => {
+      vi.mocked(fetchTauri).mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockResolvedValue({
+          models: [{ modelId: 'zai-org/GLM-5.1-FP8' }, { modelId: 'Qwen/Qwen3.6-35B-A3B-FP8' }],
+        }),
+      } as any)
+
+      const result = await svc.fetchModelsFromProvider({
+        ...baseProvider,
+        provider: 'nearai',
+        base_url: 'https://cloud-api.near.ai/v1/',
+      })
+      expect(result).toEqual(['zai-org/GLM-5.1-FP8', 'Qwen/Qwen3.6-35B-A3B-FP8'])
+      expect(fetchTauri).toHaveBeenCalledWith(
+        'https://cloud-api.near.ai/v1/model/list',
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+
     it('returns empty for unexpected format', async () => {
       vi.mocked(fetchTauri).mockResolvedValueOnce({
         ok: true,

--- a/web-app/src/services/providers/tauri.ts
+++ b/web-app/src/services/providers/tauri.ts
@@ -171,7 +171,9 @@ export class TauriProvidersService extends DefaultProvidersService {
           })
         }
 
-        const response = await fetchTauri(`${provider.base_url}/models`, {
+        const baseUrl = provider.base_url.replace(/\/+$/, '')
+        const modelsPath = provider.provider === 'nearai' ? 'model/list' : 'models'
+        const response = await fetchTauri(`${baseUrl}/${modelsPath}`, {
           method: 'GET',
           headers,
         })
@@ -223,10 +225,10 @@ export class TauriProvidersService extends DefaultProvidersService {
         }
         if (data.models && Array.isArray(data.models)) {
           return data.models
-            .map((model: string | { id: string }) =>
-              typeof model === 'string' ? model : model.id
+            .map((model: string | { id?: string; modelId?: string }) =>
+              typeof model === 'string' ? model : model.modelId || model.id
             )
-            .filter(Boolean)
+            .filter((id): id is string => Boolean(id))
         }
         console.warn('Unexpected response format from provider API:', data)
         return []


### PR DESCRIPTION
## Describe Your Changes

- Add NEAR AI Cloud as a predefined OpenAI-compatible remote provider using `https://cloud-api.near.ai/v1`.
- Refresh NEAR AI model choices from the live `/model/list` catalog and filter out non-chat utility, embedding, image, transcription, and reranker entries.
- Add provider display naming, focused unit coverage, and a desktop remote-models docs page.

## Testing

- `yarn vitest run --project @janhq/web-app web-app/src/constants/__tests__/nearai-provider.test.ts web-app/src/lib/__tests__/remoteModelCatalog.test.ts web-app/src/lib/__tests__/model-factory.test.ts web-app/src/lib/__tests__/utils.test.ts`
- `yarn workspace @janhq/web-app eslint src/constants/models.ts src/constants/providers.ts src/lib/remoteModelCatalog.ts src/lib/model-factory.ts src/lib/utils.ts`
- `yarn workspace @janhq/web-app tsc -b --pretty false`

## Self Checklist

- [x] Updated docs