### PR TITLE
fix(settings): restore Attachments entry in settings menu

### DIFF
--- a/web-app/src/containers/SettingsMenu.tsx
+++ b/web-app/src/containers/SettingsMenu.tsx
@@ -15,6 +15,7 @@ import {
   IconLock,
   IconCpu,
   IconWorld,
+  IconPaperclip,
 } from '@tabler/icons-react'
 import { useMatches, useNavigate } from '@tanstack/react-router'
 import { cn } from '@/lib/utils'
@@ -176,6 +177,11 @@ const SettingsMenu = () => {
       icon: IconPalette,
     },
     { title: 'common:assistants', route: route.settings.assistant, icon: IconFeather },
+    {
+      title: 'common:attachments',
+      route: route.settings.attachments,
+      icon: IconPaperclip,
+    },
     {
       title: 'common:local_api_server',
       route: route.settings.local_api_server,


### PR DESCRIPTION
## Describe Your Changes

- Commit 45320917c (#7839) reorganized the settings sidebar and dropped the Attachments link while leaving the route and page in place, making /settings/attachments reachable only by URL.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
