### PR TITLE
fix(docs): guard null entity arrays in TweetCard

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -47,7 +47,7 @@
     "react-icons": "^5.0.1",
     "react-markdown": "^9.0.1",
     "react-share": "^5.1.0",
-    "react-tweet": "^3.2.2",
+    "react-tweet": "^3.3.0",
     "sass": "^1.72.0",
     "sharp": "^0.33.3",
     "tailwind-merge": "^2.2.2",

--- a/docs/src/components/ui/tweet-card.tsx
+++ b/docs/src/components/ui/tweet-card.tsx
@@ -224,7 +224,23 @@ export const MagicTweet = ({
   components?: TwitterComponents
   className?: string
 }) => {
-  const enrichedTweet = enrichTweet(tweet)
+  const normalizeEntities = <T extends { entities?: Tweet['entities'] }>(t: T): T => ({
+    ...t,
+    entities: {
+      hashtags: t.entities?.hashtags ?? [],
+      urls: t.entities?.urls ?? [],
+      user_mentions: t.entities?.user_mentions ?? [],
+      symbols: t.entities?.symbols ?? [],
+      ...(t.entities?.media?.length ? { media: t.entities.media } : {}),
+    },
+  })
+  const safeTweet = {
+    ...normalizeEntities(tweet),
+    ...(tweet.quoted_tweet
+      ? { quoted_tweet: normalizeEntities(tweet.quoted_tweet) }
+      : {}),
+  } as Tweet
+  const enrichedTweet = enrichTweet(safeTweet)
   return (
     <div
       className={cn(

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -7936,10 +7936,10 @@ react-style-singleton@^2.2.2, react-style-singleton@^2.2.3:
     get-nonce "^1.0.0"
     tslib "^2.0.0"
 
-react-tweet@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/react-tweet/-/react-tweet-3.2.2.tgz#b9a8fccbab469a02d87b26f3728275024f4e9574"
-  integrity sha512-hIkxAVPpN2RqWoDEbo3TTnN/pDcp9/Jb6pTgiA4EbXa9S+m2vHIvvZKHR+eS0PDIsYqe+zTmANRa5k6+/iwGog==
+react-tweet@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/react-tweet/-/react-tweet-3.3.0.tgz#e1bfabe65f5860f1fa67918fe44b6c006799b4c3"
+  integrity sha512-gSIG2169ZK7UH6rBzuU+j1xnQbH3IlOTLEkuGrRiJJTMgETik+h+26yHyyVKrLkzwrOaYPk4K3OtEKycqKgNLw==
   dependencies:
     "@swc/helpers" "^0.5.3"
     clsx "^2.0.0"


### PR DESCRIPTION
## Describe Your Changes

- Twitter's syndication response now returns null/missing entity arrays (hashtags, urls, user_mentions, symbols), causing enrichTweet to throw "entities is not iterable". react-tweet 3.3.0 still assumes these are present, so normalize entities on both the tweet and quoted_tweet before calling enrichTweet. Omit media when empty since fixRange dereferences media[0].


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
