### PR TITLE
chore(ci): bump dcarbone/install-jq-action from v2.0.1 to v3.2.0

### DIFF
--- a/.github/workflows/jan-docs.yml
+++ b/.github/workflows/jan-docs.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: 20
 
       - name: Install jq      
-        uses: dcarbone/install-jq-action@c1548c666da8422e8207a67fae0df364cf9ee7fe # v2.0.1
+        uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
 
       - name: Config Yarn
         run: |

--- a/.github/workflows/jan-tauri-build-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-nightly.yaml
@@ -126,7 +126,7 @@ jobs:
       - name: Getting the repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install jq
-        uses: dcarbone/install-jq-action@c1548c666da8422e8207a67fae0df364cf9ee7fe # v2.0.1
+        uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
       - name: create latest.json file
         run: |
 

--- a/.github/workflows/publish-npm-core.yml
+++ b/.github/workflows/publish-npm-core.yml
@@ -14,7 +14,7 @@ jobs:
           token: ${{ secrets.PAT_SERVICE_ACCOUNT }}
 
       - name: Install jq
-        uses: dcarbone/install-jq-action@c1548c666da8422e8207a67fae0df364cf9ee7fe # v2.0.1
+        uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
 
       - name: Extract tag name without v prefix
         id: get_version

--- a/.github/workflows/template-get-update-version.yml
+++ b/.github/workflows/template-get-update-version.yml
@@ -13,7 +13,7 @@ jobs:
       new_version: ${{ steps.version_update.outputs.new_version }}
     steps:
       - name: Install jq
-        uses: dcarbone/install-jq-action@c1548c666da8422e8207a67fae0df364cf9ee7fe # v2.0.1
+        uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
 
       - name: Get tag
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/template-tauri-build-linux-x64-external.yml
+++ b/.github/workflows/template-tauri-build-linux-x64-external.yml
@@ -55,7 +55,7 @@ jobs:
           node-version: 20
 
       - name: Install jq
-        uses: dcarbone/install-jq-action@c1548c666da8422e8207a67fae0df364cf9ee7fe # v2.0.1
+        uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
 
       - name: Install ctoml
         run: |

--- a/.github/workflows/template-tauri-build-linux-x64-flatpak.yml
+++ b/.github/workflows/template-tauri-build-linux-x64-flatpak.yml
@@ -73,7 +73,7 @@ jobs:
           node-version: 20
 
       - name: Install jq
-        uses: dcarbone/install-jq-action@c1548c666da8422e8207a67fae0df364cf9ee7fe # v2.0.1
+        uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
 
       - name: Install ctoml
         run: |

--- a/.github/workflows/template-tauri-build-linux-x64.yml
+++ b/.github/workflows/template-tauri-build-linux-x64.yml
@@ -94,7 +94,7 @@ jobs:
           node-version: 20
 
       - name: Install jq
-        uses: dcarbone/install-jq-action@c1548c666da8422e8207a67fae0df364cf9ee7fe # v2.0.1
+        uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
 
       - name: Install ctoml
         run: |

--- a/.github/workflows/template-tauri-build-macos-external.yml
+++ b/.github/workflows/template-tauri-build-macos-external.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: 20
 
       - name: Install jq
-        uses: dcarbone/install-jq-action@c1548c666da8422e8207a67fae0df364cf9ee7fe # v2.0.1
+        uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
 
       - name: Install ctoml
         run: |

--- a/.github/workflows/template-tauri-build-macos.yml
+++ b/.github/workflows/template-tauri-build-macos.yml
@@ -88,7 +88,7 @@ jobs:
           node-version: 20
 
       - name: Install jq
-        uses: dcarbone/install-jq-action@c1548c666da8422e8207a67fae0df364cf9ee7fe # v2.0.1
+        uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
 
       - name: Install ctoml
         run: |

--- a/.github/workflows/template-tauri-build-windows-x64-external.yml
+++ b/.github/workflows/template-tauri-build-windows-x64-external.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: 20
 
       - name: Install jq
-        uses: dcarbone/install-jq-action@c1548c666da8422e8207a67fae0df364cf9ee7fe # v2.0.1
+        uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
 
       - name: Install ctoml
         run: |

--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -89,7 +89,7 @@ jobs:
           node-version: 20
 
       - name: Install jq
-        uses: dcarbone/install-jq-action@c1548c666da8422e8207a67fae0df364cf9ee7fe # v2.0.1
+        uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
 
       - name: Install ctoml
         run: |


### PR DESCRIPTION
## Describe Your Changes

This pull request updates the `jq` installation step across multiple GitHub Actions workflow files to use a newer version of the `dcarbone/install-jq-action` action. The action is upgraded from version 2.0.1 to 3.2.0, ensuring all workflows use the latest features and bug fixes for this dependency.

Dependency update in CI workflows:

* Updated the `jq` installation step in the following workflow files to use `dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45` (v3.2.0) instead of the previous v2.0.1:
  * `.github/workflows/jan-docs.yml`
  * `.github/workflows/jan-tauri-build-nightly.yaml`
  * `.github/workflows/publish-npm-core.yml`
  * `.github/workflows/template-get-update-version.yml`
  * `.github/workflows/template-tauri-build-linux-x64-external.yml`
  * `.github/workflows/template-tauri-build-linux-x64-flatpak.yml`
  * `.github/workflows/template-tauri-build-linux-x64.yml`
  * `.github/workflows/template-tauri-build-macos-external.yml`
  * `.github/workflows/template-tauri-build-macos.yml`
  * `.github/workflows/template-tauri-build-windows-x64-external.yml`
  * `.github/workflows/template-tauri-build-windows-x64.yml`

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
