### PR TITLE
chore(ci): pin all GitHub Actions to SHAs and add cancel-in-progress

### DIFF
--- a/.github/workflows/auto-assign-author.yml
+++ b/.github/workflows/auto-assign-author.yml
@@ -10,6 +10,6 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: toshimaru/auto-author-assign@v1.1.0
+      - uses: toshimaru/auto-author-assign@eac0d15f4a55d1d1824f2b78fdea42de6cd59fef # v1.1.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/auto-assign-milestone.yml
+++ b/.github/workflows/auto-assign-milestone.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
     steps:
       - name: Assign Milestone
-        uses: actions/github-script@v3
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/auto-label-conventional-commits.yaml
+++ b/.github/workflows/auto-label-conventional-commits.yaml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Label PRs
         run: |
           ISSUE_TITLE=$(gh issue view ${{ github.event.number }} --json title -q ".title")

--- a/.github/workflows/autoqa-migration.yml
+++ b/.github/workflows/autoqa-migration.yml
@@ -48,10 +48,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
 
@@ -116,7 +116,7 @@ jobs:
 
       - name: Upload screen recordings
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         continue-on-error: true
         with:
           name: migration-recordings-${{ github.run_number }}-windows
@@ -124,7 +124,7 @@ jobs:
 
       - name: Upload trajectories
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         continue-on-error: true
         with:
           name: migration-trajectories-${{ github.run_number }}-windows
@@ -142,10 +142,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
 
@@ -225,7 +225,7 @@ jobs:
 
       - name: Upload screen recordings
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         continue-on-error: true
         with:
           name: migration-recordings-${{ github.run_number }}-ubuntu
@@ -233,7 +233,7 @@ jobs:
 
       - name: Upload trajectories
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         continue-on-error: true
         with:
           name: migration-trajectories-${{ github.run_number }}-ubuntu
@@ -250,10 +250,10 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
 
@@ -308,7 +308,7 @@ jobs:
 
       - name: Upload screen recordings
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         continue-on-error: true
         with:
           name: migration-recordings-${{ github.run_number }}-macos
@@ -316,7 +316,7 @@ jobs:
 
       - name: Upload trajectories
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         continue-on-error: true
         with:
           name: migration-trajectories-${{ github.run_number }}-macos

--- a/.github/workflows/autoqa-reliability.yml
+++ b/.github/workflows/autoqa-reliability.yml
@@ -55,10 +55,10 @@ jobs:
       DEFAULT_IS_NIGHTLY: 'false'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
 
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload screen recordings
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         continue-on-error: true
         with:
           name: reliability-recordings-${{ github.run_number }}-${{ runner.os }}
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload trajectories
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         continue-on-error: true
         with:
           name: reliability-trajectories-${{ github.run_number }}-${{ runner.os }}

--- a/.github/workflows/autoqa-template.yml
+++ b/.github/workflows/autoqa-template.yml
@@ -56,16 +56,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
 
       - name: Download artifact (if source_type is local)
         if: inputs.source_type == 'local'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ inputs.artifact_name_windows }}
           path: ${{ runner.temp }}/windows-artifact
@@ -145,7 +145,7 @@ jobs:
 
       - name: Upload screen recordings
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         continue-on-error: true
         with:
           name: ${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-recordings-${{ github.run_number }}-${{ runner.os }}
@@ -153,7 +153,7 @@ jobs:
 
       - name: Upload Jan logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-logs-${{ github.run_number }}-${{ runner.os }}
           path: autoqa/jan-logs/
@@ -174,16 +174,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
 
       - name: Download artifact (if source_type is local)
         if: inputs.source_type == 'local'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ inputs.artifact_name_ubuntu }}
           path: ${{ runner.temp }}/ubuntu-artifact
