### PR TITLE
fix(rag): honor configured attachment size limit in document parser

### DIFF
--- a/src-tauri/plugins/tauri-plugin-rag/src/constants.rs
+++ b/src-tauri/plugins/tauri-plugin-rag/src/constants.rs
@@ -1,5 +1,8 @@
-pub const MAX_PDF_FILE_SIZE: u64 = 20 * 1024 * 1024;
-pub const MAX_CSV_FILE_SIZE: u64 = 20 * 1024 * 1024;
-pub const MAX_SPREADSHEET_FILE_SIZE: u64 = 20 * 1024 * 1024;
-pub const MAX_PPTX_FILE_SIZE: u64 = 20 * 1024 * 1024;
-pub const MAX_DOCX_FILE_SIZE: u64 = 20 * 1024 * 1024;
+/// Absolute ceiling for in-process document parsing, in bytes.
+///
+/// The user-facing limit is the `max_file_size_mb` RAG setting (1–200MB),
+/// enforced on the frontend before any file reaches the parser. This backstop
+/// only guards the parser against pathological inputs, so it is pinned to the
+/// maximum that setting permits — a smaller value here would wrongly reject
+/// files the user explicitly allowed (e.g. a 21.5MB file with a 50MB setting).
+pub const MAX_PARSE_FILE_SIZE: u64 = 200 * 1024 * 1024;

--- a/src-tauri/plugins/tauri-plugin-rag/src/parser.rs
+++ b/src-tauri/plugins/tauri-plugin-rag/src/parser.rs
@@ -1,4 +1,4 @@
-use crate::{RagError, MAX_PDF_FILE_SIZE, MAX_SPREADSHEET_FILE_SIZE, MAX_CSV_FILE_SIZE, MAX_PPTX_FILE_SIZE, MAX_DOCX_FILE_SIZE};
+use crate::{RagError, MAX_PARSE_FILE_SIZE};
 use std::borrow::Cow;
 use std::fs;
 use std::io::{Cursor, Read};
@@ -12,8 +12,8 @@ use zip::read::ZipArchive;
 
 pub fn parse_pdf(file_path: &str) -> Result<String, RagError> {
     let metadata = fs::metadata(file_path)?;
-    if metadata.len() > MAX_PDF_FILE_SIZE {
-        return Err(RagError::ParseError("File too large (max 20MB)".to_string()));
+    if metadata.len() > MAX_PARSE_FILE_SIZE {
+        return Err(RagError::ParseError("File too large (max 200MB)".to_string()));
     }
     let bytes = fs::read(file_path)?;
     // pdf-extract can panic on some malformed PDFs; guard to avoid crashing the app
@@ -128,8 +128,8 @@ pub fn parse_document(file_path: &str, file_type: &str) -> Result<String, RagErr
 
 fn parse_docx(file_path: &str) -> Result<String, RagError> {
     let metadata = std::fs::metadata(file_path)?;
-    if metadata.len() > MAX_DOCX_FILE_SIZE {
-        return Err(RagError::ParseError("File too large (max 20MB)".to_string()));
+    if metadata.len() > MAX_PARSE_FILE_SIZE {
+        return Err(RagError::ParseError("File too large (max 200MB)".to_string()));
     }
     let file = std::fs::File::open(file_path)?;
     let mut zip = ZipArchive::new(file).map_err(|e| RagError::ParseError(e.to_string()))?;
@@ -202,8 +202,8 @@ fn parse_docx(file_path: &str) -> Result<String, RagError> {
 
 fn parse_csv(file_path: &str) -> Result<String, RagError> {
     let metadata = fs::metadata(file_path)?;
-    if metadata.len() > MAX_CSV_FILE_SIZE {
-        return Err(RagError::ParseError("File too large (max 20MB)".to_string()));
+    if metadata.len() > MAX_PARSE_FILE_SIZE {
+        return Err(RagError::ParseError("File too large (max 200MB)".to_string()));
     }
     let mut rdr = csv_crate::ReaderBuilder::new()
         .has_headers(false)
@@ -221,8 +221,8 @@ fn parse_csv(file_path: &str) -> Result<String, RagError> {
 
 fn parse_spreadsheet(file_path: &str) -> Result<String, RagError> {
     let metadata = fs::metadata(file_path)?;
-    if metadata.len() > MAX_SPREADSHEET_FILE_SIZE {
-        return Err(RagError::ParseError("File too large (max 20MB)".to_string()));
+    if metadata.len() > MAX_PARSE_FILE_SIZE {
+        return Err(RagError::ParseError("File too large (max 200MB)".to_string()));
     }
     let mut workbook = open_workbook_auto(file_path)
         .map_err(|e| RagError::ParseError(e.to_string()))?;
@@ -255,8 +255,8 @@ fn parse_spreadsheet(file_path: &str) -> Result<String, RagError> {
 
 fn parse_pptx(file_path: &str) -> Result<String, RagError> {
     let metadata = std::fs::metadata(file_path)?;
-    if metadata.len() > MAX_PPTX_FILE_SIZE {
-        return Err(RagError::ParseError("File too large (max 20MB)".to_string()));
+    if metadata.len() > MAX_PARSE_FILE_SIZE {
+        return Err(RagError::ParseError("File too large (max 200MB)".to_string()));
     }
     let file = std::fs::File::open(file_path)?;
     let mut zip = ZipArchive::new(file).map_err(|e| RagError::ParseError(e.to_string()))?;
@@ -333,8 +333,8 @@ fn parse_html(file_path: &str) -> Result<String, RagError> {
 
 fn read_text_auto(file_path: &str) -> Result<String, RagError> {
     let metadata = fs::metadata(file_path)?;
-    if metadata.len() > 50 * 1024 * 1024 {
-        return Err(RagError::ParseError("File too large (max 50MB)".to_string()));
+    if metadata.len() > MAX_PARSE_FILE_SIZE {
+        return Err(RagError::ParseError("File too large (max 200MB)".to_string()));
     }
     let bytes = fs::read(file_path)?;
     // Detect encoding


### PR DESCRIPTION
## Describe Your Changes

- The Rust parser hardcoded a per-format 20MB cap (and 50MB for HTML), independent of the user's max_file_size_mb RAG setting. The frontend correctly gated against the configured value, but every parse path funnels through parse_document, so a file under the user's limit but over 20MB (e.g. 21.5MB with a 50MB setting) was rejected with 'File too large (max 20MB)'.

Collapse the per-format constants into a single MAX_PARSE_FILE_SIZE backstop pinned to the setting's documented maximum (200MB), so the parser never rejects a file the frontend allowed; the frontend remains the source of truth for the user's actual choice.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
