### PR TITLE
chore: update manifest and changelog release 0.8.0

### DIFF
--- a/docs/src/pages/changelog/2026-05-20-jan-v0.8.0.mdx
+++ b/docs/src/pages/changelog/2026-05-20-jan-v0.8.0.mdx
@@ -2,14 +2,14 @@
 title: "Jan v0.8.0: Multi-Token Prediction, llama.cpp Router Mode & Inline MCP Approval"
 version: 0.8.0
 description: "Jan v0.8.0 ships Multi-Token Prediction for compatible llama.cpp models, a unified llama.cpp router process, inline MCP tool approval with citation cards, per-model fit labels, bulk model deletion, per-thread activity indicators, and a backend dependency checker."
-date: 2026-05-20
+date: 2026-05-22
 ---
 
 import ChangelogHeader from "@/components/Changelog/ChangelogHeader"
 
 <ChangelogHeader
   title="Jan v0.8.0: Multi-Token Prediction, llama.cpp Router Mode & Inline MCP Approval"
-  date="2026-05-20"
+  date="2026-05-22"
 />
 
 # Highlights

--- a/flatpak/ai.jan.Jan.metainfo.xml
+++ b/flatpak/ai.jan.Jan.metainfo.xml
@@ -104,6 +104,11 @@
   </keywords>
 
   <releases>
+    <release version="0.8.0" date="2026-05-22">
+      <description>
+        <p>Multi-Token Prediction, a unified llama.cpp router process, inline MCP tool approval with citation cards, model fit labels, and audio attachments</p>
+      </description>
+    </release>
     <release version="0.7.9" date="2026-03-23">
       <description>
         <p>Smarter context management, fixed CLI on Windows, and safer data location handling</p>


### PR DESCRIPTION
## Describe Your Changes

This pull request updates the release date for Jan v0.8.0 to May 22, 2026 and adds the corresponding release entry to the Flatpak metadata. These changes ensure that documentation and release metadata are consistent and up-to-date.

Release documentation updates:
* Updated the release date in the changelog file `2026-05-20-jan-v0.8.0.mdx` from May 20 to May 22, 2026, including both the frontmatter and the `ChangelogHeader` component.

Release metadata updates:
* Added a new release entry for version 0.8.0 with the correct date and description to the Flatpak metadata file `ai.jan.Jan.metainfo.xml`.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