@@ -292,7 +292,7 @@ jobs:
 
       - name: Upload screen recordings
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         continue-on-error: true
         with:
           name: ${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-recordings-${{ github.run_number }}-${{ runner.os }}
@@ -300,7 +300,7 @@ jobs:
 
       - name: Upload Jan logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-logs-${{ github.run_number }}-${{ runner.os }}
           path: autoqa/jan-logs/
@@ -320,16 +320,16 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python 3.13
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
 
       - name: Download artifact (if source_type is local)
         if: inputs.source_type == 'local'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ${{ inputs.artifact_name_macos }}
           path: ${{ runner.temp }}/macos-artifact
@@ -452,7 +452,7 @@ jobs:
 
       - name: Upload screen recordings
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         continue-on-error: true
         with:
           name: ${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-recordings-${{ github.run_number }}-${{ runner.os }}
@@ -460,7 +460,7 @@ jobs:
 
       - name: Upload Jan logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-logs-${{ github.run_number }}-${{ runner.os }}
           path: autoqa/jan-logs/

--- a/.github/workflows/clean-cloudflare-page-preview-url-and-r2.yml
+++ b/.github/workflows/clean-cloudflare-page-preview-url-and-r2.yml
@@ -11,14 +11,14 @@ jobs:
         project: ["nitro", "docs"]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.x'
       - name: install requests
         run: |
           python3 -m pip install requests pytz tqdm
       - name: Python Inline script
-        uses: jannekem/run-python-script-action@v1
+        uses: jannekem/run-python-script-action@9d8e2e0878d575fb6073277f38ce3f10ebf4f059 # v1
         with: 
           script: |
             import requests

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -10,7 +10,7 @@ jobs:
     name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/${{ vars.ORG_NAME }}/projects/${{ vars.JAN_PROJECT_NUMBER }}
           github-token: ${{ secrets.AUTO_ADD_TICKET_PAT }}

--- a/.github/workflows/jan-docs.yml
+++ b/.github/workflows/jan-docs.yml
@@ -15,6 +15,10 @@ on:
     # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#on
   workflow_dispatch:
 
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     name: Deploy to CloudFlare Pages
@@ -26,13 +30,13 @@ jobs:
       deployments: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
       - name: Install jq      
-        uses: dcarbone/install-jq-action@v2.0.1
+        uses: dcarbone/install-jq-action@c1548c666da8422e8207a67fae0df364cf9ee7fe # v2.0.1
 
       - name: Config Yarn
         run: |
@@ -69,7 +73,7 @@ jobs:
 
       - name: Publish to Cloudflare Pages PR Preview and Staging
         if: github.event_name == 'pull_request'
-        uses: cloudflare/pages-action@v1
+        uses: cloudflare/pages-action@f0a1cd58cd66095dee69bfa18fa5efd1dde93bca # v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -79,7 +83,7 @@ jobs:
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
         id: deployCloudflarePages
 
-      - uses: mshick/add-pr-comment@v2
+      - uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2
         if: github.event_name == 'pull_request'
         with:
           message: |
@@ -87,7 +91,7 @@ jobs:
 
       - name: Publish to Cloudflare Pages Production
         if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/heads/release/'))
-        uses: cloudflare/pages-action@v1
+        uses: cloudflare/pages-action@f0a1cd58cd66095dee69bfa18fa5efd1dde93bca # v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/jan-linter-and-test.yml
+++ b/.github/workflows/jan-linter-and-test.yml
@@ -34,17 +34,21 @@ on:
       - 'web-app/**'
       - '!README.md'
 
+concurrency:
+  group: linter-test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   base_branch_cov:
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.base_ref }}
       - name: Use Node.js 20.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
@@ -70,7 +74,7 @@ jobs:
           yarn test:coverage
 
       - name: Upload code coverage for ref branch
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ref-lcov.info
           path: coverage/lcov.info
@@ -80,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.base_ref }}
 
@@ -90,7 +94,7 @@ jobs:
           sudo apt install -y libglib2.0-dev libatk1.0-dev libpango1.0-dev libgtk-3-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev librsvg2-dev
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@9e57365e36de1e26dea5145e57d471261468d9f7 # cargo-llvm-cov
 
       - name: Create Tauri resource stubs for CI
         run: |
@@ -117,7 +121,7 @@ jobs:
           cargo llvm-cov report --lcov --output-path rust-lcov.info --manifest-path src-tauri/Cargo.toml
 
       - name: Upload Rust code coverage for ref branch
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ref-rust-lcov.info
           path: rust-lcov.info
@@ -127,12 +131,12 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Getting the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Installing node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
@@ -167,12 +171,12 @@ jobs:
     runs-on: windows-desktop-${{ matrix.antivirus-tools }}
     steps:
       - name: Getting the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Installing node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
@@ -206,7 +210,7 @@ jobs:
     runs-on: 'windows-latest'
     steps:
       - name: Getting the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -215,7 +219,7 @@ jobs:
           choco install --yes --no-progress make
 
       - name: Installing node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
