### PR TITLE
fix(llamacpp): disable auto-fit by default, default ctx_len to 8192 

### DIFF
--- a/core/src/browser/extensions/engines/AIEngine.ts
+++ b/core/src/browser/extensions/engines/AIEngine.ts
@@ -185,10 +185,8 @@ export interface SessionInfo {
   pid: number // opaque handle for unload/chat
   port: number // llama-server output port (corrected from portid)
   model_id: string //name of the model
-  model_path: string // path of the loaded model
   is_embedding: boolean
   api_key: string
-  mmproj_path?: string
 }
 
 export interface UnloadResult {

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -350,11 +350,6 @@ export default class llamacpp_extension extends AIEngine {
 
     let settings = structuredClone(SETTINGS) // Clone to modify settings definition before registration
 
-    if (!IS_MAC) {
-      const fitItem = settings.find((s) => s.key === 'fit')
-      if (fitItem) fitItem.controllerProps.value = true
-    }
-
     // Migration: legacy `version_backend` (single composite string) → split
     // into `llamacpp_version` + `llamacpp_backend`. Read from localStorage
     // before registerSettings overwrites the persisted set.
@@ -396,11 +391,9 @@ export default class llamacpp_extension extends AIEngine {
     this.config = loadedConfig as LlamacppConfig
     this.recomposeVersionBackend()
 
-    // Migration v2: disable fit by default
-    await this.migrateFitDefault()
-
-    // Migration v3: enable fit on Windows/Linux with a discrete GPU
-    await this.migrateFitPlatformDefault()
+    // Auto-fit is disabled by default on all platforms; ctx-size owns context
+    // sizing. Force off for users a prior build left with fit enabled.
+    await this.migrateFitOff()
 
     await this.migrateAutoUnloadToModelsMax()
 
@@ -802,8 +795,8 @@ export default class llamacpp_extension extends AIEngine {
     }
   }
 
-  private async migrateFitDefault(): Promise<void> {
-    const MIGRATION_KEY = 'llamacpp_fit_disabled_v1'
+  private async migrateFitOff(): Promise<void> {
+    const MIGRATION_KEY = 'llamacpp_fit_off_v1'
     if (localStorage.getItem(MIGRATION_KEY)) return
 
     if (this.config.fit === true) {
@@ -817,48 +810,7 @@ export default class llamacpp_extension extends AIEngine {
         })
       )
       this.config.fit = false
-      logger.info('Migrated fit setting: disabled by default')
-    }
-
-    localStorage.setItem(MIGRATION_KEY, '1')
-  }
-
-  private async migrateFitPlatformDefault(): Promise<void> {
-    const MIGRATION_KEY = 'llamacpp_fit_platform_v2'
-    if (localStorage.getItem(MIGRATION_KEY)) return
-
-    if (IS_MAC) {
-      localStorage.setItem(MIGRATION_KEY, '1')
-      return
-    }
-
-    let hasDiscreteGpu = false
-    try {
-      const sysInfo = await getSystemInfo()
-      hasDiscreteGpu = (sysInfo?.gpus ?? []).some(
-        (g: any) =>
-          g?.nvidia_info != null ||
-          g?.vulkan_info?.device_type === 'DiscreteGpu'
-      )
-    } catch (error) {
-      // Skip writing the migration key so a transient probe failure retries.
-      logger.warn('Failed to probe GPU info for fit migration:', error)
-      return
-    }
-
-    // Only upgrade the v1 auto-default; preserve any explicit user override.
-    if (this.config.fit === false && hasDiscreteGpu) {
-      const settings = await this.getSettings()
-      await this.updateSettings(
-        settings.map((item) => {
-          if (item.key === 'fit') {
-            item.controllerProps.value = true
-          }
-          return item
-        })
-      )
-      this.config.fit = true
-      logger.info('Migrated fit setting: enabled (discrete GPU detected)')
+      logger.info('Migrated fit setting: disabled')
     }
 
     localStorage.setItem(MIGRATION_KEY, '1')

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -23,6 +23,7 @@ import {
   DownloadEvent,
   chatCompletionRequestMessage,
   SettingComponentProps,
+  DropdownComponentProps,
 } from '@janhq/core'
 import {
   readSettingsFile,
@@ -1194,14 +1195,16 @@ export default class llamacpp_extension extends AIEngine {
     const allBackends = Array.from(
       new Set(version_backends.map((b) => b.backend))
     )
-    versionSetting.controllerProps.options = allVersions.map((v) => ({
-      value: v,
-      name: v,
-    }))
-    backendSetting.controllerProps.options = allBackends.map((b) => ({
-      value: b,
-      name: b,
-    }))
+    ;(versionSetting.controllerProps as DropdownComponentProps).options =
+      allVersions.map((v) => ({
+        value: v,
+        name: v,
+      }))
+    ;(backendSetting.controllerProps as DropdownComponentProps).options =
+      allBackends.map((b) => ({
+        value: b,
+        name: b,
+      }))
 
     const currentV = String(versionSetting.controllerProps.value ?? '')
     const currentB = String(backendSetting.controllerProps.value ?? '')

--- a/extensions/llamacpp-extension/src/test/index.test.ts
+++ b/extensions/llamacpp-extension/src/test/index.test.ts
@@ -425,7 +425,7 @@ describe('llamacpp_extension', () => {
     })
   })
 
-  describe('migrateFitDefault', () => {
+  describe('migrateFitOff', () => {
     beforeEach(() => {
       vi.mocked(localStorage.getItem).mockReturnValue(null)
     })
@@ -435,7 +435,7 @@ describe('llamacpp_extension', () => {
       extension['config'] = { fit: true } as any
       extension['getSettings'] = vi.fn()
 
-      await extension['migrateFitDefault']()
+      await extension['migrateFitOff']()
 
       expect(extension['getSettings']).not.toHaveBeenCalled()
     })
@@ -445,11 +445,11 @@ describe('llamacpp_extension', () => {
       extension['getSettings'] = vi.fn()
       extension['updateSettings'] = vi.fn()
 
-      await extension['migrateFitDefault']()
+      await extension['migrateFitOff']()
 
       expect(extension['getSettings']).not.toHaveBeenCalled()
       expect(extension['updateSettings']).not.toHaveBeenCalled()
-      expect(localStorage.setItem).toHaveBeenCalledWith('llamacpp_fit_disabled_v1', '1')
+      expect(localStorage.setItem).toHaveBeenCalledWith('llamacpp_fit_off_v1', '1')
     })
 
     it('should disable fit when it is true', async () => {
@@ -460,13 +460,13 @@ describe('llamacpp_extension', () => {
       ])
       extension['updateSettings'] = vi.fn().mockResolvedValue(undefined)
 
-      await extension['migrateFitDefault']()
+      await extension['migrateFitOff']()
 
       const updatedSettings = vi.mocked(extension['updateSettings']).mock.calls[0][0]
       expect(updatedSettings.find((s: any) => s.key === 'fit').controllerProps.value).toBe(false)
       expect(updatedSettings.find((s: any) => s.key === 'ctx_size').controllerProps.value).toBe(2048)
       expect(extension['config'].fit).toBe(false)
-      expect(localStorage.setItem).toHaveBeenCalledWith('llamacpp_fit_disabled_v1', '1')
+      expect(localStorage.setItem).toHaveBeenCalledWith('llamacpp_fit_off_v1', '1')
     })
 
     it('should not modify other settings during fit migration', async () => {
@@ -478,7 +478,7 @@ describe('llamacpp_extension', () => {
       ])
       extension['updateSettings'] = vi.fn().mockResolvedValue(undefined)
 
-      await extension['migrateFitDefault']()
+      await extension['migrateFitOff']()
 
       const updatedSettings = vi.mocked(extension['updateSettings']).mock.calls[0][0]
       expect(updatedSettings.find((s: any) => s.key === 'fit_target').controllerProps.value).toBe('1024')

--- a/extensions/llamacpp-extension/tsconfig.json
+++ b/extensions/llamacpp-extension/tsconfig.json
@@ -1,7 +1,9 @@
 {
   "compilerOptions": {
     "target": "es2018",
-    "module": "ES6",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2018", "DOM", "DOM.Iterable"],
     "outDir": "./dist",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,

--- a/web-app/src/hooks/__tests__/useModelProvider.coverage.test.ts
+++ b/web-app/src/hooks/__tests__/useModelProvider.coverage.test.ts
@@ -302,7 +302,7 @@ describe('useModelProvider - coverage', () => {
       }, (migrated: any) => {
         expect(migrated.providers[0].models[0].settings.auto_increase_ctx_len).toBeUndefined()
       }],
-      [12, 'v12 resets legacy string ctx_len=8192 back to auto', {
+      [12, 'v12 resets legacy 8192 to auto, v16 re-seeds 8192 default', {
         providers: [{
           provider: 'llamacpp',
           models: [{
@@ -316,7 +316,23 @@ describe('useModelProvider - coverage', () => {
       }, (migrated: any) => {
         expect(
           migrated.providers[0].models[0].settings.ctx_len.controller_props.value
-        ).toBe('')
+        ).toBe(8192)
+      }],
+      [16, 'v16 seeds empty ctx_len with 8192 default', {
+        providers: [{
+          provider: 'llamacpp',
+          models: [{
+            id: 'm1',
+            settings: { ctx_len: { controller_props: { value: '' } } },
+            capabilities: [],
+          }],
+          settings: [],
+        }],
+        deletedModels: [],
+      }, (migrated: any) => {
+        expect(
+          migrated.providers[0].models[0].settings.ctx_len.controller_props.value
+        ).toBe(8192)
       }],
       [14, 'v14 → v15 strips orphan auto_increase_ctx_len', {
         providers: [{

--- a/web-app/src/hooks/useModelProvider.ts
+++ b/web-app/src/hooks/useModelProvider.ts
@@ -800,9 +800,28 @@ export const useModelProvider = create<ModelProviderState>()(
           })
         }
 
+        if (version <= 16 && state?.providers) {
+          // Auto-fit is now disabled by default, so seed empty/auto ctx_len
+          // with the new 8192 default. Preserve any user-customised value.
+          state.providers.forEach((provider) => {
+            if (provider.provider !== 'llamacpp' || !provider.models) return
+            provider.models.forEach((model) => {
+              const ctx = model.settings?.ctx_len as
+                | { controller_props?: { value?: unknown } }
+                | undefined
+              const controllerProps = ctx?.controller_props
+              if (!controllerProps) return
+              const value = controllerProps.value
+              if (value === '' || value == null) {
+                controllerProps.value = 8192
+              }
+            })
+          })
+        }
+
         return state
       },
-      version: 16,
+      version: 17,
     }
   )
 )

--- a/web-app/src/lib/predefined.ts
+++ b/web-app/src/lib/predefined.ts
@@ -3,11 +3,11 @@ export const modelSettings = {
     key: 'ctx_len',
     title: 'Context Size',
     description:
-      'Size of the prompt context. Leave empty to auto-fit when --fit is on, or fall back to 4096 when off.',
+      'Size of the prompt context. Leave empty to auto-fit when --fit is on.',
     controller_type: 'input',
     controller_props: {
-      value: '',
-      placeholder: 'auto',
+      value: 8192,
+      placeholder: '8192',
       type: 'number',
     },
   },


### PR DESCRIPTION
## Describe Your Changes

- Revert back to fit disabled by default and set default ctx_len to 8192
- tsc fixes for llamacpp extension 

## Fixes Issues

- Closes #8181 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
