### PR TITLE
chore: merge dev branch fix/macos backend-install-ux

### DIFF
--- a/extensions/llamacpp-extension/settings.json
+++ b/extensions/llamacpp-extension/settings.json
@@ -1,8 +1,19 @@
 [
   {
-    "key": "version_backend",
-    "title": "Version & Backend",
-    "description": "Version and Backend for llama.cpp",
+    "key": "llamacpp_version",
+    "title": "Version",
+    "description": "llama.cpp release version",
+    "controllerType": "dropdown",
+    "controllerProps": {
+      "value": "none",
+      "options": [],
+      "recommended": ""
+    }
+  },
+  {
+    "key": "llamacpp_backend",
+    "title": "Backend",
+    "description": "Hardware backend for llama.cpp (CUDA, Vulkan, CPU, etc.)",
     "controllerType": "dropdown",
     "controllerProps": {
       "value": "none",
@@ -23,9 +34,16 @@
     }
   },
   {
+    "key": "check_for_updates",
+    "title": "Check for updates",
+    "description": "Fetch the remote llama.cpp release list. Required for the version dropdown to show releases beyond what's installed locally, and for update notifications.",
+    "controllerType": "checkbox",
+    "controllerProps": { "value": true }
+  },
+  {
     "key": "auto_update_engine",
     "title": "Auto update engine",
-    "description": "Automatically update llamacpp engine to latest version",
+    "description": "Automatically download and switch to the latest llamacpp engine when available. Requires \"Check for updates\" to be on.",
     "controllerType": "checkbox",
     "controllerProps": { "value": true }
   },

--- a/extensions/llamacpp-extension/settings.json
+++ b/extensions/llamacpp-extension/settings.json
@@ -30,6 +30,13 @@
     "controllerProps": { "value": true }
   },
   {
+    "key": "verify_backend_deps",
+    "title": "Verify backend dependencies",
+    "description": "Check that GPU backend shared libraries (CUDA, Vulkan, etc.) resolve on startup and warn if any are missing.",
+    "controllerType": "checkbox",
+    "controllerProps": { "value": true }
+  },
+  {
     "key": "models_max",
     "title": "Max Concurrently Loaded Models",
     "description": "Maximum number of models the router will keep loaded at once. 0 = unlimited.",

--- a/extensions/llamacpp-extension/src/backend.ts
+++ b/extensions/llamacpp-extension/src/backend.ts
@@ -32,7 +32,12 @@ export async function getLocalInstalledBackends(): Promise<
 // <Jan's data folder>/llamacpp/backends/<backend_version>/<backend_type>
 
 // what should be available to the user for selection?
-export async function listSupportedBackends(): Promise<BackendVersion[]> {
+/**
+ * Hardware-supported backends published by upstream. Excludes
+ * locally-installed-only entries, so the "recommended backend" calculation
+ * isn't biased by user side-loads.
+ */
+export async function fetchRemoteBackends(): Promise<BackendVersion[]> {
   const sysInfo = await getSystemInfo()
   const rawFeatures = await getSupportedFeaturesFromRust(
     sysInfo.os_type,
@@ -40,18 +45,14 @@ export async function listSupportedBackends(): Promise<BackendVersion[]> {
     sysInfo.gpus
   )
   const features = normalizeFeatures(rawFeatures)
-
-  // Get supported backend names from Rust
   const supportedBackends = await determineSupportedBackends(
     sysInfo.os_type,
     sysInfo.cpu.arch,
     features
   )
 
-  // Get remote backends via Rust (handles GitHub + CDN fallback)
-  let remoteBackendVersions: BackendVersion[] = []
   try {
-    remoteBackendVersions = await invoke(
+    return await invoke<BackendVersion[]>(
       'plugin:llamacpp|fetch_remote_supported_backends',
       { supportedBackends, proxy: getProxyConfig() }
     )
@@ -59,12 +60,15 @@ export async function listSupportedBackends(): Promise<BackendVersion[]> {
     console.debug(
       `Not able to get remote backends, Jan might be offline or network problem: ${String(e)}`
     )
+    return []
   }
+}
 
-  // Get locally installed versions
+export async function listSupportedBackends(
+  checkRemote: boolean = true
+): Promise<BackendVersion[]> {
+  const remoteBackendVersions = checkRemote ? await fetchRemoteBackends() : []
   const localBackendVersions = await getLocalInstalledBackends()
-
-  // Merge & sort via Rust
   return listSupportedBackendsFromRust(remoteBackendVersions, localBackendVersions)
 }
 

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -981,7 +981,7 @@ export default class llamacpp_extension extends AIEngine {
       // Run dependency verification once after the backend is confirmed
       // installed. This covers both fresh downloads and pre-existing installs,
       // and runs only once per app startup via the isConfiguringBackends guard.
-      if (effectiveBackendString) {
+      if (effectiveBackendString && this.config.verify_backend_deps !== false) {
         // effectiveBackendString is expected to be "<version>/<backend>" (e.g.
         // "b4589/linux-cuda-12"). Any other shape silently skips verification.
         const [version, backend] = effectiveBackendString.split('/')

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -22,12 +22,19 @@ import {
   AppEvent,
   DownloadEvent,
   chatCompletionRequestMessage,
+  SettingComponentProps,
 } from '@janhq/core'
+import {
+  readSettingsFile,
+  writeSettingsFile,
+  settingsFileExists,
+} from './settings-store'
 
 import { error, info, warn } from '@tauri-apps/plugin-log'
 import { listen } from '@tauri-apps/api/event'
 import {
   listSupportedBackends,
+  fetchRemoteBackends,
   downloadBackend,
   isBackendInstalled,
   verifyBackendInstallation,
@@ -324,6 +331,8 @@ export default class llamacpp_extension extends AIEngine {
   override async onLoad(): Promise<void> {
     super.onLoad() // Calls registerEngine() from AIEngine
 
+    await this.migrateLocalStorageToFile()
+
     let settings = structuredClone(SETTINGS) // Clone to modify settings definition before registration
 
     if (!IS_MAC) {
@@ -331,8 +340,34 @@ export default class llamacpp_extension extends AIEngine {
       if (fitItem) fitItem.controllerProps.value = true
     }
 
-    // This makes the settings (including the backend options and initial value) available to the Jan UI.
-    this.registerSettings(settings)
+    // Migration: legacy `version_backend` (single composite string) → split
+    // into `llamacpp_version` + `llamacpp_backend`. Read from localStorage
+    // before registerSettings overwrites the persisted set.
+    try {
+      const prior = await this.getSettings()
+      const legacy = prior.find((s) => s.key === 'version_backend')
+      const legacyValue = legacy?.controllerProps?.value
+      if (
+        typeof legacyValue === 'string' &&
+        legacyValue.includes('/') &&
+        legacyValue !== 'none'
+      ) {
+        const [v, b] = legacyValue.split('/')
+        if (v && b) {
+          const vSetting = settings.find((s) => s.key === 'llamacpp_version')
+          const bSetting = settings.find((s) => s.key === 'llamacpp_backend')
+          if (vSetting) vSetting.controllerProps.value = v
+          if (bSetting) bSetting.controllerProps.value = b
+          logger.info(
+            `Migrated legacy version_backend '${legacyValue}' → version='${v}', backend='${b}'`
+          )
+        }
+      }
+    } catch (e) {
+      logger.warn('version_backend migration check failed (ignored):', e)
+    }
+
+    await this.registerSettings(settings)
 
     let loadedConfig: any = {}
     for (const item of settings) {
@@ -344,6 +379,7 @@ export default class llamacpp_extension extends AIEngine {
       )
     }
     this.config = loadedConfig as LlamacppConfig
+    this.recomposeVersionBackend()
 
     // Migration v2: disable fit by default
     await this.migrateFitDefault()
@@ -382,6 +418,109 @@ export default class llamacpp_extension extends AIEngine {
       await this.startRouter()
     } catch (e) {
       logger.error('Router failed to start during onLoad:', e)
+    }
+  }
+
+  override async getSettings(): Promise<SettingComponentProps[]> {
+    return readSettingsFile()
+  }
+
+  override async updateSettings(
+    componentProps: Partial<SettingComponentProps>[]
+  ): Promise<void> {
+    const current = await readSettingsFile()
+    const updated = current.length
+      ? current.map((s) => {
+          const patch = componentProps.find((p) => p.key === s.key)
+          if (patch?.controllerProps) {
+            ;(s.controllerProps as { value?: unknown }).value = (
+              patch.controllerProps as { value?: unknown }
+            ).value
+          }
+          return s
+        })
+      : (componentProps as SettingComponentProps[])
+    await writeSettingsFile(updated)
+  }
+
+  override async registerSettings(
+    settings: SettingComponentProps[]
+  ): Promise<void> {
+    settings.forEach((s) => {
+      s.extensionName = this.name
+    })
+    const old = await readSettingsFile()
+    if (old.length) {
+      settings.forEach((s) => {
+        const prev = old.find((o) => o.key === s.key)
+        if (!prev) return
+        const cp = s.controllerProps as Record<string, unknown>
+        const pcp = prev.controllerProps as Record<string, unknown>
+        if (pcp.value !== undefined) cp.value = pcp.value
+        if ('options' in cp) {
+          const newOptions = (cp.options as unknown[]) ?? []
+          if (newOptions.length === 0 && Array.isArray(pcp.options)) {
+            cp.options = pcp.options
+          }
+          const opts = (cp.options as { value: unknown }[]) ?? []
+          if (opts.length && !opts.some((o) => o.value === cp.value)) {
+            cp.value = opts[0]?.value
+          }
+        }
+      })
+    }
+    await writeSettingsFile(settings)
+  }
+
+  private async migrateLocalStorageToFile(): Promise<void> {
+    if (await settingsFileExists()) return
+    if (!this.name) return
+    let raw: string | null = null
+    try {
+      raw = localStorage.getItem(this.name)
+    } catch {
+      raw = null
+    }
+    if (!raw) return
+    try {
+      const parsed = JSON.parse(raw)
+      if (Array.isArray(parsed)) {
+        await writeSettingsFile(parsed as SettingComponentProps[])
+        logger.info(
+          `Migrated llamacpp settings from localStorage → file (${parsed.length} entries)`
+        )
+      }
+    } catch (e) {
+      logger.warn('Failed to migrate localStorage settings to file:', e)
+      return
+    }
+    try {
+      localStorage.removeItem(this.name)
+    } catch (e) {
+      logger.warn('Failed to clear migrated localStorage entry:', e)
+    }
+  }
+
+  private async persistRecommended(
+    key: string,
+    value: string
+  ): Promise<void> {
+    const settings = await readSettingsFile()
+    const entry = settings.find((s) => s.key === key)
+    if (!entry) return
+    const cp = entry.controllerProps as { recommended?: string }
+    if (cp.recommended === value) return
+    cp.recommended = value
+    await writeSettingsFile(settings)
+  }
+
+  private recomposeVersionBackend(): void {
+    const v = this.config?.llamacpp_version
+    const b = this.config?.llamacpp_backend
+    if (v && b && v !== 'none' && b !== 'none') {
+      this.config.version_backend = `${v}/${b}`
+    } else if (!this.config.version_backend) {
+      this.config.version_backend = ''
     }
   }
 
@@ -757,7 +896,9 @@ export default class llamacpp_extension extends AIEngine {
       let version_backends: { version: string; backend: string }[] = []
 
       try {
-        version_backends = await listSupportedBackends()
+        version_backends = await listSupportedBackends(
+          this.config.check_for_updates !== false
+        )
         if (version_backends.length === 0) {
           throw new Error(
             'No supported backend binaries found for this system. Backend selection and auto-update will be unavailable.'
@@ -777,9 +918,18 @@ export default class llamacpp_extension extends AIEngine {
       const storedBackendType = this.getStoredBackendType()
       let bestAvailableBackendString = ''
 
-      // Calculate the "best" backend first, as it's used for fallback and defaults
+      // "Recommended" is computed against upstream releases only — a
+      // user-side-loaded backend (Install from File) must not bias the
+      // suggestion. If we have no remote data (check_for_updates off or
+      // offline), there is no honest recommendation to surface.
+      const remoteOnly =
+        this.config.check_for_updates !== false
+          ? await fetchRemoteBackends()
+          : []
       bestAvailableBackendString =
-        await this.determineBestBackend(version_backends)
+        remoteOnly.length > 0
+          ? await this.determineBestBackend(remoteOnly)
+          : ''
 
       if (storedBackendType) {
         // Delegate migration check to Rust
@@ -821,84 +971,99 @@ export default class llamacpp_extension extends AIEngine {
       }
 
       let settings = structuredClone(SETTINGS)
-      const backendSettingIndex = settings.findIndex(
-        (item) => item.key === 'version_backend'
-      )
-
-      let originalDefaultBackendValue = ''
-      if (backendSettingIndex !== -1) {
-        const backendSetting = settings[backendSettingIndex]
-        originalDefaultBackendValue = backendSetting.controllerProps
-          .value as string
-
-        backendSetting.controllerProps.options = version_backends.map((b) => {
-          const key = `${b.version}/${b.backend}`
-          return { value: key, name: key }
-        })
-
-        // Set the recommended backend based on bestAvailableBackendString
-        if (bestAvailableBackendString) {
-          backendSetting.controllerProps.recommended =
-            bestAvailableBackendString
-        }
-
-        const savedBackendSetting = await this.getSetting<string>(
-          'version_backend',
-          originalDefaultBackendValue
+      const versionSetting = settings.find((s) => s.key === 'llamacpp_version')
+      const backendSetting = settings.find((s) => s.key === 'llamacpp_backend')
+      if (!versionSetting || !backendSetting) {
+        throw new Error(
+          'Critical settings "llamacpp_version" / "llamacpp_backend" not found.'
         )
-
-        // Determine initial UI default based on priority:
-        // 1. Saved setting (if valid and not original default)
-        // 2. Best available for stored backend type or automatic best
-        // 3. Original default
-        let initialUiDefault = originalDefaultBackendValue
-
-        if (
-          savedBackendSetting &&
-          savedBackendSetting !== originalDefaultBackendValue
-        ) {
-          const [savedVersion, savedBackend] = savedBackendSetting.split('/')
-          if (savedVersion && savedBackend) {
-            // Map saved backend to new format if needed
-            const normalizedBackend = await mapOldBackendToNew(savedBackend)
-            initialUiDefault = `${savedVersion}/${normalizedBackend}`
-
-            // Store the backend type from the saved setting only if different
-            const currentStoredBackend = this.getStoredBackendType()
-            if (currentStoredBackend !== normalizedBackend) {
-              this.setStoredBackendType(normalizedBackend)
-              logger.info(
-                `Stored backend type preference from saved setting: ${normalizedBackend}`
-              )
-            }
-          }
-        } else if (bestAvailableBackendString) {
-          initialUiDefault = bestAvailableBackendString
-          // Store the backend type from the best available only if different
-          const [, backendType] = bestAvailableBackendString.split('/')
-          if (backendType) {
-            const currentStoredBackend = this.getStoredBackendType()
-            if (currentStoredBackend !== backendType) {
-              this.setStoredBackendType(backendType)
-              logger.info(
-                `Stored backend type preference from best available: ${backendType}`
-              )
-            }
-          }
-        }
-
-        backendSetting.controllerProps.value = initialUiDefault
-        logger.info(
-          `Initial UI default for version_backend set to: ${initialUiDefault}`
-        )
-      } else {
-        logger.error(
-          'Critical setting "version_backend" definition not found in SETTINGS.'
-        )
-        throw new Error('Critical setting "version_backend" not found.')
       }
 
-      this.registerSettings(settings)
+      // Read prior persisted values (may have been pre-populated by the
+      // legacy-migration pass in onLoad, or carry user-edited values from a
+      // prior session).
+      const priorPersisted = await this.getSettings()
+      const priorVersion = String(
+        priorPersisted.find((s) => s.key === 'llamacpp_version')?.controllerProps
+          .value ?? ''
+      )
+      const priorBackend = String(
+        priorPersisted.find((s) => s.key === 'llamacpp_backend')?.controllerProps
+          .value ?? ''
+      )
+
+      const allVersions = Array.from(
+        new Set(version_backends.map((b) => b.version))
+      )
+      versionSetting.controllerProps.options = allVersions.map((v) => ({
+        value: v,
+        name: v,
+      }))
+
+      const allBackends = Array.from(
+        new Set(version_backends.map((b) => b.backend))
+      )
+      backendSetting.controllerProps.options = allBackends.map((b) => ({
+        value: b,
+        name: b,
+      }))
+
+      const [bestVersion, bestBackend] =
+        bestAvailableBackendString.split('/')
+      if (bestVersion) versionSetting.controllerProps.recommended = bestVersion
+      if (bestBackend) backendSetting.controllerProps.recommended = bestBackend
+
+      // Decide initial UI values. Priority: valid prior selection → best-available.
+      let initialVersion = bestVersion || ''
+      let initialBackend = bestBackend || ''
+      if (
+        priorVersion &&
+        priorBackend &&
+        priorVersion !== 'none' &&
+        priorBackend !== 'none'
+      ) {
+        const normalizedBackend = await mapOldBackendToNew(priorBackend)
+        const composed = `${priorVersion}/${normalizedBackend}`
+        if (
+          version_backends.some(
+            (e) => `${e.version}/${e.backend}` === composed
+          )
+        ) {
+          initialVersion = priorVersion
+          initialBackend = normalizedBackend
+          const currentStoredBackend = this.getStoredBackendType()
+          if (currentStoredBackend !== normalizedBackend) {
+            this.setStoredBackendType(normalizedBackend)
+            logger.info(
+              `Stored backend type preference from saved setting: ${normalizedBackend}`
+            )
+          }
+        }
+      } else if (bestBackend) {
+        const currentStoredBackend = this.getStoredBackendType()
+        if (currentStoredBackend !== bestBackend) {
+          this.setStoredBackendType(bestBackend)
+          logger.info(
+            `Stored backend type preference from best available: ${bestBackend}`
+          )
+        }
+      }
+
+      versionSetting.controllerProps.value = initialVersion
+      backendSetting.controllerProps.value = initialBackend
+      logger.info(
+        `Initial UI defaults: llamacpp_version='${initialVersion}', llamacpp_backend='${initialBackend}'`
+      )
+
+      // Must await — registerSettings is async; without await, the
+      // persistRecommended writes below race with its merge+write and lose.
+      await this.registerSettings(settings)
+
+      // core's registerSettings preserves the previous `recommended` over the
+      // new one (see extension.ts:142-148). Force-write afterward so a stale
+      // recommendation from a prior session can't outlive a fresh compute.
+      await this.persistRecommended('llamacpp_version', bestVersion || '')
+      await this.persistRecommended('llamacpp_backend', bestBackend || '')
 
       let effectiveBackendString = this.config.version_backend
       let backendWasDownloaded = false
@@ -921,29 +1086,32 @@ export default class llamacpp_extension extends AIEngine {
           `Fresh installation or invalid backend detected, using: ${effectiveBackendString}`
         )
 
-        // Update the config immediately
-        this.config.version_backend = effectiveBackendString
+        const [newV, newB] = effectiveBackendString.split('/')
+        this.config.llamacpp_version = newV
+        this.config.llamacpp_backend = newB
+        this.recomposeVersionBackend()
 
-        // Update the settings to reflect the change in UI
         const updatedSettings = await this.getSettings()
         await this.updateSettings(
           updatedSettings.map((item) => {
-            if (item.key === 'version_backend') {
-              item.controllerProps.value = effectiveBackendString
+            if (item.key === 'llamacpp_version') {
+              item.controllerProps.value = newV
+            } else if (item.key === 'llamacpp_backend') {
+              item.controllerProps.value = newB
             }
             return item
           })
         )
         logger.info(`Updated UI settings to show: ${effectiveBackendString}`)
 
-        // Emit for updating fe
         if (events && typeof events.emit === 'function') {
-          logger.info(
-            `Emitting settingsChanged event for version_backend with value: ${effectiveBackendString}`
-          )
           events.emit('settingsChanged', {
-            key: 'version_backend',
-            value: effectiveBackendString,
+            key: 'llamacpp_version',
+            value: newV,
+          })
+          events.emit('settingsChanged', {
+            key: 'llamacpp_backend',
+            value: newB,
           })
         }
       }
@@ -964,7 +1132,7 @@ export default class llamacpp_extension extends AIEngine {
         }
       }
 
-      if (this.config.auto_update_engine) {
+      if (this.config.auto_update_engine && this.config.check_for_updates) {
         const updateResult = await this.handleAutoUpdate(
           bestAvailableBackendString
         )
@@ -1009,7 +1177,9 @@ export default class llamacpp_extension extends AIEngine {
   async refreshBackendOptions(): Promise<void> {
     let version_backends: { version: string; backend: string }[] = []
     try {
-      version_backends = await listSupportedBackends()
+      version_backends = await listSupportedBackends(
+        this.config.check_for_updates !== false
+      )
     } catch (e) {
       logger.error(
         `refreshBackendOptions: failed to list supported backends: ${String(e)}`
@@ -1023,49 +1193,59 @@ export default class llamacpp_extension extends AIEngine {
     version_backends.sort((a, b) => b.version.localeCompare(a.version))
 
     const settings = await this.getSettings()
-    const backendSetting = settings.find(
-      (item) => item.key === 'version_backend'
-    )
-    if (!backendSetting) {
+    const versionSetting = settings.find((s) => s.key === 'llamacpp_version')
+    const backendSetting = settings.find((s) => s.key === 'llamacpp_backend')
+    if (!versionSetting || !backendSetting) {
       logger.error(
-        'refreshBackendOptions: version_backend setting not found in persisted settings'
+        'refreshBackendOptions: llamacpp_version/llamacpp_backend not found in persisted settings'
       )
       return
     }
 
-    const newOptions = version_backends.map((b) => {
-      const key = `${b.version}/${b.backend}`
-      return { value: key, name: key }
-    })
+    const allVersions = Array.from(
+      new Set(version_backends.map((b) => b.version))
+    )
+    const allBackends = Array.from(
+      new Set(version_backends.map((b) => b.backend))
+    )
+    versionSetting.controllerProps.options = allVersions.map((v) => ({
+      value: v,
+      name: v,
+    }))
+    backendSetting.controllerProps.options = allBackends.map((b) => ({
+      value: b,
+      name: b,
+    }))
 
-    backendSetting.controllerProps.options = newOptions
-
-    // Preserve current selection if still present; otherwise fall back to
-    // the best available so the UI stays consistent.
-    const currentValue = backendSetting.controllerProps.value as
-      | string
-      | undefined
-    const stillPresent =
-      typeof currentValue === 'string' &&
-      newOptions.some((o) => o.value === currentValue)
-    if (!stillPresent) {
+    const currentV = String(versionSetting.controllerProps.value ?? '')
+    const currentB = String(backendSetting.controllerProps.value ?? '')
+    const composedStillPresent =
+      currentV &&
+      currentB &&
+      version_backends.some(
+        (e) => e.version === currentV && e.backend === currentB
+      )
+    if (!composedStillPresent) {
       const best = await this.determineBestBackend(version_backends)
-      if (best) {
-        backendSetting.controllerProps.value = best
-        this.config.version_backend = best
+      const [bv, bb] = best.split('/')
+      if (bv && bb) {
+        versionSetting.controllerProps.value = bv
+        backendSetting.controllerProps.value = bb
+        this.config.llamacpp_version = bv
+        this.config.llamacpp_backend = bb
+        this.recomposeVersionBackend()
       }
     }
 
-    // registerSettings overwrites the persisted settings (including the
-    // new options array). updateSettings only copies `value`, which would
-    // silently drop our options change.
     await this.registerSettings(settings)
 
-    // Tell the rest of the app (GlobalEventHandler) to refetch providers
-    // so the dropdown re-renders with the new options.
     if (events && typeof events.emit === 'function') {
       events.emit('settingsChanged', {
-        key: 'version_backend',
+        key: 'llamacpp_version',
+        value: versionSetting.controllerProps.value,
+      })
+      events.emit('settingsChanged', {
+        key: 'llamacpp_backend',
         value: backendSetting.controllerProps.value,
       })
     }
@@ -1156,18 +1336,18 @@ export default class llamacpp_extension extends AIEngine {
       // Persist settings and stored preference before mutating in-memory config,
       // so that if any of these steps fail, config remains consistent.
 
-      // Update settings first — if this fails, we haven't mutated any state yet
       const settings = await this.getSettings()
       await this.updateSettings(
         settings.map((item) => {
-          if (item.key === 'version_backend') {
-            item.controllerProps.value = targetBackendString
+          if (item.key === 'llamacpp_version') {
+            item.controllerProps.value = version
+          } else if (item.key === 'llamacpp_backend') {
+            item.controllerProps.value = backend
           }
           return item
         })
       )
 
-      // Store the backend type preference only if it changed
       if (currentStoredBackend !== effectiveBackendType) {
         this.setStoredBackendType(effectiveBackendType)
         logger.info(
@@ -1175,20 +1355,21 @@ export default class llamacpp_extension extends AIEngine {
         )
       }
 
-      // All critical side effects succeeded — now commit to in-memory config
-      this.config.version_backend = targetBackendString
+      this.config.llamacpp_version = version
+      this.config.llamacpp_backend = backend
+      this.recomposeVersionBackend()
       this.config.device = ''
 
       logger.info(`Successfully updated to backend: ${targetBackendString}`)
 
-      // Emit for updating frontend
       if (events && typeof events.emit === 'function') {
-        logger.info(
-          `Emitting settingsChanged event for version_backend with value: ${targetBackendString}`
-        )
         events.emit('settingsChanged', {
-          key: 'version_backend',
-          value: targetBackendString,
+          key: 'llamacpp_version',
+          value: version,
+        })
+        events.emit('settingsChanged', {
+          key: 'llamacpp_backend',
+          value: backend,
         })
       }
 
@@ -1248,7 +1429,7 @@ export default class llamacpp_extension extends AIEngine {
     }
 
     // Use Rust checkBackendForUpdates logic implicitly here by using the helpers
-    const version_backends = await listSupportedBackends()
+    const version_backends = await listSupportedBackends(true)
     const checkResult = await checkBackendForUpdates(
       this.config.version_backend,
       version_backends
@@ -1289,7 +1470,7 @@ export default class llamacpp_extension extends AIEngine {
     targetBackend?: string
   }> {
     try {
-      const version_backends = await listSupportedBackends()
+      const version_backends = await listSupportedBackends(true)
       const result = await checkBackendForUpdates(
         this.config.version_backend,
         version_backends
@@ -1374,10 +1555,7 @@ export default class llamacpp_extension extends AIEngine {
   }
 
   onSettingUpdate<T>(key: string, value: T): void {
-    if (key === 'version_backend') {
-      // Skip entirely if updateBackend() is already handling it —
-      // updateBackend() will commit to in-memory config itself after all
-      // side effects succeed.
+    if (key === 'llamacpp_version' || key === 'llamacpp_backend') {
       if (this.isUpdatingBackend) {
         return
       }
@@ -1385,13 +1563,59 @@ export default class llamacpp_extension extends AIEngine {
 
     this.config[key] = value
 
-    if (key === 'version_backend') {
-      const valueStr = value as string
-      // Async logic wrapped in IIFE since onSettingUpdate is void
+    if (key === 'llamacpp_version' || key === 'llamacpp_backend') {
       ;(async () => {
         try {
+          let v = this.config.llamacpp_version
+          let b = this.config.llamacpp_backend
+          if (!v || !b || v === 'none' || b === 'none') return
+
+          // Validate (v, b) combination exists; if not, auto-resolve the
+          // backend to the best one available for the chosen version.
+          const supported = await listSupportedBackends(
+            this.config.check_for_updates !== false
+          )
+          const combos = new Set(
+            supported.map((e) => `${e.version}/${e.backend}`)
+          )
+          if (!combos.has(`${v}/${b}`)) {
+            const candidates = supported.filter((e) => e.version === v)
+            if (candidates.length === 0) {
+              logger.warn(
+                `No backends available for version '${v}'; ignoring update.`
+              )
+              return
+            }
+            const best = await this.determineBestBackend(candidates)
+            const [, bb] = best.split('/')
+            if (!bb) return
+            b = bb
+            this.config.llamacpp_backend = bb
+            const settings = await this.getSettings()
+            await this.updateSettings(
+              settings.map((item) => {
+                if (item.key === 'llamacpp_backend') {
+                  item.controllerProps.value = bb
+                }
+                return item
+              })
+            )
+            if (events && typeof events.emit === 'function') {
+              events.emit('settingsChanged', {
+                key: 'llamacpp_backend',
+                value: bb,
+              })
+            }
+          }
+
+          this.recomposeVersionBackend()
+          const composite = this.config.version_backend
           const currentStored = this.getStoredBackendType() || undefined
-          const result = await handleSettingUpdate(key, valueStr, currentStored)
+          const result = await handleSettingUpdate(
+            'version_backend',
+            composite,
+            currentStored
+          )
 
           if (result.backend_type_updated && result.effective_backend_type) {
             this.setStoredBackendType(result.effective_backend_type)

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -117,18 +117,33 @@ const PRESET_AFFECTING_KEYS = new Set<string>([
  * Override the default app.log function to use Jan's logging system.
  * @param args
  */
+function formatLogArg(arg: unknown): string {
+  if (arg instanceof Error) {
+    return arg.stack ? `${arg.message}\n${arg.stack}` : arg.message
+  }
+  if (arg === null || arg === undefined) return String(arg)
+  if (typeof arg === 'object') {
+    try {
+      return JSON.stringify(arg)
+    } catch {
+      return String(arg)
+    }
+  }
+  return String(arg)
+}
+
 const logger = {
   info: function (...args: any[]) {
     console.log(...args)
-    info(args.map((arg) => ` ${arg}`).join(` `))
+    info(args.map((arg) => ` ${formatLogArg(arg)}`).join(` `))
   },
   warn: function (...args: any[]) {
     console.warn(...args)
-    warn(args.map((arg) => ` ${arg}`).join(` `))
+    warn(args.map((arg) => ` ${formatLogArg(arg)}`).join(` `))
   },
   error: function (...args: any[]) {
     console.error(...args)
-    error(args.map((arg) => ` ${arg}`).join(` `))
+    error(args.map((arg) => ` ${formatLogArg(arg)}`).join(` `))
   },
 }
 

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -2342,6 +2342,7 @@ export default class llamacpp_extension extends AIEngine {
     const fullModelPath = await joinPath([janDataFolderPath, modelPath])
     let isEmbedding = false
     let mtpLayers = 0
+    let resolvedName: string | undefined
 
     try {
       // Validate main model file
@@ -2354,6 +2355,12 @@ export default class llamacpp_extension extends AIEngine {
         isEmbedding = true
       }
       mtpLayers = detectMtpLayersFromGgufMeta(modelMetadata.metadata)
+
+      const rawName = modelMetadata.metadata?.['general.name']
+      if (typeof rawName === 'string') {
+        const normalized = rawName.trim().replace(/\s+/g, '-')
+        if (normalized.length > 0) resolvedName = normalized
+      }
 
       // Validate mmproj file if present
       if (mmprojPath) {
@@ -2380,12 +2387,16 @@ export default class llamacpp_extension extends AIEngine {
       ).size
     }
 
-    // TODO: add name as import() argument
+    if (!resolvedName) {
+      const base = opts.modelPath.split(/[\\/]/).pop() ?? modelId
+      resolvedName = base.replace(/\.gguf$/i, '') || modelId
+    }
+
     // TODO: add updateModelConfig() method
     const modelConfig = {
       model_path: modelPath,
       mmproj_path: mmprojPath,
-      name: modelId,
+      name: resolvedName,
       size_bytes,
       model_sha256: opts.modelSha256,
       model_size_bytes: opts.modelSize,

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -604,14 +604,16 @@ export default class llamacpp_extension extends AIEngine {
       const n = parseInt(rawMax, 10)
       if (!Number.isNaN(n) && n >= 0) modelsMax = n
     }
-    // Reserve extra slots for embedding models so loading an embedder doesn't
-    // evict the user's chat model. `models_max` governs chat models only;
-    // Jan pre-evicts the oldest chat model in `performLoad` so the router's
-    // LRU never picks the embedding. 0 (unlimited) stays unlimited.
+    // Reserve a single extra slot when any embedder is installed, so loading
+    // an embedder doesn't evict the user's chat model. Only one embedding is
+    // ever loaded at a time (RAG calls load() once per request), so the bonus
+    // is +1 regardless of how many embedders are installed. 0 (unlimited)
+    // stays unlimited.
     const userModelsMax = modelsMax
     this.userModelsMax = userModelsMax
-    if (modelsMax > 0 && embeddingCount > 0) {
-      modelsMax += embeddingCount
+    const embeddingSlotBonus = embeddingCount > 0 ? 1 : 0
+    if (modelsMax > 0 && embeddingSlotBonus > 0) {
+      modelsMax += embeddingSlotBonus
     }
 
     // Defensive: if a router is already running (hot reload / dev), stop it
@@ -650,7 +652,7 @@ export default class llamacpp_extension extends AIEngine {
     this.routerPort = info.port
     this.routerApiKey = info.api_key
     logger.info(
-      `Router started on port ${info.port} (pid ${info.pid}, models_max=${modelsMax} [user=${userModelsMax}, +${embeddingCount} embedding], preset=${presetPath})`
+      `Router started on port ${info.port} (pid ${info.pid}, models_max=${modelsMax} [user=${userModelsMax}, +${embeddingSlotBonus} embedding, ${embeddingCount} installed], preset=${presetPath})`
     )
   }
 

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -444,18 +444,35 @@ export default class llamacpp_extension extends AIEngine {
     componentProps: Partial<SettingComponentProps>[]
   ): Promise<void> {
     const current = await readSettingsFile()
+    const changed: { key: string; value: unknown }[] = []
     const updated = current.length
       ? current.map((s) => {
           const patch = componentProps.find((p) => p.key === s.key)
           if (patch?.controllerProps) {
-            ;(s.controllerProps as { value?: unknown }).value = (
-              patch.controllerProps as { value?: unknown }
-            ).value
+            const nextValue = (patch.controllerProps as { value?: unknown })
+              .value
+            const prevValue = (s.controllerProps as { value?: unknown }).value
+            if (nextValue !== prevValue) {
+              changed.push({ key: s.key, value: nextValue })
+            }
+            ;(s.controllerProps as { value?: unknown }).value = nextValue
           }
           return s
         })
-      : (componentProps as SettingComponentProps[])
+      : ((): SettingComponentProps[] => {
+          const arr = componentProps as SettingComponentProps[]
+          for (const s of arr) {
+            changed.push({
+              key: s.key,
+              value: (s.controllerProps as { value?: unknown })?.value,
+            })
+          }
+          return arr
+        })()
     await writeSettingsFile(updated)
+    for (const { key, value } of changed) {
+      this.onSettingUpdate(key, value)
+    }
   }
 
   override async registerSettings(

--- a/extensions/llamacpp-extension/src/settings-store.ts
+++ b/extensions/llamacpp-extension/src/settings-store.ts
@@ -1,0 +1,56 @@
+import { fs, joinPath, getJanDataFolderPath } from '@janhq/core'
+import type { SettingComponentProps } from '@janhq/core'
+
+const DIR_NAME = 'llamacpp'
+const FILE_NAME = 'settings.json'
+const TMP_NAME = 'settings.json.tmp'
+
+let writeChain: Promise<unknown> = Promise.resolve()
+
+async function paths(): Promise<{ dir: string; file: string; tmp: string }> {
+  const root = await getJanDataFolderPath()
+  const dir = await joinPath([root, DIR_NAME])
+  const file = await joinPath([dir, FILE_NAME])
+  const tmp = await joinPath([dir, TMP_NAME])
+  return { dir, file, tmp }
+}
+
+export async function readSettingsFile(): Promise<SettingComponentProps[]> {
+  const { file } = await paths()
+  if (!(await fs.existsSync(file))) return []
+  try {
+    const raw = await fs.readFileSync(file, 'utf8')
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? (parsed as SettingComponentProps[]) : []
+  } catch {
+    return []
+  }
+}
+
+export async function writeSettingsFile(
+  settings: SettingComponentProps[]
+): Promise<void> {
+  const task = async () => {
+    const { dir, file, tmp } = await paths()
+    if (!(await fs.existsSync(dir))) await fs.mkdir(dir)
+    const json = JSON.stringify(settings, null, 2)
+    await fs.writeFileSync(tmp, json)
+    try {
+      await fs.mv(tmp, file)
+    } catch {
+      await fs.writeFileSync(file, json)
+      try {
+        if (await fs.existsSync(tmp)) await fs.rm(tmp)
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
+  writeChain = writeChain.then(task, task)
+  await writeChain
+}
+
+export async function settingsFileExists(): Promise<boolean> {
+  const { file } = await paths()
+  return await fs.existsSync(file)
+}

--- a/extensions/llamacpp-extension/src/test/backend.test.ts
+++ b/extensions/llamacpp-extension/src/test/backend.test.ts
@@ -5,6 +5,7 @@ import {
   isBackendInstalled,
   downloadBackend,
   verifyBackendInstallation,
+  fetchRemoteBackends,
 } from '../backend'
 import { getSystemInfo } from '@janhq/tauri-plugin-hardware-api'
 import { fs, getJanDataFolderPath, events } from '@janhq/core'
@@ -48,6 +49,11 @@ vi.mock('@janhq/tauri-plugin-llamacpp-api', async () => {
 
   return {
     ...actual,
+    getSupportedFeaturesFromRust: vi.fn().mockResolvedValue({}),
+    normalizeFeatures: vi.fn().mockReturnValue({}),
+    determineSupportedBackends: vi
+      .fn()
+      .mockResolvedValue(['linux-vulkan-x64']),
   }
 })
 
@@ -550,6 +556,33 @@ describe('Backend functions', () => {
         'plugin:llamacpp|build_backend_download_items',
         expect.objectContaining({ source: 'cdn' })
       )
+    })
+  })
+
+  describe('fetchRemoteBackends', () => {
+    it('returns the upstream-released backends from the plugin invoke', async () => {
+      const remote = [
+        { version: 'b9300', backend: 'linux-vulkan-common_cpus-x64' },
+        { version: 'b9222', backend: 'linux-vulkan-common_cpus-x64' },
+      ]
+      vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+        if (cmd === 'plugin:llamacpp|fetch_remote_supported_backends')
+          return remote as any
+        return undefined as any
+      })
+
+      const result = await fetchRemoteBackends()
+      expect(result).toEqual(remote)
+    })
+
+    it('returns [] when the remote fetch fails (offline)', async () => {
+      vi.mocked(invoke).mockImplementation(async (cmd: string) => {
+        if (cmd === 'plugin:llamacpp|fetch_remote_supported_backends')
+          throw new Error('offline')
+        return undefined as any
+      })
+      const result = await fetchRemoteBackends()
+      expect(result).toEqual([])
     })
   })
 })

--- a/extensions/llamacpp-extension/src/test/index.test.ts
+++ b/extensions/llamacpp-extension/src/test/index.test.ts
@@ -616,7 +616,7 @@ describe('llamacpp_extension', () => {
         extension['isUpdatingBackend'] = true
 
         // Call onSettingUpdate while updateBackend is "running"
-        extension.onSettingUpdate('version_backend', 'v2.0.0/linux-avx2-x64')
+        extension.onSettingUpdate('llamacpp_backend', 'linux-avx2-x64')
 
         // ensureBackendReady should NOT have been called from onSettingUpdate
         expect(extension['ensureBackendReady']).not.toHaveBeenCalled()

--- a/extensions/llamacpp-extension/src/test/settings-store.test.ts
+++ b/extensions/llamacpp-extension/src/test/settings-store.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { fsMock } = vi.hoisted(() => ({
+  fsMock: {
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    mkdir: vi.fn(),
+    mv: vi.fn(),
+    rm: vi.fn(),
+  },
+}))
+
+vi.mock('@janhq/core', () => ({
+  getJanDataFolderPath: vi.fn().mockResolvedValue('/jan'),
+  joinPath: vi.fn(async (parts: string[]) => parts.join('/')),
+  fs: fsMock,
+}))
+
+import {
+  readSettingsFile,
+  writeSettingsFile,
+  settingsFileExists,
+} from '../settings-store'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  fsMock.mv.mockResolvedValue(undefined)
+  fsMock.mkdir.mockResolvedValue(undefined)
+  fsMock.writeFileSync.mockResolvedValue(undefined)
+  fsMock.rm.mockResolvedValue(undefined)
+})
+
+describe('settings-store', () => {
+  it('returns [] when the file does not exist', async () => {
+    fsMock.existsSync.mockResolvedValue(false)
+    const result = await readSettingsFile()
+    expect(result).toEqual([])
+  })
+
+  it('parses an existing settings file', async () => {
+    fsMock.existsSync.mockResolvedValue(true)
+    const data = [{ key: 'a', controllerProps: { value: 1 } }]
+    fsMock.readFileSync.mockResolvedValue(JSON.stringify(data))
+    const result = await readSettingsFile()
+    expect(result).toEqual(data)
+  })
+
+  it('returns [] on malformed JSON instead of throwing', async () => {
+    fsMock.existsSync.mockResolvedValue(true)
+    fsMock.readFileSync.mockResolvedValue('{not json')
+    const result = await readSettingsFile()
+    expect(result).toEqual([])
+  })
+
+  it('settingsFileExists reflects fs.existsSync', async () => {
+    fsMock.existsSync.mockResolvedValueOnce(true)
+    expect(await settingsFileExists()).toBe(true)
+    fsMock.existsSync.mockResolvedValueOnce(false)
+    expect(await settingsFileExists()).toBe(false)
+  })
+
+  it('writes via tmp + mv (atomic-ish) and creates the dir if missing', async () => {
+    fsMock.existsSync.mockResolvedValue(false)
+    await writeSettingsFile([{ key: 'k', controllerProps: { value: 1 } }] as any)
+    expect(fsMock.mkdir).toHaveBeenCalledWith('/jan/llamacpp')
+    expect(fsMock.writeFileSync).toHaveBeenCalledWith(
+      '/jan/llamacpp/settings.json.tmp',
+      expect.any(String)
+    )
+    expect(fsMock.mv).toHaveBeenCalledWith(
+      '/jan/llamacpp/settings.json.tmp',
+      '/jan/llamacpp/settings.json'
+    )
+  })
+
+  it('falls back to direct write when mv fails', async () => {
+    fsMock.existsSync.mockResolvedValue(true)
+    fsMock.mv.mockRejectedValueOnce(new Error('cross-device'))
+    await writeSettingsFile([{ key: 'k', controllerProps: { value: 1 } }] as any)
+    expect(fsMock.writeFileSync).toHaveBeenCalledWith(
+      '/jan/llamacpp/settings.json',
+      expect.any(String)
+    )
+  })
+
+  it('serializes concurrent writes', async () => {
+    fsMock.existsSync.mockResolvedValue(true)
+    let inflight = 0
+    let maxInflight = 0
+    fsMock.writeFileSync.mockImplementation(async () => {
+      inflight += 1
+      maxInflight = Math.max(maxInflight, inflight)
+      await new Promise((r) => setTimeout(r, 5))
+      inflight -= 1
+    })
+    await Promise.all([
+      writeSettingsFile([{ key: 'a' }] as any),
+      writeSettingsFile([{ key: 'b' }] as any),
+      writeSettingsFile([{ key: 'c' }] as any),
+    ])
+    expect(maxInflight).toBe(1)
+  })
+})

--- a/src-tauri/plugins/tauri-plugin-hardware/build.rs
+++ b/src-tauri/plugins/tauri-plugin-hardware/build.rs
@@ -1,4 +1,4 @@
-const COMMANDS: &[&str] = &["get_system_info", "get_system_usage"];
+const COMMANDS: &[&str] = &["get_system_info", "get_system_usage", "refresh_system_info"];
 
 fn main() {
     tauri_plugin::Builder::new(COMMANDS).build();

--- a/src-tauri/plugins/tauri-plugin-hardware/permissions/default.toml
+++ b/src-tauri/plugins/tauri-plugin-hardware/permissions/default.toml
@@ -2,5 +2,6 @@
 description = "Default permissions for the hardware plugin"
 permissions = [
     "allow-get-system-info",
-    "allow-get-system-usage"
+    "allow-get-system-usage",
+    "allow-refresh-system-info"
 ]

--- a/src-tauri/plugins/tauri-plugin-hardware/src/cpu.rs
+++ b/src-tauri/plugins/tauri-plugin-hardware/src/cpu.rs
@@ -2,6 +2,12 @@ use sysinfo::System;
 
 use crate::types::CpuStaticInfo;
 
+impl Default for CpuStaticInfo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CpuStaticInfo {
     pub fn new() -> Self {
         let mut system = System::new();

--- a/src-tauri/plugins/tauri-plugin-hardware/src/tests.rs
+++ b/src-tauri/plugins/tauri-plugin-hardware/src/tests.rs
@@ -1,6 +1,5 @@
 use crate::commands::*;
 use crate::types::CpuStaticInfo;
-use tauri::test::mock_app;
 
 #[test]
 fn test_system_info() {
@@ -57,7 +56,6 @@ mod cpu_tests {
     fn test_cpu_name_not_empty() {
         let cpu_info = CpuStaticInfo::new();
         assert!(!cpu_info.name.is_empty());
-        assert!(cpu_info.name.len() > 0);
     }
 
     #[test]

--- a/src-tauri/plugins/tauri-plugin-hardware/src/vendor/amd.rs
+++ b/src-tauri/plugins/tauri-plugin-hardware/src/vendor/amd.rs
@@ -58,7 +58,7 @@ impl GpuInfo {
                     used_memory: read_mem(&device_path.join("mem_info_vram_used")),
                 });
             }
-            Err(format!("GPU not found").into())
+            Err("GPU not found".to_string().into())
         };
 
         match closure() {

--- a/src-tauri/plugins/tauri-plugin-hardware/src/vendor/nvidia.rs
+++ b/src-tauri/plugins/tauri-plugin-hardware/src/vendor/nvidia.rs
@@ -54,7 +54,7 @@ where
                 }
             }
         }
-        return f(guard.as_ref());
+        f(guard.as_ref())
     }
 }
 
@@ -166,8 +166,8 @@ fn create_gpu_info(nvml: &Nvml, index: u32, driver_version: &str) -> Result<GpuI
     let compute_capability = device.cuda_compute_capability()?;
 
     let uuid = device.uuid()?;
-    let clean_uuid = if uuid.starts_with("GPU-") {
-        uuid[4..].to_string()
+    let clean_uuid = if let Some(stripped) = uuid.strip_prefix("GPU-") {
+        stripped.to_string()
     } else {
         uuid
     };

--- a/src-tauri/plugins/tauri-plugin-hardware/src/vendor/tests.rs
+++ b/src-tauri/plugins/tauri-plugin-hardware/src/vendor/tests.rs
@@ -26,7 +26,7 @@ fn test_get_vulkan_gpus_on_desktop() {
     let gpus = vulkan::get_vulkan_gpus();
 
     // Test that function returns without panicking on desktop platforms
-    assert!(gpus.len() >= 0);
+    let _ = gpus.len();
 
     // If GPUs are found, verify they have valid properties
     for (i, gpu) in gpus.iter().enumerate() {

--- a/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/index.ts
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/index.ts
@@ -42,9 +42,22 @@ function asString(v: any, defaultValue = ''): string {
 }
 
 export function normalizeLlamacppConfig(config: any): LlamacppConfig {
+  const llamacpp_version = asString(config.llamacpp_version)
+  const llamacpp_backend = asString(config.llamacpp_backend)
+  const composedVersionBackend =
+    llamacpp_version && llamacpp_backend
+      ? `${llamacpp_version}/${llamacpp_backend}`
+      : asString(config.version_backend)
   return {
-    version_backend: asString(config.version_backend),
+    llamacpp_version,
+    llamacpp_backend,
+    version_backend: composedVersionBackend,
     auto_update_engine: asBool(config.auto_update_engine),
+    check_for_updates:
+      config.check_for_updates === undefined ||
+      config.check_for_updates === null
+        ? true
+        : asBool(config.check_for_updates),
     verify_backend_deps:
       config.verify_backend_deps === undefined || config.verify_backend_deps === null
         ? true

--- a/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/index.ts
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/index.ts
@@ -45,6 +45,10 @@ export function normalizeLlamacppConfig(config: any): LlamacppConfig {
   return {
     version_backend: asString(config.version_backend),
     auto_update_engine: asBool(config.auto_update_engine),
+    verify_backend_deps:
+      config.verify_backend_deps === undefined || config.verify_backend_deps === null
+        ? true
+        : asBool(config.verify_backend_deps),
     auto_unload: asBool(config.auto_unload),
     models_max:
       typeof config.models_max === 'number'

--- a/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/types.ts
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/types.ts
@@ -33,8 +33,12 @@ export interface GgufMetadata {
 
 // llama.cpp settings
 export type LlamacppConfig = {
+  llamacpp_version: string
+  llamacpp_backend: string
+  /** Composed from llamacpp_version + llamacpp_backend as `${version}/${backend}`. Not user-settable. */
   version_backend: string
   auto_update_engine: boolean
+  check_for_updates: boolean
   verify_backend_deps: boolean
   auto_unload: boolean
   models_max: string | number

--- a/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/types.ts
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/types.ts
@@ -35,6 +35,7 @@ export interface GgufMetadata {
 export type LlamacppConfig = {
   version_backend: string
   auto_update_engine: boolean
+  verify_backend_deps: boolean
   auto_unload: boolean
   models_max: string | number
   timeout: number

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/backend.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/backend.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[tauri::command]
 pub fn map_old_backend_to_new(old_backend: String) -> String {
@@ -860,16 +860,47 @@ pub struct BackendVerificationResult {
     pub resolved_libraries: Vec<String>,
 }
 
-fn expected_gpu_lib_name(backend: &str) -> Option<&'static str> {
+fn gpu_backend_keyword(backend: &str) -> Option<&'static str> {
     let b = backend.to_lowercase();
-    let is_windows = cfg!(target_os = "windows");
     if b.contains("cuda") {
-        Some(if is_windows { "ggml-cuda.dll" } else { "libggml-cuda.so" })
+        Some("cuda")
     } else if b.contains("vulkan") {
-        Some(if is_windows { "ggml-vulkan.dll" } else { "libggml-vulkan.so" })
+        Some("vulkan")
     } else {
         None
     }
+}
+
+fn is_shared_lib_name(name: &str) -> bool {
+    let lower = name.to_lowercase();
+    if cfg!(target_os = "windows") {
+        lower.ends_with(".dll")
+    } else {
+        lower.ends_with(".so") || lower.contains(".so.")
+    }
+}
+
+fn find_gpu_libs(bin_dir: &Path, keyword: &str) -> Vec<PathBuf> {
+    let entries = match std::fs::read_dir(bin_dir) {
+        Ok(e) => e,
+        Err(_) => return Vec::new(),
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+        let name = match path.file_name().and_then(|n| n.to_str()) {
+            Some(n) => n.to_lowercase(),
+            None => continue,
+        };
+        if name.contains(keyword) && is_shared_lib_name(&name) {
+            out.push(path);
+        }
+    }
+    out.sort();
+    out
 }
 
 fn verify_backend_dependencies(
@@ -888,28 +919,16 @@ fn verify_backend_dependencies(
     let start = std::time::Instant::now();
     let mut missing: std::collections::HashSet<String> = std::collections::HashSet::new();
 
-    // Existence check runs before parsing so a deleted lib is caught without
-    // handing a bad path to goblin.
-    let gpu_lib_path: Option<PathBuf> = if cfg!(target_os = "macos") {
-        None
+    let paths: Vec<PathBuf> = if cfg!(target_os = "macos") {
+        Vec::new()
     } else {
-        expected_gpu_lib_name(backend).and_then(|name| {
-            let path = bin_dir.join(name);
-            if path.exists() {
-                Some(path)
-            } else {
-                missing.insert(name.to_string());
-                None
-            }
-        })
+        match gpu_backend_keyword(backend) {
+            Some(kw) => find_gpu_libs(bin_dir, kw),
+            None => Vec::new(),
+        }
     };
 
-    // Skip CPU variants (ggml-cpu-haswell, etc.) — they're loaded only when
-    // the host's detected features match, so parsing them false-flags deps.
-    let mut paths: Vec<PathBuf> = vec![exe_path.clone()];
-    if let Some(p) = gpu_lib_path {
-        paths.push(p);
-    }
+    let _ = exe_path;
 
     let analysis = crate::deps_analyzer::analyze_out_of_process(bin_dir, &paths);
 
@@ -957,6 +976,15 @@ pub async fn verify_backend_installation(
             "Backend executable not found".into(),
             Some(exe_path.to_string_lossy().to_string()),
         ));
+    }
+
+    #[cfg(target_os = "linux")]
+    if jan_utils::system::is_flatpak() {
+        return Ok(BackendVerificationResult {
+            verified: true,
+            missing_libraries: Vec::new(),
+            resolved_libraries: Vec::new(),
+        });
     }
     // Libs sit next to the exe (build/bin/ when present); backend_dir is too high.
     let bin_dir = exe_path

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/backend.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/backend.rs
@@ -144,7 +144,7 @@ pub async fn get_local_installed_backends(
 
 /// Helper function to check if a backend is properly installed
 /// Checks for the existence of llama-server executable in the expected locations
-fn is_backend_installed(backend_dir: &PathBuf) -> bool {
+fn is_backend_installed(backend_dir: &Path) -> bool {
     if !backend_dir.exists() || !backend_dir.is_dir() {
         return false;
     }
@@ -904,8 +904,8 @@ fn find_gpu_libs(bin_dir: &Path, keyword: &str) -> Vec<PathBuf> {
 }
 
 fn verify_backend_dependencies(
-    bin_dir: &PathBuf,
-    exe_path: &PathBuf,
+    bin_dir: &Path,
+    exe_path: &Path,
     backend: &str,
 ) -> Result<BackendVerificationResult, crate::error::LlamacppError> {
     if !bin_dir.exists() {
@@ -1545,7 +1545,7 @@ mod tests {
         let backend_a = v1_path.join("backend-a");
         let backend_empty = v1_path.join("backend-empty");
 
-        fs::create_dir_all(&backend_a.join("build").join("bin")).unwrap();
+        fs::create_dir_all(backend_a.join("build").join("bin")).unwrap();
         fs::create_dir_all(&backend_empty).unwrap();
 
         // Create mock executable

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/commands.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/commands.rs
@@ -335,7 +335,7 @@ pub async fn load_llama_model<R: Runtime>(
 ) -> ServerResult<SessionInfo> {
     let (port, api_key, pid) = router_endpoint(&app_handle)
         .await
-        .map_err(|e| ServerError::InvalidArgument(e))?;
+        .map_err(ServerError::InvalidArgument)?;
     post_load(port, &api_key, &model_id).await?;
     Ok(SessionInfo {
         pid: pid as i32,
@@ -353,7 +353,7 @@ pub async fn unload_llama_model<R: Runtime>(
 ) -> ServerResult<UnloadResult> {
     let (port, api_key, _pid) = router_endpoint(&app_handle)
         .await
-        .map_err(|e| ServerError::InvalidArgument(e))?;
+        .map_err(ServerError::InvalidArgument)?;
     match post_unload(port, &api_key, &model_id).await {
         Ok(()) => Ok(UnloadResult { success: true, error: None }),
         Err(e) => Ok(UnloadResult { success: false, error: Some(e) }),

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/device.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/device.rs
@@ -166,9 +166,9 @@ fn parse_device_line(line: &str) -> ServerResult<Option<DeviceInfo>> {
 fn find_memory_pattern(text: &str) -> Option<(usize, &str)> {
     // Find the last parenthesis that contains the memory pattern
     let mut last_match = None;
-    let mut chars = text.char_indices().peekable();
+    let chars = text.char_indices();
 
-    while let Some((start_idx, ch)) = chars.next() {
+    for (start_idx, ch) in chars {
         if ch == '(' {
             // Find the closing parenthesis
             let remaining = &text[start_idx + 1..];
@@ -203,7 +203,7 @@ fn is_memory_pattern(content: &str) -> bool {
         // Each part should start with a number and contain "MiB"
         part.split_whitespace()
             .next()
-            .map_or(false, |first_word| first_word.parse::<i32>().is_ok())
+            .is_some_and(|first_word| first_word.parse::<i32>().is_ok())
             && part.contains("MiB")
     })
 }

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/error.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/error.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use thiserror;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/gguf/commands.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/gguf/commands.rs
@@ -8,7 +8,7 @@ use tauri_plugin_hardware::{get_system_info, SystemInfo};
 /// Read GGUF metadata from a model file
 #[tauri::command]
 pub async fn read_gguf_metadata(path: String) -> Result<GgufMetadata, String> {
-    return read_gguf_metadata_internal(path).await;
+    read_gguf_metadata_internal(path).await
 }
 
 #[tauri::command]
@@ -139,11 +139,7 @@ pub async fn is_model_supported(
 
     log::info!("Total VRAM reported/calculated (in bytes): {}", &total_vram);
 
-    let usable_vram = if total_vram > RESERVE_BYTES {
-        total_vram - RESERVE_BYTES
-    } else {
-        0
-    };
+    let usable_vram = total_vram.saturating_sub(RESERVE_BYTES);
 
     let usable_total_memory = if total_system_memory > RESERVE_BYTES {
         (total_system_memory - RESERVE_BYTES) + usable_vram

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/gguf/commands.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/gguf/commands.rs
@@ -78,13 +78,32 @@ pub async fn is_model_supported(
             .size
     };
 
-    // Total memory consumption = model weights + kvcache
-    let total_required = model_size + kv_cache_size;
+    // Multimodal projector lives next to model.gguf as mmproj.gguf and is
+    // loaded into the same device alongside the weights + KV cache. Only
+    // inspected for local paths — remote URLs route through the importer
+    // and won't hit this branch with the final on-disk layout.
+    let mmproj_size: u64 = if path.starts_with("https://") {
+        0
+    } else {
+        std::path::Path::new(&path)
+            .parent()
+            .map(|d| d.join("mmproj.gguf"))
+            .and_then(|p| fs::metadata(&p).ok())
+            .map(|m| m.len())
+            .unwrap_or(0)
+    };
+    if mmproj_size > 0 {
+        log::info!("mmprojSize: {}", mmproj_size);
+    }
+
+    // Total memory consumption = model weights + kvcache + mmproj
+    let total_required = model_size + kv_cache_size + mmproj_size;
     log::info!(
-        "isModelSupported: Total memory requirement: {} for {}; Got kvCacheSize: {} from BE",
+        "isModelSupported: Total memory requirement: {} for {}; kvCacheSize: {}, mmprojSize: {}",
         total_required,
         path,
-        kv_cache_size
+        kv_cache_size,
+        mmproj_size
     );
 
     // Apple Silicon: macOS + ARM64 + no discrete GPUs = unified memory.

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/gguf/helpers.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/gguf/helpers.rs
@@ -42,10 +42,10 @@ pub fn read_gguf_metadata<R: Read + Seek>(reader: R) -> io::Result<GgufMetadata>
     })
 }
 
-fn read_metadata_entry<R: Read + Seek>(reader: &mut R, index: u64) -> io::Result<(String, String)>
-where
-    R: ReadBytesExt,
-{
+fn read_metadata_entry<R: Read + Seek + ReadBytesExt>(
+    reader: &mut R,
+    index: u64,
+) -> io::Result<(String, String)> {
     let key = read_gguf_string(reader).map_err(|e| {
         io::Error::new(
             io::ErrorKind::InvalidData,
@@ -60,10 +60,7 @@ where
     Ok((key, value))
 }
 
-fn read_gguf_string<R: Read>(reader: &mut R) -> io::Result<String>
-where
-    R: ReadBytesExt,
-{
+fn read_gguf_string<R: Read + ReadBytesExt>(reader: &mut R) -> io::Result<String> {
     let len = reader.read_u64::<LittleEndian>()?;
     if len > (1024 * 1024) {
         return Err(io::Error::new(
@@ -73,13 +70,13 @@ where
     }
     let mut buf = vec![0u8; len as usize];
     reader.read_exact(&mut buf)?;
-    Ok(String::from_utf8(buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?)
+    String::from_utf8(buf).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
 }
 
-fn read_gguf_value<R: Read + Seek>(reader: &mut R, value_type: GgufValueType) -> io::Result<String>
-where
-    R: ReadBytesExt,
-{
+fn read_gguf_value<R: Read + Seek + ReadBytesExt>(
+    reader: &mut R,
+    value_type: GgufValueType,
+) -> io::Result<String> {
     match value_type {
         GgufValueType::Uint8 => Ok(reader.read_u8()?.to_string()),
         GgufValueType::Int8 => Ok(reader.read_i8()?.to_string()),
@@ -122,14 +119,11 @@ where
     }
 }
 
-fn skip_array_data<R: Read + Seek>(
+fn skip_array_data<R: Read + Seek + ReadBytesExt>(
     reader: &mut R,
     elem_type: GgufValueType,
     len: u64,
-) -> io::Result<()>
-where
-    R: ReadBytesExt,
-{
+) -> io::Result<()> {
     match elem_type {
         GgufValueType::Uint8 | GgufValueType::Int8 | GgufValueType::Bool => {
             reader.seek(io::SeekFrom::Current(len as i64))?;

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/router.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/router.rs
@@ -89,6 +89,7 @@ pub fn router_args(
 ///
 /// On readiness-detection failure or spawn failure, the child is killed before
 /// returning the error.
+#[allow(clippy::too_many_arguments)]
 pub async fn start_router(
     backend_exe: PathBuf,
     preset_path: PathBuf,

--- a/src-tauri/plugins/tauri-plugin-mlx/src/commands.rs
+++ b/src-tauri/plugins/tauri-plugin-mlx/src/commands.rs
@@ -35,6 +35,7 @@ pub struct MlxConfig {
 /// Core model-loading logic, decoupled from Tauri AppHandle.
 /// `binary_path` must point to the mlx-server executable.
 /// `process_map_arc` is the shared session map from MlxState.
+#[allow(clippy::too_many_arguments)]
 pub async fn load_mlx_model_impl(
     process_map_arc: Arc<Mutex<HashMap<i32, MlxBackendSession>>>,
     binary_path: &Path,
@@ -274,6 +275,7 @@ pub async fn load_mlx_model_impl(
 
 /// Load a model using the MLX server binary (Tauri command wrapper)
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn load_mlx_model<R: Runtime>(
     app_handle: tauri::AppHandle<R>,
     model_id: String,

--- a/src-tauri/plugins/tauri-plugin-rag/src/parser.rs
+++ b/src-tauri/plugins/tauri-plugin-rag/src/parser.rs
@@ -6,8 +6,6 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use calamine::{open_workbook_auto, DataType, Reader as _};
 use chardetng::EncodingDetector;
 use csv as csv_crate;
-use html2text;
-use infer;
 use quick_xml::events::Event;
 use quick_xml::Reader;
 use zip::read::ZipArchive;
@@ -249,7 +247,7 @@ fn parse_spreadsheet(file_path: &str) -> Result<String, RagError> {
                 out.push_str(&cells);
                 out.push('\n');
             }
-            out.push_str("\n");
+            out.push('\n');
         }
     }
     Ok(out)

--- a/src-tauri/plugins/tauri-plugin-vector-db/src/commands.rs
+++ b/src-tauri/plugins/tauri-plugin-vector-db/src/commands.rs
@@ -43,13 +43,13 @@ pub async fn get_status(state: State<'_, VectorDBState>) -> Result<Status, Vecto
             for p in paths {
                 println!("[VectorDB]   Trying: {}", p);
                 unsafe {
-                    if let Ok(_) = conn.load_extension(&p, Some("sqlite3_vec_init")) {
-                        if conn.execute("CREATE VIRTUAL TABLE IF NOT EXISTS temp.temp_vec USING vec0(embedding float[1])", []).is_ok() {
-                            let _ = conn.execute("DROP TABLE IF EXISTS temp.temp_vec", []);
-                            println!("[VectorDB] ✓ sqlite-vec loaded from: {}", p);
-                            found = true;
-                            break;
-                        }
+                    if conn.load_extension(&p, Some("sqlite3_vec_init")).is_ok()
+                        && conn.execute("CREATE VIRTUAL TABLE IF NOT EXISTS temp.temp_vec USING vec0(embedding float[1])", []).is_ok()
+                    {
+                        let _ = conn.execute("DROP TABLE IF EXISTS temp.temp_vec", []);
+                        println!("[VectorDB] ✓ sqlite-vec loaded from: {}", p);
+                        found = true;
+                        break;
                     }
                 }
             }
@@ -128,6 +128,7 @@ pub async fn delete_file<R: tauri::Runtime>(
 }
 
 #[tauri::command]
+#[allow(clippy::too_many_arguments)]
 pub async fn search_collection<R: tauri::Runtime>(
     _app: tauri::AppHandle<R>,
     state: State<'_, VectorDBState>,

--- a/src-tauri/plugins/tauri-plugin-vector-db/src/db.rs
+++ b/src-tauri/plugins/tauri-plugin-vector-db/src/db.rs
@@ -3,7 +3,7 @@ use crate::utils::{cosine_similarity, from_le_bytes_vec, to_le_bytes_vec};
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -48,8 +48,8 @@ pub struct MinimalChunkInput {
 // Connection & Path Management
 // ============================================================================
 
-pub fn collection_path(base: &PathBuf, name: &str) -> PathBuf {
-    let mut p = base.clone();
+pub fn collection_path(base: &Path, name: &str) -> PathBuf {
+    let mut p = base.to_path_buf();
     let clean = name.replace(['/', '\\'], "_");
     let filename = format!("{}.db", clean);
     p.push(&filename);
@@ -82,11 +82,11 @@ pub fn try_load_sqlite_vec(conn: &Connection) -> bool {
     let paths = possible_sqlite_vec_paths();
     for p in paths {
         unsafe {
-            if let Ok(_) = conn.load_extension(&p, Some("sqlite3_vec_init")) {
-                if conn.execute("CREATE VIRTUAL TABLE IF NOT EXISTS temp.temp_vec USING vec0(embedding float[1])", []).is_ok() {
-                    let _ = conn.execute("DROP TABLE IF EXISTS temp.temp_vec", []);
-                    return true;
-                }
+            if conn.load_extension(&p, Some("sqlite3_vec_init")).is_ok()
+                && conn.execute("CREATE VIRTUAL TABLE IF NOT EXISTS temp.temp_vec USING vec0(embedding float[1])", []).is_ok()
+            {
+                let _ = conn.execute("DROP TABLE IF EXISTS temp.temp_vec", []);
+                return true;
             }
         }
     }

--- a/src-tauri/plugins/tauri-plugin-vector-db/src/state.rs
+++ b/src-tauri/plugins/tauri-plugin-vector-db/src/state.rs
@@ -4,6 +4,12 @@ pub struct VectorDBState {
     pub base_dir: PathBuf,
 }
 
+impl Default for VectorDBState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl VectorDBState {
     pub fn new() -> Self {
         // Default vector db path: /Jan/data/db

--- a/src-tauri/plugins/yarn.lock
+++ b/src-tauri/plugins/yarn.lock
@@ -28,18 +28,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@janhq/tauri-plugin-foundation-models-api@workspace:tauri-plugin-foundation-models":
-  version: 0.0.0-use.local
-  resolution: "@janhq/tauri-plugin-foundation-models-api@workspace:tauri-plugin-foundation-models"
-  dependencies:
-    "@rollup/plugin-typescript": "npm:^12.0.0"
-    "@tauri-apps/api": "npm:>=2.0.0-beta.6"
-    rollup: "npm:^4.9.6"
-    tslib: "npm:^2.6.2"
-    typescript: "npm:^5.3.3"
-  languageName: unknown
-  linkType: soft
-
 "@janhq/tauri-plugin-hardware-api@workspace:tauri-plugin-hardware":
   version: 0.0.0-use.local
   resolution: "@janhq/tauri-plugin-hardware-api@workspace:tauri-plugin-hardware"

--- a/src-tauri/src/bin/jan-cli.rs
+++ b/src-tauri/src/bin/jan-cli.rs
@@ -760,11 +760,13 @@ fn spawn_detached(model_id: &str, args: &ServeArgs) {
             cmd.pre_exec(|| {
                 nix::unistd::setsid()
                     .map(|_| ())
-                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e.to_string()))
+                    .map_err(|e| std::io::Error::other(e.to_string()))
             });
         }
     }
 
+    // child is intentionally detached via setsid; reaping is the OS's job
+    #[allow(clippy::zombie_processes)]
     let child = cmd.spawn().unwrap_or_else(|e| {
         eprintln!("Failed to spawn detached process: {e}");
         std::process::exit(1);
@@ -973,6 +975,7 @@ struct RouterServeInfo {
     api_key: String,
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn ensure_router_and_load(
     llama_state: &std::sync::Arc<LlamacppState>,
     bin_path: &str,
@@ -1284,6 +1287,7 @@ fn configure_openclaw(v1_url: &str, api_key: &str, model_id: &str) {
 
 /// Start the model server and return `(pid, actual_port)`.
 /// Resolves the engine automatically (LlamaCPP or MLX).
+#[allow(clippy::too_many_arguments)]
 async fn start_model_server(
     model_id: &str,
     bin: Option<String>,

--- a/src-tauri/src/core/app/models.rs
+++ b/src-tauri/src/core/app/models.rs
@@ -6,11 +6,10 @@ pub struct AppConfiguration {
     // Add other fields as needed
 }
 
-impl AppConfiguration {
-    pub fn default() -> Self {
+impl Default for AppConfiguration {
+    fn default() -> Self {
         Self {
-            data_folder: String::from("./data"), // Set a default value for the data_folder
-                                                 // Add other fields with default values as needed
+            data_folder: String::from("./data"),
         }
     }
 }

--- a/src-tauri/src/core/cli/mod.rs
+++ b/src-tauri/src/core/cli/mod.rs
@@ -93,6 +93,7 @@ pub fn cli_get_thread(thread_id: &str) -> Result<serde_json::Value, String> {
 // ── Server operations ──────────────────────────────────────────────────────
 
 /// Start the OpenAI-compatible proxy server. Returns the port it's listening on.
+#[allow(clippy::too_many_arguments)]
 pub async fn cli_start_server(
     app_state: Arc<AppState>,
     llama_state: Arc<LlamacppState>,
@@ -296,7 +297,7 @@ pub fn discover_llamacpp_binary() -> Option<PathBuf> {
         .filter_map(|e| e.ok())
         .filter(|e| e.path().is_dir())
         .collect();
-    version_entries.sort_by(|a, b| b.file_name().cmp(&a.file_name()));
+    version_entries.sort_by_key(|b| std::cmp::Reverse(b.file_name()));
 
     for version_entry in version_entries {
         let version_dir = version_entry.path();
@@ -305,7 +306,7 @@ pub fn discover_llamacpp_binary() -> Option<PathBuf> {
             .filter_map(|e| e.ok())
             .filter(|e| e.path().is_dir())
             .collect();
-        backend_entries.sort_by(|a, b| a.file_name().cmp(&b.file_name()));
+        backend_entries.sort_by_key(|a| a.file_name());
 
         for backend_entry in backend_entries {
             let backend_dir = backend_entry.path();
@@ -530,7 +531,7 @@ pub async fn download_hf_model(
         "llamacpp/models/{}/{}",
         repo_id, file.filename
     );
-    let display_name = repo_id.split('/').last().unwrap_or(repo_id);
+    let display_name = repo_id.split('/').next_back().unwrap_or(repo_id);
 
     let mut yml = format!(
         "model_path: {rel_path}\nname: {display_name}\nsize_bytes: {}\nembedding: false\n",

--- a/src-tauri/src/core/downloads/helpers.rs
+++ b/src-tauri/src/core/downloads/helpers.rs
@@ -109,8 +109,7 @@ async fn validate_downloaded_file(
     // Path structure: llamacpp/models/{modelId}/model.gguf or llamacpp/models/{modelId}/mmproj.gguf
     let model_id = item
         .model_id
-        .as_ref()
-        .map(|s| s.as_str())
+        .as_deref()
         .unwrap_or_else(|| {
             save_path
                 .parent() // get parent directory (modelId folder)

--- a/src-tauri/src/core/filesystem/helpers.rs
+++ b/src-tauri/src/core/filesystem/helpers.rs
@@ -98,6 +98,14 @@ pub fn resolve_path_within_jan_data_folder(
     Ok((canonical_data, canonical_path))
 }
 
+pub fn resolve_app_path_within_jan_data_folder<R: Runtime>(
+    app_handle: tauri::AppHandle<R>,
+    path: &str,
+) -> Result<(PathBuf, PathBuf), String> {
+    let jan_data_folder = get_jan_data_folder_path(app_handle);
+    resolve_path_within_jan_data_folder(&jan_data_folder, path)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -181,12 +189,4 @@ mod tests {
         assert!(resolved.starts_with(&root));
         assert!(resolved.ends_with("file.txt"));
     }
-}
-
-pub fn resolve_app_path_within_jan_data_folder<R: Runtime>(
-    app_handle: tauri::AppHandle<R>,
-    path: &str,
-) -> Result<(PathBuf, PathBuf), String> {
-    let jan_data_folder = get_jan_data_folder_path(app_handle);
-    resolve_path_within_jan_data_folder(&jan_data_folder, path)
 }

--- a/src-tauri/src/core/mcp/commands.rs
+++ b/src-tauri/src/core/mcp/commands.rs
@@ -297,7 +297,7 @@ pub async fn get_tools<R: Runtime>(
     app: AppHandle<R>,
     state: State<'_, AppState>,
 ) -> Result<Vec<ToolWithServer>, String> {
-    collect_mcp_tools(&app, &*state, None).await
+    collect_mcp_tools(&app, &state, None).await
 }
 
 /// Retrieves tools from a specific subset of MCP servers by name.
@@ -391,7 +391,7 @@ pub async fn call_tool(
     arguments: Option<Map<String, Value>>,
     cancellation_token: Option<String>,
 ) -> Result<CallToolResult, String> {
-    let timeout_duration = tool_call_timeout(&*state).await;
+    let timeout_duration = tool_call_timeout(&state).await;
     // Set up cancellation if token is provided
     let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
 

--- a/src-tauri/src/core/mcp/helpers.rs
+++ b/src-tauri/src/core/mcp/helpers.rs
@@ -172,9 +172,9 @@ pub async fn monitor_mcp_server_handle<R: Runtime>(
     let mut consecutive_failures: u32 = 0;
 
     loop {
-        // Wait for either the periodic health check or an immediate reconnect signal
+        // 30s, not 2s: every probe forces a ListToolsRequest the server echoes to stderr.
         tokio::select! {
-            _ = sleep(Duration::from_secs(2)) => {}
+            _ = sleep(Duration::from_secs(30)) => {}
             _ = reconnect_notify.notified() => {
                 log::info!("MCP server {name} monitor received reconnect signal");
             }
@@ -640,7 +640,7 @@ async fn schedule_mcp_start_task<R: Runtime>(
                             if let Ok(text) = std::str::from_utf8(&buf[..n]) {
                                 for line in text.lines() {
                                     if !line.trim().is_empty() {
-                                        log::warn!("[mcp-stderr:{}] {}", stderr_name, line);
+                                        log_mcp_stderr_line(&stderr_name, line);
                                     }
                                 }
                             }
@@ -760,6 +760,25 @@ async fn schedule_mcp_start_task<R: Runtime>(
         emit_mcp_update_event(&app, &name);
     }
     Ok(())
+}
+
+/// Route an MCP server's stderr line through Jan's logger at the level the
+/// server itself reported, defaulting to info when no level tag is present.
+fn log_mcp_stderr_line(server_name: &str, line: &str) {
+    let trimmed = line.trim_start();
+    let level_token = trimmed
+        .split_whitespace()
+        .next()
+        .map(|t| t.trim_matches(|c: char| !c.is_ascii_alphabetic()).to_ascii_uppercase());
+    match level_token.as_deref() {
+        Some("ERROR" | "CRITICAL" | "FATAL") => {
+            log::error!("[mcp-stderr:{server_name}] {line}")
+        }
+        Some("WARN" | "WARNING") => log::warn!("[mcp-stderr:{server_name}] {line}"),
+        Some("DEBUG") => log::debug!("[mcp-stderr:{server_name}] {line}"),
+        Some("TRACE") => log::trace!("[mcp-stderr:{server_name}] {line}"),
+        _ => log::info!("[mcp-stderr:{server_name}] {line}"),
+    }
 }
 
 fn emit_mcp_update_event<R: Runtime>(app: &AppHandle<R>, name: &str) {

--- a/src-tauri/src/core/mcp/helpers.rs
+++ b/src-tauri/src/core/mcp/helpers.rs
@@ -398,7 +398,10 @@ async fn schedule_mcp_start_task<R: Runtime>(
     let config_params = extract_command_args(&config)
         .ok_or_else(|| format!("Failed to extract command args from config for {name}"))?;
 
-    if config_params.transport_type.as_deref() == Some("http") && config_params.url.is_some() {
+    if let (Some("http"), Some(url)) = (
+        config_params.transport_type.as_deref(),
+        config_params.url.clone(),
+    ) {
         let transport = StreamableHttpClientTransport::with_client(
             reqwest::Client::builder()
                 .default_headers({
@@ -425,7 +428,7 @@ async fn schedule_mcp_start_task<R: Runtime>(
                 .build()
                 .unwrap(),
             StreamableHttpClientTransportConfig {
-                uri: config_params.url.unwrap().into(),
+                uri: url.into(),
                 ..Default::default()
             },
         );
@@ -460,8 +463,10 @@ async fn schedule_mcp_start_task<R: Runtime>(
                 return Err(format!("Failed to connect to server: {e}"));
             }
         }
-    } else if config_params.transport_type.as_deref() == Some("sse") && config_params.url.is_some()
-    {
+    } else if let (Some("sse"), Some(url)) = (
+        config_params.transport_type.as_deref(),
+        config_params.url.clone(),
+    ) {
         let transport = SseClientTransport::start_with_client(
             reqwest::Client::builder()
                 .default_headers({
@@ -488,7 +493,7 @@ async fn schedule_mcp_start_task<R: Runtime>(
                 .build()
                 .unwrap(),
             rmcp::transport::sse_client::SseClientConfig {
-                sse_endpoint: config_params.url.unwrap().into(),
+                sse_endpoint: url.into(),
                 ..Default::default()
             },
         )

--- a/src-tauri/src/core/mcp/lockfile.rs
+++ b/src-tauri/src/core/mcp/lockfile.rs
@@ -152,20 +152,21 @@ pub async fn cleanup_all_stale_locks<R: Runtime>(app: &AppHandle<R>) -> Result<(
     let pattern = app_data_dir.join("mcp_lock_*.json");
     let pattern_str = pattern.to_string_lossy();
 
-    for entry in glob::glob(&pattern_str).map_err(|e| format!("Glob error: {}", e))? {
-        if let Ok(path) = entry {
-            if let Some(file_name) = path.file_name() {
-                let file_name_str = file_name.to_string_lossy();
-                if let Some(port_str) = file_name_str
-                    .strip_prefix("mcp_lock_")
-                    .and_then(|s| s.strip_suffix(".json"))
-                {
-                    if let Ok(port) = port_str.parse::<u16>() {
-                        match check_and_cleanup_stale_lock(app, port).await {
-                            Ok(true) => log::info!("Cleaned up stale lock for port {}", port),
-                            Err(e) => log::warn!("Failed to cleanup lock for port {}: {}", port, e),
-                            _ => {}
-                        }
+    for path in glob::glob(&pattern_str)
+        .map_err(|e| format!("Glob error: {}", e))?
+        .flatten()
+    {
+        if let Some(file_name) = path.file_name() {
+            let file_name_str = file_name.to_string_lossy();
+            if let Some(port_str) = file_name_str
+                .strip_prefix("mcp_lock_")
+                .and_then(|s| s.strip_suffix(".json"))
+            {
+                if let Ok(port) = port_str.parse::<u16>() {
+                    match check_and_cleanup_stale_lock(app, port).await {
+                        Ok(true) => log::info!("Cleaned up stale lock for port {}", port),
+                        Err(e) => log::warn!("Failed to cleanup lock for port {}: {}", port, e),
+                        _ => {}
                     }
                 }
             }
@@ -185,14 +186,15 @@ pub fn cleanup_own_locks<R: Runtime>(app: &AppHandle<R>) -> Result<(), String> {
     let pattern_str = pattern.to_string_lossy();
     let current_pid = std::process::id();
 
-    for entry in glob::glob(&pattern_str).map_err(|e| format!("Glob error: {}", e))? {
-        if let Ok(path) = entry {
-            if let Ok(content) = fs::read_to_string(&path) {
-                if let Ok(lock) = serde_json::from_str::<McpLockFile>(&content) {
-                    if lock.pid == current_pid {
-                        fs::remove_file(&path).ok();
-                        log::debug!("Removed own lock file: {:?}", path);
-                    }
+    for path in glob::glob(&pattern_str)
+        .map_err(|e| format!("Glob error: {}", e))?
+        .flatten()
+    {
+        if let Ok(content) = fs::read_to_string(&path) {
+            if let Ok(lock) = serde_json::from_str::<McpLockFile>(&content) {
+                if lock.pid == current_pid {
+                    fs::remove_file(&path).ok();
+                    log::debug!("Removed own lock file: {:?}", path);
                 }
             }
         }

--- a/src-tauri/src/core/mcp/tests.rs
+++ b/src-tauri/src/core/mcp/tests.rs
@@ -506,7 +506,7 @@ fn test_default_constants_values() {
     assert_eq!(DEFAULT_MCP_BASE_RESTART_DELAY_MS, 1000);
     assert_eq!(DEFAULT_MCP_MAX_RESTART_DELAY_MS, 30000);
     assert!((DEFAULT_MCP_BACKOFF_MULTIPLIER - 2.0).abs() < f64::EPSILON);
-    assert!(DEFAULT_MCP_BASE_RESTART_DELAY_MS < DEFAULT_MCP_MAX_RESTART_DELAY_MS);
+    const _: () = assert!(DEFAULT_MCP_BASE_RESTART_DELAY_MS < DEFAULT_MCP_MAX_RESTART_DELAY_MS);
 }
 
 #[test]
@@ -572,8 +572,10 @@ fn test_mcp_settings_default_matches_constants() {
 #[test]
 fn test_mcp_settings_tool_call_timeout_duration_enforces_minimum() {
     use super::models::McpSettings;
-    let mut s = McpSettings::default();
-    s.tool_call_timeout_seconds = 0;
+    let mut s = McpSettings {
+        tool_call_timeout_seconds: 0,
+        ..McpSettings::default()
+    };
     assert_eq!(s.tool_call_timeout_duration(), Duration::from_secs(1));
     s.tool_call_timeout_seconds = 5;
     assert_eq!(s.tool_call_timeout_duration(), Duration::from_secs(5));
@@ -612,11 +614,13 @@ impl PartialEq for super::models::McpSettings {
 #[test]
 fn test_mcp_settings_round_trip_camel_case() {
     use super::models::McpSettings;
-    let mut s = McpSettings::default();
-    s.tool_call_timeout_seconds = 42;
-    s.router_model_provider = "openai".into();
-    s.router_model_id = "gpt-4".into();
-    s.use_lightweight_router_model = true;
+    let s = McpSettings {
+        tool_call_timeout_seconds: 42,
+        router_model_provider: "openai".into(),
+        router_model_id: "gpt-4".into(),
+        use_lightweight_router_model: true,
+        ..McpSettings::default()
+    };
     let json = serde_json::to_string(&s).unwrap();
     assert!(json.contains("\"toolCallTimeoutSeconds\":42"));
     assert!(json.contains("\"routerModelProvider\":\"openai\""));
@@ -822,7 +826,7 @@ fn test_is_process_alive_for_almost_certainly_dead_pid() {
     // PID 0 is the scheduler / not a real signalable process on Linux/macOS
     // and PID 999999 is extremely unlikely to exist
     // (i32::MAX as u32) exceeds Linux pid_max → kernel returns ESRCH/EINVAL
-    assert!(!is_process_alive((i32::MAX as u32)));
+    assert!(!is_process_alive(i32::MAX as u32));
 }
 
 #[test]
@@ -903,7 +907,7 @@ async fn test_check_and_cleanup_stale_lock_removes_dead_pid_lock() {
     let lock_path = app_data_dir.join(format!("mcp_lock_{}.json", port));
 
     // PID above pid_max guarantees ESRCH/EINVAL on Unix → reported as not alive
-    let dead_pid: u32 = (i32::MAX as u32);
+    let dead_pid: u32 = i32::MAX as u32;
     let lock = McpLockFile {
         pid: dead_pid,
         port,

--- a/src-tauri/src/core/server/proxy.rs
+++ b/src-tauri/src/core/server/proxy.rs
@@ -304,10 +304,7 @@ pub(crate) fn convert_messages(
             continue;
         }
 
-        let content_array = match content.as_array() {
-            Some(arr) => arr,
-            None => return None,
-        };
+        let content_array = content.as_array()?;
 
         match role {
             "assistant" => {
@@ -1006,6 +1003,8 @@ async fn call_openai_chat_completions(
     Err(last_err)
 }
 
+// orchestration coordinator threads state from multiple subsystems
+#[allow(clippy::too_many_arguments)]
 async fn run_server_side_openai_orchestration(
     json_body: &serde_json::Value,
     client: &Client,
@@ -1155,6 +1154,7 @@ async fn run_server_side_openai_orchestration(
 }
 
 /// Handles the proxy request logic
+#[allow(clippy::too_many_arguments)]
 async fn proxy_request(
     req: Request<Body>,
     client: Client,
@@ -2774,6 +2774,7 @@ pub async fn start_server(
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn start_server_internal(
     server_handle: Arc<Mutex<Option<ServerHandle>>>,
     llama_state: Arc<LlamacppState>,

--- a/src-tauri/src/core/server/tests.rs
+++ b/src-tauri/src/core/server/tests.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-mod tests {
+mod server_tests {
     use crate::core::server::proxy;
     use serde_json::json;
 
@@ -1060,7 +1060,7 @@ mod tests {
     fn get_destination_path_trailing_slash() {
         let result = proxy::get_destination_path("/v1/", "/v1");
         // remove_prefix should leave "/" or "" — either way no panic, deterministic.
-        assert!(result == "/" || result == "");
+        assert!(result == "/" || result.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/core/system/commands.rs
+++ b/src-tauri/src/core/system/commands.rs
@@ -193,8 +193,9 @@ pub fn factory_reset<R: Runtime>(
 
         // Reset app configuration to defaults unless user chose to keep configs
         if !keep_models_and_configs {
-            let mut default_config = AppConfiguration::default();
-            default_config.data_folder = default_data_folder_path(app_handle.clone());
+            let default_config = AppConfiguration {
+                data_folder: default_data_folder_path(app_handle.clone()),
+            };
             let _ = update_app_configuration(app_handle.clone(), default_config);
         }
 
@@ -349,11 +350,12 @@ pub fn launch_claude_code_with_config(
         match std::fs::OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(false)
             .open(&env_file_path)
         {
             Ok(_) => {
                 write_env_to_shell(&env_file_path, &env_vars)?;
-                return Ok(());
+                Ok(())
             }
             Err(_) => {
                 // Use admin privileges to write
@@ -397,7 +399,7 @@ pub fn launch_claude_code_with_config(
                     "Env vars written to {} with admin privileges",
                     env_file_path
                 );
-                return Ok(());
+                Ok(())
             }
         }
     } else if cfg!(target_os = "linux") {
@@ -412,17 +414,18 @@ pub fn launch_claude_code_with_config(
         match std::fs::OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(false)
             .open(&env_file_path)
         {
             Ok(_) => {
                 write_env_to_shell(&env_file_path, &env_vars)?;
-                return Ok(());
+                Ok(())
             }
             Err(_) => {
                 let jan_config_dir = format!("{}/.config/jan", home_dir);
                 let ext = if shell_name == "bash" { "bash" } else { "zsh" };
                 let env_file = format!("{}/claude-code-env.{}", jan_config_dir, ext);
-                return Err(format!("NEED_PERMISSION:{}", env_file));
+                Err(format!("NEED_PERMISSION:{}", env_file))
             }
         }
     } else {
@@ -441,7 +444,7 @@ pub fn launch_claude_code_with_config(
         }
 
         log::info!("Environment variables set permanently in Windows registry.");
-        return Ok(());
+        Ok(())
     }
 }
 
@@ -664,11 +667,12 @@ pub fn clear_claude_code_env() -> Result<(), String> {
         match std::fs::OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(false)
             .open(&env_file_path)
         {
             Ok(_) => {
                 std::fs::write(&env_file_path, &cleaned).map_err(|e| e.to_string())?;
-                return Ok(());
+                Ok(())
             }
             Err(_) => {
                 // Write cleaned content to a temp file, then use osascript to move it
@@ -690,7 +694,7 @@ pub fn clear_claude_code_env() -> Result<(), String> {
                     "CC env cleared from {} with admin privileges",
                     env_file_path
                 );
-                return Ok(());
+                Ok(())
             }
         }
     } else if cfg!(target_os = "linux") {
@@ -707,6 +711,7 @@ pub fn clear_claude_code_env() -> Result<(), String> {
         match std::fs::OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(false)
             .open(&env_file_path)
         {
             Ok(_) => {

--- a/src-tauri/src/core/threads/commands.rs
+++ b/src-tauri/src/core/threads/commands.rs
@@ -189,6 +189,18 @@ pub async fn create_message<R: Runtime>(
         // Ensure directory exists right before file operations to handle race conditions
         ensure_thread_dir_exists(&data_folder, &thread_id)?;
 
+        // Dedupe against a modify_message upsert that landed first.
+        let message_id = message.get("id").and_then(|v| v.as_str()).map(|s| s.to_string());
+        if let Some(ref id) = message_id {
+            let existing = read_messages_from_file(&data_folder, &thread_id)?;
+            if existing
+                .iter()
+                .any(|m| m.get("id").and_then(|v| v.as_str()) == Some(id.as_str()))
+            {
+                return Ok(message);
+            }
+        }
+
         let mut file: File = fs::OpenOptions::new()
             .create(true)
             .append(true)
@@ -235,16 +247,23 @@ pub async fn modify_message<R: Runtime>(
         let _guard = lock.lock().await;
 
         let mut messages = read_messages_from_file(&data_folder, thread_id)?;
-        if let Some(index) = messages
+        match messages
             .iter()
             .position(|m| m.get("id").and_then(|v| v.as_str()) == Some(message_id))
         {
-            messages[index] = message.clone();
-
-            // Rewrite all messages
-            let path = get_messages_path(&data_folder, thread_id);
-            write_messages_to_file(&messages, &path)?;
+            Some(index) => {
+                messages[index] = message.clone();
+            }
+            // Upsert when create_message lost the lock race; its dedupe path
+            // reconciles a subsequent late create.
+            None => {
+                ensure_thread_dir_exists(&data_folder, thread_id)?;
+                messages.push(message.clone());
+            }
         }
+
+        let path = get_messages_path(&data_folder, thread_id);
+        write_messages_to_file(&messages, &path)?;
     }
     Ok(message)
 }

--- a/src-tauri/src/core/threads/db.rs
+++ b/src-tauri/src/core/threads/db.rs
@@ -244,7 +244,11 @@ pub async fn db_create_message<R: Runtime>(
 
     let data = serde_json::to_string(&message).map_err(|e| e.to_string())?;
 
-    sqlx::query("INSERT INTO messages (id, thread_id, data) VALUES (?1, ?2, ?3)")
+    // INSERT OR IGNORE: a concurrent modify_message may have already upserted
+    // this row (race when the UI stamps metadata onto a freshly-sent message
+    // before the original create lands). Skipping rather than replacing
+    // preserves the modify's data.
+    sqlx::query("INSERT OR IGNORE INTO messages (id, thread_id, data) VALUES (?1, ?2, ?3)")
         .bind(message_id)
         .bind(thread_id)
         .bind(&data)
@@ -267,14 +271,26 @@ pub async fn db_modify_message<R: Runtime>(
         .and_then(|v| v.as_str())
         .ok_or("Missing message id")?;
 
+    let thread_id = message
+        .get("thread_id")
+        .and_then(|v| v.as_str())
+        .ok_or("Missing thread_id")?;
+
     let data = serde_json::to_string(&message).map_err(|e| e.to_string())?;
 
-    sqlx::query("UPDATE messages SET data = ?1 WHERE id = ?2")
-        .bind(&data)
-        .bind(message_id)
-        .execute(&pool)
-        .await
-        .map_err(|e| format!("Failed to modify message: {}", e))?;
+    // UPSERT: a plain UPDATE silently affects 0 rows when modify_message races
+    // ahead of the original create_message — dropping metadata edits (e.g.
+    // metadata.error stamped onto the user message right after an OOM).
+    sqlx::query(
+        "INSERT INTO messages (id, thread_id, data) VALUES (?1, ?2, ?3) \
+         ON CONFLICT(id) DO UPDATE SET data = excluded.data",
+    )
+    .bind(message_id)
+    .bind(thread_id)
+    .bind(&data)
+    .execute(&pool)
+    .await
+    .map_err(|e| format!("Failed to modify message: {}", e))?;
 
     Ok(message)
 }

--- a/src-tauri/src/core/threads/db.rs
+++ b/src-tauri/src/core/threads/db.rs
@@ -244,10 +244,7 @@ pub async fn db_create_message<R: Runtime>(
 
     let data = serde_json::to_string(&message).map_err(|e| e.to_string())?;
 
-    // INSERT OR IGNORE: a concurrent modify_message may have already upserted
-    // this row (race when the UI stamps metadata onto a freshly-sent message
-    // before the original create lands). Skipping rather than replacing
-    // preserves the modify's data.
+    // Skip if a modify_message upsert already landed for this id.
     sqlx::query("INSERT OR IGNORE INTO messages (id, thread_id, data) VALUES (?1, ?2, ?3)")
         .bind(message_id)
         .bind(thread_id)
@@ -278,9 +275,7 @@ pub async fn db_modify_message<R: Runtime>(
 
     let data = serde_json::to_string(&message).map_err(|e| e.to_string())?;
 
-    // UPSERT: a plain UPDATE silently affects 0 rows when modify_message races
-    // ahead of the original create_message — dropping metadata edits (e.g.
-    // metadata.error stamped onto the user message right after an OOM).
+    // Upsert so a modify ahead of create still lands instead of UPDATEing 0 rows.
     sqlx::query(
         "INSERT INTO messages (id, thread_id, data) VALUES (?1, ?2, ?3) \
          ON CONFLICT(id) DO UPDATE SET data = excluded.data",

--- a/src-tauri/src/core/updater/session.rs
+++ b/src-tauri/src/core/updater/session.rs
@@ -1,11 +1,9 @@
-/**
- * Session Management Module
- * 
- * Manages persistent session identifier for request signing and caching.
- * Uses tauri-plugin-store for persistence (compatible with TypeScript).
- * 
- * Storage location: {app_data_dir}/updater.json
- */
+//! Session Management Module
+//!
+//! Manages persistent session identifier for request signing and caching.
+//! Uses tauri-plugin-store for persistence (compatible with TypeScript).
+//!
+//! Storage location: {app_data_dir}/updater.json
 
 use std::sync::OnceLock;
 use tauri::{AppHandle, Runtime};

--- a/web-app/src/constants/providers.ts
+++ b/web-app/src/constants/providers.ts
@@ -1,3 +1,30 @@
+export const anthropicProviderSettings = [
+  {
+    key: 'api-key',
+    title: 'API Key',
+    description:
+      "The Anthropic API uses API keys for authentication. Visit your [API Keys](https://console.anthropic.com/settings/keys) page to retrieve the API key you'll use in your requests.",
+    controller_type: 'input',
+    controller_props: {
+      placeholder: 'Insert API Key',
+      value: '',
+      type: 'password',
+      input_actions: ['unobscure', 'copy'],
+    },
+  },
+  {
+    key: 'base-url',
+    title: 'Base URL',
+    description:
+      'The base endpoint to use. See the [Anthropic API documentation](https://docs.anthropic.com/en/api/getting-started) for more information.',
+    controller_type: 'input',
+    controller_props: {
+      placeholder: 'https://api.anthropic.com/v1',
+      value: 'https://api.anthropic.com/v1',
+    },
+  },
+]
+
 export const openAIProviderSettings = [
   {
     key: 'api-key',
@@ -76,6 +103,7 @@ export const predefinedProviders = [
     api_key: '',
     base_url: 'https://api.anthropic.com/v1',
     provider: 'anthropic',
+    api_type: 'anthropic',
     explore_models_url:
       'https://docs.anthropic.com/en/docs/about-claude/models',
     settings: [

--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -241,6 +241,9 @@ const ChatInput = memo(function ChatInput({
     (a) => a.type === 'document' && a.processing
   )
   const ingestingAny = attachments.some((a) => a.processing)
+  const hasSendableMedia = attachments.some(
+    (a) => (a.type === 'image' || a.type === 'audio') && !!a.dataUrl
+  )
 
   const [, setFileIngestProgress] = useState<{
     completed: number
@@ -307,7 +310,7 @@ const ChatInput = memo(function ChatInput({
       setMessage('Please select a model to start chatting.')
       return
     }
-    if (!prompt.trim()) {
+    if (!prompt.trim() && !hasSendableMedia) {
       return
     }
     if (ingestingAny) {
@@ -1718,7 +1721,7 @@ const ChatInput = memo(function ChatInput({
                   e.preventDefault()
                   // Submit prompt when Enter is pressed without Shift and prompt is not empty.
                   // If streaming, handleSendMessage will queue the message automatically.
-                  if (prompt.trim() && !ingestingAny) {
+                  if ((prompt.trim() || hasSendableMedia) && !ingestingAny) {
                     handleSendMessage(prompt)
                   }
                   // When Shift+Enter is pressed, a new line is added (default behavior)
@@ -2186,7 +2189,7 @@ const ChatInput = memo(function ChatInput({
                 <Button
                   variant="default"
                   size="icon-sm"
-                  disabled={!prompt.trim() || ingestingAny}
+                  disabled={(!prompt.trim() && !hasSendableMedia) || ingestingAny}
                   data-test-id="send-message-button"
                   onClick={() => handleSendMessage(prompt)}
                   className="rounded-full mr-1 mb-1"

--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -15,9 +15,6 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
 } from '@/components/ui/dropdown-menu'
 import { ArrowRight, PlusIcon } from 'lucide-react'
 import {
@@ -32,11 +29,11 @@ import {
   IconLoader2,
   IconWorld,
   IconBrandChrome,
-  IconUser,
 } from '@tabler/icons-react'
 import { generateId } from 'ai'
 import { useMessageQueue } from '@/stores/message-queue-store'
 import { QueuedMessageChip } from '@/containers/QueuedMessageBubble'
+import { SamplerPopover } from '@/containers/SamplerPopover'
 import { BotIcon } from 'lucide-react'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { useGeneralSetting } from '@/hooks/useGeneralSetting'
@@ -56,7 +53,6 @@ import {
 import { defaultModel } from '@/lib/models'
 import { useAssistant } from '@/hooks/useAssistant'
 import DropdownToolsAvailable from '@/containers/DropdownToolsAvailable'
-import { AvatarEmoji } from '@/containers/AvatarEmoji'
 import { useServiceHub } from '@/hooks/useServiceHub'
 import { useTools } from '@/hooks/useTools'
 import { TokenCounter } from '@/components/TokenCounter'
@@ -88,7 +84,6 @@ import {
 import JanBrowserExtensionDialog from '@/containers/dialogs/JanBrowserExtensionDialog'
 import { useJanBrowserExtension } from '@/hooks/useJanBrowserExtension'
 import { useAgentMode } from '@/hooks/useAgentMode'
-import { AssistantsMenu } from '@/components/AssistantsMenu'
 
 type ChatInputProps = {
   className?: string
@@ -183,8 +178,6 @@ const ChatInput = memo(function ChatInput({
   const [isDragOver, setIsDragOver] = useState(false)
   const [hasMmproj, setHasMmproj] = useState(false)
   const activeModels = useAppState(useShallow((state) => state.activeModels))
-  const wasPointerDown = useRef(false)
-
   // Check if selected model is currently loaded/active
   const isModelActive = selectedModel?.id ? activeModels.includes(selectedModel.id) : false
   const [selectedAssistantId, setSelectedAssistantId] = useState<
@@ -195,16 +188,6 @@ const ChatInput = memo(function ChatInput({
     setSelectedAssistantId(currentAssistant?.id || '')
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loading])
-
-  const avatar = currentThread
-    ? assistants.find((a) => a.id === currentThread?.assistants?.[0]?.id)
-        ?.avatar ||
-      currentThread?.assistants?.[0]?.avatar ||
-      ''
-    : assistants.find((a) => a.id === selectedAssistantId)?.avatar || ''
-
-  const assistantCount = assistants?.length || 0
-
 
   // Jan Browser Extension hook
   const {
@@ -1845,89 +1828,6 @@ const ChatInput = memo(function ChatInput({
                           : 'Add documents or files'}
                       </span>
                     </DropdownMenuItem>
-                    {/* Use Assistant - only show when no projectId */}
-                    {!projectId && assistantCount < 2 && (
-                      <DropdownMenuSub>
-                        <DropdownMenuSubTrigger>
-                          <IconUser size={18} className="text-muted-foreground" />
-                          <span>Use Assistant</span>
-                        </DropdownMenuSubTrigger>
-                        <DropdownMenuSubContent className="max-h-64 overflow-y-auto">
-                          <AssistantsMenu
-                            selectedAssistant={selectedAssistantId}
-                            setSelectedAssistant={setSelectedAssistantId}
-                            currentThread={currentThread}
-                            updateCurrentThreadAssistant={
-                              updateCurrentThreadAssistant
-                            }
-                            assistants={assistants}
-                          />
-                        </DropdownMenuSubContent>
-                      </DropdownMenuSub>
-                    )}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                )}
-                {!projectId && assistantCount >= 2 && (
-                  <DropdownMenu>
-                    <Tooltip
-                      open={tooltipShown === 'assistants'}
-                      onOpenChange={(newValue) =>
-                        setTooltipShown(newValue ? 'assistants' : false)
-                      }
-                    >
-                      <TooltipTrigger asChild>
-                        <DropdownMenuTrigger
-                          asChild
-                          onPointerDown={() => {
-                            wasPointerDown.current = true
-                          }}
-                          onKeyDown={() => {
-                            wasPointerDown.current = false
-                          }}
-                        >
-                          <Button
-                            variant="secondary"
-                            size="icon-sm"
-                            className="rounded-full mr-2 mb-1"
-                          >
-                            {avatar && (
-                              <AvatarEmoji
-                                avatar={avatar}
-                                imageClassName="w-4 h-4 object-contain"
-                                textClassName="text-xs relative inline-block"
-                              />
-                            )}
-                            {!avatar && (
-                              <IconUser
-                                size={18}
-                                className="text-muted-foreground"
-                              />
-                            )}
-                          </Button>
-                        </DropdownMenuTrigger>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        <p>{t('assistants')}</p>
-                      </TooltipContent>
-                    </Tooltip>
-                    <DropdownMenuContent
-                      onCloseAutoFocus={(event) => {
-                        if (wasPointerDown.current) {
-                          event.preventDefault()
-                        }
-                      }}
-                      align="start"
-                    >
-                      <AssistantsMenu
-                        selectedAssistant={selectedAssistantId}
-                        setSelectedAssistant={setSelectedAssistantId}
-                        currentThread={currentThread}
-                        updateCurrentThreadAssistant={
-                          updateCurrentThreadAssistant
-                        }
-                        assistants={assistants}
-                      />
                     </DropdownMenuContent>
                   </DropdownMenu>
                 )}
@@ -1939,6 +1839,21 @@ const ChatInput = memo(function ChatInput({
                     useLastUsedModel={initialMessage}
                   />
                 )} */}
+                <SamplerPopover
+                  providerId={selectedProvider}
+                  modelId={selectedModel?.id}
+                  assistantSwitcher={
+                    !projectId
+                      ? {
+                          assistants,
+                          currentThread,
+                          selectedAssistantId,
+                          setSelectedAssistantId,
+                          updateCurrentThreadAssistant,
+                        }
+                      : undefined
+                  }
+                />
                 {!effectiveAgentMode && hasJanBrowserMCPConfig && modelSupportsBrowser && (
                   <Tooltip>
                     <TooltipTrigger asChild>

--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -2094,8 +2094,8 @@ const ChatInput = memo(function ChatInput({
                             <DropdownMenuTrigger asChild>
                               <Button
                                 variant="ghost"
-                                size="sm"
-                                className="h-7 gap-1 px-1.5"
+                                size="icon-xs"
+                                aria-label={`Reasoning: ${label}`}
                               >
                                 <IconBrain
                                   size={18}
@@ -2105,9 +2105,6 @@ const ChatInput = memo(function ChatInput({
                                     reasoningValue === 'off' && 'opacity-50'
                                   )}
                                 />
-                                <span className="text-xs text-muted-foreground lowercase">
-                                  {label}
-                                </span>
                               </Button>
                             </DropdownMenuTrigger>
                           </TooltipTrigger>

--- a/web-app/src/containers/McpRouterModelPicker.tsx
+++ b/web-app/src/containers/McpRouterModelPicker.tsx
@@ -50,18 +50,27 @@ export function McpRouterModelPicker({
   const searchInputRef = useRef<HTMLInputElement>(null)
 
   const availableModels = useMemo((): Entry[] => {
-    return providers
-      .filter((p) => p.active)
-      .flatMap((p) =>
-        p.models
-          .filter((m) => isRouterModelSelectable(p, m))
-          .map((m) => ({
-            model: m,
-            providerName: p.provider,
-            isLocal: !!isLocalProvider(p.provider),
-            hasApiKey: !!p.api_key?.length,
-          }))
-      )
+    // Dedupe by `${provider}:${modelId}` — provider model lists can carry
+    // duplicates (registry + locally imported, or upstream `/v1/models`
+    // returning the same id twice). React keys must be unique downstream.
+    const seen = new Set<string>()
+    const entries: Entry[] = []
+    for (const p of providers) {
+      if (!p.active) continue
+      for (const m of p.models) {
+        if (!isRouterModelSelectable(p, m)) continue
+        const key = `${p.provider}:${m.id}`
+        if (seen.has(key)) continue
+        seen.add(key)
+        entries.push({
+          model: m,
+          providerName: p.provider,
+          isLocal: !!isLocalProvider(p.provider),
+          hasApiKey: !!p.api_key?.length,
+        })
+      }
+    }
+    return entries
   }, [providers])
 
   const filteredModels = useMemo(() => {

--- a/web-app/src/containers/MessageItem.tsx
+++ b/web-app/src/containers/MessageItem.tsx
@@ -21,7 +21,12 @@ import {
 import { CopyButton } from './CopyButton'
 import { formatDate } from '@/utils/formatDate'
 import { useModelProvider } from '@/hooks/useModelProvider'
-import { IconRefresh, IconPaperclip, IconArrowDown } from '@tabler/icons-react'
+import {
+  IconRefresh,
+  IconPaperclip,
+  IconArrowDown,
+  IconAlertTriangle,
+} from '@tabler/icons-react'
 import { EditMessageDialog } from '@/containers/dialogs/EditMessageDialog'
 import { DeleteMessageDialog } from '@/containers/dialogs/DeleteMessageDialog'
 import TokenSpeedIndicator from '@/containers/TokenSpeedIndicator'
@@ -568,6 +573,38 @@ export const MessageItem = memo(
             )}
           </div>
         )}
+
+        {message.role === 'user' &&
+          !hideActions &&
+          typeof metadata?.error === 'string' &&
+          metadata.error.length > 0 && (
+            <div className="mt-2 flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm">
+              <IconAlertTriangle
+                size={16}
+                className="mt-0.5 shrink-0 text-destructive"
+              />
+              <div className="flex-1 min-w-0">
+                <div className="font-medium text-destructive">
+                  Generation failed
+                </div>
+                <div className="text-muted-foreground break-words">
+                  {metadata.error as string}
+                </div>
+              </div>
+              {selectedModel && onRegenerate && status !== CHAT_STATUS.STREAMING &&
+                status !== CHAT_STATUS.SUBMITTED && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={handleRegenerate}
+                    className="shrink-0"
+                  >
+                    <IconRefresh size={14} />
+                    <span>Regenerate</span>
+                  </Button>
+                )}
+            </div>
+          )}
 
         {/* Message actions for assistant messages (non-tool) */}
         {message.role === 'assistant' && (

--- a/web-app/src/containers/MessageItem.tsx
+++ b/web-app/src/containers/MessageItem.tsx
@@ -21,6 +21,7 @@ import {
 import { CopyButton } from './CopyButton'
 import { formatDate } from '@/utils/formatDate'
 import { useModelProvider } from '@/hooks/useModelProvider'
+import { useMessageErrors } from '@/stores/message-errors'
 import {
   IconRefresh,
   IconPaperclip,
@@ -86,6 +87,7 @@ export const MessageItem = memo(
   }: MessageItemProps) => {
     const selectedModel = useModelProvider((state) => state.selectedModel)
     const metadata = message.metadata as Record<string, unknown> | undefined
+    const messageError = useMessageErrors((s) => s.errors[message.id])
     const createdAt = (metadata?.createdAt as Date) ?? new Date()
     const [previewImage, setPreviewImage] = useState<{
       url: string
@@ -576,8 +578,8 @@ export const MessageItem = memo(
 
         {message.role === 'user' &&
           !hideActions &&
-          typeof metadata?.error === 'string' &&
-          metadata.error.length > 0 && (
+          typeof messageError === 'string' &&
+          messageError.length > 0 && (
             <div className="mt-2 flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm">
               <IconAlertTriangle
                 size={16}
@@ -588,7 +590,7 @@ export const MessageItem = memo(
                   Generation failed
                 </div>
                 <div className="text-muted-foreground break-words">
-                  {metadata.error as string}
+                  {messageError}
                 </div>
               </div>
               {selectedModel && onRegenerate && status !== CHAT_STATUS.STREAMING &&

--- a/web-app/src/containers/ModelSetting.tsx
+++ b/web-app/src/containers/ModelSetting.tsx
@@ -19,6 +19,7 @@ import { useServiceHub } from '@/hooks/useServiceHub'
 import { cn, getModelDisplayName } from '@/lib/utils'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { useAppState } from '@/hooks/useAppState'
+import { paramsSettings } from '@/lib/predefinedParams'
 
 const MTP_MIN_BUILD = 9193
 
@@ -277,6 +278,8 @@ export function ModelSetting({
             // localStorage state that still carries the orphan entry.
             if (entry[0] === 'auto_increase_ctx_len') return acc
             if (fitEnabled && entry[0] === 'ctx_len') return acc
+            // Sampling params live in the composer popover, not the sidebar.
+            if (entry[0] in paramsSettings) return acc
             acc.push(entry)
             return acc
           }, [])

--- a/web-app/src/containers/ModelSetting.tsx
+++ b/web-app/src/containers/ModelSetting.tsx
@@ -366,10 +366,10 @@ function MtpPanel({
     }
   }, [modelId, serviceHub])
 
-  const versionBackend = provider.settings?.find(
-    (s) => s.key === 'version_backend'
+  const llamacppVersion = provider.settings?.find(
+    (s) => s.key === 'llamacpp_version'
   )?.controller_props?.value as string | undefined
-  const buildNo = parseBuildNumber(versionBackend?.split('/')[0])
+  const buildNo = parseBuildNumber(llamacppVersion)
   const backendSupports = buildNo !== null && buildNo >= MTP_MIN_BUILD
 
   const persist = useCallback(

--- a/web-app/src/containers/ModelSupportStatus.tsx
+++ b/web-app/src/containers/ModelSupportStatus.tsx
@@ -1,5 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
-import { invoke } from '@tauri-apps/api/core'
+import { useEffect, useState } from 'react'
 import { cn } from '@/lib/utils'
 import {
   Tooltip,
@@ -7,8 +6,13 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '@/components/ui/tooltip'
-import { getJanDataFolderPath, joinPath, fs } from '@janhq/core'
 import { useServiceHub } from '@/hooks/useServiceHub'
+import { useHardware } from '@/hooks/useHardware'
+import {
+  DEFAULT_CTX_LENGTH,
+  estimateModelFit,
+  type FitTier,
+} from '@/lib/modelCompatibility'
 
 interface ModelSupportStatusProps {
   modelId: string | undefined
@@ -17,29 +21,14 @@ interface ModelSupportStatusProps {
   className?: string
 }
 
-type CheckResult = {
-  status: 'RED' | 'YELLOW' | 'GREEN' | 'GREY' | null
-  effectiveCtx: number
-}
-
-const readTrainContext = async (
-  modelPath: string
-): Promise<number | undefined> => {
-  try {
-    const result = await invoke<{ metadata?: Record<string, string> }>(
-      'plugin:llamacpp|read_gguf_metadata',
-      { path: modelPath }
-    )
-    const meta = result?.metadata
-    const arch = meta?.['general.architecture']
-    if (!arch) return undefined
-    const raw = meta?.[`${arch}.context_length`]
-    const parsed = raw ? parseInt(raw, 10) : NaN
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
-  } catch (e) {
-    console.error('Error reading GGUF context length:', e)
-    return undefined
-  }
+const TIER_STYLES: Record<FitTier, { dot: string; label: string }> = {
+  green: { dot: 'bg-green-500', label: 'Should run comfortably on your device' },
+  yellow: {
+    dot: 'bg-yellow-500',
+    label: 'Will run but leaves little memory headroom',
+  },
+  red: { dot: 'bg-red-500', label: 'Likely exceeds your available memory' },
+  unknown: { dot: 'bg-secondary', label: 'Fit unknown' },
 }
 
 export const ModelSupportStatus = ({
@@ -48,141 +37,45 @@ export const ModelSupportStatus = ({
   contextSize,
   className,
 }: ModelSupportStatusProps) => {
-  const [modelSupportStatus, setModelSupportStatus] = useState<
-    'RED' | 'YELLOW' | 'GREEN' | 'LOADING' | null | 'GREY'
-  >(null)
-  const [effectiveCtx, setEffectiveCtx] = useState<number>(contextSize)
   const serviceHub = useServiceHub()
+  const hardwareData = useHardware((s) => s.hardwareData)
+  const [sizeBytes, setSizeBytes] = useState<number | null>(null)
 
-  // Helper function to check model support with proper path resolution
-  const checkModelSupportWithPath = useCallback(
-    async (id: string, ctxSize: number): Promise<CheckResult> => {
-      try {
-        const janDataFolder = await getJanDataFolderPath()
-
-        // First try the standard downloaded model path
-        const ggufModelPath = await joinPath([
-          janDataFolder,
-          'llamacpp',
-          'models',
-          id,
-          'model.gguf',
-        ])
-
-        let actualModelPath: string | null = null
-        if (await fs.existsSync(ggufModelPath)) {
-          actualModelPath = ggufModelPath
-        } else {
-          // If model.gguf doesn't exist, try reading from model.yml (for imported models)
-          const modelConfigPath = await joinPath([
-            janDataFolder,
-            'llamacpp',
-            'models',
-            id,
-            'model.yml',
-          ])
-
-          if (!(await fs.existsSync(modelConfigPath))) {
-            console.error(
-              `Neither model.gguf nor model.yml found for model: ${id}`
-            )
-            return { status: null, effectiveCtx: ctxSize }
-          }
-
-          const modelConfig = await serviceHub
-            .app()
-            .readYaml<{ model_path: string }>(
-              `llamacpp/models/${id}/model.yml`
-            )
-
-          actualModelPath =
-            modelConfig.model_path.startsWith('/') ||
-            modelConfig.model_path.match(/^[A-Za-z]:/)
-              ? modelConfig.model_path
-              : await joinPath([janDataFolder, modelConfig.model_path])
-        }
-
-        const trainCtx = await readTrainContext(actualModelPath)
-        const ctxForCheck = trainCtx
-          ? Math.min(ctxSize, trainCtx)
-          : ctxSize
-        const status = await serviceHub
-          .models()
-          .isModelSupported(actualModelPath, ctxForCheck)
-        return { status, effectiveCtx: trainCtx ?? ctxSize }
-      } catch (error) {
-        console.error(
-          'Error checking model support with path resolution:',
-          error
-        )
-        return { status: null, effectiveCtx: ctxSize }
-      }
-    },
-    [serviceHub]
-  )
-
-  // Helper function to get icon color based on model support status
-  const getStatusColor = (): string => {
-    switch (modelSupportStatus) {
-      case 'GREEN':
-        return 'bg-green-500'
-      case 'YELLOW':
-        return 'bg-yellow-500'
-      case 'RED':
-        return 'bg-red-500'
-      case 'LOADING':
-        return 'bg-secondary'
-      default:
-        return 'bg-secondary'
-    }
-  }
-
-  // Helper function to get tooltip text based on model support status
-  const getStatusTooltip = (): string => {
-    switch (modelSupportStatus) {
-      case 'GREEN':
-        return `Works Well on your device (ctx: ${effectiveCtx})`
-      case 'YELLOW':
-        return `Might work on your device (ctx: ${effectiveCtx})`
-      case 'RED':
-        return `Doesn't work on your device  (ctx: ${effectiveCtx})`
-      case 'LOADING':
-        return 'Checking device compatibility...'
-      default:
-        return 'Unknown'
-    }
-  }
-
-  // Check model support when model changes
   useEffect(() => {
-    const checkModelSupport = async () => {
-      if (modelId && provider === 'llamacpp') {
-        // Set loading state immediately
-        setModelSupportStatus('LOADING')
-        try {
-          const { status, effectiveCtx: ctx } = await checkModelSupportWithPath(
-            modelId,
-            contextSize
-          )
-          setEffectiveCtx(ctx)
-          setModelSupportStatus(status)
-        } catch (error) {
-          console.error('Error checking model support:', error)
-          setModelSupportStatus('RED')
-        }
-      } else {
-        // Only show status for llamacpp models since isModelSupported is specific to llamacpp
-        setModelSupportStatus(null)
-      }
+    if (!modelId || provider !== 'llamacpp') {
+      setSizeBytes(null)
+      return
     }
+    let cancelled = false
+    serviceHub
+      .models()
+      .fetchModels()
+      .then((infos) => {
+        if (cancelled) return
+        const match = infos.find(
+          (i) => i.id === modelId && i.providerId === provider
+        )
+        setSizeBytes(match?.sizeBytes ?? null)
+      })
+      .catch(() => {
+        if (!cancelled) setSizeBytes(null)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [modelId, provider, serviceHub])
 
-    checkModelSupport()
-  }, [modelId, provider, contextSize, checkModelSupportWithPath])
+  if (!modelId || provider !== 'llamacpp') return null
 
-  // Don't render anything if no status or not llamacpp
-  if (!modelSupportStatus || provider !== 'llamacpp') {
-    return null
-  }
+  const tier = estimateModelFit(
+    sizeBytes,
+    contextSize || DEFAULT_CTX_LENGTH,
+    hardwareData
+  )
+  if (tier === 'unknown') return null
+
+  const style = TIER_STYLES[tier]
+  const tooltip = `${style.label} (estimated, ctx: ${contextSize || DEFAULT_CTX_LENGTH})`
 
   return (
     <TooltipProvider>
@@ -191,15 +84,14 @@ export const ModelSupportStatus = ({
           <div
             className={cn(
               'size-2 flex items-center justify-center rounded-full',
-              modelSupportStatus === 'LOADING'
-                ? 'size-2.5 border border-t-transparent animate-spin'
-                : getStatusColor(),
+              style.dot,
               className
             )}
+            aria-label={`Device compatibility: ${tier}`}
           />
         </TooltipTrigger>
         <TooltipContent>
-          <p>{getStatusTooltip()}</p>
+          <p>{tooltip}</p>
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>

--- a/web-app/src/containers/ModelSupportStatus.tsx
+++ b/web-app/src/containers/ModelSupportStatus.tsx
@@ -75,7 +75,7 @@ export const ModelSupportStatus = ({
   if (tier === 'unknown') return null
 
   const style = TIER_STYLES[tier]
-  const tooltip = `${style.label} (estimated, ctx: ${contextSize || DEFAULT_CTX_LENGTH})`
+  const tooltip = `${style.label} (estimated)`
 
   return (
     <TooltipProvider>

--- a/web-app/src/containers/ParametersSection.tsx
+++ b/web-app/src/containers/ParametersSection.tsx
@@ -1,0 +1,470 @@
+import { useMemo } from 'react'
+import { IconTrash, IconPlus, IconAlertTriangle } from '@tabler/icons-react'
+
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import {
+  paramsSettings,
+  paramGroups,
+  paramCategories,
+  evaluateDisabled,
+  isGroupedParamKey,
+  type ParamDef,
+  type ParamGroup,
+} from '@/lib/predefinedParams'
+import {
+  paramsForProviders,
+  resolveProviderCaps,
+  isModelLevelRejected,
+} from '@/lib/providerCaps'
+import { DynamicControllerSetting } from '@/containers/dynamicControllerSetting'
+
+export interface ParametersSectionProps {
+  params: Record<string, unknown>
+  providers: Array<Pick<ProviderObject, 'provider'>>
+  onToggle: (def: ParamDef) => void
+  onChange: (key: string, value: unknown) => void
+  onRemove: (key: string) => void
+  /** Bulk add (used when adding a coupled group). */
+  onAddMany?: (values: Record<string, unknown>) => void
+  /** Bulk remove (used when removing a coupled group). */
+  onRemoveMany?: (keys: string[]) => void
+  /** When set, params model-rejected by (providerId, modelId) are flagged
+   *  in active rows and hidden from the add menu. Pass from the composer
+   *  where the selected model is known; omit in the assistant editor. */
+  providerId?: string
+  modelId?: string
+}
+
+export function ParametersSection({
+  params,
+  providers,
+  onToggle,
+  onChange,
+  onRemove,
+  onAddMany,
+  onRemoveMany,
+  providerId,
+  modelId,
+}: ParametersSectionProps) {
+  const modelRejects = (key: string) =>
+    !!(providerId && modelId && isModelLevelRejected(key, providerId, modelId))
+  const supportIndex = useMemo(() => {
+    const idx: Record<
+      string,
+      { supportedBy: string[]; maybeBy: string[]; known: boolean }
+    > = {}
+    for (const def of Object.values(paramsSettings)) {
+      idx[def.key] = { supportedBy: [], maybeBy: [], known: false }
+    }
+    for (const entry of paramsForProviders(providers)) {
+      idx[entry.def.key] = {
+        supportedBy: entry.supportedBy,
+        maybeBy: entry.maybeBy,
+        known: true,
+      }
+    }
+    return idx
+  }, [providers])
+
+  const activeKeys = Object.keys(params)
+  const activeGroups = paramGroups.filter((g) =>
+    g.members.some((k) => k in params)
+  )
+  const activeStandaloneKeys = activeKeys
+    .filter((k) => k in paramsSettings && !isGroupedParamKey(k))
+    .sort((a, b) => canonicalOrder(a) - canonicalOrder(b))
+  const unknownKeys = activeKeys.filter((k) => !(k in paramsSettings))
+
+  const addStandalone = (def: ParamDef) => onToggle(def)
+  const addGroup = (group: ParamGroup) => {
+    if (onAddMany) {
+      const defaults: Record<string, unknown> = {}
+      for (const memberKey of group.members) {
+        const def = paramsSettings[memberKey]
+        if (!def) continue
+        defaults[memberKey] =
+          memberKey === group.triggerKey ? group.triggerValue : def.value
+      }
+      onAddMany(defaults)
+    } else {
+      for (const memberKey of group.members) {
+        const def = paramsSettings[memberKey]
+        if (!def) continue
+        if (memberKey in params) continue
+        onChange(
+          memberKey,
+          memberKey === group.triggerKey ? group.triggerValue : def.value
+        )
+      }
+    }
+  }
+  const removeGroup = (group: ParamGroup) => {
+    const keys = group.members.filter((k) => k in params)
+    if (onRemoveMany) onRemoveMany(keys)
+    else keys.forEach(onRemove)
+  }
+
+  const hasAny = activeGroups.length + activeStandaloneKeys.length > 0
+
+  return (
+    <div className="space-y-3">
+      {!hasAny && (
+        <div className="text-xs text-muted-foreground py-2">
+          No overrides — using model defaults.
+        </div>
+      )}
+
+      {activeStandaloneKeys.map((key) => (
+        <StandaloneRow
+          key={key}
+          paramKey={key}
+          params={params}
+          support={supportIndex[key]}
+          modelRejected={modelRejects(key)}
+          onChange={onChange}
+          onRemove={onRemove}
+        />
+      ))}
+
+      {activeGroups.map((group) => (
+        <GroupBlock
+          key={group.id}
+          group={group}
+          params={params}
+          onChange={onChange}
+          onRemoveGroup={() => removeGroup(group)}
+        />
+      ))}
+
+      {unknownKeys.length > 0 && (
+        <div className="text-xs text-muted-foreground">
+          {unknownKeys.length} unrecognized parameter
+          {unknownKeys.length === 1 ? '' : 's'} hidden:{' '}
+          {unknownKeys.join(', ')}
+        </div>
+      )}
+
+      <AddParameterMenu
+        params={params}
+        providers={providers}
+        onAddStandalone={addStandalone}
+        onAddGroup={addGroup}
+        modelRejects={modelRejects}
+      />
+    </div>
+  )
+}
+
+interface StandaloneRowProps {
+  paramKey: string
+  params: Record<string, unknown>
+  support?: { supportedBy: string[]; maybeBy: string[]; known: boolean }
+  modelRejected?: boolean
+  onChange: (key: string, value: unknown) => void
+  onRemove: (key: string) => void
+}
+
+function StandaloneRow({
+  paramKey,
+  params,
+  support,
+  modelRejected,
+  onChange,
+  onRemove,
+}: StandaloneRowProps) {
+  const def = paramsSettings[paramKey]
+  if (!def) return null
+  const disabledReason = evaluateDisabled(def, params)
+  const value = params[paramKey] ?? def.value
+  const capUnsupported =
+    support && def.capability !== 'core' && def.capability !== 'client_only' && !support.known
+  const unsupported = modelRejected || capUnsupported
+  const maybeOnly =
+    !modelRejected &&
+    support &&
+    support.known &&
+    support.supportedBy.length === 0 &&
+    support.maybeBy.length > 0
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-2 min-w-0">
+        <div className="flex items-center gap-1 min-w-0 flex-1 text-sm">
+          <span className="truncate">{def.title}</span>
+          {unsupported && (
+            <IconAlertTriangle
+              size={12}
+              className="text-destructive shrink-0"
+              aria-label="Not supported — will be stripped on send"
+            />
+          )}
+          {!unsupported && maybeOnly && (
+            <IconAlertTriangle
+              size={12}
+              className="text-amber-500 shrink-0"
+              aria-label="May be ignored by this provider"
+            />
+          )}
+        </div>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => onRemove(paramKey)}
+          className="shrink-0 h-7 w-7"
+          aria-label={`Remove ${def.title}`}
+        >
+          <IconTrash size={14} className="text-destructive" />
+        </Button>
+      </div>
+      <DynamicControllerSetting
+        controllerType={def.controllerType}
+        controllerProps={{
+          value: value as string | number | boolean,
+          ...(def.controllerProps ?? {}),
+        }}
+        disabledReason={disabledReason ?? undefined}
+        onChange={(v) => onChange(paramKey, v)}
+      />
+      {(unsupported || def.effectHint) && (
+        <div
+          className={
+            unsupported
+              ? 'text-xs text-destructive'
+              : 'text-xs text-muted-foreground'
+          }
+        >
+          {unsupported ? 'Not supported — will be skipped.' : def.effectHint}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface GroupBlockProps {
+  group: ParamGroup
+  params: Record<string, unknown>
+  onChange: (key: string, value: unknown) => void
+  onRemoveGroup: () => void
+}
+
+function GroupBlock({
+  group,
+  params,
+  onChange,
+  onRemoveGroup,
+}: GroupBlockProps) {
+  return (
+    <div className="rounded-md border border-border/60 p-3 space-y-3">
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-sm font-medium">{group.title}</div>
+          <div className="text-xs text-muted-foreground">{group.description}</div>
+        </div>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={onRemoveGroup}
+          aria-label={`Remove ${group.title}`}
+        >
+          <IconTrash size={16} className="text-destructive" />
+        </Button>
+      </div>
+      <div className="space-y-2 pl-2 border-l border-border/40">
+        {group.members
+          .filter((k) => k in params)
+          .map((memberKey) => {
+            const def = paramsSettings[memberKey]
+            if (!def) return null
+            const disabledReason = evaluateDisabled(def, params)
+            const value = params[memberKey] ?? def.value
+            return (
+              <div key={memberKey} className="space-y-1">
+                <div className="text-xs text-muted-foreground">{def.title}</div>
+                <DynamicControllerSetting
+                  controllerType={def.controllerType}
+                  controllerProps={{
+                    value: value as string | number | boolean,
+                    ...(def.controllerProps ?? {}),
+                  }}
+                  disabledReason={disabledReason ?? undefined}
+                  onChange={(v) => onChange(memberKey, v)}
+                />
+              </div>
+            )
+          })}
+      </div>
+    </div>
+  )
+}
+
+interface AddParameterMenuProps {
+  params: Record<string, unknown>
+  providers: Array<Pick<ProviderObject, 'provider'>>
+  onAddStandalone: (def: ParamDef) => void
+  onAddGroup: (group: ParamGroup) => void
+  modelRejects: (key: string) => boolean
+}
+
+function AddParameterMenu({
+  params,
+  providers,
+  onAddStandalone,
+  onAddGroup,
+  modelRejects,
+}: AddParameterMenuProps) {
+  const items = useMemo(() => {
+    return paramCategories
+      .map((cat) => {
+        const standalone = cat.paramKeys
+          .map((k) => paramsSettings[k])
+          .filter((def): def is ParamDef => Boolean(def))
+          .filter((def) => isCapabilitySupported(def, providers))
+          .filter((def) => !modelRejects(def.key))
+          .map((def) => ({
+            kind: 'param' as const,
+            def,
+            active: def.key in params,
+            support: providerSupportFor(def, providers),
+          }))
+        const groups = cat.groupIds
+          .map((id) => paramGroups.find((g) => g.id === id))
+          .filter((g): g is ParamGroup => Boolean(g))
+          .filter((g) => isGroupCapabilitySupported(g, providers))
+          .map((g) => ({
+            kind: 'group' as const,
+            group: g,
+            active: g.members.some((k) => k in params),
+          }))
+        const entries = [...standalone, ...groups]
+        return { cat, entries }
+      })
+      .filter(({ entries }) => entries.length > 0)
+  }, [params, providers, modelRejects])
+
+  if (items.length === 0) {
+    return (
+      <div className="text-xs text-muted-foreground">
+        No tunable parameters for this provider.
+      </div>
+    )
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className="w-full justify-start">
+          <IconPlus size={14} className="mr-1" />
+          Add parameter
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-72 max-h-[60vh] overflow-y-auto">
+        {items.map(({ cat, entries }, catIdx) => (
+          <div key={cat.id}>
+            {catIdx > 0 && <DropdownMenuSeparator />}
+            <DropdownMenuLabel className="text-[10px] uppercase tracking-wide text-muted-foreground">
+              {cat.title}
+            </DropdownMenuLabel>
+            {entries.map((entry) =>
+              entry.kind === 'param' ? (
+                <DropdownMenuItem
+                  key={`p:${entry.def.key}`}
+                  disabled={entry.active}
+                  onSelect={() => onAddStandalone(entry.def)}
+                  className="flex flex-col items-start gap-0.5 py-1.5"
+                >
+                  <div className="flex items-center gap-1 w-full">
+                    <span className="text-sm">{entry.def.title}</span>
+                    {entry.support.supportedBy.length === 0 &&
+                      entry.support.maybeBy.length > 0 && (
+                        <IconAlertTriangle
+                          size={11}
+                          className="text-amber-500 ml-auto"
+                        />
+                      )}
+                  </div>
+                  <span className="text-xs text-muted-foreground line-clamp-1">
+                    {entry.def.effectHint ?? entry.def.description}
+                  </span>
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem
+                  key={`g:${entry.group.id}`}
+                  disabled={entry.active}
+                  onSelect={() => onAddGroup(entry.group)}
+                  className="flex flex-col items-start gap-0.5 py-1.5"
+                >
+                  <span className="text-sm">{entry.group.title}</span>
+                  <span className="text-xs text-muted-foreground line-clamp-1">
+                    {entry.group.description}
+                  </span>
+                </DropdownMenuItem>
+              )
+            )}
+          </div>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+/**
+ * Stable display order for active rows: same order the Add menu uses
+ * (categories top-to-bottom, items within a category in declared order).
+ * Unknown / category-less keys sort to the end, preserving relative order.
+ */
+const CANONICAL_INDEX: Record<string, number> = (() => {
+  const idx: Record<string, number> = {}
+  let i = 0
+  for (const cat of paramCategories) {
+    for (const key of cat.paramKeys) {
+      if (!(key in idx)) idx[key] = i++
+    }
+  }
+  return idx
+})()
+
+function canonicalOrder(key: string): number {
+  return key in CANONICAL_INDEX ? CANONICAL_INDEX[key] : Number.MAX_SAFE_INTEGER
+}
+
+function providerSupportFor(
+  def: ParamDef,
+  providers: Array<Pick<ProviderObject, 'provider'>>
+): { supportedBy: string[]; maybeBy: string[] } {
+  const supportedBy: string[] = []
+  const maybeBy: string[] = []
+  for (const p of providers) {
+    const caps = resolveProviderCaps(p)
+    if (caps.supported.has(def.capability)) supportedBy.push(p.provider)
+    else if (caps.maybe.has(def.capability)) maybeBy.push(p.provider)
+  }
+  return { supportedBy, maybeBy }
+}
+
+function isCapabilitySupported(
+  def: ParamDef,
+  providers: Array<Pick<ProviderObject, 'provider'>>
+): boolean {
+  if (def.capability === 'client_only' || def.capability === 'core') return true
+  return providers.some((p) => {
+    const caps = resolveProviderCaps(p)
+    return caps.supported.has(def.capability) || caps.maybe.has(def.capability)
+  })
+}
+
+function isGroupCapabilitySupported(
+  group: ParamGroup,
+  providers: Array<Pick<ProviderObject, 'provider'>>
+): boolean {
+  return providers.some((p) => {
+    const caps = resolveProviderCaps(p)
+    return caps.supported.has(group.capability) || caps.maybe.has(group.capability)
+  })
+}

--- a/web-app/src/containers/SamplerPopover.tsx
+++ b/web-app/src/containers/SamplerPopover.tsx
@@ -32,6 +32,7 @@ import { ParametersSection } from '@/containers/ParametersSection'
 import { useAssistant } from '@/hooks/useAssistant'
 import { useModelProvider } from '@/hooks/useModelProvider'
 import { paramsSettings, type ParamDef } from '@/lib/predefinedParams'
+import { isPredefinedRemoteProvider } from '@/lib/providerCaps'
 import { cn } from '@/lib/utils'
 
 interface SamplerPopoverProps {
@@ -115,6 +116,8 @@ export function SamplerPopover({
     }
     writeParams(next)
   }
+
+  if (isPredefinedRemoteProvider(providerId)) return null
 
   const triggerLabel = currentAssistant
     ? `Sampling — ${currentAssistant.name}`

--- a/web-app/src/containers/SamplerPopover.tsx
+++ b/web-app/src/containers/SamplerPopover.tsx
@@ -60,6 +60,7 @@ export function SamplerPopover({
 }: SamplerPopoverProps) {
   const currentAssistant = useAssistant((s) => s.currentAssistant)
   const updateAssistant = useAssistant((s) => s.updateAssistant)
+  const assistantsLoading = useAssistant((s) => s.loading)
   const providers = useModelProvider((s) => s.providers)
 
   const scopedProviders = useMemo(() => {
@@ -119,9 +120,11 @@ export function SamplerPopover({
 
   if (isPredefinedRemoteProvider(providerId)) return null
 
-  const triggerLabel = currentAssistant
-    ? `Sampling — ${currentAssistant.name}`
-    : 'Sampling'
+  const triggerLabel = assistantsLoading
+    ? 'Loading assistant…'
+    : currentAssistant
+      ? `Sampling — ${currentAssistant.name}`
+      : 'Sampling'
 
   return (
     <Popover>
@@ -133,6 +136,7 @@ export function SamplerPopover({
               size="icon-xs"
               aria-label="Sampling parameters"
               className="relative"
+              disabled={assistantsLoading}
             >
               <IconAdjustmentsHorizontal
                 size={18}

--- a/web-app/src/containers/SamplerPopover.tsx
+++ b/web-app/src/containers/SamplerPopover.tsx
@@ -1,0 +1,270 @@
+import { useMemo } from 'react'
+import {
+  IconAdjustmentsHorizontal,
+  IconChevronDown,
+  IconSettings,
+  IconUser,
+} from '@tabler/icons-react'
+import { Link } from '@tanstack/react-router'
+
+import { route } from '@/constants/routes'
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Button } from '@/components/ui/button'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+
+import { AssistantsMenu } from '@/components/AssistantsMenu'
+import { AvatarEmoji } from '@/containers/AvatarEmoji'
+import { ParametersSection } from '@/containers/ParametersSection'
+import { useAssistant } from '@/hooks/useAssistant'
+import { useModelProvider } from '@/hooks/useModelProvider'
+import { paramsSettings, type ParamDef } from '@/lib/predefinedParams'
+import { cn } from '@/lib/utils'
+
+interface SamplerPopoverProps {
+  /** Provider ID of the currently-selected model, if any. Used to scope the
+   *  chip palette to a single provider's capabilities. */
+  providerId?: string
+  /** Currently-selected model ID. Drives model-family rejection (e.g. o1/gpt-5
+   *  reasoning models reject temperature/top_p). */
+  modelId?: string
+  /** Optional assistant switcher. When omitted, the header shows the active
+   *  assistant name as static text. */
+  assistantSwitcher?: {
+    assistants: Assistant[]
+    currentThread: Thread | undefined
+    selectedAssistantId: string | undefined
+    setSelectedAssistantId: (id: string) => void
+    updateCurrentThreadAssistant: (assistant: Assistant) => void
+  }
+}
+
+export function SamplerPopover({
+  providerId,
+  modelId,
+  assistantSwitcher,
+}: SamplerPopoverProps) {
+  const currentAssistant = useAssistant((s) => s.currentAssistant)
+  const updateAssistant = useAssistant((s) => s.updateAssistant)
+  const providers = useModelProvider((s) => s.providers)
+
+  const scopedProviders = useMemo(() => {
+    if (providerId) {
+      const p = providers.find((x) => x.provider === providerId)
+      return p ? [p] : []
+    }
+    return providers.filter((p) => p.active)
+  }, [providers, providerId])
+
+  const params = currentAssistant?.parameters ?? {}
+  const samplerKeys = Object.keys(params).filter((k) => k in paramsSettings)
+  const hasOverrides = samplerKeys.length > 0
+
+  const writeParams = (next: Record<string, unknown>) => {
+    if (!currentAssistant) return
+    updateAssistant({ ...currentAssistant, parameters: next })
+  }
+
+  const handleToggle = (def: ParamDef) => {
+    if (def.key in params) {
+      const next = { ...params }
+      delete next[def.key]
+      writeParams(next)
+    } else {
+      writeParams({ ...params, [def.key]: def.value })
+    }
+  }
+
+  const handleChange = (key: string, value: unknown) => {
+    writeParams({ ...params, [key]: value })
+  }
+
+  const handleRemove = (key: string) => {
+    const next = { ...params }
+    delete next[key]
+    writeParams(next)
+  }
+
+  const handleAddMany = (values: Record<string, unknown>) => {
+    writeParams({ ...params, ...values })
+  }
+
+  const handleRemoveMany = (keys: string[]) => {
+    const next = { ...params }
+    for (const k of keys) delete next[k]
+    writeParams(next)
+  }
+
+  const handleResetAll = () => {
+    const next: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(params)) {
+      if (!(k in paramsSettings)) next[k] = v
+    }
+    writeParams(next)
+  }
+
+  const triggerLabel = currentAssistant
+    ? `Sampling — ${currentAssistant.name}`
+    : 'Sampling'
+
+  return (
+    <Popover>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              aria-label="Sampling parameters"
+              className="relative"
+            >
+              <IconAdjustmentsHorizontal
+                size={18}
+                className={cn(
+                  'text-muted-foreground',
+                  hasOverrides && 'text-primary'
+                )}
+              />
+              {hasOverrides && (
+                <span
+                  aria-hidden
+                  className="absolute top-0.5 right-0.5 size-1.5 rounded-full bg-primary"
+                />
+              )}
+            </Button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>{triggerLabel}</p>
+        </TooltipContent>
+      </Tooltip>
+
+      <PopoverContent
+        align="start"
+        side="top"
+        sideOffset={8}
+        collisionPadding={12}
+        avoidCollisions
+        className="w-[380px] p-0 flex flex-col max-h-[var(--radix-popover-content-available-height)]"
+      >
+        <div className="flex items-center justify-between gap-2 px-4 pt-3 pb-2 border-b">
+          <AssistantHeader
+            currentAssistant={currentAssistant}
+            assistantSwitcher={assistantSwitcher}
+          />
+          <div className="flex items-center gap-1 shrink-0">
+            {hasOverrides && (
+              <Button variant="ghost" size="sm" onClick={handleResetAll}>
+                Reset all
+              </Button>
+            )}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="ghost" size="icon-sm" asChild>
+                  <Link to={route.settings.assistant}>
+                    <IconSettings size={16} className="text-muted-foreground" />
+                  </Link>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Open assistant settings</p>
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        </div>
+        {currentAssistant ? (
+          <div className="flex-1 min-h-0 overflow-y-auto px-4 py-3">
+            <ParametersSection
+              params={params}
+              providers={scopedProviders}
+              providerId={providerId}
+              modelId={modelId}
+              onToggle={handleToggle}
+              onChange={handleChange}
+              onRemove={handleRemove}
+              onAddMany={handleAddMany}
+              onRemoveMany={handleRemoveMany}
+            />
+          </div>
+        ) : (
+          <div className="text-xs text-muted-foreground px-4 py-3">
+            Pick an assistant above to configure sampling.
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+interface AssistantHeaderProps {
+  currentAssistant: Assistant | undefined
+  assistantSwitcher: SamplerPopoverProps['assistantSwitcher']
+}
+
+function AssistantHeader({
+  currentAssistant,
+  assistantSwitcher,
+}: AssistantHeaderProps) {
+  const label = (
+    <span className="flex items-center gap-1.5 min-w-0">
+      {currentAssistant?.avatar ? (
+        <AvatarEmoji
+          avatar={currentAssistant.avatar}
+          imageClassName="size-4 object-contain"
+          textClassName="text-sm"
+        />
+      ) : (
+        <IconUser size={14} className="text-muted-foreground" />
+      )}
+      <span className="text-sm font-medium truncate">
+        {currentAssistant?.name ?? 'No assistant'}
+      </span>
+    </span>
+  )
+
+  if (!assistantSwitcher) {
+    return <div className="flex items-center gap-1 min-w-0">{label}</div>
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="-ml-2 h-7 px-2 gap-1 min-w-0"
+        >
+          {label}
+          <IconChevronDown size={14} className="text-muted-foreground" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        className="max-h-64 overflow-y-auto"
+      >
+        <AssistantsMenu
+          selectedAssistant={assistantSwitcher.selectedAssistantId}
+          setSelectedAssistant={assistantSwitcher.setSelectedAssistantId}
+          currentThread={assistantSwitcher.currentThread}
+          updateCurrentThreadAssistant={
+            assistantSwitcher.updateCurrentThreadAssistant
+          }
+          assistants={assistantSwitcher.assistants}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/web-app/src/containers/SettingsMenu.tsx
+++ b/web-app/src/containers/SettingsMenu.tsx
@@ -22,7 +22,10 @@ import { useModelProvider } from '@/hooks/useModelProvider'
 import { getProviderTitle, isLocalProvider } from '@/lib/utils'
 import ProvidersAvatar from '@/containers/ProvidersAvatar'
 import { AddProviderDialog } from '@/containers/dialogs'
-import { openAIProviderSettings } from '@/constants/providers'
+import {
+  openAIProviderSettings,
+  anthropicProviderSettings,
+} from '@/constants/providers'
 import cloneDeep from 'lodash/cloneDeep'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -37,14 +40,23 @@ const SettingsMenu = () => {
   const { providers, addProvider } = useModelProvider()
 
   const createProvider = useCallback(
-    (name: string, baseUrl: string, apiKey: string) => {
+    (
+      name: string,
+      baseUrl: string,
+      apiKey: string,
+      apiType: ProviderApiType
+    ) => {
       if (
         providers.some((e) => e.provider.toLowerCase() === name.toLowerCase())
       ) {
         toast.error(t('provider:providerAlreadyExists', { name }))
         return
       }
-      const settings = cloneDeep(openAIProviderSettings) as ProviderSetting[]
+      const template =
+        apiType === 'anthropic'
+          ? anthropicProviderSettings
+          : openAIProviderSettings
+      const settings = cloneDeep(template) as ProviderSetting[]
       for (const s of settings) {
         if (s.key === 'base-url') {
           (s.controller_props as { value: string }).value = baseUrl
@@ -59,6 +71,7 @@ const SettingsMenu = () => {
         settings,
         api_key: apiKey,
         base_url: baseUrl,
+        ...(apiType === 'anthropic' ? { api_type: 'anthropic' as const } : {}),
       }
       addProvider(newProvider)
       setTimeout(() => {

--- a/web-app/src/containers/ThreadList.tsx
+++ b/web-app/src/containers/ThreadList.tsx
@@ -75,7 +75,10 @@ const ThreadItem = memo(
           .messages()
           .fetchMessages(thread.id)
           .then((fetchedMessages) => {
-            if (fetchedMessages) {
+            // Only overwrite if the disk actually has content. A brand-new
+            // thread starts empty on disk, and racing this against the
+            // optimistic addMessage write was wiping the user message.
+            if (fetchedMessages && fetchedMessages.length > 0) {
               setMessages(thread.id, fetchedMessages)
               setLocalMessages(fetchedMessages)
               messagesLengthRef.current = fetchedMessages.length

--- a/web-app/src/containers/__tests__/ChatInput.test.tsx
+++ b/web-app/src/containers/__tests__/ChatInput.test.tsx
@@ -73,6 +73,7 @@ vi.mock('@/hooks/useModelProvider', () => ({
     selector({
       selectedModel: selectedModelOverride,
       selectedProvider: { provider: 'llamacpp' },
+      providers: [],
       selectModelProvider: vi.fn(),
       updateProvider: vi.fn(),
       getProviderByName: getProviderByNameMock,
@@ -201,6 +202,7 @@ vi.mock('@janhq/core', () => ({
 
 vi.mock('@tanstack/react-router', () => ({
   useRouter: () => ({ navigate: vi.fn() }),
+  Link: ({ children, ...props }: any) => <a {...props}>{children}</a>,
 }))
 
 vi.mock('@/i18n/react-i18next-compat', () => ({

--- a/web-app/src/containers/dialogs/AddEditAssistant.tsx
+++ b/web-app/src/containers/dialogs/AddEditAssistant.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useMemo } from 'react'
 import {
   Dialog,
   DialogContent,
@@ -8,28 +8,17 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
-import {
-  IconPlus,
-  IconTrash,
-  IconChevronDown,
-  IconMoodSmile,
-} from '@tabler/icons-react'
+import { IconMoodSmile } from '@tabler/icons-react'
 import EmojiPicker, { EmojiClickData, Theme } from 'emoji-picker-react'
 
 import { Textarea } from '@/components/ui/textarea'
-import { paramsSettings } from '@/lib/predefinedParams'
-
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
+import { type ParamDef } from '@/lib/predefinedParams'
+import { ParametersSection } from '@/containers/ParametersSection'
+import { useModelProvider } from '@/hooks/useModelProvider'
 import { useTheme } from '@/hooks/useTheme'
 import { useGeneralSetting } from '@/hooks/useGeneralSetting'
 import { AvatarEmoji } from '@/containers/AvatarEmoji'
 import { useTranslation } from '@/i18n/react-i18next-compat'
-import { cn } from '@/lib/utils'
 
 interface AddEditAssistantProps {
   open: boolean
@@ -57,9 +46,14 @@ export default function AddEditAssistant({
   )
   const { isDark } = useTheme()
   const spellCheckChatInput = useGeneralSetting((s) => s.spellCheckChatInput)
-  const [paramsKeys, setParamsKeys] = useState<string[]>([''])
-  const [paramsValues, setParamsValues] = useState<unknown[]>([''])
-  const [paramsTypes, setParamsTypes] = useState<string[]>(['string'])
+  const providers = useModelProvider((s) => s.providers)
+  const activeProviders = useMemo(
+    () => providers.filter((p) => p.active),
+    [providers]
+  )
+  const [params, setParams] = useState<Record<string, unknown>>(
+    () => initialData?.parameters ?? {}
+  )
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
   const emojiPickerRef = useRef<HTMLDivElement>(null)
   const emojiPickerTriggerRef = useRef<HTMLDivElement>(null)
@@ -96,25 +90,8 @@ export default function AddEditAssistant({
       setDescription(initialData.description)
       setInstructions(initialData.instructions)
       setShowEmojiPicker(false)
-      // setToolStepsInput(String(initialData.tool_steps ?? 20))
-
-      // Convert parameters object to arrays of keys and values
-      const keys = Object.keys(initialData.parameters || {})
-      const values = Object.values(initialData.parameters || {})
-
-      // Determine parameter types based on values
-      const types = values.map((value) => {
-        if (typeof value === 'boolean') return 'boolean'
-        if (typeof value === 'number') return 'number'
-        if (typeof value === 'object') return 'json'
-        return 'string'
-      })
-
-      setParamsKeys(keys.length > 0 ? keys : [''])
-      setParamsValues(values.length > 0 ? values : [''])
-      setParamsTypes(types.length > 0 ? types : ['string'])
+      setParams(initialData.parameters ?? {})
     } else if (open) {
-      // Add mode - reset form
       resetForm()
     }
   }, [open, editingKey, initialData])
@@ -124,85 +101,44 @@ export default function AddEditAssistant({
     setName('')
     setDescription(undefined)
     setInstructions('')
-    setParamsKeys([''])
-    setParamsValues([''])
-    setParamsTypes(['string'])
+    setParams({})
     setNameError(null)
     setShowEmojiPicker(false)
-    // setToolStepsInput('20')
   }
 
-  const handleParameterChange = (
-    index: number,
-    value: unknown,
-    field: 'key' | 'value' | 'type'
-  ) => {
-    if (field === 'key') {
-      const newKeys = [...paramsKeys]
-      newKeys[index] = value as string
-      setParamsKeys(newKeys)
-    } else if (field === 'value') {
-      const newValues = [...paramsValues]
+  const setParamValue = (key: string, value: unknown) => {
+    setParams((prev) => ({ ...prev, [key]: value }))
+  }
 
-      // Convert value based on parameter type
-      if (paramsTypes[index] === 'number' && typeof value === 'string') {
-        // Preserve raw string while typing (e.g., "0."), convert on save
-        newValues[index] = value
-      } else if (
-        paramsTypes[index] === 'boolean' &&
-        typeof value === 'boolean'
-      ) {
-        newValues[index] = value
-      } else if (paramsTypes[index] === 'json' && typeof value === 'string') {
-        try {
-          newValues[index] = value === '' ? {} : JSON.parse(value)
-        } catch {
-          // If JSON is invalid, keep as string
-          newValues[index] = value
-        }
-      } else {
-        newValues[index] = value
+  const removeParam = (key: string) => {
+    setParams((prev) => {
+      const next = { ...prev }
+      delete next[key]
+      return next
+    })
+  }
+
+  const toggleParam = (def: ParamDef) => {
+    setParams((prev) => {
+      if (def.key in prev) {
+        const next = { ...prev }
+        delete next[def.key]
+        return next
       }
-
-      setParamsValues(newValues)
-    } else {
-      const newTypes = [...paramsTypes]
-      newTypes[index] = value as string
-
-      // Reset value based on the new type
-      const newValues = [...paramsValues]
-
-      if (value === 'string') {
-        newValues[index] = ''
-      } else if (value === 'number') {
-        newValues[index] = ''
-      } else if (value === 'boolean') {
-        newValues[index] = false
-      } else if (value === 'json') {
-        newValues[index] = {}
-      }
-
-      setParamsValues(newValues)
-      setParamsTypes(newTypes)
-    }
+      return { ...prev, [def.key]: def.value }
+    })
   }
 
-  const handleAddParameter = () => {
-    setParamsKeys([...paramsKeys, ''])
-    setParamsValues([...paramsValues, ''])
-    setParamsTypes([...paramsTypes, 'string'])
+  const addManyParams = (values: Record<string, unknown>) => {
+    setParams((prev) => ({ ...prev, ...values }))
   }
 
-  const handleRemoveParameter = (index: number) => {
-    const newKeys = [...paramsKeys]
-    const newValues = [...paramsValues]
-    const newTypes = [...paramsTypes]
-    newKeys.splice(index, 1)
-    newValues.splice(index, 1)
-    newTypes.splice(index, 1)
-    setParamsKeys(newKeys.length > 0 ? newKeys : [''])
-    setParamsValues(newValues.length > 0 ? newValues : [''])
-    setParamsTypes(newTypes.length > 0 ? newTypes : ['string'])
+  const removeManyParams = (keys: string[]) => {
+    setParams((prev) => {
+      const next = { ...prev }
+      for (const k of keys) delete next[k]
+      return next
+    })
   }
 
   const handleSave = () => {
@@ -211,20 +147,6 @@ export default function AddEditAssistant({
       return
     }
     setNameError(null)
-    // Convert parameters arrays to object
-    const parameters: Record<string, unknown> = {}
-    paramsKeys.forEach((key, index) => {
-      if (!key) return
-      const value = paramsValues[index]
-      if (paramsTypes[index] === 'number') {
-        const parsed = Number(value as string)
-        parameters[key] = isNaN(parsed) ? 0 : parsed
-      } else {
-        parameters[key] = value
-      }
-    })
-
-    // const parsedToolSteps = Number(toolStepsInput)
     const assistant: Assistant = {
       avatar,
       id: initialData?.id || Math.random().toString(36).substring(7),
@@ -232,8 +154,7 @@ export default function AddEditAssistant({
       created_at: initialData?.created_at || Date.now(),
       description,
       instructions,
-      parameters: parameters || {},
-      // tool_steps: isNaN(parsedToolSteps) ? 20 : parsedToolSteps,
+      parameters: params,
     }
     onSave(assistant)
     onOpenChange(false)
@@ -353,232 +274,16 @@ export default function AddEditAssistant({
           </div>
 
           <div className="space-y-2 my-4 mt-6">
-            <div className="flex items-center justify-between">
-              <label className="text-sm">{t('common:settings')}</label>
-            </div>
-            {/* <div className="flex justify-between items-center gap-2">
-              <div className="w-full">
-                <p className="text-sm">{t('assistants:maxToolSteps')}</p>
-              </div>
-              <Input
-                value={toolStepsInput}
-                type="number"
-                min={0}
-                step="any"
-                onChange={(e) => {
-                  setToolStepsInput(e.target.value)
-                }}
-                placeholder="20"
-                className="w-18 text-right"
-              />
-            </div> */}
-          </div>
-
-          <div className="space-y-2 my-4">
-            <div className="flex items-center justify-between">
-              <label className="text-sm">
-                {t('assistants:predefinedParameters')}
-              </label>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              {Object.entries(paramsSettings).map(([key, setting]) => (
-                <div
-                  key={key}
-                  onClick={() => {
-                    // Check if parameter already exists
-                    const existingIndex = paramsKeys.findIndex(
-                      (k) => k === setting.key
-                    )
-                    if (existingIndex === -1) {
-                      // Add new parameter
-                      const newKeys = [...paramsKeys]
-                      const newValues = [...paramsValues]
-                      const newTypes = [...paramsTypes]
-
-                      // If the last param is empty, replace it, otherwise add new
-                      if (paramsKeys[paramsKeys.length - 1] === '') {
-                        newKeys[newKeys.length - 1] = setting.key
-                        newValues[newValues.length - 1] = setting.value
-                        newTypes[newTypes.length - 1] =
-                          typeof setting.value === 'boolean'
-                            ? 'boolean'
-                            : typeof setting.value === 'number'
-                              ? 'number'
-                              : 'string'
-                      } else {
-                        newKeys.push(setting.key)
-                        newValues.push(setting.value)
-                        newTypes.push(
-                          typeof setting.value === 'boolean'
-                            ? 'boolean'
-                            : typeof setting.value === 'number'
-                              ? 'number'
-                              : 'string'
-                        )
-                      }
-
-                      setParamsKeys(newKeys)
-                      setParamsValues(newValues)
-                      setParamsTypes(newTypes)
-                    }
-                  }}
-                  title={setting.description}
-                  className={cn(
-                    'text-xs bg-secondary-foreground/5 py-1 px-2 rounded-sm cursor-pointer',
-                    paramsKeys.includes(setting.key) && 'opacity-50'
-                  )}
-                >
-                  {setting.title}
-                </div>
-              ))}
-            </div>
-          </div>
-
-          <div className="space-y-2">
-            <div className="flex items-center justify-between">
-              <label className="text-sm">{t('assistants:parameters')}</label>
-              <Button
-                variant="ghost"
-                size="icon-xs"
-                onClick={handleAddParameter}
-              >
-                <IconPlus size={18} className="text-muted-foreground" />
-              </Button>
-            </div>
-
-            {paramsKeys.map((key, index) => (
-              <div key={index} className="flex items-center gap-4">
-                <div
-                  key={index}
-                  className="flex items-center flex-col sm:flex-row w-full gap-2"
-                >
-                  <Input
-                    value={key}
-                    onChange={(e) =>
-                      handleParameterChange(index, e.target.value, 'key')
-                    }
-                    placeholder={t('assistants:key')}
-                    className="w-full sm:w-24"
-                  />
-
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <div className="relative w-full sm:w-30">
-                        <Input
-                          value={
-                            paramsTypes[index].charAt(0).toUpperCase() +
-                            paramsTypes[index].slice(1)
-                          }
-                          readOnly
-                        />
-                        <IconChevronDown
-                          size={14}
-                          className="text-muted-foreground absolute right-2 top-1/2 -translate-y-1/2"
-                        />
-                      </div>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent className="w-32" align="start">
-                      <DropdownMenuItem
-                        onClick={() =>
-                          handleParameterChange(index, 'string', 'type')
-                        }
-                      >
-                        {t('assistants:stringValue')}
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={() =>
-                          handleParameterChange(index, 'number', 'type')
-                        }
-                      >
-                        {t('assistants:numberValue')}
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={() =>
-                          handleParameterChange(index, 'boolean', 'type')
-                        }
-                      >
-                        {t('assistants:booleanValue')}
-                      </DropdownMenuItem>
-                      <DropdownMenuItem
-                        onClick={() =>
-                          handleParameterChange(index, 'json', 'type')
-                        }
-                      >
-                        {t('assistants:jsonValue')}
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-
-                  {paramsTypes[index] === 'boolean' ? (
-                    <DropdownMenu>
-                      <DropdownMenuTrigger asChild>
-                        <div className="relative sm:flex-1 w-full">
-                          <Input
-                            value={
-                              paramsValues[index]
-                                ? t('assistants:trueValue')
-                                : t('assistants:falseValue')
-                            }
-                            readOnly
-                          />
-                          <IconChevronDown
-                            size={14}
-                            className="text-muted-foreground absolute right-2 top-1/2 -translate-y-1/2"
-                          />
-                        </div>
-                      </DropdownMenuTrigger>
-                      <DropdownMenuContent className="w-24" align="start">
-                        <DropdownMenuItem
-                          onClick={() =>
-                            handleParameterChange(index, true, 'value')
-                          }
-                        >
-                          {t('assistants:trueValue')}
-                        </DropdownMenuItem>
-                        <DropdownMenuItem
-                          onClick={() =>
-                            handleParameterChange(index, false, 'value')
-                          }
-                        >
-                          {t('assistants:falseValue')}
-                        </DropdownMenuItem>
-                      </DropdownMenuContent>
-                    </DropdownMenu>
-                  ) : paramsTypes[index] === 'json' ? (
-                    <Input
-                      value={
-                        typeof paramsValues[index] === 'object'
-                          ? JSON.stringify(paramsValues[index], null, 2)
-                          : paramsValues[index]?.toString() || ''
-                      }
-                      onChange={(e) =>
-                        handleParameterChange(index, e.target.value, 'value')
-                      }
-                      placeholder={t('assistants:jsonValuePlaceholder')}
-                      className="sm:flex-1 h-9 w-full"
-                    />
-                  ) : (
-                    <Input
-                      value={paramsValues[index]?.toString() || ''}
-                      onChange={(e) =>
-                        handleParameterChange(index, e.target.value, 'value')
-                      }
-                      type={paramsTypes[index] === 'number' ? 'number' : 'text'}
-                      step={paramsTypes[index] === 'number' ? 'any' : undefined}
-                      placeholder={t('assistants:value')}
-                      className="sm:flex-1 h-9 w-full"
-                    />
-                  )}
-                </div>
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  onClick={() => handleRemoveParameter(index)}
-                >
-                  <IconTrash size={18} className="text-destructive" />
-                </Button>
-              </div>
-            ))}
+            <label className="text-sm">{t('assistants:parameters')}</label>
+            <ParametersSection
+              params={params}
+              providers={activeProviders}
+              onToggle={toggleParam}
+              onChange={setParamValue}
+              onRemove={removeParam}
+              onAddMany={addManyParams}
+              onRemoveMany={removeManyParams}
+            />
           </div>
         </div>
 

--- a/web-app/src/containers/dialogs/AddProviderDialog.tsx
+++ b/web-app/src/containers/dialogs/AddProviderDialog.tsx
@@ -11,9 +11,15 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 
 interface AddProviderDialogProps {
-  onCreateProvider: (name: string, baseUrl: string, apiKey: string) => void
+  onCreateProvider: (
+    name: string,
+    baseUrl: string,
+    apiKey: string,
+    apiType: ProviderApiType
+  ) => void
   children: React.ReactNode
 }
 
@@ -27,6 +33,7 @@ export function AddProviderDialog({
   const [name, setName] = useState('')
   const [baseUrl, setBaseUrl] = useState('')
   const [apiKey, setApiKey] = useState('')
+  const [apiType, setApiType] = useState<ProviderApiType>('openai')
   const [error, setError] = useState<string | null>(null)
   const [isOpen, setIsOpen] = useState(false)
   const nameInputRef = useRef<HTMLInputElement>(null)
@@ -35,18 +42,20 @@ export function AddProviderDialog({
     setName('')
     setBaseUrl('')
     setApiKey('')
+    setApiType('openai')
     setError(null)
   }
 
   const handleCreate = () => {
     const trimmedName = name.trim()
     const trimmedBaseUrl = baseUrl.trim().replace(/\/+$/, '')
-    if (!trimmedName || !trimmedBaseUrl) return
+    const trimmedApiKey = apiKey.trim()
+    if (!trimmedName || !trimmedBaseUrl || !trimmedApiKey) return
     if (!URL_PATTERN.test(trimmedBaseUrl)) {
       setError(t('provider:invalidBaseUrl'))
       return
     }
-    onCreateProvider(trimmedName, trimmedBaseUrl, apiKey.trim())
+    onCreateProvider(trimmedName, trimmedBaseUrl, trimmedApiKey, apiType)
     reset()
     setIsOpen(false)
   }
@@ -56,7 +65,14 @@ export function AddProviderDialog({
     if (!open) reset()
   }
 
-  const canSubmit = name.trim().length > 0 && baseUrl.trim().length > 0
+  const canSubmit =
+    name.trim().length > 0 &&
+    baseUrl.trim().length > 0 &&
+    apiKey.trim().length > 0
+  const baseUrlPlaceholder =
+    apiType === 'anthropic'
+      ? t('provider:baseUrlPlaceholderAnthropic')
+      : t('provider:baseUrlPlaceholder')
 
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
@@ -80,6 +96,25 @@ export function AddProviderDialog({
             placeholder={t('provider:enterNameForProvider')}
             onKeyDown={(e) => e.stopPropagation()}
           />
+          <div className="flex flex-col gap-1.5">
+            <label className="text-xs text-muted-foreground">
+              {t('provider:apiTypeLabel')}
+            </label>
+            <RadioGroup
+              value={apiType}
+              onValueChange={(v) => setApiType(v as ProviderApiType)}
+              className="flex flex-row gap-4"
+            >
+              <label className="flex items-center gap-2 text-sm cursor-pointer">
+                <RadioGroupItem value="openai" />
+                {t('provider:apiTypeOpenAI')}
+              </label>
+              <label className="flex items-center gap-2 text-sm cursor-pointer">
+                <RadioGroupItem value="anthropic" />
+                {t('provider:apiTypeAnthropic')}
+              </label>
+            </RadioGroup>
+          </div>
           <div className="flex flex-col gap-1">
             <label className="text-xs text-muted-foreground">
               {t('provider:baseUrlLabel')}
@@ -90,7 +125,7 @@ export function AddProviderDialog({
                 setBaseUrl(e.target.value)
                 if (error) setError(null)
               }}
-              placeholder={t('provider:baseUrlPlaceholder')}
+              placeholder={baseUrlPlaceholder}
               onKeyDown={(e) => e.stopPropagation()}
             />
           </div>

--- a/web-app/src/containers/dialogs/BackendUpdater.tsx
+++ b/web-app/src/containers/dialogs/BackendUpdater.tsx
@@ -28,10 +28,13 @@ const BackendUpdater = () => {
     }
   }
 
-  // Check when the shell mounts or when the llamacpp provider is toggled on/off
+  // Check when the shell mounts or when the llamacpp provider is toggled on/off.
+  // Skipped when auto-update is disabled — users opt into checks via the manual
+  // "Check for Updates" button in provider settings.
   useEffect(() => {
+    if (!updateState.autoUpdateEnabled) return
     checkForUpdate()
-  }, [checkForUpdate, isLlamacppEnabled])
+  }, [checkForUpdate, isLlamacppEnabled, updateState.autoUpdateEnabled])
 
   const [backendUpdateState, setBackendUpdateState] = useState({
     remindMeLater: false,

--- a/web-app/src/containers/dialogs/LlamacppOomListener.tsx
+++ b/web-app/src/containers/dialogs/LlamacppOomListener.tsx
@@ -2,7 +2,28 @@ import { useEffect } from 'react'
 import { listen } from '@tauri-apps/api/event'
 
 import { useAppState } from '@/hooks/useAppState'
+import { useMessages } from '@/hooks/useMessages'
 import { isPlatformTauri } from '@/lib/platform/utils'
+
+function stampErrorOnLastUserMessage(
+  field: 'oomError' | 'backendError',
+  value: string
+) {
+  const threadId = useAppState.getState().currentStreamThreadId
+  if (!threadId) return
+  const messages = useMessages.getState().getMessages(threadId)
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const m = messages[i]
+    if (m.role !== 'user') continue
+    const meta = (m.metadata as Record<string, unknown> | undefined) ?? {}
+    if (meta[field] === value) return
+    useMessages.getState().updateMessage({
+      ...m,
+      metadata: { ...meta, [field]: value },
+    })
+    return
+  }
+}
 
 function clearActiveWork() {
   const app = useAppState.getState()
@@ -27,8 +48,10 @@ export default function LlamacppOomListener() {
   useEffect(() => {
     if (!isPlatformTauri()) return
     const unlistenOom = listen<string>('llamacpp-router-oom', (event) => {
+      const payload = event.payload ?? ''
+      stampErrorOnLastUserMessage('oomError', payload)
       clearActiveWork()
-      useAppState.getState().setOomError(event.payload ?? '')
+      useAppState.getState().setOomError(payload)
     }).catch((e) => {
       console.warn('listen llamacpp-router-oom failed:', e)
       return () => {}
@@ -36,8 +59,10 @@ export default function LlamacppOomListener() {
     const unlistenBackend = listen<string>(
       'llamacpp-router-backend-error',
       (event) => {
+        const payload = event.payload ?? ''
+        stampErrorOnLastUserMessage('backendError', payload)
         clearActiveWork()
-        useAppState.getState().setBackendError(event.payload ?? '')
+        useAppState.getState().setBackendError(payload)
       }
     ).catch((e) => {
       console.warn('listen llamacpp-router-backend-error failed:', e)

--- a/web-app/src/containers/dialogs/__tests__/AddEditAssistant.test.tsx
+++ b/web-app/src/containers/dialogs/__tests__/AddEditAssistant.test.tsx
@@ -1,6 +1,15 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import '@testing-library/jest-dom'
+
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+beforeAll(() => {
+  ;(global as any).ResizeObserver = MockResizeObserver
+})
 
 vi.mock('@/i18n/react-i18next-compat', () => ({
   useTranslation: () => ({ t: (k: string) => k }),
@@ -43,14 +52,32 @@ vi.mock('@/lib/predefinedParams', () => ({
       value: 0.7,
       title: 'Temperature',
       description: 'temp',
+      capability: 'core',
+      controllerType: 'slider',
+      controllerProps: { min: 0, max: 2, step: 0.1 },
     },
     stream: {
       key: 'stream',
       value: true,
       title: 'Stream',
       description: 'stream',
+      capability: 'client_only',
+      controllerType: 'checkbox',
+      controllerProps: {},
     },
   },
+  paramCategories: [
+    {
+      id: 'common',
+      title: 'Common',
+      paramKeys: ['temperature', 'stream'],
+      groupIds: [],
+    },
+  ],
+  paramGroups: [],
+  LLAMACPP_ONLY_PARAM_KEYS: new Set<string>(),
+  evaluateDisabled: () => ({ disabled: false }),
+  isGroupedParamKey: () => false,
 }))
 
 import AddEditAssistant from '../AddEditAssistant'
@@ -133,56 +160,6 @@ describe('AddEditAssistant', () => {
     expect(
       screen.queryByText('assistants:nameRequired')
     ).not.toBeInTheDocument()
-  })
-
-  it('adds a new empty parameter row on Add click', () => {
-    const props = baseProps()
-    render(<AddEditAssistant {...props} />)
-    const keyInputs = () =>
-      screen.getAllByPlaceholderText('assistants:key') as HTMLInputElement[]
-    expect(keyInputs()).toHaveLength(1)
-    // Plus icon button — first button with empty accessible name in params row; pick via closest
-    const addButtons = screen.getAllByRole('button')
-    // Click the "+" adjacent to predefined params heading — it's the first svg+button with no text
-    const plusBtn = addButtons.find(
-      (b) => b.querySelector('svg') && b.textContent === ''
-    )
-    expect(plusBtn).toBeTruthy()
-    fireEvent.click(plusBtn!)
-    expect(keyInputs().length).toBeGreaterThanOrEqual(2)
-  })
-
-  it('adds a predefined parameter via chip click and saves numeric conversion', () => {
-    const props = baseProps()
-    render(<AddEditAssistant {...props} />)
-    fireEvent.change(screen.getByPlaceholderText('assistants:enterName'), {
-      target: { value: 'n' },
-    })
-    fireEvent.click(screen.getByText('Temperature'))
-    // The first empty param row is replaced; key input now contains "temperature"
-    expect(screen.getByDisplayValue('temperature')).toBeInTheDocument()
-    fireEvent.click(screen.getByText('assistants:save'))
-    const saved = props.onSave.mock.calls[0][0]
-    expect(saved.parameters.temperature).toBe(0.7)
-  })
-
-  it('converts number strings via Number() on save, defaulting NaN to 0', () => {
-    const props = baseProps()
-    props.editingKey = 'a'
-    props.initialData = {
-      id: 'a',
-      name: 'A',
-      instructions: '',
-      parameters: { topk: 5 },
-      created_at: 1,
-    }
-    render(<AddEditAssistant {...props} />)
-    // Edit the number input to a non-numeric string
-    const valueInput = screen.getByDisplayValue('5') as HTMLInputElement
-    fireEvent.change(valueInput, { target: { value: 'abc' } })
-    fireEvent.click(screen.getByText('assistants:save'))
-    const saved = props.onSave.mock.calls[0][0]
-    expect(saved.parameters.topk).toBe(0)
   })
 
   it('preserves an existing id and created_at when editing', () => {

--- a/web-app/src/containers/dynamicControllerSetting/DropdownControl.tsx
+++ b/web-app/src/containers/dynamicControllerSetting/DropdownControl.tsx
@@ -25,6 +25,17 @@ export function DropdownControl({
   const isSelected =
     options.find((option) => option.value === value)?.name || value
 
+  if (options.length <= 1) {
+    return (
+      <div
+        className="text-sm text-muted-foreground px-3 py-1.5 max-w-full truncate"
+        title={String(isSelected)}
+      >
+        {isSelected}
+      </div>
+    )
+  }
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>

--- a/web-app/src/containers/dynamicControllerSetting/SliderControl.tsx
+++ b/web-app/src/containers/dynamicControllerSetting/SliderControl.tsx
@@ -11,6 +11,8 @@ interface SliderControlProps {
   min?: number
   max?: number
   step?: number
+  warnAbove?: number
+  warnBelow?: number
   id?: string
   onChange?: (value: SliderProps['defaultValue']) => void
 }
@@ -22,17 +24,22 @@ export function SliderControl({
   min = 0,
   max = 100,
   step = 1,
+  warnAbove,
+  warnBelow,
   onChange,
 }: SliderControlProps) {
-  const initialValue = Array.isArray(value) && value[0] !== undefined ? value : [min]
+  const initialValue =
+    Array.isArray(value) && value[0] !== undefined ? value : [min]
   const [currentValue, setCurrentValue] = React.useState<number[]>(initialValue)
   const [inputValue, setInputValue] = React.useState<string>(
     initialValue[0].toString()
   )
   const [inputNumber, setInputNumber] = React.useState<number>(initialValue[0])
   const isExceedingMax = inputNumber > max
+  const isInWarnBand =
+    (warnAbove !== undefined && inputNumber > warnAbove) ||
+    (warnBelow !== undefined && inputNumber < warnBelow)
 
-  // Sync with external value changes
   React.useEffect(() => {
     if (Array.isArray(value) && value[0] !== undefined) {
       setCurrentValue(value)
@@ -51,51 +58,54 @@ export function SliderControl({
   }
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = e.target.value
-    setInputValue(value)
-
-    const newValue = parseFloat(value)
-    if (!isNaN(newValue)) {
-      setInputNumber(newValue)
-      if (newValue >= min && newValue <= max) {
-        handleValueChange([newValue])
+    const v = e.target.value
+    setInputValue(v)
+    const parsed = parseFloat(v)
+    if (!isNaN(parsed)) {
+      setInputNumber(parsed)
+      if (parsed >= min && parsed <= max) {
+        handleValueChange([parsed])
       }
     }
   }
 
   return (
-    <div className="grid gap-2 pt-2">
-      <div className="flex flex-col gap-1">
-        <div className="flex items-center justify-between gap-4">
-          <div className="w-full space-y-2">
-            <Slider
-              id={key}
-              min={min}
-              max={max}
-              step={step}
-              value={currentValue}
-              onValueChange={handleValueChange}
-              className="**:[[role=slider]]:h-4 **:[[role=slider]]:w-4"
-              aria-label={title}
-            />
-            <div className="flex justify-between px-1">
-              <span className="text-xs text-muted-foreground">{min}</span>
-              <span className="text-xs text-muted-foreground">{max}</span>
-            </div>
-          </div>
-          <Input
-            className={`w-16 h-8 -mt-6 rounded-md border px-2 text-right text-xs ${
-              isExceedingMax
-                ? 'border-destructive text-destructive'
-                : 'text-muted-foreground'
-            } transition-all duration-200 ease-in-out`}
-            value={inputValue}
-            onChange={handleInputChange}
+    <div className="w-full">
+      <div className="flex items-center gap-3">
+        <div className="flex-1 min-w-0 flex items-center gap-2">
+          <span className="text-[10px] text-muted-foreground tabular-nums shrink-0">
+            {min}
+          </span>
+          <Slider
+            id={key}
+            min={min}
+            max={max}
+            step={step}
+            value={currentValue}
+            onValueChange={handleValueChange}
+            className={`flex-1 **:[[role=slider]]:h-4 **:[[role=slider]]:w-4 ${
+              isInWarnBand
+                ? '**:[[data-slot=slider-range]]:bg-amber-500'
+                : ''
+            }`}
+            aria-label={title}
           />
+          <span className="text-[10px] text-muted-foreground tabular-nums shrink-0">
+            {max}
+          </span>
         </div>
+        <Input
+          className={`w-16 h-7 shrink-0 rounded-md border px-2 text-right text-xs tabular-nums ${
+            isExceedingMax
+              ? 'border-destructive text-destructive'
+              : 'text-foreground'
+          }`}
+          value={inputValue}
+          onChange={handleInputChange}
+        />
       </div>
       {isExceedingMax && (
-        <p className="text-xs text-destructive">
+        <p className="text-xs text-destructive mt-1">
           Maximum value allowed is <span className="font-medium">{max}</span>
         </p>
       )}

--- a/web-app/src/containers/dynamicControllerSetting/index.tsx
+++ b/web-app/src/containers/dynamicControllerSetting/index.tsx
@@ -11,6 +11,8 @@ type DynamicControllerProps = {
   className?: string
   description?: string
   readonly?: boolean
+  /** Human reason the control is disabled (e.g. "Controlled by Mirostat"). */
+  disabledReason?: string
   controllerType:
     | 'input'
     | 'checkbox'
@@ -28,6 +30,8 @@ type DynamicControllerProps = {
     min?: number
     max?: number
     step?: number
+    warnAbove?: number
+    warnBelow?: number
     recommended?: string
   }
   onChange: (value: string | boolean | number) => void
@@ -37,8 +41,28 @@ export function DynamicControllerSetting({
   className,
   controllerType,
   controllerProps,
+  disabledReason,
   onChange,
 }: DynamicControllerProps) {
+  const control = renderControl(controllerType, controllerProps, className, onChange)
+  if (!disabledReason) return control
+  return (
+    <div
+      className="opacity-50 pointer-events-none select-none"
+      title={disabledReason}
+      aria-disabled
+    >
+      {control}
+    </div>
+  )
+}
+
+function renderControl(
+  controllerType: DynamicControllerProps['controllerType'],
+  controllerProps: DynamicControllerProps['controllerProps'],
+  className: string | undefined,
+  onChange: DynamicControllerProps['onChange']
+) {
   if (controllerType === 'input') {
     return (
       <InputControl
@@ -90,6 +114,8 @@ export function DynamicControllerSetting({
         min={controllerProps.min}
         max={controllerProps.max}
         step={controllerProps.step}
+        warnAbove={controllerProps.warnAbove}
+        warnBelow={controllerProps.warnBelow}
         onChange={(newValue) => newValue && onChange(newValue[0])}
       />
     )

--- a/web-app/src/hooks/__tests__/useModelProvider.test.ts
+++ b/web-app/src/hooks/__tests__/useModelProvider.test.ts
@@ -391,4 +391,48 @@ describe('useModelProvider migrations', () => {
     expect(migratedState.providers[0].base_url).toBe('https://api.mistral.ai/v1')
     expect(migratedState.providers[1].base_url).toBe('https://api.openai.com/v1')
   })
+
+  it('backfills api_type on the built-in anthropic provider (v15 → v16)', () => {
+    const persistApi = (useModelProvider as any).persist
+    const migrate = persistApi?.getOptions().migrate as
+      | ((state: unknown, version: number) => any)
+      | undefined
+
+    expect(migrate).toBeDefined()
+
+    const persistedState = {
+      providers: [
+        {
+          provider: 'anthropic',
+          models: [],
+          base_url: 'https://api.anthropic.com/v1',
+          settings: [],
+        },
+        {
+          provider: 'openai',
+          models: [],
+          base_url: 'https://api.openai.com/v1',
+          settings: [],
+        },
+        {
+          provider: 'my-anthropic-proxy',
+          models: [],
+          api_type: 'anthropic',
+          base_url: 'https://proxy.example.com/v1',
+          settings: [],
+        },
+      ],
+      selectedProvider: 'anthropic',
+      selectedModel: null,
+      deletedModels: [],
+    }
+
+    const migratedState = migrate!(persistedState, 15)
+    const [anthropic, openai, customAnthropic] = migratedState.providers
+
+    expect(anthropic.api_type).toBe('anthropic')
+    expect(openai.api_type).toBeUndefined()
+    // Pre-set api_type must round-trip untouched.
+    expect(customAnthropic.api_type).toBe('anthropic')
+  })
 })

--- a/web-app/src/hooks/useAssistant.ts
+++ b/web-app/src/hooks/useAssistant.ts
@@ -31,12 +31,7 @@ export const defaultAssistant: Assistant = {
   id: 'jan',
   name: 'Jan',
   created_at: 1747029866.542,
-  parameters: {
-    temperature: 0.7,
-    top_k: 20,
-    top_p: 0.8,
-    repeat_penalty: 1.12,
-  },
+  parameters: {},
   avatar: '👋',
   description:
     "Jan is a helpful desktop assistant that can reason through complex tasks and use tools to complete them on the user's behalf.",

--- a/web-app/src/hooks/useBackendUpdater.ts
+++ b/web-app/src/hooks/useBackendUpdater.ts
@@ -36,23 +36,13 @@ async function getCurrentBackendTypeFromSettings(
   extension: ExtensionWithSettings
 ): Promise<string> {
   const settings = await extension.getSettings?.()
-  const currentBackendSetting = settings?.find(
-    (s) => s.key === 'version_backend'
-  )
-  const currentBackend = currentBackendSetting?.controllerProps?.value as string
+  const backendSetting = settings?.find((s) => s.key === 'llamacpp_backend')
+  const currentBackendType = (
+    backendSetting?.controllerProps?.value as string | undefined
+  )?.trim()
 
-  if (!currentBackend) {
+  if (!currentBackendType) {
     throw new Error('Current backend not found')
-  }
-
-  const parts = currentBackend.split('/')
-  const currentVersionPart = parts[0]?.trim()
-  const currentBackendType = parts[1]?.trim()
-
-  if (parts.length !== 2 || !currentVersionPart || !currentBackendType) {
-    throw new Error(
-      `Invalid current backend format: "${currentBackend}". Expected "version/backendType".`
-    )
   }
 
   return currentBackendType

--- a/web-app/src/hooks/useModelProvider.ts
+++ b/web-app/src/hooks/useModelProvider.ts
@@ -176,7 +176,9 @@ export const useModelProvider = create<ModelProviderState>()(
               // the fresh extension fetch (otherwise stale recommendations
               // and stale option lists outlive the underlying setting).
               const existingValue = (
-                existingSetting?.controller_props as { value?: unknown } | undefined
+                existingSetting?.controller_props as
+                  | { value?: string | number | boolean }
+                  | undefined
               )?.value
               return {
                 ...setting,

--- a/web-app/src/hooks/useModelProvider.ts
+++ b/web-app/src/hooks/useModelProvider.ts
@@ -789,9 +789,20 @@ export const useModelProvider = create<ModelProviderState>()(
             })
           })
         }
+        if (version <= 15 && state?.providers) {
+          // Introduce `api_type` discriminant. Backfill on the built-in
+          // Anthropic provider; everything else stays undefined (defaults to
+          // 'openai' at dispatch time).
+          state.providers.forEach((provider) => {
+            if (provider.provider === 'anthropic' && !provider.api_type) {
+              provider.api_type = 'anthropic'
+            }
+          })
+        }
+
         return state
       },
-      version: 15,
+      version: 16,
     }
   )
 )

--- a/web-app/src/hooks/useModelProvider.ts
+++ b/web-app/src/hooks/useModelProvider.ts
@@ -171,11 +171,20 @@ export const useModelProvider = create<ModelProviderState>()(
                 : existingProvider?.settings?.find(
                     (x) => x.key === setting.key
                   )
+              // Only the user's `value` is carried over from existing state;
+              // metadata like `recommended` / `options` must always reflect
+              // the fresh extension fetch (otherwise stale recommendations
+              // and stale option lists outlive the underlying setting).
+              const existingValue = (
+                existingSetting?.controller_props as { value?: unknown } | undefined
+              )?.value
               return {
                 ...setting,
                 controller_props: {
                   ...setting.controller_props,
-                  ...(existingSetting?.controller_props || {}),
+                  ...(existingSetting && existingValue !== undefined
+                    ? { value: existingValue }
+                    : {}),
                 },
               }
             })

--- a/web-app/src/lib/__tests__/model-factory.test.ts
+++ b/web-app/src/lib/__tests__/model-factory.test.ts
@@ -93,6 +93,30 @@ describe('ModelFactory', () => {
       expect(model.type).toBe('anthropic')
     })
 
+    it('routes a custom provider with api_type="anthropic" through the Anthropic SDK', async () => {
+      const { createAnthropic } = await import('@ai-sdk/anthropic')
+      vi.mocked(createAnthropic).mockClear()
+      const provider: ProviderObject = {
+        provider: 'my-claude-proxy',
+        api_type: 'anthropic',
+        api_key: 'sk-proxy',
+        base_url: 'https://proxy.example.com/v1',
+        models: [],
+        settings: [],
+        active: true,
+      }
+
+      const model = await ModelFactory.createModel('claude-3-haiku', provider)
+      expect(model).toBeDefined()
+      expect(model.type).toBe('anthropic')
+      expect(createAnthropic).toHaveBeenCalledWith(
+        expect.objectContaining({
+          apiKey: 'sk-proxy',
+          baseURL: 'https://proxy.example.com/v1',
+        })
+      )
+    })
+
     it('routes google and gemini through the native @ai-sdk/google client and strips the /openai suffix', async () => {
       const { createGoogleGenerativeAI } = await import('@ai-sdk/google')
       for (const name of ['google', 'gemini'] as const) {

--- a/web-app/src/lib/ai-model.ts
+++ b/web-app/src/lib/ai-model.ts
@@ -1,5 +1,7 @@
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
+import { createAnthropic } from '@ai-sdk/anthropic'
 import type { LanguageModel } from 'ai'
+import { getProviderApiType } from '@/lib/providerCaps'
 
 /**
  * Llama.cpp timings structure from the response
@@ -96,6 +98,24 @@ export function createLanguageModel(
     return openAICompatible.languageModel(modelId, {
       metadataExtractor: llamaCppMetadataExtractor,
     })
+  }
+
+  // Anthropic-wire-format providers (built-in 'anthropic' + custom proxies)
+  // need the Anthropic SDK; openai-compatible's schema rejects Messages-API
+  // shaped streams.
+  if (getProviderApiType(provider) === 'anthropic') {
+    const headers: Record<string, string> = {}
+    if (provider.custom_header) {
+      for (const h of provider.custom_header) {
+        headers[h.header] = h.value
+      }
+    }
+    const anthropic = createAnthropic({
+      apiKey: provider.api_key ?? '',
+      baseURL: provider.base_url,
+      headers: Object.keys(headers).length > 0 ? headers : undefined,
+    })
+    return anthropic(modelId)
   }
 
   // For remote providers, use the configured base_url and api_key

--- a/web-app/src/lib/custom-chat-transport.ts
+++ b/web-app/src/lib/custom-chat-transport.ts
@@ -36,6 +36,8 @@ import { mcpOrchestrator } from '@/lib/mcp-orchestrator'
 import { isRouterModelSelectable } from '@/lib/mcp-router-model-filter'
 import { encodeAudioSentinel, parseAudioDataUrl } from '@/lib/audio-sentinel'
 import { extractFilesFromPrompt, type FileMetadata } from '@/lib/fileMetadata'
+import { isPredefinedRemoteProvider } from '@/lib/providerCaps'
+import { paramsSettings } from '@/lib/predefinedParams'
 
 export type TokenUsageCallback = (
   usage: LanguageModelUsage,
@@ -864,14 +866,18 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
 
       // Create the model before refreshing tools so the MCP orchestrator can run
       // structured LLM routing when many servers are connected.
+      const mergedParams: Record<string, unknown> = {
+        ...modelSamplingDefaults,
+        ...(inferenceParams ?? {}),
+        ...reasoningParams,
+      }
+      if (isPredefinedRemoteProvider(effectiveProviderName)) {
+        for (const key of Object.keys(paramsSettings)) delete mergedParams[key]
+      }
       this.model = await ModelFactory.createModel(
         modelId,
         updatedProvider ?? provider,
-        {
-          ...modelSamplingDefaults,
-          ...(inferenceParams ?? {}),
-          ...reasoningParams,
-        }
+        mergedParams
       )
       useAppState.getState().updateLoadingModel(false)
       useAppState.getState().updateThreadLoadingModel(threadId, false)

--- a/web-app/src/lib/custom-chat-transport.ts
+++ b/web-app/src/lib/custom-chat-transport.ts
@@ -36,7 +36,7 @@ import { mcpOrchestrator } from '@/lib/mcp-orchestrator'
 import { isRouterModelSelectable } from '@/lib/mcp-router-model-filter'
 import { encodeAudioSentinel, parseAudioDataUrl } from '@/lib/audio-sentinel'
 import { extractFilesFromPrompt, type FileMetadata } from '@/lib/fileMetadata'
-import { isPredefinedRemoteProvider } from '@/lib/providerCaps'
+import { isPredefinedRemoteProvider, getProviderApiType } from '@/lib/providerCaps'
 import { paramsSettings } from '@/lib/predefinedParams'
 
 export type TokenUsageCallback = (
@@ -897,8 +897,9 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
     // split it into separate messages so convertToModelMessages produces the
     // tool_use / tool_result pairing that the Claude API requires.
     // See: https://platform.claude.com/docs/en/agents-and-tools/tool-use/implement-tool-use#parallel-tool-use
+    const effectiveApiType = getProviderApiType(provider)
     let messagesToConvert = (() => {
-      if (effectiveProviderName !== 'anthropic') {
+      if (effectiveApiType !== 'anthropic') {
         return options.messages
       }
       return options.messages.flatMap((message) => {

--- a/web-app/src/lib/extension.ts
+++ b/web-app/src/lib/extension.ts
@@ -124,7 +124,15 @@ export class ExtensionManager {
    * Loads all registered extension.
    */
   async load() {
-    await Promise.all(this.listExtensions().map((ext) => ext.onLoad()))
+    const results = await Promise.allSettled(
+      this.listExtensions().map((ext) => ext.onLoad())
+    )
+    results.forEach((r, i) => {
+      if (r.status === 'rejected') {
+        const name = this.listExtensions()[i]?.name ?? `index ${i}`
+        console.error(`Extension onLoad failed (${name}):`, r.reason)
+      }
+    })
   }
 
   /**

--- a/web-app/src/lib/messages.ts
+++ b/web-app/src/lib/messages.ts
@@ -1,5 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { ThreadMessage, ContentType, MessageStatus } from '@janhq/core'
+import {
+  ThreadMessage,
+  ContentType,
+  MessageStatus,
+  ChatCompletionRole,
+} from '@janhq/core'
 import type { UIMessage } from '@ai-sdk/react'
 // Attachments are now handled upstream in newUserThreadContent
 
@@ -341,6 +346,50 @@ export function convertThreadMessageToUIMessage(
       createdAt: new Date(threadMessage.created_at || Date.now()),
     },
   } as UIMessage
+}
+
+export function uiMessageHasMeaningfulContent(message: {
+  parts?: any[]
+}): boolean {
+  if (!message.parts?.length) return false
+  for (const part of message.parts) {
+    if (!part || typeof part !== 'object') continue
+    if (part.type === 'text' && typeof part.text === 'string' && part.text.trim())
+      return true
+    if (
+      part.type === 'reasoning' &&
+      ((typeof part.text === 'string' && part.text.trim()) ||
+        (typeof part.reasoning === 'string' && part.reasoning.trim()))
+    )
+      return true
+    if (part.type === 'file' && part.url) return true
+    if (
+      typeof part.type === 'string' &&
+      part.type.startsWith('tool-') &&
+      (part.input !== undefined || part.args !== undefined ||
+        part.output !== undefined || part.result !== undefined)
+    )
+      return true
+  }
+  return false
+}
+
+export function threadMessageIsEmpty(message: ThreadMessage): boolean {
+  if (message.role !== ChatCompletionRole.Assistant) return false
+  const content = message.content || []
+  if (content.length === 0) return true
+  for (const c of content) {
+    if (c.type === ContentType.Text || c.type === ContentType.Reasoning) {
+      if (c.text?.value && c.text.value.trim()) return false
+    } else if (c.type === ContentType.Image && c.image_url?.url) {
+      return false
+    } else if (c.type === ContentType.InputAudio && c.input_audio?.data) {
+      return false
+    } else if (c.type === ContentType.ToolCall) {
+      return false
+    }
+  }
+  return true
 }
 
 /**

--- a/web-app/src/lib/model-factory.ts
+++ b/web-app/src/lib/model-factory.ts
@@ -62,7 +62,15 @@ import { fetch as httpFetch } from '@tauri-apps/plugin-http'
 import { hasAudioSentinel, splitAudioSentinels } from './audio-sentinel'
 import { isPlatformTauri } from '@/lib/platform/utils'
 import { providerRemoteApiKeyChain } from '@/lib/provider-api-keys'
-import { LLAMACPP_ONLY_PARAM_KEYS } from '@/lib/predefinedParams'
+import {
+  LLAMACPP_ONLY_PARAM_KEYS,
+  paramsSettings,
+} from '@/lib/predefinedParams'
+import {
+  resolveProviderCaps,
+  isModelLevelRejected,
+  getMutualExclusionDrops,
+} from '@/lib/providerCaps'
 import { useAppState } from '@/hooks/useAppState'
 
 /**
@@ -183,6 +191,46 @@ function filterParameters(
 }
 
 /**
+ * Strip sampler params the active provider doesn't accept. Built-in providers
+ * with strict capability tables (e.g. real OpenAI rejecting `top_k`) drop the
+ * unsupported keys here so the wire request never carries them. Custom/permissive
+ * providers keep everything — the user opted into an unknown OAI-compat endpoint.
+ *
+ * Unknown keys (not in paramsSettings) pass through untouched so non-sampler
+ * fields like reasoning controls aren't affected.
+ */
+function stripUnsupportedSamplers(
+  parameters: Record<string, unknown>,
+  provider: ProviderObject,
+  modelId: string
+): Record<string, unknown> {
+  const caps = resolveProviderCaps(provider)
+  const exclusionDrops = getMutualExclusionDrops(parameters, provider.provider)
+  const out: Record<string, unknown> = {}
+  for (const [k, v] of Object.entries(parameters)) {
+    if (exclusionDrops.has(k)) continue
+    if (isModelLevelRejected(k, provider.provider, modelId)) continue
+    const def = paramsSettings[k]
+    if (!def) {
+      out[k] = v
+      continue
+    }
+    if (def.capability === 'client_only') {
+      out[k] = v
+      continue
+    }
+    if (def.capability === 'core') {
+      out[k] = v
+      continue
+    }
+    if (caps.supported.has(def.capability) || caps.maybe.has(def.capability)) {
+      out[k] = v
+    }
+  }
+  return out
+}
+
+/**
  * Strip Jinja-stack-trace noise and other diagnostic prelude from upstream
  * error messages so the UI shows the human-readable cause. Examples:
  *
@@ -197,6 +245,27 @@ function filterParameters(
  *
  * Pure / no I/O so it can be exercised from tests.
  */
+/**
+ * Heuristic: does this upstream error look like "this parameter is not
+ * accepted"? Catches OpenAI's "Unsupported parameter", Anthropic's mutual
+ * exclusion, Mistral/Cohere "unknown/disallowed field" shapes, etc.
+ *
+ * Used to gate a one-shot retry with all our injected sampling params
+ * stripped — cheap recovery without parsing per-provider error grammars.
+ */
+export function isSamplingParamRejection(message: string): boolean {
+  if (typeof message !== 'string') return false
+  return (
+    /unsupported parameter/i.test(message) ||
+    /is not supported with this model/i.test(message) ||
+    /cannot both be specified|use only one/i.test(message) ||
+    /unknown field/i.test(message) ||
+    /property\s+['"`][^'"`]+['"`]\s+is unsupported/i.test(message) ||
+    /field\s+['"`][^'"`]+['"`]\s+is not allowed/i.test(message) ||
+    /unrecognized arguments?/i.test(message)
+  )
+}
+
 export function cleanUpstreamErrorMessage(raw: string): string {
   if (typeof raw !== 'string') return raw
   let msg = raw.replace(/\r\n/g, '\n').trim()
@@ -231,33 +300,41 @@ export function createCustomFetch(
   keepLlamacppOnly = false,
   onLlamacppServerError?: () => void
 ): typeof globalThis.fetch {
+  const buildBody = (
+    rawBody: Record<string, unknown>,
+    includeOurParams: boolean
+  ): Record<string, unknown> => {
+    if (!includeOurParams) {
+      decodeAudioSentinelsInBody(rawBody)
+      return rawBody
+    }
+    const normalised: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(parameters)) {
+      if (CLIENT_SIDE_PARAM_KEYS.has(key)) continue
+      if (!keepLlamacppOnly && LLAMACPP_ONLY_PARAM_KEYS.has(key)) continue
+      const targetKey = key === 'max_output_tokens' ? 'max_tokens' : key
+      normalised[targetKey] = value
+    }
+    const merged = { ...rawBody, ...normalised }
+    if (keepLlamacppOnly && merged.stream === true) {
+      merged.return_progress = true
+    }
+    // llama-server convention: max_tokens = -1 means "unlimited". Users who
+    // set max_output_tokens = 0 in assistant params mean "no cap", not
+    // "produce zero tokens" — coerce here, gated to llamacpp only because
+    // OpenAI/Anthropic reject negative values.
+    if (keepLlamacppOnly && merged.max_tokens === 0) {
+      merged.max_tokens = -1
+    }
+    decodeAudioSentinelsInBody(merged)
+    return merged
+  }
+
   return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    let rawBody: Record<string, unknown> | null = null
     if (init?.method === 'POST' || !init?.method) {
-      const body = init?.body ? JSON.parse(init.body as string) : {}
-
-      // Normalise and merge inference parameters
-      const normalised: Record<string, unknown> = {}
-      for (const [key, value] of Object.entries(parameters)) {
-        if (CLIENT_SIDE_PARAM_KEYS.has(key)) continue
-        if (!keepLlamacppOnly && LLAMACPP_ONLY_PARAM_KEYS.has(key)) continue
-        // max_output_tokens → max_tokens (OpenAI-compatible field name)
-        const targetKey = key === 'max_output_tokens' ? 'max_tokens' : key
-        normalised[targetKey] = value
-      }
-
-      const merged = { ...body, ...normalised }
-      if (keepLlamacppOnly && merged.stream === true) {
-        merged.return_progress = true
-      }
-      // llama-server convention: max_tokens = -1 means "unlimited". Users who
-      // set max_output_tokens = 0 in assistant params mean "no cap", not
-      // "produce zero tokens" — coerce here, gated to llamacpp only because
-      // OpenAI/Anthropic reject negative values.
-      if (keepLlamacppOnly && merged.max_tokens === 0) {
-        merged.max_tokens = -1
-      }
-      decodeAudioSentinelsInBody(merged)
-      init = { ...init, body: JSON.stringify(merged) }
+      rawBody = init?.body ? JSON.parse(init.body as string) : {}
+      init = { ...init, body: JSON.stringify(buildBody(rawBody!, true)) }
     }
 
     const res = await baseFetch(input, init)
@@ -302,6 +379,32 @@ export function createCustomFetch(
     }
 
     if (!innerMessage) return res
+
+    // Sampling-rejection auto-retry: when the upstream complains about an
+    // injected parameter (top_k on OpenAI, temp+top_p on Anthropic, etc.),
+    // retry once with all our injected params stripped, surface a toast so
+    // the user knows their popover knob was ignored this turn, and return
+    // the bare-body response. Only attempts when we have a captured body
+    // and the request looked like a chat completion / messages POST.
+    if (
+      rawBody &&
+      res.status >= 400 &&
+      res.status < 500 &&
+      isSamplingParamRejection(innerMessage) &&
+      Object.keys(parameters).length > 0
+    ) {
+      const bareInit = {
+        ...init,
+        body: JSON.stringify(buildBody(rawBody, false)),
+      }
+      const retry = await baseFetch(input, bareInit)
+      if (retry.ok) {
+        notifySamplingStripped(innerMessage)
+        return retry
+      }
+      // Retry also failed — fall through to surface the cleaned original error.
+    }
+
     const cleaned = cleanUpstreamErrorMessage(innerMessage)
     if (cleaned === innerMessage) return res
     const nextBody = JSON.stringify({
@@ -314,6 +417,22 @@ export function createCustomFetch(
       headers: res.headers,
     })
   }
+}
+
+let lastSamplingNoticeAt = 0
+function notifySamplingStripped(reason: string): void {
+  const now = Date.now()
+  if (now - lastSamplingNoticeAt < 3000) return
+  lastSamplingNoticeAt = now
+  void import('sonner')
+    .then(({ toast }) => {
+      toast.warning('Sampling parameters dropped', {
+        description: `${cleanUpstreamErrorMessage(reason)} — request retried without your sampling overrides. Adjust in the Sampling popover.`,
+      })
+    })
+    .catch(() => {
+      console.warn('[sampling-retry]', reason)
+    })
 }
 
 /**
@@ -486,6 +605,7 @@ export class ModelFactory {
     parameters: Record<string, unknown> = {}
   ): Promise<LanguageModel> {
     const providerName = provider.provider.toLowerCase()
+    parameters = stripUnsupportedSamplers(parameters, provider, modelId)
 
     switch (providerName) {
       case 'llamacpp':

--- a/web-app/src/lib/model-factory.ts
+++ b/web-app/src/lib/model-factory.ts
@@ -70,6 +70,7 @@ import {
   resolveProviderCaps,
   isModelLevelRejected,
   getMutualExclusionDrops,
+  getProviderApiType,
 } from '@/lib/providerCaps'
 import { useAppState } from '@/hooks/useAppState'
 
@@ -205,7 +206,11 @@ function stripUnsupportedSamplers(
   modelId: string
 ): Record<string, unknown> {
   const caps = resolveProviderCaps(provider)
-  const exclusionDrops = getMutualExclusionDrops(parameters, provider.provider)
+  const exclusionDrops = getMutualExclusionDrops(
+    parameters,
+    provider.provider,
+    getProviderApiType(provider)
+  )
   const out: Record<string, unknown> = {}
   for (const [k, v] of Object.entries(parameters)) {
     if (exclusionDrops.has(k)) continue
@@ -606,6 +611,13 @@ export class ModelFactory {
   ): Promise<LanguageModel> {
     const providerName = provider.provider.toLowerCase()
     parameters = stripUnsupportedSamplers(parameters, provider, modelId)
+
+    // Wire-format dispatch wins over name-based dispatch — custom providers
+    // pointing at Anthropic-compatible proxies (LiteLLM, Bedrock gateways)
+    // need the Anthropic SDK regardless of the user-chosen provider name.
+    if (getProviderApiType(provider) === 'anthropic' && providerName !== 'anthropic') {
+      return this.createAnthropicModel(modelId, provider, parameters)
+    }
 
     switch (providerName) {
       case 'llamacpp':

--- a/web-app/src/lib/predefinedParams.ts
+++ b/web-app/src/lib/predefinedParams.ts
@@ -1,158 +1,359 @@
-export const paramsSettings = {
+/**
+ * Sampling-parameter schema.
+ *
+ * Each ParamDef carries enough metadata for the UI to render the right
+ * widget, validate values in isolation, and reason about mutual-exclusion
+ * with other params (e.g. mirostat overrides top_k/top_p). Provider
+ * applicability is expressed through `capability`, not provider IDs, so
+ * provider-capability mapping lives in one place (resolveProviderCaps).
+ */
+
+export type ParamControllerType =
+  | 'slider'
+  | 'input'
+  | 'checkbox'
+  | 'dropdown'
+  | 'textarea'
+
+export type SamplerCap =
+  | 'core'
+  | 'penalties'
+  | 'top_k'
+  | 'min_p'
+  | 'repetition'
+  | 'mirostat'
+  | 'dry'
+  | 'xtc'
+  | 'dynatemp'
+  | 'typical_p'
+  | 'top_n_sigma'
+  | 'grammar'
+  | 'json_schema'
+  | 'ignore_eos'
+  | 'client_only'
+
+export interface ParamControllerProps {
+  min?: number
+  max?: number
+  step?: number
+  /** Values strictly greater than this render as a "warn" segment. */
+  warnAbove?: number
+  /** Values strictly less than this render as a "warn" segment. */
+  warnBelow?: number
+  placeholder?: string
+  rows?: number
+  options?: Array<{ value: number | string; name: string }>
+}
+
+export interface ParamDef {
+  key: string
+  title: string
+  description: string
+  /** Default value; type witness for the param. */
+  value: string | number | boolean
+  controllerType: ParamControllerType
+  controllerProps?: ParamControllerProps
+  /** Drives provider gating and outbound filtering. */
+  capability: SamplerCap
+  /**
+   * Returns a short human reason when this param should be disabled given
+   * the other current values (e.g. "Controlled by Mirostat"), else null.
+   */
+  disabledBy?: (vals: Record<string, unknown>) => string | null
+  /** Plain-English one-liner shown under the control. */
+  effectHint?: string
+}
+
+export const paramsSettings: Record<string, ParamDef> = {
   stream: {
     key: 'stream',
-    value: true,
     title: 'Stream',
-    description: `Enables real-time response streaming.`,
+    description: 'Enables real-time response streaming.',
+    value: true,
+    controllerType: 'checkbox',
+    capability: 'core',
   },
   max_context_tokens: {
     key: 'max_context_tokens',
-    value: 0,
     title: 'Max Context Tokens',
-    description: `Total token budget (input + output) for the model. When set (> 0), older messages are automatically trimmed or compacted to stay within this limit. Set to 0 to disable (no trimming). Common values: 4096, 8192, 16384, 32768, 128000.`,
+    description:
+      'Total token budget (input + output). Older messages are trimmed/compacted to stay within this. 0 disables trimming.',
+    value: 0,
+    controllerType: 'input',
+    controllerProps: { min: 0, step: 1 },
+    capability: 'client_only',
   },
   max_output_tokens: {
     key: 'max_output_tokens',
-    value: 2048,
     title: 'Max Output Tokens',
-    description: `Maximum number of tokens the model can generate in a single reply. Sent as max_tokens to OpenAI-compatible APIs.`,
+    description:
+      'Maximum tokens the model may generate in one reply. Sent as max_tokens to OpenAI-compatible APIs.',
+    value: 2048,
+    controllerType: 'input',
+    controllerProps: { min: 0, step: 1 },
+    capability: 'core',
   },
   auto_compact: {
     key: 'auto_compact',
-    value: false,
     title: 'Auto Compact',
-    description: `When enabled and context limit is reached, automatically summarize older messages instead of dropping them. Preserves conversation meaning while reducing token usage. Requires max_context_tokens to be set.`,
+    description:
+      'When context limit is reached, summarize older messages instead of dropping them. Requires Max Context Tokens to be set.',
+    value: false,
+    controllerType: 'checkbox',
+    capability: 'client_only',
   },
   temperature: {
     key: 'temperature',
-    value: 0.7,
     title: 'Temperature',
-    description: `Controls response randomness. Higher values produce more creative, varied responses. `,
-  },
-  frequency_penalty: {
-    key: 'frequency_penalty',
+    description: 'Controls response randomness.',
     value: 0.7,
-    title: 'Frequency Penalty',
-    description: `Reduces word repetition. Higher values encourage more varied language. Useful for creative writing and content generation.`,
-  },
-  presence_penalty: {
-    key: 'presence_penalty',
-    value: 0.7,
-    title: 'Presence Penalty',
-    description: `Encourages the model to explore new topics. Higher values help prevent the model from fixating on already-discussed subjects.`,
+    controllerType: 'slider',
+    controllerProps: { min: 0, max: 2, step: 0.05, warnAbove: 1.5 },
+    capability: 'core',
+    effectHint: 'Higher = more varied; 0 = deterministic.',
   },
   top_p: {
     key: 'top_p',
-    value: 0.95,
     title: 'Top P',
-    description: `Set probability threshold for more relevant outputs. Higher values allow more diverse word choices.`,
+    description:
+      'Nucleus sampling threshold. Higher values allow more diverse word choices.',
+    value: 0.95,
     controllerType: 'slider',
+    controllerProps: { min: 0, max: 1, step: 0.01 },
+    capability: 'core',
+    disabledBy: (v) =>
+      Number(v.temperature) === 0
+        ? 'Ignored when Temperature is 0'
+        : Number(v.mirostat) > 0
+          ? 'Controlled by Mirostat'
+          : null,
   },
   top_k: {
     key: 'top_k',
-    value: 2,
     title: 'Top K',
+    description: 'Sample from the top K most likely tokens. 0 = disabled.',
+    value: 40,
+    controllerType: 'slider',
+    controllerProps: { min: 0, max: 200, step: 1 },
+    capability: 'top_k',
+    disabledBy: (v) =>
+      Number(v.temperature) === 0
+        ? 'Ignored when Temperature is 0'
+        : Number(v.mirostat) > 0
+          ? 'Controlled by Mirostat'
+          : null,
+  },
+  min_p: {
+    key: 'min_p',
+    title: 'Min P',
+    description: 'Minimum relative probability for a token to be considered.',
+    value: 0.05,
+    controllerType: 'slider',
+    controllerProps: { min: 0, max: 1, step: 0.01 },
+    capability: 'min_p',
+    disabledBy: (v) =>
+      Number(v.mirostat) > 0 ? 'Controlled by Mirostat' : null,
+  },
+  frequency_penalty: {
+    key: 'frequency_penalty',
+    title: 'Frequency Penalty',
+    description: 'Reduces word repetition based on prior frequency.',
+    value: 0,
+    controllerType: 'slider',
+    controllerProps: { min: -2, max: 2, step: 0.05, warnAbove: 1.5 },
+    capability: 'penalties',
+  },
+  presence_penalty: {
+    key: 'presence_penalty',
+    title: 'Presence Penalty',
+    description: 'Encourages the model to introduce new topics.',
+    value: 0,
+    controllerType: 'slider',
+    controllerProps: { min: -2, max: 2, step: 0.05, warnAbove: 1.5 },
+    capability: 'penalties',
+  },
+  repeat_penalty: {
+    key: 'repeat_penalty',
+    title: 'Repeat Penalty',
     description:
-      'Number of most relevant documents to retrieve. Higher values return more results.',
+      'llama.cpp-style multiplicative penalty for repeated tokens. 1.0 = disabled.',
+    value: 1.1,
+    controllerType: 'slider',
+    controllerProps: { min: 1, max: 2, step: 0.01, warnAbove: 1.3 },
+    capability: 'repetition',
   },
   mirostat: {
     key: 'mirostat',
-    value: 0,
     title: 'Mirostat',
-    description: `Mirostat sampling mode (llama.cpp only). 0 = disabled, 1 = Mirostat v1, 2 = Mirostat v2.`,
+    description: 'Adaptive perplexity-targeting sampler.',
+    value: 0,
+    controllerType: 'dropdown',
+    controllerProps: {
+      options: [
+        { value: 0, name: 'Off' },
+        { value: 1, name: 'v1' },
+        { value: 2, name: 'v2' },
+      ],
+    },
+    capability: 'mirostat',
+    effectHint: 'When enabled, overrides Top K / Top P / Min P.',
   },
   mirostat_tau: {
     key: 'mirostat_tau',
-    value: 5.0,
     title: 'Mirostat Tau',
-    description: `Mirostat target entropy (llama.cpp only). Lower values produce more focused output.`,
+    description: 'Target entropy. Lower = more focused.',
+    value: 5.0,
+    controllerType: 'slider',
+    controllerProps: { min: 0, max: 10, step: 0.1 },
+    capability: 'mirostat',
+    disabledBy: (v) =>
+      Number(v.mirostat) === 0 ? 'Enable Mirostat to use' : null,
   },
   mirostat_eta: {
     key: 'mirostat_eta',
-    value: 0.1,
     title: 'Mirostat Eta',
-    description: `Mirostat learning rate (llama.cpp only).`,
+    description: 'Mirostat learning rate.',
+    value: 0.1,
+    controllerType: 'slider',
+    controllerProps: { min: 0, max: 1, step: 0.01 },
+    capability: 'mirostat',
+    disabledBy: (v) =>
+      Number(v.mirostat) === 0 ? 'Enable Mirostat to use' : null,
   },
   grammar: {
     key: 'grammar',
-    value: '',
     title: 'Grammar (GBNF)',
-    description: `GBNF grammar string to constrain generations (llama.cpp only). Paste the grammar contents directly.`,
+    description: 'GBNF grammar to constrain generations.',
+    value: '',
+    controllerType: 'textarea',
+    controllerProps: { rows: 4, placeholder: 'root ::= ...' },
+    capability: 'grammar',
   },
   json_schema: {
     key: 'json_schema',
-    value: '',
     title: 'JSON Schema',
-    description: `JSON schema string to constrain generations as valid JSON (llama.cpp only).`,
+    description: 'JSON schema constraining the output to valid JSON.',
+    value: '',
+    controllerType: 'textarea',
+    controllerProps: { rows: 4, placeholder: '{"type":"object", ...}' },
+    capability: 'json_schema',
   },
   typical_p: {
     key: 'typical_p',
-    value: 1.0,
     title: 'Typical P',
-    description: `Locally-typical sampling (llama.cpp only). 1.0 = disabled. Lower values bias toward tokens whose probability is close to the conditional entropy.`,
+    description: 'Locally-typical sampling. 1.0 = disabled.',
+    value: 1.0,
+    controllerType: 'slider',
+    controllerProps: { min: 0, max: 1, step: 0.01 },
+    capability: 'typical_p',
   },
   top_n_sigma: {
     key: 'top_n_sigma',
-    value: -1.0,
     title: 'Top N Sigma',
-    description: `Top-n-sigma sampling (llama.cpp only). -1 = disabled. Filters tokens by standard deviations above the max logit.`,
+    description: 'Filter by standard deviations above the max logit. -1 = off.',
+    value: -1.0,
+    controllerType: 'slider',
+    controllerProps: { min: -1, max: 10, step: 0.1 },
+    capability: 'top_n_sigma',
   },
   dynatemp_range: {
     key: 'dynatemp_range',
-    value: 0.0,
     title: 'Dynamic Temperature Range',
-    description: `Dynamic temperature range (llama.cpp only). 0 = disabled. The effective temperature is sampled in [temperature - range, temperature + range].`,
+    description:
+      'Effective temperature is sampled in [temperature - range, temperature + range]. 0 = off.',
+    value: 0.0,
+    controllerType: 'slider',
+    controllerProps: { min: 0, max: 2, step: 0.05 },
+    capability: 'dynatemp',
   },
   dynatemp_exp: {
     key: 'dynatemp_exp',
-    value: 1.0,
     title: 'Dynamic Temperature Exponent',
-    description: `Dynamic temperature exponent (llama.cpp only). Shapes the temperature distribution within the dynamic range.`,
+    description: 'Shapes the temperature distribution within the range.',
+    value: 1.0,
+    controllerType: 'slider',
+    controllerProps: { min: 0, max: 5, step: 0.1 },
+    capability: 'dynatemp',
+    disabledBy: (v) =>
+      Number(v.dynatemp_range) === 0 ? 'Set Dynamic Temperature Range > 0' : null,
   },
   xtc_probability: {
     key: 'xtc_probability',
-    value: 0.0,
     title: 'XTC Probability',
-    description: `Probability of activating the XTC (Exclude Top Choices) sampler (llama.cpp only). 0 = disabled.`,
+    description: 'Probability of activating the Exclude-Top-Choices sampler.',
+    value: 0.0,
+    controllerType: 'slider',
+    controllerProps: { min: 0, max: 1, step: 0.01 },
+    capability: 'xtc',
   },
   xtc_threshold: {
     key: 'xtc_threshold',
-    value: 0.1,
     title: 'XTC Threshold',
-    description: `Minimum probability of a token to be considered for XTC exclusion (llama.cpp only). Only used when XTC probability > 0.`,
+    description: 'Minimum token probability to be eligible for XTC exclusion.',
+    value: 0.1,
+    controllerType: 'slider',
+    controllerProps: { min: 0, max: 1, step: 0.01 },
+    capability: 'xtc',
+    disabledBy: (v) =>
+      Number(v.xtc_probability) === 0 ? 'Set XTC Probability > 0' : null,
   },
   dry_multiplier: {
     key: 'dry_multiplier',
-    value: 0.0,
     title: 'DRY Multiplier',
-    description: `DRY (Don't Repeat Yourself) penalty multiplier (llama.cpp only). 0 = disabled. Penalizes sequences that have appeared before in the context.`,
+    description:
+      "Don't-Repeat-Yourself penalty multiplier. 0 = disabled.",
+    value: 0.0,
+    controllerType: 'slider',
+    controllerProps: { min: 0, max: 5, step: 0.1 },
+    capability: 'dry',
   },
   dry_base: {
     key: 'dry_base',
-    value: 1.75,
     title: 'DRY Base',
-    description: `DRY penalty base (llama.cpp only). Exponential base for penalty growth as repeated-sequence length increases.`,
+    description: 'Exponential base for penalty growth.',
+    value: 1.75,
+    controllerType: 'slider',
+    controllerProps: { min: 1, max: 4, step: 0.05 },
+    capability: 'dry',
+    disabledBy: (v) =>
+      Number(v.dry_multiplier) === 0 ? 'Set DRY Multiplier > 0' : null,
   },
   dry_allowed_length: {
     key: 'dry_allowed_length',
-    value: 2,
     title: 'DRY Allowed Length',
-    description: `Minimum repeated-sequence length before DRY starts penalizing (llama.cpp only).`,
+    description: 'Minimum repeated-sequence length before DRY engages.',
+    value: 2,
+    controllerType: 'slider',
+    controllerProps: { min: 1, max: 20, step: 1 },
+    capability: 'dry',
+    disabledBy: (v) =>
+      Number(v.dry_multiplier) === 0 ? 'Set DRY Multiplier > 0' : null,
   },
   dry_penalty_last_n: {
     key: 'dry_penalty_last_n',
-    value: -1,
     title: 'DRY Penalty Window',
-    description: `Window of recent tokens DRY scans for repetitions (llama.cpp only). 0 = disabled, -1 = full context.`,
+    description: 'Recent-token window DRY scans. -1 = full context, 0 = off.',
+    value: -1,
+    controllerType: 'input',
+    controllerProps: { min: -1, step: 1 },
+    capability: 'dry',
+    disabledBy: (v) =>
+      Number(v.dry_multiplier) === 0 ? 'Set DRY Multiplier > 0' : null,
   },
   ignore_eos: {
     key: 'ignore_eos',
-    value: false,
     title: 'Ignore EOS',
-    description: `Continue generating past the end-of-sequence token (llama.cpp only). Useful for forcing the model to fill a token budget.`,
+    description: 'Continue past the end-of-sequence token.',
+    value: false,
+    controllerType: 'checkbox',
+    capability: 'ignore_eos',
   },
 }
 
+/**
+ * Outbound strip list for non-llamacpp providers. Kept explicit to preserve
+ * existing wire-level behavior. resolveProviderCaps owns the richer UI gating.
+ */
 export const LLAMACPP_ONLY_PARAM_KEYS: ReadonlySet<string> = new Set([
   'mirostat',
   'mirostat_tau',
@@ -170,4 +371,130 @@ export const LLAMACPP_ONLY_PARAM_KEYS: ReadonlySet<string> = new Set([
   'dry_allowed_length',
   'dry_penalty_last_n',
   'ignore_eos',
+  'min_p',
+  'repeat_penalty',
 ])
+
+export function evaluateDisabled(
+  def: ParamDef,
+  currentValues: Record<string, unknown>
+): string | null {
+  return def.disabledBy?.(currentValues) ?? null
+}
+
+/**
+ * Coupled samplers that only make sense as a unit. Adding the group writes
+ * `triggerValue` to the first member (the on/off knob) plus the defaults of
+ * the rest. Removing the group deletes every member key.
+ */
+export interface ParamGroup {
+  id: string
+  title: string
+  description: string
+  members: string[]
+  triggerKey: string
+  triggerValue: string | number | boolean
+  capability: SamplerCap
+}
+
+export const paramGroups: ParamGroup[] = [
+  {
+    id: 'mirostat',
+    title: 'Mirostat',
+    description:
+      'Adaptive perplexity-targeting sampler. Overrides Top K / Top P / Min P.',
+    members: ['mirostat', 'mirostat_tau', 'mirostat_eta'],
+    triggerKey: 'mirostat',
+    triggerValue: 1,
+    capability: 'mirostat',
+  },
+  {
+    id: 'dry',
+    title: 'DRY',
+    description: "Don't-Repeat-Yourself penalty for long repeated sequences.",
+    members: [
+      'dry_multiplier',
+      'dry_base',
+      'dry_allowed_length',
+      'dry_penalty_last_n',
+    ],
+    triggerKey: 'dry_multiplier',
+    triggerValue: 0.8,
+    capability: 'dry',
+  },
+  {
+    id: 'xtc',
+    title: 'XTC',
+    description:
+      'Exclude-Top-Choices sampler — probabilistically removes high-prob tokens.',
+    members: ['xtc_probability', 'xtc_threshold'],
+    triggerKey: 'xtc_probability',
+    triggerValue: 0.1,
+    capability: 'xtc',
+  },
+  {
+    id: 'dynatemp',
+    title: 'Dynamic Temperature',
+    description: 'Sample the effective temperature from a range around the base.',
+    members: ['dynatemp_range', 'dynatemp_exp'],
+    triggerKey: 'dynatemp_range',
+    triggerValue: 0.5,
+    capability: 'dynatemp',
+  },
+]
+
+const GROUPED_KEYS = new Set(paramGroups.flatMap((g) => g.members))
+
+/** True iff this param belongs to a coupled group (rendered as a unit). */
+export function isGroupedParamKey(key: string): boolean {
+  return GROUPED_KEYS.has(key)
+}
+
+export type ParamCategory =
+  | 'common'
+  | 'penalties'
+  | 'output'
+  | 'advanced'
+
+export interface CategoryDef {
+  id: ParamCategory
+  title: string
+  /** Standalone param keys in display order. */
+  paramKeys: string[]
+  /** Coupled groups shown as a single menu entry in this category. */
+  groupIds: string[]
+}
+
+export const paramCategories: CategoryDef[] = [
+  {
+    id: 'common',
+    title: 'Common',
+    paramKeys: ['temperature', 'top_p', 'top_k', 'min_p', 'max_output_tokens'],
+    groupIds: [],
+  },
+  {
+    id: 'penalties',
+    title: 'Penalties',
+    paramKeys: ['frequency_penalty', 'presence_penalty', 'repeat_penalty'],
+    groupIds: [],
+  },
+  {
+    id: 'output',
+    title: 'Output control',
+    paramKeys: [
+      'stream',
+      'json_schema',
+      'grammar',
+      'auto_compact',
+      'max_context_tokens',
+      'ignore_eos',
+    ],
+    groupIds: [],
+  },
+  {
+    id: 'advanced',
+    title: 'Advanced samplers',
+    paramKeys: ['typical_p', 'top_n_sigma'],
+    groupIds: ['mirostat', 'dry', 'xtc', 'dynatemp'],
+  },
+]

--- a/web-app/src/lib/providerCaps.ts
+++ b/web-app/src/lib/providerCaps.ts
@@ -158,10 +158,22 @@ const BUILTIN_CAPS: Record<string, ProviderCaps> = {
 }
 
 export function resolveProviderCaps(
-  provider: Pick<ProviderObject, 'provider'> | string
+  provider: Pick<ProviderObject, 'provider' | 'api_type'> | string
 ): ProviderCaps {
+  if (typeof provider !== 'string' && provider.api_type === 'anthropic') {
+    return ANTHROPIC
+  }
   const id = typeof provider === 'string' ? provider : provider.provider
   return BUILTIN_CAPS[id] ?? CUSTOM_PERMISSIVE
+}
+
+/** Wire format the provider speaks. Defaults to 'openai' when unset. */
+export function getProviderApiType(
+  provider: Pick<ProviderObject, 'provider' | 'api_type'> | undefined | null
+): ProviderApiType {
+  if (!provider) return 'openai'
+  if (provider.api_type) return provider.api_type
+  return provider.provider === 'anthropic' ? 'anthropic' : 'openai'
 }
 
 const LOCAL_PROVIDER_IDS = new Set<string>(['llamacpp', 'mlx'])
@@ -210,10 +222,11 @@ const GROK_NO_PENALTY_RE = /^grok-[3-9]/i
  */
 export function getMutualExclusionDrops(
   parameters: Record<string, unknown>,
-  providerId: string
+  providerId: string,
+  apiType: ProviderApiType = 'openai'
 ): Set<string> {
   const drops = new Set<string>()
-  if (providerId === 'anthropic') {
+  if (providerId === 'anthropic' || apiType === 'anthropic') {
     if ('temperature' in parameters && 'top_p' in parameters) {
       drops.add('top_p')
     }

--- a/web-app/src/lib/providerCaps.ts
+++ b/web-app/src/lib/providerCaps.ts
@@ -1,0 +1,273 @@
+import {
+  paramsSettings,
+  type ParamDef,
+  type SamplerCap,
+} from '@/lib/predefinedParams'
+
+/**
+ * Per-provider sampler capabilities. Built-in providers ship with locked
+ * base_url (see web-app/src/constants/providers.ts), so the provider ID is
+ * a reliable proxy for the underlying engine. User-added "custom" providers
+ * point at arbitrary OpenAI-compatible endpoints — we can't know what
+ * samplers they accept, so they fall through to a permissive set.
+ */
+
+export type CapabilitySupport = 'supported' | 'maybe'
+
+export interface ProviderCaps {
+  /** Forwarded as-is; UI control rendered without warning. */
+  supported: ReadonlySet<SamplerCap>
+  /** Forwarded; UI control marked with "may be ignored by this endpoint". */
+  maybe: ReadonlySet<SamplerCap>
+}
+
+const CORE_ONLY = new Set<SamplerCap>(['core', 'client_only'])
+
+const set = (...c: SamplerCap[]) =>
+  new Set<SamplerCap>([...CORE_ONLY, ...c])
+
+const OPENAI_STRICT: ProviderCaps = {
+  supported: set('penalties', 'json_schema'),
+  maybe: new Set(),
+}
+
+const ANTHROPIC: ProviderCaps = {
+  supported: set('top_k'),
+  maybe: new Set(),
+}
+
+const GOOGLE: ProviderCaps = {
+  supported: set('top_k', 'min_p', 'repetition', 'penalties'),
+  maybe: new Set(),
+}
+
+const COHERE: ProviderCaps = {
+  supported: set('top_k', 'penalties'),
+  maybe: new Set(),
+}
+
+const MISTRAL: ProviderCaps = {
+  supported: set('penalties'),
+  maybe: new Set(),
+}
+
+const GROQ: ProviderCaps = {
+  supported: set(),
+  maybe: new Set(['penalties']),
+}
+
+const OPENROUTER: ProviderCaps = {
+  supported: set('penalties', 'top_k', 'min_p', 'repetition'),
+  maybe: new Set(['typical_p']),
+}
+
+const XAI: ProviderCaps = {
+  supported: set(),
+  maybe: new Set(['penalties']),
+}
+
+const HUGGINGFACE: ProviderCaps = {
+  supported: set('penalties'),
+  maybe: new Set([
+    'top_k',
+    'min_p',
+    'repetition',
+    'typical_p',
+  ]),
+}
+
+const NVIDIA: ProviderCaps = {
+  supported: set('penalties'),
+  maybe: new Set(['top_k']),
+}
+
+const AZURE: ProviderCaps = {
+  supported: set('penalties', 'json_schema'),
+  maybe: new Set(),
+}
+
+const MINIMAX: ProviderCaps = {
+  supported: set('penalties'),
+  maybe: new Set(),
+}
+
+const LLAMACPP: ProviderCaps = {
+  supported: set(
+    'penalties',
+    'top_k',
+    'min_p',
+    'repetition',
+    'mirostat',
+    'dry',
+    'xtc',
+    'dynatemp',
+    'typical_p',
+    'top_n_sigma',
+    'grammar',
+    'json_schema',
+    'ignore_eos'
+  ),
+  maybe: new Set(),
+}
+
+const MLX: ProviderCaps = {
+  supported: set('top_k', 'repetition'),
+  maybe: new Set(),
+}
+
+/**
+ * Custom user-added providers default to permissive — the user explicitly
+ * pointed at an OpenAI-compatible endpoint of unknown shape, so showing all
+ * common samplers (marked "may be ignored") is more useful than hiding them.
+ */
+const CUSTOM_PERMISSIVE: ProviderCaps = {
+  supported: set(),
+  maybe: new Set([
+    'penalties',
+    'top_k',
+    'min_p',
+    'repetition',
+    'mirostat',
+    'dry',
+    'xtc',
+    'dynatemp',
+    'typical_p',
+    'top_n_sigma',
+    'grammar',
+    'json_schema',
+    'ignore_eos',
+  ]),
+}
+
+const BUILTIN_CAPS: Record<string, ProviderCaps> = {
+  openai: OPENAI_STRICT,
+  azure: AZURE,
+  anthropic: ANTHROPIC,
+  gemini: GOOGLE,
+  google: GOOGLE,
+  cohere: COHERE,
+  mistral: MISTRAL,
+  groq: GROQ,
+  openrouter: OPENROUTER,
+  xai: XAI,
+  huggingface: HUGGINGFACE,
+  nvidia: NVIDIA,
+  minimax: MINIMAX,
+  llamacpp: LLAMACPP,
+  mlx: MLX,
+}
+
+export function resolveProviderCaps(
+  provider: Pick<ProviderObject, 'provider'> | string
+): ProviderCaps {
+  const id = typeof provider === 'string' ? provider : provider.provider
+  return BUILTIN_CAPS[id] ?? CUSTOM_PERMISSIVE
+}
+
+/**
+ * Sampler keys that some model families reject outright even when the
+ * provider's API surface accepts them. Indexed by sampler capability — the
+ * value is a predicate against (providerId, modelId).
+ *
+ * Sources:
+ * - OpenAI/Azure reasoning families (o1, o3, o4, gpt-5*) hard-reject
+ *   temperature, top_p, frequency_penalty, presence_penalty.
+ * - xAI grok-3-mini rejects temperature/top_p; grok-3 and grok-4 reject
+ *   penalties.
+ */
+const REASONING_MODEL_RE = /^(o[1-9]|gpt-?[5-9])/i
+const GROK_NO_TEMP_RE = /^grok-3-mini/i
+const GROK_NO_PENALTY_RE = /^grok-[3-9]/i
+
+/**
+ * Sampler keys some model families reject even when the provider's API
+ * accepts them generally. Operates on param key (not capability) because
+ * reasoning models reject `temperature`/`top_p` but still accept
+ * `max_output_tokens` and `stream` — all four share capability='core'.
+ */
+/**
+ * Cross-param conflicts the provider rejects (vs single-param rejections).
+ * Returns the set of keys to drop from `parameters` to satisfy the rule.
+ * Currently:
+ *   - Anthropic forbids sending `temperature` and `top_p` together. We keep
+ *     `temperature` (the more commonly tuned of the two) and drop `top_p`.
+ */
+export function getMutualExclusionDrops(
+  parameters: Record<string, unknown>,
+  providerId: string
+): Set<string> {
+  const drops = new Set<string>()
+  if (providerId === 'anthropic') {
+    if ('temperature' in parameters && 'top_p' in parameters) {
+      drops.add('top_p')
+    }
+  }
+  return drops
+}
+
+export function isModelLevelRejected(
+  paramKey: string,
+  providerId: string,
+  modelId: string
+): boolean {
+  if (providerId === 'openai' || providerId === 'azure') {
+    if (REASONING_MODEL_RE.test(modelId)) {
+      return (
+        paramKey === 'temperature' ||
+        paramKey === 'top_p' ||
+        paramKey === 'frequency_penalty' ||
+        paramKey === 'presence_penalty'
+      )
+    }
+    return false
+  }
+  if (providerId === 'xai') {
+    if (
+      GROK_NO_TEMP_RE.test(modelId) &&
+      (paramKey === 'temperature' || paramKey === 'top_p')
+    )
+      return true
+    if (
+      GROK_NO_PENALTY_RE.test(modelId) &&
+      (paramKey === 'frequency_penalty' || paramKey === 'presence_penalty')
+    )
+      return true
+    return false
+  }
+  return false
+}
+
+export interface ParamSupportEntry {
+  def: ParamDef
+  /** Providers (by ID) that fully support this param. */
+  supportedBy: string[]
+  /** Providers (by ID) that may silently ignore it. */
+  maybeBy: string[]
+}
+
+/**
+ * Union of params across the given providers. Each entry records which
+ * providers support vs. may-ignore the param so the UI can render a tooltip.
+ * A param is included iff at least one provider lists it as supported or maybe.
+ */
+export function paramsForProviders(
+  providers: Array<Pick<ProviderObject, 'provider'>>
+): ParamSupportEntry[] {
+  const entries: ParamSupportEntry[] = []
+  for (const def of Object.values(paramsSettings)) {
+    if (def.capability === 'client_only') {
+      entries.push({ def, supportedBy: providers.map((p) => p.provider), maybeBy: [] })
+      continue
+    }
+    const supportedBy: string[] = []
+    const maybeBy: string[] = []
+    for (const p of providers) {
+      const caps = resolveProviderCaps(p)
+      if (caps.supported.has(def.capability)) supportedBy.push(p.provider)
+      else if (caps.maybe.has(def.capability)) maybeBy.push(p.provider)
+    }
+    if (supportedBy.length + maybeBy.length === 0) continue
+    entries.push({ def, supportedBy, maybeBy })
+  }
+  return entries
+}

--- a/web-app/src/lib/providerCaps.ts
+++ b/web-app/src/lib/providerCaps.ts
@@ -164,6 +164,22 @@ export function resolveProviderCaps(
   return BUILTIN_CAPS[id] ?? CUSTOM_PERMISSIVE
 }
 
+const LOCAL_PROVIDER_IDS = new Set<string>(['llamacpp', 'mlx'])
+
+/**
+ * Predefined remote providers ship locked base_urls and expose only a fixed
+ * sampling surface — exposing the in-app sampler UI for them invites silent
+ * 400s. Local engines and user-added custom OpenAI-compatible providers keep
+ * the sampler UI.
+ */
+export function isPredefinedRemoteProvider(
+  provider: Pick<ProviderObject, 'provider'> | string | undefined
+): boolean {
+  if (!provider) return false
+  const id = typeof provider === 'string' ? provider : provider.provider
+  return id in BUILTIN_CAPS && !LOCAL_PROVIDER_IDS.has(id)
+}
+
 /**
  * Sampler keys that some model families reject outright even when the
  * provider's API surface accepts them. Indexed by sampler capability — the

--- a/web-app/src/locales/en/provider.json
+++ b/web-app/src/locales/en/provider.json
@@ -1,10 +1,14 @@
 {
   "addProvider": "Add Provider",
-  "addOpenAIProvider": "Add OpenAI-compatible Provider",
+  "addOpenAIProvider": "Add Custom Provider",
   "enterNameForProvider": "Provider name (e.g. my-llm-server)",
+  "apiTypeLabel": "API format",
+  "apiTypeOpenAI": "OpenAI-compatible",
+  "apiTypeAnthropic": "Anthropic-compatible",
   "baseUrlLabel": "Base URL",
   "baseUrlPlaceholder": "https://your-endpoint/v1",
-  "apiKeyLabel": "API key (optional)",
+  "baseUrlPlaceholderAnthropic": "https://api.anthropic.com/v1",
+  "apiKeyLabel": "API key",
   "apiKeyPlaceholder": "Paste your API key",
   "invalidBaseUrl": "Base URL must be a valid http(s) URL"
 }

--- a/web-app/src/providers/ExtensionProvider.tsx
+++ b/web-app/src/providers/ExtensionProvider.tsx
@@ -35,11 +35,17 @@ export function ExtensionProvider({ children }: PropsWithChildren) {
       return
     }
 
-    // Register extensions - same pattern for both platforms
-    await ExtensionManager.getInstance()
-      .registerActive()
-      .then(() => ExtensionManager.getInstance().load())
-      .then(() => setFinishedSetup(true))
+    // Register extensions - same pattern for both platforms.
+    // Always finish setup even if registration/load throws so a single
+    // faulty extension can't gate the entire UI.
+    try {
+      await ExtensionManager.getInstance().registerActive()
+      await ExtensionManager.getInstance().load()
+    } catch (e) {
+      console.error('Extension setup failed:', e)
+    } finally {
+      setFinishedSetup(true)
+    }
   }, [])
 
   useEffect(() => {

--- a/web-app/src/providers/GlobalEventHandler.tsx
+++ b/web-app/src/providers/GlobalEventHandler.tsx
@@ -53,13 +53,13 @@ export function GlobalEventHandler() {
     }) => {
       console.log('Global settingsChanged event:', event)
 
-      // Handle version_backend changes specifically
-      if (event.key === 'version_backend') {
+      if (
+        event.key === 'llamacpp_version' ||
+        event.key === 'llamacpp_backend'
+      ) {
         try {
-          // Refresh providers to get updated settings from the extension
           const updatedProviders = await serviceHub.providers().getProviders()
           setProviders(updatedProviders)
-          console.log('Providers refreshed after version_backend change')
         } catch (error) {
           console.error(
             'Failed to refresh providers after settingsChanged:',

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -150,11 +150,13 @@ function ProviderDetail() {
   ])
 
   // Check if llamacpp/mlx provider needs backend configuration
+  const isBackendKey = (k: string) =>
+    k === 'llamacpp_version' || k === 'llamacpp_backend'
   const needsBackendConfig =
     (provider?.provider === 'llamacpp' || provider?.provider === 'mlx') &&
     provider.settings?.some(
       (setting) =>
-        setting.key === 'version_backend' &&
+        isBackendKey(setting.key) &&
         (setting.controller_props.value === 'none' ||
           setting.controller_props.value === '' ||
           !setting.controller_props.value)
@@ -795,8 +797,7 @@ function ProviderDetail() {
                   // Use the DynamicController component
                   const actionComponent = (
                     <div className="mt-2">
-                      {needsBackendConfig &&
-                      setting.key === 'version_backend' ? (
+                      {needsBackendConfig && isBackendKey(setting.key) ? (
                         <div className="flex items-center gap-1 text-sm">
                           <IconLoader size={16} className="animate-spin" />
                           <span>loading</span>
@@ -836,8 +837,8 @@ function ProviderDetail() {
                                 updateObj.base_url = newValue
                               }
 
-                              // Reset device setting to empty when backend version changes
-                              if (settingKey === 'version_backend') {
+                              // Reset device setting to empty when backend or version changes
+                              if (isBackendKey(settingKey)) {
                                 const deviceSettingIndex =
                                   newSettings.findIndex(
                                     (s) => s.key === 'device'
@@ -918,19 +919,16 @@ function ProviderDetail() {
                               ),
                             }}
                           />
-                          {setting.key === 'version_backend' &&
+                          {setting.key === 'llamacpp_backend' &&
                             setting.controller_props?.recommended && (
                               <div className="mt-1 text-sm text-muted-foreground">
                                 <span className="font-medium">
-                                  {setting.controller_props.recommended
-                                    ?.split('/')
-                                    .pop() ||
-                                    setting.controller_props.recommended}
+                                  {setting.controller_props.recommended}
                                 </span>
                                 <span> is the recommended backend.</span>
                               </div>
                             )}
-                          {setting.key === 'version_backend' &&
+                          {setting.key === 'llamacpp_backend' &&
                             (provider?.provider === 'llamacpp' ||
                               provider?.provider === 'mlx') && (
                               <div className="mt-2 flex flex-wrap gap-2">

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -657,16 +657,26 @@ function ProviderDetail() {
 
     setIsInstallingBackend(true)
     try {
-      // Open file dialog with filter for .tar.gz and .zip files
+      // macOS NSOpenPanel maps filter strings to UTTypes via
+      // typeWithFilenameExtension:, which only accepts single-component
+      // extensions. `.tar.gz` resolves to org.gnu.gnu-zip-tar-archive,
+      // which is a sibling — not a child — of `.gz`'s UTType, so neither
+      // a `tar.gz` nor `gz` filter enables `.tar.gz` files in the picker.
+      // Skip the filter on macOS and revalidate after the pick.
+      const isMac =
+        typeof navigator !== 'undefined' &&
+        navigator.userAgent.toUpperCase().includes('MAC')
       const selectedFile = await serviceHub.dialog().open({
         multiple: false,
         directory: false,
-        filters: [
-          {
-            name: 'Backend Archives',
-            extensions: ['tar.gz', 'zip', 'gz'],
-          },
-        ],
+        filters: isMac
+          ? undefined
+          : [
+              {
+                name: 'Backend Archives',
+                extensions: ['tar.gz', 'zip'],
+              },
+            ],
       })
 
       if (selectedFile && typeof selectedFile === 'string') {

--- a/web-app/src/routes/settings/providers/__tests__/$providerName.test.tsx
+++ b/web-app/src/routes/settings/providers/__tests__/$providerName.test.tsx
@@ -47,11 +47,18 @@ const h = vi.hoisted(() => {
     ],
     settings: [
       {
-        key: 'version_backend',
-        title: 'Backend',
-        description: 'Backend version',
+        key: 'llamacpp_version',
+        title: 'Version',
+        description: 'llama.cpp release version',
         controller_type: 'input',
-        controller_props: { value: 'v1', recommended: 'cuda/v1' },
+        controller_props: { value: 'v1', recommended: 'v1' },
+      },
+      {
+        key: 'llamacpp_backend',
+        title: 'Backend',
+        description: 'Hardware backend',
+        controller_type: 'input',
+        controller_props: { value: 'cuda', recommended: 'cuda' },
       },
       {
         key: 'device',
@@ -792,12 +799,12 @@ describe('ProviderDetail route', () => {
       )
     })
 
-    it('for llamacpp, the version_backend control also stops all running models on change', async () => {
+    it('for llamacpp, the llamacpp_version control also stops all running models on change', async () => {
       h.params.providerName = 'llamacpp'
       renderComponent()
       const dyns = screen.getAllByTestId('dynamic-ctrl')
       await act(async () => {
-        fireEvent.click(dyns[0]) // version_backend
+        fireEvent.click(dyns[0]) // llamacpp_version
       })
       expect(h.modelsSvc.stopAllModels).toHaveBeenCalled()
     })

--- a/web-app/src/routes/settings/providers/index.tsx
+++ b/web-app/src/routes/settings/providers/index.tsx
@@ -13,7 +13,10 @@ import ProvidersAvatar from '@/containers/ProvidersAvatar'
 import { AddProviderDialog } from '@/containers/dialogs'
 import { Switch } from '@/components/ui/switch'
 import { useCallback } from 'react'
-import { openAIProviderSettings } from '@/constants/providers'
+import {
+  openAIProviderSettings,
+  anthropicProviderSettings,
+} from '@/constants/providers'
 import cloneDeep from 'lodash/cloneDeep'
 import { toast } from 'sonner'
 import { useServiceHub } from '@/hooks/useServiceHub'
@@ -30,14 +33,23 @@ function ModelProviders() {
   const navigate = useNavigate()
 
   const createProvider = useCallback(
-    (name: string, baseUrl: string, apiKey: string) => {
+    (
+      name: string,
+      baseUrl: string,
+      apiKey: string,
+      apiType: ProviderApiType
+    ) => {
       if (
         providers.some((e) => e.provider.toLowerCase() === name.toLowerCase())
       ) {
         toast.error(t('providerAlreadyExists', { name }))
         return
       }
-      const settings = cloneDeep(openAIProviderSettings) as ProviderSetting[]
+      const template =
+        apiType === 'anthropic'
+          ? anthropicProviderSettings
+          : openAIProviderSettings
+      const settings = cloneDeep(template) as ProviderSetting[]
       for (const s of settings) {
         if (s.key === 'base-url') {
           (s.controller_props as { value: string }).value = baseUrl
@@ -52,6 +64,7 @@ function ModelProviders() {
         settings,
         api_key: apiKey,
         base_url: baseUrl,
+        ...(apiType === 'anthropic' ? { api_type: 'anthropic' as const } : {}),
       }
       addProvider(newProvider)
       setTimeout(() => {

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -1165,7 +1165,7 @@ function ThreadDetail() {
 
   // Persist whenever the user message lands in useMessages — covers the race
   // where the stamping effect ran before addMessage's commit was observable.
-  const localThreadMessages = useMessages((s) => s.messages[threadId])
+  const localThreadMessages = useMessages((s) => s.messages?.[threadId])
   const errorEntries = useMessageErrors((s) => s.errors)
   useEffect(() => {
     if (!localThreadMessages) return

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -9,6 +9,7 @@ import { useShallow } from 'zustand/react/shallow'
 import { MessageItem } from '@/containers/MessageItem'
 
 import { useMessages } from '@/hooks/useMessages'
+import { useMessageErrors } from '@/stores/message-errors'
 import { useServiceHub } from '@/hooks/useServiceHub'
 import { useTools } from '@/hooks/useTools'
 import { useAppState } from '@/hooks/useAppState'
@@ -275,14 +276,13 @@ function ThreadDetail() {
           addMessage(assistantMessage)
         }
 
-        // A successful assistant turn clears any sticky error on prior user
-        // messages — the conversation has moved forward.
         for (const m of existingMessages) {
           const meta = m.metadata as Record<string, unknown> | undefined
           if (meta?.error) {
             const { error: _drop, ...rest } = meta
             updateMessage({ ...m, metadata: rest })
           }
+          useMessageErrors.getState().clearError(m.id)
         }
       }
 
@@ -589,6 +589,16 @@ function ThreadDetail() {
           }
 
           setMessages(threadId, messagesToSet)
+
+          const hydrated: Record<string, string> = {}
+          for (const m of messagesToSet) {
+            const err = (m.metadata as Record<string, unknown> | undefined)
+              ?.error
+            if (typeof err === 'string' && err.length > 0) {
+              hydrated[m.id] = err
+            }
+          }
+          useMessageErrors.getState().hydrate(hydrated)
 
           const uiMessages = convertThreadMessagesToUIMessages(messagesToSet)
           setChatMessages(uiMessages)
@@ -914,6 +924,7 @@ function ThreadDetail() {
         metadata: cleanedMeta,
       }
       updateMessage(updatedMessage)
+      useMessageErrors.getState().clearError(messageId)
 
       // Update chat messages for UI
       const updatedChatMessages = chatMessages.map((msg) => {
@@ -953,6 +964,7 @@ function ThreadDetail() {
   const handleDeleteMessage = useCallback(
     (messageId: string) => {
       deleteMessage(threadId, messageId)
+      useMessageErrors.getState().clearError(messageId)
 
       // Update chat messages for UI
       const updatedChatMessages = chatMessages.filter(
@@ -1119,31 +1131,54 @@ function ThreadDetail() {
     }
   }, [status, threadId])
 
-  // Stamp the last user message with the error so it survives reload and
-  // navigation. Cleared on the next successful assistant onFinish, or when
-  // the user edits that message.
+  // Source the user id from chatMessages — useMessages may not have it yet
+  // when the transport rejects on the same tick as addMessage.
   useEffect(() => {
-    if (status !== 'error' || !error) return
-    const messages = useMessages.getState().getMessages(threadId)
-    let lastUserIndex = -1
-    for (let i = messages.length - 1; i >= 0; i--) {
-      if (messages[i].role === ChatCompletionRole.User) {
-        lastUserIndex = i
+    if (!error) return
+    let lastUserId: string | undefined
+    for (let i = chatMessages.length - 1; i >= 0; i--) {
+      if (chatMessages[i].role === 'user') {
+        lastUserId = chatMessages[i].id
         break
       }
     }
-    if (lastUserIndex === -1) return
-    const target = messages[lastUserIndex]
+    if (!lastUserId) return
     const errMessage =
       error instanceof Error ? error.message : String(error || 'Error')
-    const existingError = (target.metadata as Record<string, unknown> | undefined)
-      ?.error
-    if (existingError === errMessage) return
-    updateMessage({
-      ...target,
-      metadata: { ...(target.metadata || {}), error: errMessage },
-    })
-  }, [status, error, threadId, updateMessage])
+    useMessageErrors.getState().setError(lastUserId, errMessage)
+    const tm = useMessages.getState().getMessages(threadId).find(
+      (m) => m.id === lastUserId
+    )
+    if (tm) {
+      const existingError = (tm.metadata as Record<string, unknown> | undefined)
+        ?.error
+      if (existingError !== errMessage) {
+        updateMessage({
+          ...tm,
+          metadata: { ...(tm.metadata || {}), error: errMessage },
+        })
+      }
+    }
+  }, [status, error, threadId, chatMessages, updateMessage])
+
+  // Persist whenever the user message lands in useMessages — covers the race
+  // where the stamping effect ran before addMessage's commit was observable.
+  const localThreadMessages = useMessages((s) => s.messages[threadId])
+  const errorEntries = useMessageErrors((s) => s.errors)
+  useEffect(() => {
+    if (!localThreadMessages) return
+    for (const m of localThreadMessages) {
+      const err = errorEntries[m.id]
+      if (typeof err !== 'string' || !err) continue
+      const existing = (m.metadata as Record<string, unknown> | undefined)
+        ?.error
+      if (existing === err) continue
+      updateMessage({
+        ...m,
+        metadata: { ...(m.metadata || {}), error: err },
+      })
+    }
+  }, [localThreadMessages, errorEntries, updateMessage])
 
   // Clear the queue when navigating away from this thread
   useEffect(() => {
@@ -1224,7 +1259,7 @@ function ThreadDetail() {
                   {!lastIsAssistant && <PromptProgress />}
                 </div>
               )}
-              {(error || contextLimitError || oomError || backendError) && (
+              {(contextLimitError || oomError || backendError) && (
                 <div className="px-4 py-3 mx-4 my-2 rounded-lg border border-destructive/10 bg-destructive/10">
                   <div className="flex items-start gap-3">
                     <IconAlertCircle className="size-5 text-destructive shrink-0 mt-0.5" />
@@ -1246,7 +1281,7 @@ function ThreadDetail() {
                           }
                           style={{ wordWrap: 'break-word' }}
                         >
-                          {oomError ?? backendError ?? (error ?? contextLimitError)?.message}
+                          {oomError ?? backendError ?? contextLimitError?.message}
                         </span>
                       </div>
                       {oomError && (

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -279,7 +279,8 @@ function ThreadDetail() {
         for (const m of existingMessages) {
           const meta = m.metadata as Record<string, unknown> | undefined
           if (meta?.error) {
-            const { error: _drop, ...rest } = meta
+            const rest = { ...meta }
+            delete rest.error
             updateMessage({ ...m, metadata: rest })
           }
           useMessageErrors.getState().clearError(m.id)
@@ -912,7 +913,8 @@ function ThreadDetail() {
         string,
         unknown
       >
-      const { error: _droppedError, ...cleanedMeta } = priorMeta
+      const cleanedMeta = { ...priorMeta }
+      delete cleanedMeta.error
       const updatedMessage = {
         ...originalMessage,
         content: [

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -617,6 +617,24 @@ function ThreadDetail() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  // Resync the OOM/backend banner from message metadata on every thread switch.
+  // Persisted by LlamacppOomListener at error time; unset state when this
+  // thread carries no such metadata so the banner doesn't leak across threads.
+  const threadMessagesForBanner = useMessages((s) => s.messages?.[threadId])
+  useEffect(() => {
+    let oom: string | undefined
+    let be: string | undefined
+    for (const m of threadMessagesForBanner ?? []) {
+      const meta = m.metadata as Record<string, unknown> | undefined
+      const o = meta?.oomError
+      if (typeof o === 'string' && o.length > 0) oom = o
+      const b = meta?.backendError
+      if (typeof b === 'string' && b.length > 0) be = b
+    }
+    useAppState.getState().setOomError(oom)
+    useAppState.getState().setBackendError(be)
+  }, [threadId, threadMessagesForBanner])
+
   // Consolidated function to process and send a message
   const processAndSendMessage = useCallback(
     async (
@@ -829,6 +847,19 @@ function ThreadDetail() {
     }
   }, [threadId, processAndSendMessage])
 
+  const stripBannerMetadata = useCallback(() => {
+    const tmsgs = useMessages.getState().getMessages(threadId)
+    for (const m of tmsgs) {
+      const meta = m.metadata as Record<string, unknown> | undefined
+      if (!meta) continue
+      if (meta.oomError == null && meta.backendError == null) continue
+      const nextMeta = { ...meta }
+      delete nextMeta.oomError
+      delete nextMeta.backendError
+      updateMessage({ ...m, metadata: nextMeta })
+    }
+  }, [threadId, updateMessage])
+
   // Handle submit from ChatInput
   const handleSubmit = useCallback(
     async (
@@ -837,21 +868,33 @@ function ThreadDetail() {
     ) => {
       if (oomError) setOomError(undefined)
       if (backendError) setBackendError(undefined)
+      if (oomError || backendError) stripBannerMetadata()
       await processAndSendMessage(text, files)
     },
-    [processAndSendMessage, oomError, setOomError, backendError, setBackendError]
+    [
+      processAndSendMessage,
+      oomError,
+      setOomError,
+      backendError,
+      setBackendError,
+      stripBannerMetadata,
+    ]
   )
 
   // Handle regenerate from any message (user or assistant)
   // - For user messages: keeps the user message, deletes all after, regenerates assistant response
   // - For assistant messages: finds the closest preceding user message, deletes from there
   const handleRegenerate = useCallback((messageId?: string) => {
+    const hadBannerError =
+      useAppState.getState().oomError != null ||
+      useAppState.getState().backendError != null
     if (useAppState.getState().oomError) {
       useAppState.getState().setOomError(undefined)
     }
     if (useAppState.getState().backendError) {
       useAppState.getState().setBackendError(undefined)
     }
+    if (hadBannerError) stripBannerMetadata()
     // Cancel any in-flight title summarization before regenerating
     titleAbortRef.current?.abort()
     titleAbortRef.current = null
@@ -895,7 +938,7 @@ function ThreadDetail() {
     // Call the AI SDK regenerate function - it will handle truncating the UI messages
     // and generating a new response from the selected message
     regenerate(messageId ? { messageId } : undefined)
-  }, [threadId, deleteMessage, regenerate])
+  }, [threadId, deleteMessage, regenerate, stripBannerMetadata])
 
   // Handle edit message - updates the message and regenerates from it
   const handleEditMessage = useCallback(

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -156,10 +156,17 @@ function ThreadDetail() {
   const [processingEmbeddings, setProcessingEmbeddings] = useState(false)
 
   // Refs so onFinish (captured in closure) always calls the latest callbacks
-  const oomError = useAppState((s) => s.oomError)
+  const oomErrorRaw = useAppState((s) => s.oomError)
   const setOomError = useAppState((s) => s.setOomError)
-  const backendError = useAppState((s) => s.backendError)
+  const backendErrorRaw = useAppState((s) => s.backendError)
   const setBackendError = useAppState((s) => s.setBackendError)
+
+  // These signals come from the llamacpp router via global Tauri events.
+  // Mask them when the active provider isn't llamacpp so a router crash
+  // doesn't decorate chats running against MLX / OpenAI / Anthropic / etc.
+  const isLlamacppActive = selectedProvider === 'llamacpp'
+  const oomError = isLlamacppActive ? oomErrorRaw : undefined
+  const backendError = isLlamacppActive ? backendErrorRaw : undefined
 
   const handleContextSizeIncreaseRef = useRef<(() => void) | null>(null)
   const setContinueFromContentRef = useRef<((content: string) => void) | null>(

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -28,6 +28,8 @@ import { useChatSessions } from '@/stores/chat-session-store'
 import {
   convertThreadMessagesToUIMessages,
   extractContentPartsFromUIMessage,
+  uiMessageHasMeaningfulContent,
+  threadMessageIsEmpty,
 } from '@/lib/messages'
 import { newUserThreadContent } from '@/lib/completion'
 import {
@@ -238,38 +240,48 @@ function ThreadDetail() {
       // Persist assistant message to backend (skip if aborted).
       // For continuations, message.parts already contains partial + new content
       // because the stream wrapper prepended the partial text as the first delta.
-      if (!isAbort && message.role === 'assistant') {
+      if (
+        !isAbort &&
+        message.role === 'assistant' &&
+        uiMessageHasMeaningfulContent(message)
+      ) {
         const contentParts = extractContentPartsFromUIMessage(message)
+        const messageMetadata = (message.metadata || {}) as Record<
+          string,
+          unknown
+        >
 
-        if (contentParts.length > 0) {
-          const messageMetadata = (message.metadata || {}) as Record<
-            string,
-            unknown
-          >
+        const assistantMessage: ThreadMessage = {
+          type: 'text',
+          role: ChatCompletionRole.Assistant,
+          content: contentParts,
+          id: message.id,
+          object: 'thread.message',
+          thread_id: threadId,
+          status: MessageStatus.Ready,
+          created_at: Date.now(),
+          completed_at: Date.now(),
+          metadata: messageMetadata,
+        }
 
-          const assistantMessage: ThreadMessage = {
-            type: 'text',
-            role: ChatCompletionRole.Assistant,
-            content: contentParts,
-            id: message.id,
-            object: 'thread.message',
-            thread_id: threadId,
-            status: MessageStatus.Ready,
-            created_at: Date.now(),
-            completed_at: Date.now(),
-            metadata: messageMetadata,
-          }
+        const existingMessages = useMessages.getState().getMessages(threadId)
+        const existingMessage = existingMessages.find(
+          (m) => m.id === message.id
+        )
 
-          // Check if message with this ID already exists (onFinish can be called multiple times)
-          const existingMessages = useMessages.getState().getMessages(threadId)
-          const existingMessage = existingMessages.find(
-            (m) => m.id === message.id
-          )
+        if (existingMessage) {
+          updateMessage(assistantMessage)
+        } else {
+          addMessage(assistantMessage)
+        }
 
-          if (existingMessage) {
-            updateMessage(assistantMessage)
-          } else {
-            addMessage(assistantMessage)
+        // A successful assistant turn clears any sticky error on prior user
+        // messages — the conversation has moved forward.
+        for (const m of existingMessages) {
+          const meta = m.metadata as Record<string, unknown> | undefined
+          if (meta?.error) {
+            const { error: _drop, ...rest } = meta
+            updateMessage({ ...m, metadata: rest })
           }
         }
       }
@@ -561,10 +573,23 @@ function ThreadDetail() {
             }
           }
 
-          // Update the legacy store
+          // Drop and delete any persisted empty assistant rows produced by
+          // the old bug where errored generations were written as empty-text
+          // messages. Lossless cleanup — these carry no information.
+          const emptyAssistantIds = messagesToSet
+            .filter(threadMessageIsEmpty)
+            .map((m) => m.id)
+          if (emptyAssistantIds.length > 0) {
+            messagesToSet = messagesToSet.filter(
+              (m) => !emptyAssistantIds.includes(m.id)
+            )
+            for (const id of emptyAssistantIds) {
+              deleteMessage(threadId, id)
+            }
+          }
+
           setMessages(threadId, messagesToSet)
 
-          // Convert and set messages for AI SDK chat
           const uiMessages = convertThreadMessagesToUIMessages(messagesToSet)
           setChatMessages(uiMessages)
           currentThread.current = threadId
@@ -873,7 +898,11 @@ function ThreadDetail() {
 
       const originalMessage = currentLocalMessages[messageIndex]
 
-      // Update the message content
+      const priorMeta = (originalMessage.metadata || {}) as Record<
+        string,
+        unknown
+      >
+      const { error: _droppedError, ...cleanedMeta } = priorMeta
       const updatedMessage = {
         ...originalMessage,
         content: [
@@ -882,6 +911,7 @@ function ThreadDetail() {
             text: { value: newText, annotations: [] },
           },
         ],
+        metadata: cleanedMeta,
       }
       updateMessage(updatedMessage)
 
@@ -1088,6 +1118,32 @@ function ThreadDetail() {
       useMessageQueue.getState().clearQueue(threadId)
     }
   }, [status, threadId])
+
+  // Stamp the last user message with the error so it survives reload and
+  // navigation. Cleared on the next successful assistant onFinish, or when
+  // the user edits that message.
+  useEffect(() => {
+    if (status !== 'error' || !error) return
+    const messages = useMessages.getState().getMessages(threadId)
+    let lastUserIndex = -1
+    for (let i = messages.length - 1; i >= 0; i--) {
+      if (messages[i].role === ChatCompletionRole.User) {
+        lastUserIndex = i
+        break
+      }
+    }
+    if (lastUserIndex === -1) return
+    const target = messages[lastUserIndex]
+    const errMessage =
+      error instanceof Error ? error.message : String(error || 'Error')
+    const existingError = (target.metadata as Record<string, unknown> | undefined)
+      ?.error
+    if (existingError === errMessage) return
+    updateMessage({
+      ...target,
+      metadata: { ...(target.metadata || {}), error: errMessage },
+    })
+  }, [status, error, threadId, updateMessage])
 
   // Clear the queue when navigating away from this thread
   useEffect(() => {

--- a/web-app/src/routes/threads/__tests__/$threadId.test.tsx
+++ b/web-app/src/routes/threads/__tests__/$threadId.test.tsx
@@ -529,29 +529,6 @@ describe('ThreadDetail route', () => {
     expect(screen.getByTestId('prompt-progress')).toBeInTheDocument()
   })
 
-  it('shows error banner with Regenerate button for generic errors', () => {
-    h.chatState.error = new Error('something broke')
-    renderComponent()
-    expect(screen.getByText('Error generating response')).toBeInTheDocument()
-    expect(screen.getByText('something broke')).toBeInTheDocument()
-    expect(screen.getByText('Regenerate')).toBeInTheDocument()
-  })
-
-  it('shows Increase Context Size button on context-length errors (agent mode)', () => {
-    // Agent mode bypasses auto-increase effect so the UI stays on the error.
-    h.agentModeState.agentThreads = { 'thread-1': true }
-    h.chatState.error = new Error('context length limit exceeded')
-    renderComponent()
-    expect(screen.getByText('Increase Context Size')).toBeInTheDocument()
-  })
-
-  it('clicking Regenerate in error banner triggers regenerate()', () => {
-    h.chatState.error = new Error('something broke')
-    renderComponent()
-    screen.getByText('Regenerate').click()
-    expect(h.mockRegenerate).toHaveBeenCalled()
-  })
-
   it('processes an initial message from sessionStorage on mount', async () => {
     sessionStorage.setItem(
       'initial-message-thread-1',

--- a/web-app/src/routes/threads/__tests__/$threadId.test.tsx
+++ b/web-app/src/routes/threads/__tests__/$threadId.test.tsx
@@ -51,6 +51,8 @@ const h = vi.hoisted(() => {
   const appStateState = {
     ragToolNames: new Set<string>(),
     mcpToolNames: new Set<string>(),
+    setOomError: vi.fn(),
+    setBackendError: vi.fn(),
   }
   const useAppStateMock: any = (selector: any) => selector(appStateState)
   useAppStateMock.getState = () => appStateState

--- a/web-app/src/stores/message-errors.ts
+++ b/web-app/src/stores/message-errors.ts
@@ -19,7 +19,8 @@ export const useMessageErrors = create<MessageErrorsState>()((set) => ({
   clearError: (messageId) =>
     set((state) => {
       if (!(messageId in state.errors)) return state
-      const { [messageId]: _drop, ...rest } = state.errors
+      const rest = { ...state.errors }
+      delete rest[messageId]
       return { errors: rest }
     }),
   clearAll: () => set({ errors: {} }),

--- a/web-app/src/stores/message-errors.ts
+++ b/web-app/src/stores/message-errors.ts
@@ -1,0 +1,27 @@
+import { create } from 'zustand'
+
+type MessageErrorsState = {
+  errors: Record<string, string>
+  setError: (messageId: string, error: string) => void
+  clearError: (messageId: string) => void
+  clearAll: () => void
+  hydrate: (entries: Record<string, string>) => void
+}
+
+export const useMessageErrors = create<MessageErrorsState>()((set) => ({
+  errors: {},
+  setError: (messageId, error) =>
+    set((state) =>
+      state.errors[messageId] === error
+        ? state
+        : { errors: { ...state.errors, [messageId]: error } }
+    ),
+  clearError: (messageId) =>
+    set((state) => {
+      if (!(messageId in state.errors)) return state
+      const { [messageId]: _drop, ...rest } = state.errors
+      return { errors: rest }
+    }),
+  clearAll: () => set({ errors: {} }),
+  hydrate: (entries) => set({ errors: entries }),
+}))

--- a/web-app/src/types/modelProviders.d.ts
+++ b/web-app/src/types/modelProviders.d.ts
@@ -47,6 +47,8 @@ type Model = {
 /**
  * The provider object structure
  */
+type ProviderApiType = 'openai' | 'anthropic'
+
 type ProviderObject = {
   active: boolean
   provider: string
@@ -59,6 +61,8 @@ type ProviderObject = {
   models: Model[]
   persist?: boolean
   custom_header?: ProviderCustomHeader[] | null
+  /** Wire format of the provider's HTTP API. Missing = 'openai' (default). */
+  api_type?: ProviderApiType
 }
 
 /**


### PR DESCRIPTION
## Describe Your Changes

### Sampling & chat composer
- **Restrict sampler UI to local/custom providers** — predefined remote providers (OpenAI, Anthropic, Gemini, Groq, etc.) reject unknown sampler fields; hide the composer SamplerPopover for them and strip `paramsSettings` keys from the request body so assistant overrides set on a local model can't leak into a remote request. (2147fea13)
- **Provider-aware sampler popover** — sampler capability matrix per built-in provider, plus permissive defaults for custom OpenAI-compatible endpoints. (318294085)
- **Align reasoning trigger with sibling icon buttons** in ChatInput — drop the inline `on/off/auto` label so the row keeps a consistent rhythm; state still readable via icon color + tooltip + dropdown checkmark. (bd1ccba92)
- **Allow media-only messages** — send images/audio without requiring text. (1c1c8aa87)

### Threads & error UX
- **Persist `metadata.error` across restart and dedupe the error UI** — errors now survive thread reload. (5eeced021, f6e491122)
- **Stop persisting empty assistant rows**; pin errors to the user message. (827d9dd19)
- **Scope llamacpp router error banner to llamacpp threads** — no more cross-provider banner pollution. (ea4206dff)
- **Persist OOM/backend banner per-thread across restart** — the banner state survives reload instead of being stuck on whichever thread was open when the error fired. (11f0f28db)

### llamacpp
- **Include `mmproj.gguf` in VRAM precheck**. (20b705e68)
- **Format `Error`/object log args** instead of dumping `[object Object]`. (1780ff740)
- **Split version/backend selectors and overhaul settings UX**. (5e79398d0)
- **Backend dependency verification**: add a toggle (956fc13b6), scope to GPU backend lib + skip on flatpak (ae49fed87), and skip the startup check when auto-update is off (f5de440af).
- **Allow `.tar.gz` backends** in the macOS file picker. (2f03053ad)
- **Name imported GGUFs from `general.name`** — read the metadata, trim and dash-join whitespace; fall back to the file basename (sans `.gguf`), then `modelId`. (ec0d85d848b8679e48a41413e0aa3e56ed55bebb)
- **Cap embedding-slot bonus at +1 in router `models_max`** — was inflating by N per installed embedder, but only one embedding loads at a time; the phantom slots stalled chat-model eviction. (a4ac3783f)
- **Emit `onSettingUpdate` from overridden `updateSettings`** so the router restarts when version/backend changes via the API path, not just the UI. (a4047c967)

### MCP
- **Stop flooding logs** from stdio MCP server health probes (#8190). (37bbdc6ac)
- **Dedupe router model picker entries** by `provider+id`. (d6a3f0613)

### Models / providers
- **Anthropic-compatible custom providers** — Add Provider dialog gets an API-format selector (OpenAI / Anthropic). `api_type` discriminant on `ProviderObject` routes the model factory and `ai-model.ts` through `@ai-sdk/anthropic` when set, so LiteLLM/Bedrock proxies and self-hosted Claude gateways work without a built-in entry. Built-in Anthropic backfilled via a v15→v16 store migration. Custom providers now require an API key (matches existing backend gates). (b9c3fbf5f)
- **Replace dropdown compat indicator with hub estimator** for faster, richer model-fit info (6d949616f); drop the ctx value from the tooltip to reduce noise (c9ba4d83c).
- **Don't carry stale metadata across provider refetches**. (18f12819a)
- **Render single-option dropdowns as inert text** — no fake interactivity when there's nothing to pick. (7c372cb67)

### Reliability
- **Isolate `onLoad` failures** so one bad extension can't gate the entire UI. (1c7658c75)
- **Repair broken test mocks** after the sampling/router refactors. (34e376ebd)
- **Tighten hardware ACL + gate sampler UI on hydration** — restrict `refresh_system_info` permission and avoid rendering sampler controls before settings hydrate (no more flash of stale defaults). (99b075f23)

## Fixes Issues

- Closes #8190
- Closes #8192
- Closes #8195

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