@@ -256,12 +260,12 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Getting the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
           android: true
@@ -272,7 +276,7 @@ jobs:
           swap-storage: true
 
       - name: Installing node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
@@ -300,7 +304,7 @@ jobs:
           echo -e "Display ID: $DISPLAY"
           make test
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: playwright-report
@@ -314,12 +318,12 @@ jobs:
     continue-on-error: true
     steps:
       - name: Getting the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Installing node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
       - name: 'Cleanup cache'
@@ -349,7 +353,7 @@ jobs:
           sudo apt install -y libglib2.0-dev libatk1.0-dev libpango1.0-dev libgtk-3-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev librsvg2-dev
 
       - name: Install cargo-llvm-cov
-        uses: taiki-e/install-action@cargo-llvm-cov
+        uses: taiki-e/install-action@9e57365e36de1e26dea5145e57d471261468d9f7 # cargo-llvm-cov
 
       - name: Run Rust test coverage
         run: ./scripts/rust-coverage.sh
@@ -359,14 +363,14 @@ jobs:
           cat ./coverage/lcov.info rust-lcov.info > merged-lcov.info
 
       - name: Download code coverage report from base branch
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ref-lcov.info
 
       - name: Download Rust code coverage report from base branch
         id: download-rust-cov
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ref-rust-lcov.info
           path: base-rust-cov
@@ -382,7 +386,7 @@ jobs:
 
       - name: Generate Code Coverage report
         id: code-coverage
-        uses: barecheck/code-coverage-action@v1
+        uses: barecheck/code-coverage-action@d92cdaec187f89f0886ccec37acf11e2a6a85f70 # v1.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           lcov-file: './merged-lcov.info'

--- a/.github/workflows/jan-tauri-build-nightly-external.yaml
+++ b/.github/workflows/jan-tauri-build-nightly-external.yaml
@@ -16,6 +16,10 @@ on:
       - 'Makefile'
       - 'package.json'
 
+concurrency:
+  group: nightly-external-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   get-update-version:
     if: github.event.pull_request.head.repo.full_name != github.repository

--- a/.github/workflows/jan-tauri-build-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-nightly.yaml
@@ -37,6 +37,10 @@ on:
       - 'package.json'
 
 
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   set-public-provider:
     runs-on: ubuntu-latest
@@ -120,9 +124,9 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Getting the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install jq
-        uses: dcarbone/install-jq-action@v2.0.1
+        uses: dcarbone/install-jq-action@c1548c666da8422e8207a67fae0df364cf9ee7fe # v2.0.1
       - name: create latest.json file
         run: |
 

--- a/.github/workflows/jan-tauri-build.yaml
+++ b/.github/workflows/jan-tauri-build.yaml
@@ -4,6 +4,10 @@ on:
   push:
     tags: ["v[0-9]+.[0-9]+.[0-9]+"]
 
+concurrency:
+  group: tauri-tag-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   # Job create Update app version based on latest release tag with build number and save to output
   get-update-version:
@@ -25,7 +29,7 @@ jobs:
           GITHUB_REF: ${{ github.ref }}
       - name: Create Draft Release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ github.ref_name }}
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -74,7 +78,7 @@ jobs:
       contents: write
     steps:
       - name: Getting the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: create latest.json file
         run: |
@@ -114,7 +118,7 @@ jobs:
       - name: Upload release assert if public provider is github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: actions/upload-release-asset@v1.0.1
+        uses: actions/upload-release-asset@64e5e85fc528f162d7ba7ce2d15a3bb67efb3d80 # v1.0.1
         with:
           upload_url: ${{ needs.create-draft-release.outputs.upload_url }}
           asset_path: ./latest.json

--- a/.github/workflows/publish-npm-core.yml
+++ b/.github/workflows/publish-npm-core.yml
@@ -8,13 +8,13 @@ jobs:
   build-and-publish-plugins:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: '0'
           token: ${{ secrets.PAT_SERVICE_ACCOUNT }}
 
       - name: Install jq
-        uses: dcarbone/install-jq-action@v2.0.1
+        uses: dcarbone/install-jq-action@c1548c666da8422e8207a67fae0df364cf9ee7fe # v2.0.1
 
       - name: Extract tag name without v prefix
         id: get_version
