### PR TITLE
fix(i18n): complete and improve German (de-DE) provider translations

### DIFF
--- a/web-app/src/locales/de-DE/provider.json
+++ b/web-app/src/locales/de-DE/provider.json
@@ -1,5 +1,14 @@
 {
   "addProvider": "Anbieter hinzufügen",
-  "addOpenAIProvider": "OpenAI Anbieter hinzufügen",
-  "enterNameForProvider": "Namen für Anbieter eingeben"
+  "addOpenAIProvider": "Benutzerdefinierten Anbieter hinzufügen",
+  "enterNameForProvider": "Anbietername (z. B. my-llm-server)",
+  "apiTypeLabel": "API-Format",
+  "apiTypeOpenAI": "OpenAI-kompatibel",
+  "apiTypeAnthropic": "Anthropic-kompatibel",
+  "baseUrlLabel": "Basis-URL",
+  "baseUrlPlaceholder": "https://dein-endpunkt/v1",
+  "baseUrlPlaceholderAnthropic": "https://api.anthropic.com/v1",
+  "apiKeyLabel": "API-Schlüssel",
+  "apiKeyPlaceholder": "Füge deinen API-Schlüssel ein",
+  "invalidBaseUrl": "Die Basis-URL muss eine gültige http(s)-URL sein"
 }

--- a/web-app/src/locales/de-DE/provider.json
+++ b/web-app/src/locales/de-DE/provider.json
@@ -1,7 +1,7 @@
 {
-  "addProvider": "Provider hinzufügen",
-  "addOpenAIProvider": "Benutzerdefinierten Provider hinzufügen",
-  "enterNameForProvider": "Providername (z. B. my-llm-server)",
+  "addProvider": "Anbieter hinzufügen",
+  "addOpenAIProvider": "Benutzerdefinierten Anbieter hinzufügen",
+  "enterNameForProvider": "Anbietername (z. B. my-llm-server)",
   "apiTypeLabel": "API-Format",
   "apiTypeOpenAI": "OpenAI-kompatibel",
   "apiTypeAnthropic": "Anthropic-kompatibel",

--- a/web-app/src/locales/de-DE/provider.json
+++ b/web-app/src/locales/de-DE/provider.json
@@ -1,7 +1,7 @@
 {
-  "addProvider": "Anbieter hinzufügen",
-  "addOpenAIProvider": "Benutzerdefinierten Anbieter hinzufügen",
-  "enterNameForProvider": "Anbietername (z. B. my-llm-server)",
+  "addProvider": "Provider hinzufügen",
+  "addOpenAIProvider": "Benutzerdefinierten Provider hinzufügen",
+  "enterNameForProvider": "Providername (z. B. my-llm-server)",
   "apiTypeLabel": "API-Format",
   "apiTypeOpenAI": "OpenAI-kompatibel",
   "apiTypeAnthropic": "Anthropic-kompatibel",
@@ -9,6 +9,6 @@
   "baseUrlPlaceholder": "https://dein-endpunkt/v1",
   "baseUrlPlaceholderAnthropic": "https://api.anthropic.com/v1",
   "apiKeyLabel": "API-Schlüssel",
-  "apiKeyPlaceholder": "Füge deinen API-Schlüssel ein",
+  "apiKeyPlaceholder": "Füge Deinen API-Schlüssel ein",
   "invalidBaseUrl": "Die Basis-URL muss eine gültige http(s)-URL sein"
 }


### PR DESCRIPTION
## What
Completes and improves the German (de-DE) translation of `web-app/src/locales/de-DE/provider.json`. Part of #8221.

## Changes
- Adds the **9 missing keys** (API format/type labels, base-URL + API-key labels & placeholders, validation message).
- Fixes **2 stale values** where the English source had drifted:
  - `addOpenAIProvider`: „OpenAI Anbieter hinzufügen" → „Benutzerdefinierten Anbieter hinzufügen" (EN is now *"Add Custom Provider"*).
  - `enterNameForProvider`: generic label → placeholder with example, matching current EN.
- Keeps the existing informal *du* / imperative register, preserves key order, and leaves the real Anthropic endpoint URL untouched.

## Testing
JSON validated (parses; key order matches `en/provider.json`). No missing keys remain for this file.

## Note on screenshots
The contributing guide asks for a screenshot. This PR only edits a locale JSON file (no layout or logic change). As a free-time contributor on my personal device, I deliberately did **not** install and build the full app for security reasons, so I can't provide a running-app screenshot. Happy to coordinate if a maintainer wants to verify in-app.
