### PR TITLE
feat: manual model filter for providers and filtered model dropdown

### DIFF
--- a/web-app/src/containers/DropdownModelProvider.tsx
+++ b/web-app/src/containers/DropdownModelProvider.tsx
@@ -22,6 +22,7 @@ import { useTranslation } from '@/i18n/react-i18next-compat'
 import { useFavoriteModel } from '@/hooks/useFavoriteModel'
 import { predefinedProviders } from '@/constants/providers'
 import { providerHasRemoteApiKeys } from '@/lib/provider-api-keys'
+import { isManuallyAdded } from '@/lib/models'
 import { useServiceHub } from '@/hooks/useServiceHub'
 import { getLastUsedModel } from '@/utils/getModelToStart'
 import { ChevronsUpDown } from 'lucide-react'
@@ -266,18 +267,14 @@ const DropdownModelProvider = memo(function DropdownModelProvider({
 
       // Check if this provider has any manually-added/pinned models.
       // If so, only show those in the dropdown to keep the list manageable.
-      const hasManualModels = provider.models.some(
-        (m) => (m as any).manuallyAdded === true
-      )
+      const hasManualModels = provider.models.some(isManuallyAdded)
 
       provider.models.forEach((modelItem) => {
         // Skip embedding models - they can't be used for chat
         if (modelItem.embedding) return
 
         // If the provider has pinned models, hide auto-fetched ones
-        if (hasManualModels) {
-          if ((modelItem as any).manuallyAdded !== true) return
-        }
+        if (hasManualModels && !isManuallyAdded(modelItem)) return
 
         // Skip models that require API key but don't have one (except llamacpp)
         // For custom providers, allow if they have at least one model loaded

--- a/web-app/src/containers/DropdownModelProvider.tsx
+++ b/web-app/src/containers/DropdownModelProvider.tsx
@@ -264,9 +264,20 @@ const DropdownModelProvider = memo(function DropdownModelProvider({
     providers.forEach((provider) => {
       if (!provider.active) return
 
+      // Check if this provider has any manually-added/pinned models.
+      // If so, only show those in the dropdown to keep the list manageable.
+      const hasManualModels = provider.models.some(
+        (m) => (m as any).manuallyAdded === true
+      )
+
       provider.models.forEach((modelItem) => {
         // Skip embedding models - they can't be used for chat
         if (modelItem.embedding) return
+
+        // If the provider has pinned models, hide auto-fetched ones
+        if (hasManualModels) {
+          if ((modelItem as any).manuallyAdded !== true) return
+        }
 
         // Skip models that require API key but don't have one (except llamacpp)
         // For custom providers, allow if they have at least one model loaded

--- a/web-app/src/containers/__tests__/DropdownModelProvider.manualFilter.test.tsx
+++ b/web-app/src/containers/__tests__/DropdownModelProvider.manualFilter.test.tsx
@@ -1,0 +1,197 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import DropdownModelProvider from '../DropdownModelProvider'
+import { useModelProvider } from '@/hooks/useModelProvider'
+
+// Minimal local types to avoid pulling ambient declarations into the test.
+type Model = {
+  id: string
+  displayName?: string
+  capabilities?: string[]
+  manuallyAdded?: boolean
+  imported?: boolean
+  embedding?: boolean
+}
+
+type ModelProvider = {
+  provider: string
+  active: boolean
+  models: Model[]
+  settings: unknown[]
+}
+
+type MockHookReturn = {
+  providers: ModelProvider[]
+  selectedProvider: string
+  selectedModel: Model
+  getProviderByName: (name: string) => ModelProvider | undefined
+  selectModelProvider: () => void
+  getModelBy: (id: string) => Model | undefined
+  updateProvider: () => void
+}
+
+vi.mock('@/hooks/useModelProvider', () => ({
+  useModelProvider: vi.fn(),
+}))
+
+vi.mock('@/hooks/useThreads', () => ({
+  useThreads: vi.fn(() => ({ updateCurrentThreadModel: vi.fn() })),
+}))
+
+vi.mock('@/hooks/useServiceHub', () => ({
+  useServiceHub: vi.fn(() => ({
+    models: () => ({
+      checkMmprojExists: vi.fn(() => Promise.resolve(false)),
+      checkMmprojExistsAndUpdateOffloadMMprojSetting: vi.fn(() =>
+        Promise.resolve()
+      ),
+    }),
+  })),
+}))
+
+vi.mock('@/i18n/react-i18next-compat', () => ({
+  useTranslation: vi.fn(() => ({ t: (key: string) => key })),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: vi.fn(() => vi.fn()),
+}))
+
+vi.mock('@/hooks/useFavoriteModel', () => ({
+  useFavoriteModel: vi.fn(() => ({ favoriteModels: [] })),
+}))
+
+vi.mock('@/lib/platform/const', () => ({
+  PlatformFeatures: {
+    WEB_AUTO_MODEL_SELECTION: false,
+    MODEL_PROVIDER_SETTINGS: true,
+    projects: true,
+  },
+}))
+
+vi.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  PopoverTrigger: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popover-trigger">{children}</div>
+  ),
+  PopoverContent: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="popover-content">{children}</div>
+  ),
+}))
+
+vi.mock('../ProvidersAvatar', () => ({
+  default: ({ provider }: { provider: any }) => (
+    <div data-testid={`provider-avatar-${provider.provider}`} />
+  ),
+}))
+
+vi.mock('../Capabilities', () => ({
+  default: ({ capabilities }: { capabilities: string[] }) => (
+    <div data-testid="capabilities">{capabilities.join(',')}</div>
+  ),
+}))
+
+vi.mock('../ModelSetting', () => ({
+  ModelSetting: () => <div data-testid="model-setting" />,
+}))
+
+vi.mock('../ModelSupportStatus', () => ({
+  ModelSupportStatus: () => <div data-testid="model-support-status" />,
+}))
+
+const mockHook = (providers: ModelProvider[], selectedModel: Model) =>
+  vi.mocked(useModelProvider).mockReturnValue({
+    providers,
+    selectedProvider: providers[0]?.provider,
+    selectedModel,
+    getProviderByName: vi.fn((name: string) =>
+      providers.find((p) => p.provider === name)
+    ),
+    selectModelProvider: vi.fn(),
+    getModelBy: vi.fn((id: string) =>
+      providers.flatMap((p) => p.models).find((m) => m.id === id)
+    ),
+    updateProvider: vi.fn(),
+  } as MockHookReturn)
+
+describe('DropdownModelProvider - manual model filter', () => {
+  beforeEach(() => vi.clearAllMocks())
+  afterEach(() => cleanup())
+
+  it('hides auto-fetched models when the provider has pinned models', () => {
+    const provider: ModelProvider = {
+      provider: 'llamacpp',
+      active: true,
+      settings: [],
+      models: [
+        { id: 'pinned.gguf', capabilities: ['completion'], manuallyAdded: true },
+        { id: 'auto-1.gguf', capabilities: ['completion'] },
+        { id: 'auto-2.gguf', capabilities: ['completion'] },
+      ],
+    }
+    mockHook([provider], provider.models[0])
+
+    render(<DropdownModelProvider />)
+
+    expect(screen.getAllByText('pinned.gguf').length).toBeGreaterThanOrEqual(1)
+    expect(screen.queryByText('auto-1.gguf')).not.toBeInTheDocument()
+    expect(screen.queryByText('auto-2.gguf')).not.toBeInTheDocument()
+  })
+
+  it('treats imported models as pinned and hides auto-fetched ones', () => {
+    const provider: ModelProvider = {
+      provider: 'llamacpp',
+      active: true,
+      settings: [],
+      models: [
+        { id: 'local.gguf', capabilities: ['completion'], imported: true },
+        { id: 'auto-1.gguf', capabilities: ['completion'] },
+      ],
+    }
+    mockHook([provider], provider.models[0])
+
+    render(<DropdownModelProvider />)
+
+    expect(screen.getAllByText('local.gguf').length).toBeGreaterThanOrEqual(1)
+    expect(screen.queryByText('auto-1.gguf')).not.toBeInTheDocument()
+  })
+
+  it('shows all models when the provider has no pinned models', () => {
+    const provider: ModelProvider = {
+      provider: 'llamacpp',
+      active: true,
+      settings: [],
+      models: [
+        { id: 'auto-1.gguf', capabilities: ['completion'] },
+        { id: 'auto-2.gguf', capabilities: ['completion'] },
+        { id: 'auto-3.gguf', capabilities: ['completion'] },
+      ],
+    }
+    mockHook([provider], provider.models[0])
+
+    render(<DropdownModelProvider />)
+
+    expect(screen.getByText('auto-2.gguf')).toBeInTheDocument()
+    expect(screen.getByText('auto-3.gguf')).toBeInTheDocument()
+  })
+
+  it('does not treat a catalog displayName as a pin', () => {
+    // A displayName alone must NOT activate the filter — otherwise catalogs
+    // that ship displayName would wrongly hide every other model.
+    const provider: ModelProvider = {
+      provider: 'llamacpp',
+      active: true,
+      settings: [],
+      models: [
+        { id: 'auto-1.gguf', displayName: 'Auto One', capabilities: ['completion'] },
+        { id: 'auto-2.gguf', displayName: 'Auto Two', capabilities: ['completion'] },
+      ],
+    }
+    mockHook([provider], provider.models[0])
+
+    render(<DropdownModelProvider />)
+
+    expect(screen.getByText('Auto Two')).toBeInTheDocument()
+  })
+})

--- a/web-app/src/containers/dialogs/AddModel.tsx
+++ b/web-app/src/containers/dialogs/AddModel.tsx
@@ -40,10 +40,20 @@ export const DialogAddModel = ({ provider, trigger }: DialogAddModelProps) => {
     if (!modelId.trim()) return // Don't submit if model ID is empty
 
     if (provider.models.some((e) => e.id === modelId)) {
-      toast.error(t('providers:addModel.modelExists'), {
-        description: t('providers:addModel.modelExistsDesc'),
+      // Model already exists — upgrade it to manually-added so it appears
+      // in the "manual only" filter.  This handles the common case where a
+      // user wants to "pin" a model that was auto-fetched from a remote catalog.
+      const updatedModels = provider.models.map((m) =>
+        m.id === modelId ? { ...m, manuallyAdded: true } : m
+      )
+      updateProvider(provider.provider, {
+        ...provider,
+        models: updatedModels,
       })
-      return // Don't submit if model ID already exists
+      toast.success('Model added to your collection')
+      setModelId('')
+      setOpen(false)
+      return
     }
 
     // Create the new model
@@ -53,6 +63,7 @@ export const DialogAddModel = ({ provider, trigger }: DialogAddModelProps) => {
       name: modelId,
       capabilities: getModelCapabilities(provider.provider, modelId),
       version: '1.0',
+      manuallyAdded: true,
     }
 
     // Update the provider with the new model

--- a/web-app/src/containers/dialogs/AddModel.tsx
+++ b/web-app/src/containers/dialogs/AddModel.tsx
@@ -50,7 +50,7 @@ export const DialogAddModel = ({ provider, trigger }: DialogAddModelProps) => {
         ...provider,
         models: updatedModels,
       })
-      toast.success('Model added to your collection')
+      toast.success(t('providers:addModel.modelPinned'))
       setModelId('')
       setOpen(false)
       return

--- a/web-app/src/containers/dialogs/EditModel.tsx
+++ b/web-app/src/containers/dialogs/EditModel.tsx
@@ -119,7 +119,7 @@ export const DialogEditModel = ({
       const capabilitiesChanged = JSON.stringify(capabilities) !== JSON.stringify(originalCapabilities)
 
       // Build the update object for the selected model
-      const modelUpdate: Partial<Model> & { _userConfiguredCapabilities?: boolean; manuallyAdded?: boolean } = {}
+      const modelUpdate: Partial<Model> = {}
 
       if (nameChanged) {
         modelUpdate.displayName = displayName

--- a/web-app/src/containers/dialogs/EditModel.tsx
+++ b/web-app/src/containers/dialogs/EditModel.tsx
@@ -119,7 +119,7 @@ export const DialogEditModel = ({
       const capabilitiesChanged = JSON.stringify(capabilities) !== JSON.stringify(originalCapabilities)
 
       // Build the update object for the selected model
-      const modelUpdate: Partial<Model> & { _userConfiguredCapabilities?: boolean } = {}
+      const modelUpdate: Partial<Model> & { _userConfiguredCapabilities?: boolean; manuallyAdded?: boolean } = {}
 
       if (nameChanged) {
         modelUpdate.displayName = displayName
@@ -130,6 +130,11 @@ export const DialogEditModel = ({
           .filter(([, isEnabled]) => isEnabled)
           .map(([capName]) => capName)
         modelUpdate._userConfiguredCapabilities = true
+      }
+
+      // Mark as manually added so it shows in the "manual only" filter
+      if (nameChanged || capabilitiesChanged) {
+        modelUpdate.manuallyAdded = true
       }
 
       // Update the model in the provider models array

--- a/web-app/src/hooks/__tests__/useModelProvider.test.ts
+++ b/web-app/src/hooks/__tests__/useModelProvider.test.ts
@@ -435,4 +435,55 @@ describe('useModelProvider migrations', () => {
     // Pre-set api_type must round-trip untouched.
     expect(customAnthropic.api_type).toBe('anthropic')
   })
+
+  it('backfills manuallyAdded on curated models (v17 → v18)', () => {
+    const persistApi = (useModelProvider as any).persist
+    const migrate = persistApi?.getOptions().migrate as
+      | ((state: unknown, version: number) => any)
+      | undefined
+
+    expect(migrate).toBeDefined()
+
+    const persistedState = {
+      providers: [
+        {
+          provider: 'openrouter',
+          base_url: 'https://openrouter.ai/api/v1',
+          settings: [],
+          models: [
+            // User toggled capabilities → curated.
+            { id: 'cap', name: 'cap', _userConfiguredCapabilities: true },
+            // User renamed (displayName differs from name) → curated.
+            { id: 'renamed', name: 'renamed', displayName: 'My Model' },
+            // Catalog echoes displayName === name → NOT curated.
+            { id: 'echo-name', name: 'echo-name', displayName: 'echo-name' },
+            // Catalog echoes displayName === id → NOT curated.
+            { id: 'echo-id', name: 'Some Name', displayName: 'echo-id' },
+            // Plain auto-fetched model → untouched.
+            { id: 'plain', name: 'plain' },
+            // Already flagged → preserved.
+            { id: 'already', name: 'already', manuallyAdded: true },
+            // Imported models are recognized at read time, not backfilled here.
+            { id: 'imported', name: 'imported', imported: true },
+          ],
+        },
+      ],
+      selectedProvider: 'openrouter',
+      selectedModel: null,
+      deletedModels: [],
+    }
+
+    const migratedState = migrate!(persistedState, 17)
+    const byId = Object.fromEntries(
+      migratedState.providers[0].models.map((m: Model) => [m.id, m])
+    )
+
+    expect(byId.cap.manuallyAdded).toBe(true)
+    expect(byId.renamed.manuallyAdded).toBe(true)
+    expect(byId['echo-name'].manuallyAdded).toBeUndefined()
+    expect(byId['echo-id'].manuallyAdded).toBeUndefined()
+    expect(byId.plain.manuallyAdded).toBeUndefined()
+    expect(byId.already.manuallyAdded).toBe(true)
+    expect(byId.imported.manuallyAdded).toBeUndefined()
+  })
 })

--- a/web-app/src/hooks/useModelProvider.ts
+++ b/web-app/src/hooks/useModelProvider.ts
@@ -819,9 +819,35 @@ export const useModelProvider = create<ModelProviderState>()(
           })
         }
 
+        if (version <= 17 && state?.providers) {
+          // Backfill manuallyAdded on models that were manually customized
+          // before the "manual filter" feature existed.  This preserves the
+          // user's curated selection when upgrading.
+          state.providers.forEach((provider) => {
+            if (!provider.models) return
+            provider.models.forEach((model) => {
+              const m = model as Model & Record<string, unknown>
+              if (
+                (m as any).manuallyAdded === true ||
+                (m as any).imported === true
+              ) {
+                return // already flagged
+              }
+              // Models that were added via the "Add Model" dialog, renamed, or
+              // had capabilities manually toggled should be considered manual.
+              if (
+                m.displayName ||
+                (m as any)._userConfiguredCapabilities === true
+              ) {
+                ;(m as any).manuallyAdded = true
+              }
+            })
+          })
+        }
+
         return state
       },
-      version: 17,
+      version: 18,
     }
   )
 )

--- a/web-app/src/hooks/useModelProvider.ts
+++ b/web-app/src/hooks/useModelProvider.ts
@@ -820,26 +820,25 @@ export const useModelProvider = create<ModelProviderState>()(
         }
 
         if (version <= 17 && state?.providers) {
-          // Backfill manuallyAdded on models that were manually customized
-          // before the "manual filter" feature existed.  This preserves the
-          // user's curated selection when upgrading.
+          // One-time backfill of `manuallyAdded` for users upgrading from
+          // before the manual-filter feature. Imported models are recognized
+          // at read time (see `isManuallyAdded`), so they need no backfill.
+          //
+          // Heuristic: a model is user-curated if it has user-configured
+          // capabilities, or a displayName that differs from its name/id
+          // (i.e. the user renamed it). We deliberately ignore a displayName
+          // that merely mirrors name/id, because remote catalogs sometimes
+          // populate it verbatim — counting those would wrongly hide
+          // auto-fetched models from the chat dropdown.
           state.providers.forEach((provider) => {
-            if (!provider.models) return
-            provider.models.forEach((model) => {
-              const m = model as Model & Record<string, unknown>
-              if (
-                (m as any).manuallyAdded === true ||
-                (m as any).imported === true
-              ) {
-                return // already flagged
-              }
-              // Models that were added via the "Add Model" dialog, renamed, or
-              // had capabilities manually toggled should be considered manual.
-              if (
-                m.displayName ||
-                (m as any)._userConfiguredCapabilities === true
-              ) {
-                ;(m as any).manuallyAdded = true
+            provider.models?.forEach((model) => {
+              if (model.manuallyAdded === true) return
+              const userRenamed =
+                !!model.displayName &&
+                model.displayName !== model.name &&
+                model.displayName !== model.id
+              if (model._userConfiguredCapabilities === true || userRenamed) {
+                model.manuallyAdded = true
               }
             })
           })

--- a/web-app/src/lib/__tests__/models.test.ts
+++ b/web-app/src/lib/__tests__/models.test.ts
@@ -8,6 +8,7 @@ import {
   extractQuantLabel,
   getModelCapabilities,
   selectDefaultQuant,
+  isManuallyAdded,
 } from '../models'
 import { ModelCapabilities } from '@/types/models'
 
@@ -380,5 +381,31 @@ describe('getModelCapabilities', () => {
     expect(capabilities).toContain(ModelCapabilities.COMPLETION)
     expect(capabilities).toContain(ModelCapabilities.TOOLS)
     expect(capabilities).not.toContain(ModelCapabilities.VISION)
+  })
+})
+
+describe('isManuallyAdded', () => {
+  it('returns true when the manuallyAdded flag is set', () => {
+    expect(isManuallyAdded({ id: 'gpt-4', manuallyAdded: true })).toBe(true)
+  })
+
+  it('returns true for imported local models', () => {
+    expect(isManuallyAdded({ id: 'local.gguf', imported: true })).toBe(true)
+  })
+
+  it('returns false for plain auto-fetched models', () => {
+    expect(isManuallyAdded({ id: 'gpt-4' })).toBe(false)
+  })
+
+  it('does NOT treat a catalog displayName as manual', () => {
+    // Read-time check relies solely on the persisted flags — displayName is a
+    // migration-only heuristic and must not leak into this predicate.
+    expect(isManuallyAdded({ id: 'gpt-4', displayName: 'GPT-4' })).toBe(false)
+  })
+
+  it('does NOT treat user-configured capabilities as manual at read time', () => {
+    expect(
+      isManuallyAdded({ id: 'gpt-4', _userConfiguredCapabilities: true })
+    ).toBe(false)
   })
 })

--- a/web-app/src/lib/models.ts
+++ b/web-app/src/lib/models.ts
@@ -110,3 +110,19 @@ export const extractQuantLabel = (modelId?: string): string | null => {
   )
   return match ? match[1].toUpperCase() : null
 }
+
+/**
+ * Single source of truth for whether a model was curated by the user.
+ *
+ * A model is "manually added" when it carries the explicit `manuallyAdded`
+ * flag (set when added/pinned via the Add Model dialog or edited) or when it
+ * was `imported` from a local file. Both are real persisted flags, so the
+ * settings "manual only" filter and the chat model dropdown stay consistent.
+ *
+ * The displayName / _userConfiguredCapabilities heuristics are intentionally
+ * NOT consulted here — they are only used once, by the v17→18 migration, to
+ * backfill `manuallyAdded` for users who customized models before this flag
+ * existed.
+ */
+export const isManuallyAdded = (model: Model): boolean =>
+  model.manuallyAdded === true || model.imported === true

--- a/web-app/src/locales/en/providers.json
+++ b/web-app/src/locales/en/providers.json
@@ -35,7 +35,13 @@
     "exploreModels": "See model list from {{provider}}",
     "addModel": "Add Model",
     "modelExists": "Model already exists",
-    "modelExistsDesc": "Please choose a different model ID."
+    "modelExistsDesc": "Please choose a different model ID.",
+    "modelPinned": "Model added to your collection"
+  },
+  "manualFilter": {
+    "tooltip": "Show manually added models only",
+    "emptyTitle": "No manually added models",
+    "emptyDescription": "Use the \"Add Model\" button to add models manually, or toggle the filter off to show all models."
   },
   "deleteModel": {
     "title": "Delete Model: {{modelId}}",

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -40,6 +40,7 @@ import { useModelLoad } from '@/hooks/useModelLoad'
 import { useLlamacppDevices } from '@/hooks/useLlamacppDevices'
 import { useBackendUpdater } from '@/hooks/useBackendUpdater'
 import { basenameNoExt } from '@/lib/utils'
+import { isManuallyAdded } from '@/lib/models'
 import { useAppState } from '@/hooks/useAppState'
 import { useShallow } from 'zustand/shallow'
 import { DialogAddModel } from '@/containers/dialogs/AddModel'
@@ -110,14 +111,9 @@ function ProviderDetail() {
         : allModels,
     [isLlamacpp, allModels]
   )
-  // Filter to only show manually-added models when the filter is active.
-  // A model counts as "manual" if it was explicitly added, edited (has a
-  // custom display name or user-configured capabilities), or was imported.
-  const isManuallyAdded = (m: Model) =>
-    (m as any).manuallyAdded === true ||
-    (m as any).imported === true ||
-    !!(m as any).displayName ||
-    (m as any)._userConfiguredCapabilities === true
+  // When the filter is active, show only models the user has curated.
+  // `isManuallyAdded` is the shared definition used by the chat dropdown too,
+  // so the two views stay consistent.
   const displayedChatModels = useMemo(
     () => (showManualOnly ? chatModels.filter(isManuallyAdded) : chatModels),
     [chatModels, showManualOnly]
@@ -1210,9 +1206,8 @@ function ProviderDetail() {
                           <Button
                             variant={showManualOnly ? 'default' : 'secondary'}
                             size="icon-xs"
-                            onClick={() => setShowManualOnly(true)}
-                            disabled={showManualOnly}
-                            title="Show manually added models only"
+                            onClick={() => setShowManualOnly((prev) => !prev)}
+                            title={t('providers:manualFilter.tooltip')}
                           >
                             <IconFilter
                               size={18}
@@ -1272,11 +1267,11 @@ function ProviderDetail() {
                     <div className="-mt-2">
                       <div className="flex items-center gap-2">
                         <h6 className="font-medium text-base">
-                          No manually added models
+                          {t('providers:manualFilter.emptyTitle')}
                         </h6>
                       </div>
                       <p className="text-muted-foreground mt-1 text-xs leading-relaxed">
-                        Use the "Add Model" button to add models manually, or click the refresh button to show all models.
+                        {t('providers:manualFilter.emptyDescription')}
                       </p>
                     </div>
                   )}

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -29,6 +29,7 @@ import {
   IconInfoCircle,
   IconLoader,
   IconRefresh,
+  IconFilter,
   IconUpload,
 } from '@tabler/icons-react'
 import { useDefaultEmbeddingModel } from '@/hooks/useDefaultEmbeddingModel'
@@ -73,6 +74,7 @@ function ProviderDetail() {
   )
   const [loadingModels, setLoadingModels] = useState<string[]>([])
   const [refreshingModels, setRefreshingModels] = useState(false)
+  const [showManualOnly, setShowManualOnly] = useState(false)
   const [isCheckingBackendUpdate, setIsCheckingBackendUpdate] = useState(false)
   const [isInstallingBackend, setIsInstallingBackend] = useState(false)
   const [importingModel, setImportingModel] = useState<string | null>(null)
@@ -107,6 +109,22 @@ function ProviderDetail() {
         ? allModels.filter((m) => (m as any).embedding !== true)
         : allModels,
     [isLlamacpp, allModels]
+  )
+  // Filter to only show manually-added models when the filter is active.
+  // A model counts as "manual" if it was explicitly added, edited (has a
+  // custom display name or user-configured capabilities), or was imported.
+  const isManuallyAdded = (m: Model) =>
+    (m as any).manuallyAdded === true ||
+    (m as any).imported === true ||
+    !!(m as any).displayName ||
+    (m as any)._userConfiguredCapabilities === true
+  const displayedChatModels = useMemo(
+    () => (showManualOnly ? chatModels.filter(isManuallyAdded) : chatModels),
+    [chatModels, showManualOnly]
+  )
+  const displayedEmbeddingModels = useMemo(
+    () => (showManualOnly ? embeddingModels.filter(isManuallyAdded) : embeddingModels),
+    [embeddingModels, showManualOnly]
   )
   const defaultEmbeddingModelId = useDefaultEmbeddingModel((s) =>
     isLlamacpp ? s.getDefault('llamacpp') : undefined
@@ -496,6 +514,7 @@ function ProviderDetail() {
   // This ensures all screens receive the event intermediately
 
   const handleRefreshModels = async () => {
+    setShowManualOnly(false)
     if (!provider || !provider.base_url || !providerHasRemoteApiKeys(provider)) {
       toast.error(t('providers:models'), {
         description: t('providers:refreshModelsError'),
@@ -1188,6 +1207,18 @@ function ProviderDetail() {
                               />
                             )}
                           </Button>
+                          <Button
+                            variant={showManualOnly ? 'default' : 'secondary'}
+                            size="icon-xs"
+                            onClick={() => setShowManualOnly(true)}
+                            disabled={showManualOnly}
+                            title="Show manually added models only"
+                          >
+                            <IconFilter
+                              size={18}
+                              className={showManualOnly ? '' : 'text-muted-foreground'}
+                            />
+                          </Button>
                           <DialogAddModel provider={provider} />
                         </>
                       )}
@@ -1237,7 +1268,19 @@ function ProviderDetail() {
               >
                 {provider?.models.length ? (
                   <>
-                  {isLlamacpp && embeddingModels.length > 0 && chatModels.length > 0 && (
+                  {displayedChatModels.length === 0 && showManualOnly && (
+                    <div className="-mt-2">
+                      <div className="flex items-center gap-2">
+                        <h6 className="font-medium text-base">
+                          No manually added models
+                        </h6>
+                      </div>
+                      <p className="text-muted-foreground mt-1 text-xs leading-relaxed">
+                        Use the "Add Model" button to add models manually, or click the refresh button to show all models.
+                      </p>
+                    </div>
+                  )}
+                  {displayedChatModels.length > 0 && isLlamacpp && displayedEmbeddingModels.length > 0 && (
                     <div
                       role="separator"
                       aria-label={t('providers:chatModels')}
@@ -1249,7 +1292,7 @@ function ProviderDetail() {
                       <span className="h-0.5 flex-1 rounded-full bg-main-view-fg/15" />
                     </div>
                   )}
-                  {(isLlamacpp ? chatModels : allModels).map((model, modelIndex) => {
+                  {displayedChatModels.map((model, modelIndex) => {
                     const capabilities = model.capabilities || []
                     return (
                       <CardItem
@@ -1383,7 +1426,7 @@ function ProviderDetail() {
                   />
                 )}
 
-                {isLlamacpp && provider && embeddingModels.length > 0 && (
+                {isLlamacpp && provider && displayedEmbeddingModels.length > 0 && (
                   <>
                     <div
                       role="separator"
@@ -1395,7 +1438,7 @@ function ProviderDetail() {
                       </span>
                       <span className="h-0.5 flex-1 rounded-full bg-main-view-fg/15" />
                     </div>
-                    {embeddingModels.map((model, modelIndex) => {
+                    {displayedEmbeddingModels.map((model, modelIndex) => {
                       const isDefault = defaultEmbeddingModelId === model.id
                       return (
                         <CardItem

--- a/web-app/src/routes/settings/providers/__tests__/$providerName.test.tsx
+++ b/web-app/src/routes/settings/providers/__tests__/$providerName.test.tsx
@@ -284,6 +284,7 @@ vi.mock('@tabler/icons-react', () => ({
   IconInfoCircle: () => <span />,
   IconLoader: () => <span />,
   IconRefresh: () => <span />,
+  IconFilter: () => <span />,
   IconUpload: () => <span />,
   IconTrash: () => <span />,
   IconCircle: () => <span />,

--- a/web-app/src/types/modelProviders.d.ts
+++ b/web-app/src/types/modelProviders.d.ts
@@ -42,6 +42,13 @@ type Model = {
   /** Whether this model was imported from a user-supplied local file
    *  (path lives outside the provider's managed models directory). */
   imported?: boolean
+  /** Whether the user explicitly curated this model — added/pinned it via the
+   *  Add Model dialog or edited it. Drives the "manual only" filter and the
+   *  chat dropdown. See `isManuallyAdded` in `@/lib/models`. */
+  manuallyAdded?: boolean
+  /** Whether the user manually toggled this model's capabilities in the Edit
+   *  Model dialog (vs. capabilities inferred from the provider catalog). */
+  _userConfiguredCapabilities?: boolean
 }
 
 /**


### PR DESCRIPTION
## Describe Your Changes
Some providers like OpenRouter and Together.ai supply hundreds of models, which makes scrolling through them tedious, especially after you've already picked the few you actually want to use. This PR lets you pin your own selection so that only your chosen models appear in the model dropdown and provider settings list. Auto-fetched models stay in the background and are always one click away via the refresh button. More specifically:
- **Settings → Providers**: Add filter button to show only manually-added models (`$providerName.tsx`)
- **Chat → Model Dropdown**: Hide auto-fetched models when user has pinned models (`DropdownModelProvider.tsx`)
- **Settings → Add Model Dialog**: Upgrade existing models instead of rejecting duplicates (`AddModel.tsx`)
- **Settings → Edit Model Dialog**: Mark edited models as manually-added (`EditModel.tsx`)
- **State Migration**: Backfill `manuallyAdded` flag for existing users with customized models (`useModelProvider.ts`)
- **Tests**: Update icon mock for new filter button (`$providerName.test.tsx`)

## Fixes Issues

N/A — quality of life improvement, no linked issue.

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [x] Created issues for follow-up changes or refactoring needed — none needed
- [x] Updated docs (for bug fixes / features) — N/A, no API or config changes
