### PR TITLE
fix(threads): avoid router invariant in PromptProgress

### DIFF
--- a/web-app/src/components/PromptProgress.tsx
+++ b/web-app/src/components/PromptProgress.tsx
@@ -3,8 +3,8 @@ import { Loader } from 'lucide-react'
 import { useParams } from '@tanstack/react-router'
 
 export function PromptProgress() {
-  const params = useParams({ from: '/threads/$threadId', shouldThrow: false })
-  const threadId = params?.threadId
+  const params = useParams({ strict: false })
+  const threadId = (params as { threadId?: string })?.threadId
   const promptProgress = useAppState((state) =>
     (threadId ? state.promptProgresses[threadId] : undefined) ??
     state.promptProgress


### PR DESCRIPTION
## Describe Your Changes

- useParams({ from: '/threads/$threadId', shouldThrow: false }) still asserts a parent matchId inside the selector, which throws "Could not find parent match for matchId undefined" when the component renders outside or during a transition out of the thread route. Switch to { strict: false } so the hook returns whatever params are in scope.


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