@@ -38,7 +38,7 @@ jobs:
           cat core/package.json
 
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/template-get-update-version.yml
+++ b/.github/workflows/template-get-update-version.yml
@@ -13,12 +13,12 @@ jobs:
       new_version: ${{ steps.version_update.outputs.new_version }}
     steps:
       - name: Install jq
-        uses: dcarbone/install-jq-action@v2.0.1
+        uses: dcarbone/install-jq-action@c1548c666da8422e8207a67fae0df364cf9ee7fe # v2.0.1
 
       - name: Get tag
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         id: tag
-        uses: dawidd6/action-get-tag@v1
+        uses: dawidd6/action-get-tag@727a6f0a561be04e09013531e73a3983a65e3479 # v1
 
       - name: Update app version based on latest release tag with build number
         id: version_update

--- a/.github/workflows/template-noti-discord-and-update-url-readme.yml
+++ b/.github/workflows/template-noti-discord-and-update-url-readme.yml
@@ -31,7 +31,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: '0'
           token: ${{ secrets.PAT_SERVICE_ACCOUNT }}
@@ -42,7 +42,7 @@ jobs:
           echo "VERSION=${{ inputs.new_version }}" >> $GITHUB_ENV
 
       - name: Notify Discord
-        uses: Ilshidur/action-discord@master
+        uses: Ilshidur/action-discord@d2594079a10f1d6739ee50a2471f0ca57418b554 # 0.4.0
         with:
           args: |
             Jan App ${{ inputs.build_reason }} build artifact version {{ VERSION }}:

--- a/.github/workflows/template-tauri-build-linux-x64-external.yml
+++ b/.github/workflows/template-tauri-build-linux-x64-external.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Getting the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
 
@@ -50,12 +50,12 @@ jobs:
           cp .github/scripts/icon-${{ inputs.channel }}.png src-tauri/icons/icon.png
 
       - name: Installing node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
       - name: Install jq
-        uses: dcarbone/install-jq-action@v2.0.1
+        uses: dcarbone/install-jq-action@c1548c666da8422e8207a67fae0df364cf9ee7fe # v2.0.1
 
       - name: Install ctoml
         run: |
