### PR TITLE
fix(tls): use OS-native TLS trust store on desktop

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -98,7 +98,19 @@ tauri-plugin-llamacpp = { path = "./plugins/tauri-plugin-llamacpp" }
 tauri-plugin-mlx = { path = "./plugins/tauri-plugin-mlx", optional = true }
 tauri-plugin-vector-db = { path = "./plugins/tauri-plugin-vector-db" }
 tauri-plugin-rag = { path = "./plugins/tauri-plugin-rag" }
-tauri-plugin-http = { version = "2", features = ["unsafe-headers"] }
+# `default-features = false` drops the plugin's default `rustls-tls` (bundled
+# Mozilla roots) so `native-tls` reads the OS trust store instead. Other
+# features re-list the plugin's defaults so behaviour is otherwise unchanged.
+# `macos-system-configuration` is reqwest's legacy alias for `system-proxy` —
+# cross-platform-safe; native deps are target-gated by Cargo.
+tauri-plugin-http = { version = "2", default-features = false, features = [
+  "native-tls",
+  "http2",
+  "charset",
+  "macos-system-configuration",
+  "cookies",
+  "unsafe-headers",
+] }
 tauri-plugin-log = "2.0.0-rc"
 tauri-plugin-opener = "2.2.7"
 tauri-plugin-os = "2.2.1"
@@ -147,7 +159,7 @@ libc = "0.2.172"
 windows-sys = { version = "0.60.2", features = ["Win32_Storage_FileSystem"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
-reqwest = { version = "0.11", features = ["json", "blocking", "stream", "native-tls-vendored"] }
+reqwest = { version = "0.11", features = ["json", "blocking", "stream", "native-tls"] }
 tauri-plugin-updater = "2"
 once_cell = "1.18"
 tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }


### PR DESCRIPTION
## Describe Your Changes

On desktop (macOS/Linux/Windows), Jan's Rust HTTP clients silently fail to connect to HTTPS endpoints whose certificate chains terminate at a root trusted by the OS but NOT in the Mozilla CA bundle — most commonly home-lab/corporate/private CAs. Symptom: the user sees 'starting new connection' in the terminal for the target URL, followed by nothing — the TLS handshake fails inside reqwest and the error is swallowed before any caller-side log line is emitted.

Repro: Run any HTTPS service (e.g. a local vLLM at https://host.internal:8000/v1) with a cert signed by a private CA that is added to and trusted by the macOS Keychain (or /etc/ssl/certs on Linux, the Windows cert store on Windows). curl works against the URL. Configuring it in Jan as an OpenAI-compatible provider does not.

Root cause: two reqwest versions are linked into the desktop binary, and neither was consulting the OS trust store on macOS:

1. reqwest 0.11 (Jan's direct dep) was built with the `native-tls-vendored` feature. The '-vendored' suffix statically links a private copy of OpenSSL with its own bundled CA list — it does NOT read the macOS Keychain or any other OS trust store, even on macOS.

2. reqwest 0.12 (pulled transitively by tauri-plugin-http, tauri-plugin-updater, and rmcp) was using the plugin's default `rustls-tls` feature, which uses rustls + webpki-roots (the Mozilla bundle). Same problem: no OS trust store consulted.

Fix: switch both layers to the non-vendored `native-tls` feature. With `native-tls` (no vendoring), reqwest binds to:
  - macOS  → Security.framework        → reads the Keychain
  - Linux  → system OpenSSL            → reads /etc/ssl/certs
  - Windows→ schannel                  → reads the Windows cert store

Each platform gets OS trust for free, with no new code surface and no new configuration knobs. Mobile (iOS/Android) keeps rustls-tls as before — that branch was unaffected.

Specifically:
  - src-tauri/Cargo.toml line 101: tauri-plugin-http now explicitly selects 'native-tls' (with default-features disabled so the default 'rustls-tls' no longer gets picked up). The other defaults that Jan was implicitly relying on — http2, charset, macos-system-configuration, cookies — are re-listed explicitly so behaviour for everything else is unchanged.
  - src-tauri/Cargo.toml line 150: desktop reqwest swaps 'native-tls-vendored' → 'native-tls'. This also drops a statically linked OpenSSL from the binary (smaller artifact, no vendored OpenSSL CVE surface to keep patched).

Why not other approaches considered:
  - SSL_CERT_FILE env var: only helps the (now removed) OpenSSL path, not the rustls path, and pushes config burden onto users.
  - 'rustls-tls-native-roots' (rustls + rustls-native-certs): would fix the rustls path but leave two different TLS implementations linked in. native-tls is simpler and matches how the rest of the Tauri ecosystem typically configures TLS on desktop.
  - 'danger_accept_invalid_certs': silently weakens security; out of the question.

Verified on macOS 26.5 via Xcode 26.5 on M4 Pro by rebuilding `yarn tauri build --target universal-apple-darwin` and confirming the previously failing private-CA endpoint now returns HTTP 200 in the terminal. Public-CA endpoints (api.github.com, apps.jan.ai, release-assets.githubusercontent.com) still work as before.

This was made with assistance from Opus 4.7 for the bits other than the native-tls-vendored -> native-tls bit. I am not that familiar with Rust to be honest, however I have read and tested the changes and hope this is useful.