### PR TITLE
fix: strip x-anthropic-billing-header from messages to prevent API ca…

### DIFF
--- a/mlx-server/Sources/MLXServer/AnthropicTypes.swift
+++ b/mlx-server/Sources/MLXServer/AnthropicTypes.swift
@@ -271,19 +271,40 @@ struct AnthropicMessageStopEvent: Codable {
 
 // MARK: - Conversion: Anthropic → Internal
 
+/// Helper to strip the Anthropic billing header from message content.
+/// Claude Code injects this header into the first message or system prompt,
+/// which causes API cache misses due to its random values.
+func stripAnthropicBillingHeader(_ text: String) -> String {
+    if text.hasPrefix("x-anthropic-billing-header:") {
+        // The billing header is typically 2 lines:
+        // x-anthropic-billing-header:
+        //    cc_version=...; cc_entrypoint=...; cch=...;
+        let lines = text.split(separator: "\n", maxSplits: 2, omittingEmptySubsequences: false)
+        if lines.count >= 3 {
+            let line1 = String(lines[0])
+            let line2 = String(lines[1])
+            if line1 == "x-anthropic-billing-header:" && line2.contains("cc_version=") {
+                return String(lines[2])
+            }
+        }
+    }
+    return text
+}
+
 /// Convert an Anthropic /v1/messages request to the internal [ChatMessage] format.
 func anthropicToInternalMessages(request: AnthropicRequest) -> [ChatMessage] {
     var messages: [ChatMessage] = []
 
     // System prompt becomes a leading system-role message
     if let system = request.system {
-        messages.append(ChatMessage(role: "system", content: .string(system.text)))
+        messages.append(ChatMessage(role: "system", content: .string(stripAnthropicBillingHeader(system.text))))
     }
 
-    for msg in request.messages {
+    for (i, msg) in request.messages.enumerated() {
         switch msg.content {
         case .text(let text):
-            messages.append(ChatMessage(role: msg.role, content: .string(text)))
+            let cleanedText = (i == 0) ? stripAnthropicBillingHeader(text) : text
+            messages.append(ChatMessage(role: msg.role, content: .string(cleanedText)))
 
         case .blocks(let blocks):
             var textParts: [String] = []
@@ -291,10 +312,11 @@ func anthropicToInternalMessages(request: AnthropicRequest) -> [ChatMessage] {
             var toolCalls: [ToolCallInfo] = []
             var hasNonToolResult = false
 
-            for block in blocks {
+            for (j, block) in blocks.enumerated() {
                 switch block {
                 case .text(let tc):
-                    textParts.append(tc.text)
+                    let cleanedText = (i == 0 && j == 0) ? stripAnthropicBillingHeader(tc.text) : tc.text
+                    textParts.append(cleanedText)
                     hasNonToolResult = true
 
                 case .image(let ic):

--- a/src-tauri/src/core/server/proxy.rs
+++ b/src-tauri/src/core/server/proxy.rs
@@ -255,6 +255,28 @@ pub(crate) fn transform_anthropic_to_openai(body: &serde_json::Value) -> Option<
     Some(result)
 }
 
+/// Helper to strip the Anthropic billing header from message content.
+/// Claude Code injects this header into the first message or system prompt,
+/// which causes API cache misses due to its random values.
+pub(crate) fn strip_anthropic_billing_header(text: &str) -> &str {
+    if text.starts_with("x-anthropic-billing-header:") {
+        // The billing header is typically 2 lines:
+        // x-anthropic-billing-header:
+        //    cc_version=...; cc_entrypoint=...; cch=...;
+        let mut lines = text.splitn(3, '\n');
+        let line1 = lines.next();
+        let line2 = lines.next();
+        if let Some(rest) = lines.next() {
+            if line1 == Some("x-anthropic-billing-header:")
+                && line2.map_or(false, |l| l.contains("cc_version="))
+            {
+                return rest;
+            }
+        }
+    }
+    text
+}
+
 /// Convert Anthropic message format to OpenAI format
 pub(crate) fn convert_messages(
     anth_messages: &serde_json::Value,
@@ -268,7 +290,7 @@ pub(crate) fn convert_messages(
         if let Some(text) = system.as_str() {
             openai_messages.push(serde_json::json!({
                 "role": "system",
-                "content": text
+                "content": strip_anthropic_billing_header(text)
             }));
         } else if let Some(blocks) = system.as_array() {
             let text: String = blocks
@@ -279,17 +301,24 @@ pub(crate) fn convert_messages(
             if !text.is_empty() {
                 openai_messages.push(serde_json::json!({
                     "role": "system",
-                    "content": text
+                    "content": strip_anthropic_billing_header(&text)
                 }));
             }
         }
     }
 
-    for msg in messages_array {
+    for (i, msg) in messages_array.iter().enumerate() {
         let role = msg.get("role")?.as_str()?;
         let content = msg.get("content")?;
 
         if content.is_string() {
+            let text = content.as_str().unwrap();
+            let cleaned_text = if i == 0 {
+                strip_anthropic_billing_header(text)
+            } else {
+                text
+            };
+
             let openai_role = match role {
                 "user" => "user",
                 "assistant" => "assistant",
@@ -299,7 +328,7 @@ pub(crate) fn convert_messages(
             };
             openai_messages.push(serde_json::json!({
                 "role": openai_role,
-                "content": content
+                "content": cleaned_text
             }));
             continue;
         }
@@ -381,9 +410,14 @@ pub(crate) fn convert_messages(
                         }
                         "text" => {
                             if let Some(text) = block.get("text").and_then(|v| v.as_str()) {
+                                let cleaned_text = if i == 0 {
+                                    strip_anthropic_billing_header(text)
+                                } else {
+                                    text
+                                };
                                 text_parts.push(serde_json::json!({
                                     "type": "text",
-                                    "text": text
+                                    "text": cleaned_text
                                 }));
                             }
                         }

--- a/src-tauri/src/core/server/tests.rs
+++ b/src-tauri/src/core/server/tests.rs
@@ -757,6 +757,43 @@ mod server_tests {
     }
 
     #[test]
+    fn convert_messages_strips_anthropic_billing_header() {
+        let billing_header = "x-anthropic-billing-header:\n   cc_version=2.1.150.d66; cc_entrypoint=cli; cch=934c8;\n";
+        let actual_content = "You are Claude Code, Anthropic's official CLI for Claude.";
+        let full_content = format!("{}{}", billing_header, actual_content);
+
+        // Test stripping from first user message
+        let msgs = json!([
+            {"role": "user", "content": full_content},
+            {"role": "user", "content": full_content} // Should not be stripped from second message
+        ]);
+        let out = proxy::convert_messages(&msgs, None).unwrap();
+        let arr = out.as_array().unwrap();
+        assert_eq!(arr[0]["content"], actual_content);
+        assert_eq!(arr[1]["content"], full_content);
+
+        // Test stripping from system prompt
+        let system = json!(full_content);
+        let out = proxy::convert_messages(&json!([{"role": "user", "content": "hi"}]), Some(&system)).unwrap();
+        let arr = out.as_array().unwrap();
+        assert_eq!(arr[0]["role"], "system");
+        assert_eq!(arr[0]["content"], actual_content);
+
+        // Test stripping from array content
+        let msgs_array = json!([
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": full_content}
+                ]
+            }
+        ]);
+        let out = proxy::convert_messages(&msgs_array, None).unwrap();
+        let arr = out.as_array().unwrap();
+        assert_eq!(arr[0]["content"], actual_content);
+    }
+
+    #[test]
     fn transform_anthropic_to_openai_basic() {
         let body = json!({
             "model": "claude-x",


### PR DESCRIPTION
Describe Your Changes

   - Stripping Anthropic Billing Headers: Implemented strip_anthropic_billing_header helper functions in both the Rust
     core (src-tauri) and the Swift MLX server (mlx-server) to remove attribution headers injected by Claude Code.
   - Cache Miss Prevention: These headers (e.g., x-anthropic-billing-header: cc_version=...) often contain dynamic or
     random values that invalidate Anthropic's prompt caching, leading to unnecessary latency and costs.
   - Conversion Logic Updates:
       - In src-tauri, updated the OpenAI-to-Anthropic message conversion to strip the header from the system prompt and
         the first message in the array.
       - In mlx-server, updated the Anthropic-to-Internal message conversion to apply similar stripping logic.
   - Unit Testing: Added comprehensive tests in src-tauri/src/core/server/tests.rs to verify that the header is
     correctly removed from system prompts, user messages, and complex message blocks while ensuring regular content
     remains intact.

Fixes Issues

N/A

Self Checklist

   - [x] Added relevant comments, esp in complex areas
   - [x] Updated docs (for bug fixes / features)
   - [x] Created issues for follow-up changes or refactoring needed