@@ -139,13 +139,13 @@ jobs:
           TAURI_TRAY: libappindicator3
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jan-linux-amd64-${{ inputs.new_version }}-deb
           path: ./src-tauri/target/release/bundle/deb/*.deb
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jan-linux-amd64-${{ inputs.new_version }}-AppImage
           path: ./src-tauri/target/release/bundle/appimage/*.AppImage

--- a/.github/workflows/template-tauri-build-linux-x64-flatpak.yml
+++ b/.github/workflows/template-tauri-build-linux-x64-flatpak.yml
@@ -49,7 +49,7 @@ jobs:
       contents: write
     steps:
       - name: Getting the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
 
@@ -68,12 +68,12 @@ jobs:
           df -h
 
       - name: Installing node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
       - name: Install jq
-        uses: dcarbone/install-jq-action@v2.0.1
+        uses: dcarbone/install-jq-action@c1548c666da8422e8207a67fae0df364cf9ee7fe # v2.0.1
 
       - name: Install ctoml
         run: |
@@ -179,7 +179,7 @@ jobs:
       ## Artifacts, for dev and test
       - name: Upload Artifact
         if: inputs.public_provider != 'github'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jan-linux-amd64-flatpak-${{ inputs.new_version }}-deb
           path: ./src-tauri/target/release/bundle/deb/*.deb

--- a/.github/workflows/template-tauri-build-linux-x64.yml
+++ b/.github/workflows/template-tauri-build-linux-x64.yml
@@ -64,7 +64,7 @@ jobs:
       contents: write
     steps:
       - name: Getting the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
 
@@ -89,12 +89,12 @@ jobs:
           cp .github/scripts/icon-${{ inputs.channel }}.png src-tauri/icons/icon.png
 
       - name: Installing node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
       - name: Install jq
-        uses: dcarbone/install-jq-action@v2.0.1
+        uses: dcarbone/install-jq-action@c1548c666da8422e8207a67fae0df364cf9ee7fe # v2.0.1
 
       - name: Install ctoml
         run: |
@@ -206,14 +206,14 @@ jobs:
       ## Artifacts, for dev and test
       - name: Upload Artifact
         if: inputs.public_provider != 'github'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jan-linux-amd64-${{ inputs.new_version }}-deb
           path: ./src-tauri/target/release/bundle/deb/*.deb
 
       - name: Upload Artifact
         if: inputs.public_provider != 'github'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jan-linux-amd64-${{ inputs.new_version }}-AppImage
           path: ./src-tauri/target/release/bundle/appimage/*.AppImage
@@ -262,7 +262,7 @@ jobs:
         if: inputs.public_provider == 'github'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: actions/upload-release-asset@v1.0.1
+        uses: actions/upload-release-asset@64e5e85fc528f162d7ba7ce2d15a3bb67efb3d80 # v1.0.1
         with:
           upload_url: ${{ inputs.upload_url }}
           asset_path: ./src-tauri/target/release/bundle/appimage/${{ steps.packageinfo.outputs.APPIMAGE_FILE_NAME }}
@@ -273,7 +273,7 @@ jobs:
         if: inputs.public_provider == 'github'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: actions/upload-release-asset@v1.0.1
+        uses: actions/upload-release-asset@64e5e85fc528f162d7ba7ce2d15a3bb67efb3d80 # v1.0.1
         with:
           upload_url: ${{ inputs.upload_url }}
           asset_path: ./src-tauri/target/release/bundle/deb/${{ steps.packageinfo.outputs.DEB_FILE_NAME }}

--- a/.github/workflows/template-tauri-build-macos-external.yml
+++ b/.github/workflows/template-tauri-build-macos-external.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Getting the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
 
@@ -31,12 +31,12 @@ jobs:
           cp .github/scripts/icon-${{ inputs.channel }}.png src-tauri/icons/icon.png
 
       - name: Installing node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
       - name: Install jq
-        uses: dcarbone/install-jq-action@v2.0.1
+        uses: dcarbone/install-jq-action@c1548c666da8422e8207a67fae0df364cf9ee7fe # v2.0.1
 
       - name: Install ctoml
         run: |
@@ -112,7 +112,7 @@ jobs:
           APP_PATH: '.'
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jan-${{ inputs.channel }}-mac-universal-${{ inputs.new_version }}.dmg
           path: |

--- a/.github/workflows/template-tauri-build-macos.yml
+++ b/.github/workflows/template-tauri-build-macos.yml
@@ -73,7 +73,7 @@ jobs:
       contents: write
     steps:
       - name: Getting the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
       - name: Replace Icons for Beta Build
@@ -83,12 +83,12 @@ jobs:
           cp .github/scripts/icon-${{ inputs.channel }}.png src-tauri/icons/icon.png
 
       - name: Installing node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
       - name: Install jq
-        uses: dcarbone/install-jq-action@v2.0.1
+        uses: dcarbone/install-jq-action@c1548c666da8422e8207a67fae0df364cf9ee7fe # v2.0.1
 
       - name: Install ctoml
         run: |
@@ -167,7 +167,7 @@ jobs:
         env:
           NOTARIZE_P8_BASE64: ${{ secrets.NOTARIZE_P8_BASE64 }}
 
-      - uses: apple-actions/import-codesign-certs@v2
+      - uses: apple-actions/import-codesign-certs@8f3fb608891dd2244cdab3d69cd68c0d37a7fe93 # v2
         continue-on-error: true
         with:
           p12-file-base64: ${{ secrets.CODE_SIGN_P12_BASE64 }}
@@ -203,7 +203,7 @@ jobs:
       ## Artifacts, for dev and test
       - name: Upload Artifact
         if: inputs.public_provider != 'github'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jan-${{ inputs.channel }}-mac-universal-${{ inputs.new_version }}.dmg
           path: |
@@ -253,7 +253,7 @@ jobs:
         if: inputs.public_provider == 'github'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: actions/upload-release-asset@v1.0.1
+        uses: actions/upload-release-asset@64e5e85fc528f162d7ba7ce2d15a3bb67efb3d80 # v1.0.1
         with:
           upload_url: ${{ inputs.upload_url }}
           asset_path: ./src-tauri/target/universal-apple-darwin/release/bundle/macos/${{ steps.metadata.outputs.FILE_NAME }}
@@ -264,7 +264,7 @@ jobs:
         if: inputs.public_provider == 'github'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: actions/upload-release-asset@v1.0.1
+        uses: actions/upload-release-asset@64e5e85fc528f162d7ba7ce2d15a3bb67efb3d80 # v1.0.1
         with:
           upload_url: ${{ inputs.upload_url }}
           asset_path: ./src-tauri/target/universal-apple-darwin/release/bundle/dmg/${{ steps.metadata.outputs.DMG_NAME }}
@@ -275,7 +275,7 @@ jobs:
         if: inputs.public_provider == 'github'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: actions/upload-release-asset@v1.0.1
+        uses: actions/upload-release-asset@64e5e85fc528f162d7ba7ce2d15a3bb67efb3d80 # v1.0.1
         with:
           upload_url: ${{ inputs.upload_url }}
           asset_path: ./src-tauri/target/universal-apple-darwin/release/bundle/macos/${{ steps.metadata.outputs.TAR_NAME }}

--- a/.github/workflows/template-tauri-build-windows-x64-external.yml
+++ b/.github/workflows/template-tauri-build-windows-x64-external.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Getting the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
 
@@ -31,12 +31,12 @@ jobs:
           cp .github/scripts/icon-${{ inputs.channel }}.png src-tauri/icons/icon.png
 
       - name: Installing node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
       - name: Install jq
-        uses: dcarbone/install-jq-action@v2.0.1
+        uses: dcarbone/install-jq-action@c1548c666da8422e8207a67fae0df364cf9ee7fe # v2.0.1
 
       - name: Install ctoml
         run: |
@@ -162,7 +162,7 @@ jobs:
           make build
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jan-windows-${{ inputs.new_version }}
           path: |

--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -73,7 +73,7 @@ jobs:
       contents: write
     steps:
       - name: Getting the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ inputs.ref }}
 
@@ -84,12 +84,12 @@ jobs:
           cp .github/scripts/icon-${{ inputs.channel }}.png src-tauri/icons/icon.png
 
       - name: Installing node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
       - name: Install jq
-        uses: dcarbone/install-jq-action@v2.0.1
+        uses: dcarbone/install-jq-action@c1548c666da8422e8207a67fae0df364cf9ee7fe # v2.0.1
 
       - name: Install ctoml
         run: |
@@ -246,20 +246,20 @@ jobs:
           JAN_SIGNING_KEY: ${{ secrets.JAN_SIGNING_KEY }}
 
       - name: Upload NSIS Installer Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jan-windows-exe-${{ inputs.new_version }}
           path: |
             ./src-tauri/target/release/bundle/nsis/*.exe
       - name: Upload MSI Installer Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jan-windows-msi-${{ inputs.new_version }}
           path: |
             ./src-tauri/target/release/bundle/msi/*.msi
 
       # - name: Upload Portable Artifact
-      #   uses: actions/upload-artifact@v4
+      #   uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       #   with:
       #     name: jan-windows-portable-${{ inputs.new_version }}
       #     path: |
@@ -310,7 +310,7 @@ jobs:
         if: inputs.public_provider == 'github'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: actions/upload-release-asset@v1.0.1
+        uses: actions/upload-release-asset@64e5e85fc528f162d7ba7ce2d15a3bb67efb3d80 # v1.0.1
         with:
           upload_url: ${{ inputs.upload_url }}
           asset_path: ./src-tauri/target/release/bundle/nsis/${{ steps.metadata.outputs.FILE_NAME }}
@@ -321,7 +321,7 @@ jobs:
       #   if: inputs.public_provider == 'github'
       #   env:
       #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   uses: actions/upload-release-asset@v1.0.1
+      #   uses: actions/upload-release-asset@64e5e85fc528f162d7ba7ce2d15a3bb67efb3d80 # v1.0.1
       #   with:
       #     upload_url: ${{ inputs.upload_url }}
       #     asset_path: ./src-tauri/target/release/${{ steps.metadata.outputs.PORTABLE_FILE_NAME }}


### PR DESCRIPTION
## Describe Your Changes

This pull request updates multiple GitHub Actions workflows to improve security and maintainability by pinning action dependencies to specific commit SHAs, and introduces concurrency controls to avoid overlapping workflow runs. The main themes are dependency pinning for reproducibility and workflow reliability improvements.

**Dependency pinning for reproducibility and security:**

* Updated all `actions/checkout`, `actions/setup-node`, `actions/setup-python`, `actions/upload-artifact`, `actions/download-artifact`, and other third-party actions in various workflow files (such as `.github/workflows/autoqa-migration.yml`, `.github/workflows/autoqa-template.yml`, `.github/workflows/autoqa-reliability.yml`, `.github/workflows/jan-docs.yml`, `.github/workflows/jan-linter-and-test.yml`, etc.) to use specific commit SHAs rather than version tags, ensuring builds are deterministic and less susceptible to upstream changes or supply chain attacks. [[1]](diffhunk://#diff-a394f880f50eb3772ae5a74c2a03140168abffbc204db8945f133da68d312784L15-R15) [[2]](diffhunk://#diff-c80cb38b60bd8ab10b8225cd258c2150b91438a7c5f685e761310387863d2438L51-R54) [[3]](diffhunk://#diff-c80cb38b60bd8ab10b8225cd258c2150b91438a7c5f685e761310387863d2438L119-R127) [[4]](diffhunk://#diff-c80cb38b60bd8ab10b8225cd258c2150b91438a7c5f685e761310387863d2438L145-R148) [[5]](diffhunk://#diff-c80cb38b60bd8ab10b8225cd258c2150b91438a7c5f685e761310387863d2438L228-R236) [[6]](diffhunk://#diff-c80cb38b60bd8ab10b8225cd258c2150b91438a7c5f685e761310387863d2438L253-R256) [[7]](diffhunk://#diff-c80cb38b60bd8ab10b8225cd258c2150b91438a7c5f685e761310387863d2438L311-R319) [[8]](diffhunk://#diff-7db9c4fda5502751bb6597ec0a575340be8dda6561792a5379d3028d03fdd2deL58-R61) [[9]](diffhunk://#diff-7db9c4fda5502751bb6597ec0a575340be8dda6561792a5379d3028d03fdd2deL103-R111) [[10]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732L59-R68) [[11]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732L148-R156) [[12]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732L177-R186) [[13]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732L295-R303) [[14]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732L323-R332) [[15]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732L455-R463) [[16]](diffhunk://#diff-898a705fa8fb9d04143afeff910f5f904408321d359cfc8ce239552c29c6198fL14-R21) [[17]](diffhunk://#diff-fe198ee6d6945e09ccefa6351febac68b4b18f3ebc3503e720a8c7fee65ea5c7L13-R13) [[18]](diffhunk://#diff-241936f6a26af3f159725951c5a3302bfa839fdde96b98ed891b555e8faaab9aL13-R13) [[19]](diffhunk://#diff-8b9931223f17eabd8611776116a7f9a4cc133a5ab59ab8dd814e696fc4eebd16L16-R16) [[20]](diffhunk://#diff-307479c4bef1f0bb90238fcfe3f7df26d8a15312aab6233edf9e1c43fd3fa5a4L29-R39) [[21]](diffhunk://#diff-307479c4bef1f0bb90238fcfe3f7df26d8a15312aab6233edf9e1c43fd3fa5a4L72-R76) [[22]](diffhunk://#diff-307479c4bef1f0bb90238fcfe3f7df26d8a15312aab6233edf9e1c43fd3fa5a4L82-R94) [[23]](diffhunk://#diff-ae1c9bf4040629dc6730513192796061ca97b703eeeda939ca59dfa912c39af3R37-R51) [[24]](diffhunk://#diff-ae1c9bf4040629dc6730513192796061ca97b703eeeda939ca59dfa912c39af3L73-R77) [[25]](diffhunk://#diff-ae1c9bf4040629dc6730513192796061ca97b703eeeda939ca59dfa912c39af3L83-R87) [[26]](diffhunk://#diff-ae1c9bf4040629dc6730513192796061ca97b703eeeda939ca59dfa912c39af3L93-R97) [[27]](diffhunk://#diff-ae1c9bf4040629dc6730513192796061ca97b703eeeda939ca59dfa912c39af3L120-R124)

**Workflow reliability improvements:**

* Added `concurrency` groups to `.github/workflows/jan-docs.yml` and `.github/workflows/jan-linter-and-test.yml` to prevent overlapping runs for the same ref and ensure that only the latest workflow execution is active, reducing unnecessary resource usage and potential conflicts. [[1]](diffhunk://#diff-307479c4bef1f0bb90238fcfe3f7df26d8a15312aab6233edf9e1c43fd3fa5a4R18-R21) [[2]](diffhunk://#diff-ae1c9bf4040629dc6730513192796061ca97b703eeeda939ca59dfa912c39af3R37-R51)

These changes make the CI/CD pipelines more robust, secure, and easier to audit or troubleshoot.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
