### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/web-app/src/constants/models.ts
+++ b/web-app/src/constants/models.ts
@@ -109,12 +109,12 @@ export const providerModels = {
     supportsN: true,
   },
   minimax: {
-    models: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
+    models: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
     supportsCompletion: true,
-    supportsStreaming: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
+    supportsStreaming: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
     supportsJSON: [],
     supportsImages: [],
-    supportsToolCalls: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
+    supportsToolCalls: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
     supportsN: true,
   },
   openrouter: {

--- a/web-app/src/constants/providers.ts
+++ b/web-app/src/constants/providers.ts
@@ -287,10 +287,17 @@ export const predefinedProviders = [
     ],
     models: [
       {
+        id: 'MiniMax-M3',
+        name: 'MiniMax-M3',
+        version: '1.0',
+        description: 'Latest flagship model with enhanced reasoning and coding.',
+        capabilities: ['completion', 'tools'],
+      },
+      {
         id: 'MiniMax-M2.7',
         name: 'MiniMax-M2.7',
         version: '1.0',
-        description: 'Latest flagship model with enhanced reasoning and coding.',
+        description: 'Previous flagship model with strong reasoning and coding.',
         capabilities: ['completion', 'tools'],
       },
       {
@@ -298,20 +305,6 @@ export const predefinedProviders = [
         name: 'MiniMax-M2.7-highspeed',
         version: '1.0',
         description: 'High-speed version of M2.7 for low-latency scenarios.',
-        capabilities: ['completion', 'tools'],
-      },
-      {
-        id: 'MiniMax-M2.5',
-        name: 'MiniMax-M2.5',
-        version: '1.0',
-        description: 'Peak Performance. Ultimate Value. Master the Complex. 204K context window.',
-        capabilities: ['completion', 'tools'],
-      },
-      {
-        id: 'MiniMax-M2.5-highspeed',
-        name: 'MiniMax-M2.5-highspeed',
-        version: '1.0',
-        description: 'Same performance, faster and more agile. 204K context window.',
         capabilities: ['completion', 'tools'],
       },
     ],

--- a/web-app/src/lib/__tests__/model-factory.test.ts
+++ b/web-app/src/lib/__tests__/model-factory.test.ts
@@ -181,7 +181,7 @@ describe('ModelFactory', () => {
         active: true,
       }
 
-      const model = await ModelFactory.createModel('MiniMax-M2.7', provider)
+      const model = await ModelFactory.createModel('MiniMax-M3', provider)
       expect(model).toBeDefined()
       expect(model.type).toBe('openai-compatible')
     })


### PR DESCRIPTION
## Summary
Upgrade MiniMax model configuration in the minimax provider to include the latest M3 model as the new default.

## Changes
- Add `MiniMax-M3` to the model selection list and set it as the default (listed first)
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as available alternatives
- Remove deprecated `MiniMax-M2.5` / `MiniMax-M2.5-highspeed` from the list
- Update the capability flags in `web-app/src/constants/models.ts` (streaming / tool-calls)
- Update the relevant unit test to reference the new default model

## Why
`MiniMax-M3` is the new flagship model from MiniMax with enhanced reasoning and coding capabilities. Setting it as the default and removing the older M2.5 line keeps the provider aligned with MiniMax's current offering, while M2.7 stays around for users who still want it.

## API Reference
- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api

## Testing
- Unit test in `web-app/src/lib/__tests__/model-factory.test.ts` updated to verify the OpenAI-compatible model factory works with the new `MiniMax-M3` model id.
- Existing OpenAI-compatible path in `model-factory.ts` is unchanged, so all other minimax provider behavior continues to work.