### PR TITLE
feat: full-text thread search

### DIFF
--- a/web-app/src/containers/dialogs/SearchDialog.tsx
+++ b/web-app/src/containers/dialogs/SearchDialog.tsx
@@ -12,12 +12,17 @@ import {
   IconHistory,
   IconCirclePlus,
   IconFolder,
+  IconLoader,
 } from '@tabler/icons-react'
 import { useThreads } from '@/hooks/useThreads'
 import { localStorageKey } from '@/constants/localStorage'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { cn } from '@/lib/utils'
 import { VisuallyHidden } from '@radix-ui/react-visually-hidden'
+import {
+  getThreadSearchIndex,
+  type ThreadSearchResult,
+} from '@/lib/search-index'
 
 const MAX_RECENT_SEARCHES = 5
 
@@ -32,22 +37,61 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [recentVersion, setRecentVersion] = useState(0)
+  const [fullTextResults, setFullTextResults] = useState<ThreadSearchResult[]>([])
+  const [indexReady, setIndexReady] = useState(false)
+  const [indexBuilding, setIndexBuilding] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
 
   const threads = useThreads((state) => state.threads)
   const getFilteredThreads = useThreads((state) => state.getFilteredThreads)
+
+  // Build (or refresh) full-text search index when dialog opens.
+  // Re-runs whenever there's pending work (new threads, stale entries, deletions).
+  useEffect(() => {
+    if (!open) return
+    const index = getThreadSearchIndex()
+    if (!index.hasPendingWork) {
+      setIndexReady(true)
+      setIndexBuilding(false)
+      return
+    }
+    // Allow searching titles immediately even while content corpus is loading.
+    setIndexReady(index.isReady)
+    setIndexBuilding(true)
+    index.build(threads).then(() => {
+      setIndexReady(true)
+      setIndexBuilding(false)
+    })
+  }, [open, threads])
 
   // Focus input when dialog opens
   useEffect(() => {
     if (open) {
       setSearchQuery('')
       setSelectedIndex(0)
+      setFullTextResults([])
       setTimeout(() => {
         inputRef.current?.focus()
       }, 0)
     }
   }, [open])
+
+  // Full-text search (debounced to avoid heavy work on every keystroke).
+  // Re-runs when indexBuilding flips to false so newly-indexed threads appear.
+  useEffect(() => {
+    if (!searchQuery || !indexReady) {
+      setFullTextResults([])
+      return
+    }
+    clearTimeout(searchTimerRef.current)
+    searchTimerRef.current = setTimeout(() => {
+      const index = getThreadSearchIndex()
+      setFullTextResults(index.search(searchQuery))
+    }, 100)
+    return () => clearTimeout(searchTimerRef.current)
+  }, [searchQuery, indexReady, indexBuilding])
 
   // Load recent searches from localStorage
   const recentSearches = useMemo(() => {
@@ -77,6 +121,7 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
 
   const handleClose = () => {
     setSearchQuery('')
+    setFullTextResults([])
     onOpenChange(false)
   }
 
@@ -113,24 +158,38 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
   const searchResults = useMemo(() => {
     if (!searchQuery) return { withProject: [], withoutProject: [] }
 
-    const filteredThreads = getFilteredThreads(searchQuery)
+    // Use full-text results when available; fall back to title-only search
+    let filteredThreads: Thread[]
+    if (fullTextResults.length > 0) {
+      filteredThreads = fullTextResults.map((r) => r.thread)
+    } else {
+      // Fallback: title-only search if index isn't built yet
+      filteredThreads = getFilteredThreads(searchQuery)
+    }
+
     const withProject: Array<{
       thread: Thread
       projectName: string
+      snippet?: string
     }> = []
-    const withoutProject: Thread[] = []
+    const withoutProject: Array<{
+      thread: Thread
+      snippet?: string
+    }> = []
 
     filteredThreads.forEach((thread) => {
+      const ftResult = fullTextResults.find((r) => r.thread.id === thread.id)
+      const snippet = ftResult?.matchSource === 'content' ? ftResult.snippet : undefined
       const projectName = thread.metadata?.project?.name
       if (projectName) {
-        withProject.push({ thread, projectName })
+        withProject.push({ thread, projectName, snippet })
       } else {
-        withoutProject.push(thread)
+        withoutProject.push({ thread, snippet })
       }
     })
 
     return { withProject, withoutProject }
-  }, [searchQuery, getFilteredThreads])
+  }, [searchQuery, fullTextResults, getFilteredThreads])
 
   // Calculate all selectable items for keyboard navigation
   const allItems = useMemo(() => {
@@ -149,7 +208,7 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
         items.push({ type: 'result', id: thread.id })
       })
       // Search results without project
-      searchResults.withoutProject.forEach((thread) => {
+      searchResults.withoutProject.forEach(({ thread }) => {
         items.push({ type: 'result', id: thread.id })
       })
     }
@@ -225,6 +284,15 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
             onChange={(e) => setSearchQuery(e.target.value)}
             onKeyDown={handleKeyDown}
           />
+          {indexBuilding && (
+            <span
+              className="flex items-center gap-1.5 text-xs text-muted-foreground shrink-0"
+              title="Indexing message content for full-text search"
+            >
+              <IconLoader className="size-3.5 animate-spin" />
+              <span className="hidden sm:inline">Indexing…</span>
+            </span>
+          )}
         </div>
 
         {/* Results */}
@@ -296,7 +364,7 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
           {/* Search results with project name */}
           {searchQuery && searchResults.withProject.length > 0 && (
             <div className="p-1">
-              {searchResults.withProject.map(({ thread, projectName }, index) => {
+              {searchResults.withProject.map(({ thread, projectName, snippet }, index) => {
                 const itemIndex = index
                 return (
                   <button
@@ -309,12 +377,17 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
                     )}
                   >
                     <IconMessage className="size-4 text-muted-foreground shrink-0" />
-                    <div className="flex items-center min-w-0">
-                      <span className="text-xs text-muted-foreground flex items-center gap-1">
-                        <IconFolder className="size-3" />
-                        {projectName} -&nbsp;
-                      </span>
-                      <span className="text-sm truncate">{thread.title}</span>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center">
+                        <span className="text-xs text-muted-foreground flex items-center gap-1">
+                          <IconFolder className="size-3" />
+                          {projectName} -&nbsp;
+                        </span>
+                        <span className="text-sm truncate">{thread.title}</span>
+                      </div>
+                      {snippet && (
+                        <p className="text-xs text-muted-foreground/70 truncate mt-0.5">{snippet}</p>
+                      )}
                     </div>
                   </button>
                 )
@@ -325,7 +398,7 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
           {/* Search results without project name */}
           {searchQuery && searchResults.withoutProject.length > 0 && (
             <div className="p-1">
-              {searchResults.withoutProject.map((thread, index) => {
+              {searchResults.withoutProject.map(({ thread, snippet }, index) => {
                 const itemIndex =
                   searchResults.withProject.length + index
                 return (
@@ -334,12 +407,17 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
                     data-index={itemIndex}
                     onClick={() => handleSelectThread(thread.id)}
                     className={cn(
-                      'w-full flex items-center gap-2 px-3 py-2 rounded-md text-left hover:bg-secondary/60 transition-colors cursor-pointer',
+                      'w-full flex flex-col gap-0.5 px-3 py-2 rounded-md text-left hover:bg-secondary/60 transition-colors cursor-pointer',
                       selectedIndex === itemIndex && 'bg-secondary/50'
                     )}
                   >
-                    <IconMessage className="size-4 text-muted-foreground shrink-0" />
-                    <span className="text-sm truncate">{thread.title}</span>
+                    <div className="flex items-center gap-2">
+                      <IconMessage className="size-4 text-muted-foreground shrink-0" />
+                      <span className="text-sm truncate">{thread.title}</span>
+                    </div>
+                    {snippet && (
+                      <p className="text-xs text-muted-foreground/70 truncate pl-6">{snippet}</p>
+                    )}
                   </button>
                 )
               })}

--- a/web-app/src/containers/dialogs/SearchDialog.tsx
+++ b/web-app/src/containers/dialogs/SearchDialog.tsx
@@ -52,7 +52,7 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
   useEffect(() => {
     if (!open) return
     const index = getThreadSearchIndex()
-    if (!index.hasPendingWork) {
+    if (!index.hasPendingWork(threads)) {
       setIndexReady(true)
       setIndexBuilding(false)
       return
@@ -158,12 +158,13 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
   const searchResults = useMemo(() => {
     if (!searchQuery) return { withProject: [], withoutProject: [] }
 
-    // Use full-text results when available; fall back to title-only search
+    // Once the index is ready, trust its (strict substring) results exclusively
+    // — including the empty set. Only fall back to fuzzy title-only search while
+    // the index is still building, so results stay consistent.
     let filteredThreads: Thread[]
-    if (fullTextResults.length > 0) {
+    if (indexReady) {
       filteredThreads = fullTextResults.map((r) => r.thread)
     } else {
-      // Fallback: title-only search if index isn't built yet
       filteredThreads = getFilteredThreads(searchQuery)
     }
 
@@ -179,7 +180,7 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
 
     filteredThreads.forEach((thread) => {
       const ftResult = fullTextResults.find((r) => r.thread.id === thread.id)
-      const snippet = ftResult?.matchSource === 'content' ? ftResult.snippet : undefined
+      const snippet = ftResult?.snippet
       const projectName = thread.metadata?.project?.name
       if (projectName) {
         withProject.push({ thread, projectName, snippet })
@@ -189,7 +190,7 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
     })
 
     return { withProject, withoutProject }
-  }, [searchQuery, fullTextResults, getFilteredThreads])
+  }, [searchQuery, fullTextResults, getFilteredThreads, indexReady])
 
   // Calculate all selectable items for keyboard navigation
   const allItems = useMemo(() => {
@@ -297,8 +298,22 @@ export function SearchDialog({ open, onOpenChange }: SearchDialogProps) {
 
         {/* Results */}
         <div ref={listRef} className="max-h-80 overflow-y-auto px-1 py-2">
+          {/* Still-indexing state: avoid flashing "no results" before the
+              content corpus has finished loading. */}
+          {searchQuery && !hasResults && indexBuilding && (
+            <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
+              <IconLoader className="size-6 text-muted-foreground mb-2 animate-spin" />
+              <h3 className="text-base font-medium mb-1">
+                {t('common:searchIndexing')}
+              </h3>
+              <p className="text-xs leading-relaxed text-muted-foreground w-1/2 mx-auto">
+                {t('common:searchIndexingDesc')}
+              </p>
+            </div>
+          )}
+
           {/* Empty state when searching */}
-          {searchQuery && !hasResults && (
+          {searchQuery && !hasResults && !indexBuilding && (
             <div className="flex flex-col items-center justify-center py-12 px-4 text-center">
               <IconSearch className="size-6 text-muted-foreground mb-2" />
               <h3 className="text-base font-medium mb-1">

--- a/web-app/src/hooks/useMessages.ts
+++ b/web-app/src/hooks/useMessages.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { ThreadMessage } from '@janhq/core'
 import { getServiceHub } from '@/hooks/useServiceHub'
+import { getThreadSearchIndex } from '@/lib/search-index'
 
 type MessageState = {
   messages: Record<string, ThreadMessage[]>
@@ -42,6 +43,10 @@ export const useMessages = create<MessageState>()((set, get) => ({
       },
     }))
 
+    // Mark this thread's search-index entry as stale so the next search
+    // re-fetches its content. Cheap — just adds an ID to a Set.
+    getThreadSearchIndex().invalidateThread(message.thread_id)
+
     // Persist to storage asynchronously
     getServiceHub().messages().createMessage(newMessage).then((createdMessage) => {
       set((state) => ({
@@ -72,6 +77,9 @@ export const useMessages = create<MessageState>()((set, get) => ({
       },
     }))
 
+    // Mark this thread's search-index entry as stale.
+    getThreadSearchIndex().invalidateThread(message.thread_id)
+
     // Persist to storage asynchronously using modifyMessage instead of createMessage
     // to prevent duplicates when updating existing messages
     getServiceHub().messages().modifyMessage(updatedMessage).catch((error) => {
@@ -89,8 +97,13 @@ export const useMessages = create<MessageState>()((set, get) => ({
           ) || [],
       },
     }))
+
+    // Mark this thread's search-index entry as stale.
+    getThreadSearchIndex().invalidateThread(threadId)
   },
   clearAllMessages: () => {
     set({ messages: {} })
+    // Drop the entire search corpus when all messages are cleared.
+    getThreadSearchIndex().invalidate()
   },
 }))

--- a/web-app/src/hooks/useThreads.ts
+++ b/web-app/src/hooks/useThreads.ts
@@ -8,6 +8,7 @@ import { ExtensionManager } from '@/lib/extension'
 import { ExtensionTypeEnum, VectorDBExtension } from '@janhq/core'
 import { useChatSessions } from '@/stores/chat-session-store'
 import { useAppState } from '@/hooks/useAppState'
+import { getThreadSearchIndex } from '@/lib/search-index'
 
 type ThreadState = {
   threads: Record<string, Thread>
@@ -162,6 +163,7 @@ export const useThreads = create<ThreadState>()((set, get) => ({
       useAppState.getState().clearThreadState(threadId)
       cleanupVectorDB(threadId)
       getServiceHub().threads().deleteThread(threadId)
+      getThreadSearchIndex().removeThread(threadId)
 
       return {
         threads: remainingThreads,
@@ -198,6 +200,7 @@ export const useThreads = create<ThreadState>()((set, get) => ({
       threadsToDeleteIds.forEach((threadId) => {
         cleanupVectorDB(threadId)
         getServiceHub().threads().deleteThread(threadId)
+        getThreadSearchIndex().removeThread(threadId)
       })
 
       // Keep favorite threads and threads with project metadata
@@ -234,6 +237,9 @@ export const useThreads = create<ThreadState>()((set, get) => ({
         getServiceHub().threads().deleteThread(threadId)
       })
 
+      // Drop the entire search index — all threads are gone.
+      getThreadSearchIndex().invalidate()
+
       return {
         threads: {},
         currentThreadId: undefined,
@@ -258,6 +264,7 @@ export const useThreads = create<ThreadState>()((set, get) => ({
         useAppState.getState().clearThreadState(threadId)
         cleanupVectorDB(threadId)
         getServiceHub().threads().deleteThread(threadId)
+        getThreadSearchIndex().removeThread(threadId)
       })
 
       // Keep threads that don't belong to this project
@@ -407,6 +414,9 @@ export const useThreads = create<ThreadState>()((set, get) => ({
         updated: Date.now() / 1000,
       }
       getServiceHub().threads().updateThread(updatedThread) // External call, order is fine
+      // Mark stale so the next search rebuilds this thread's index entry
+      // with the new title.
+      getThreadSearchIndex().invalidateThread(threadId)
       const newThreads = { ...state.threads, [threadId]: updatedThread }
       return {
         threads: newThreads,

--- a/web-app/src/lib/__tests__/search-index.test.ts
+++ b/web-app/src/lib/__tests__/search-index.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { ContentType, type ThreadContent } from '@janhq/core'
+
+// Mock the service hub so build() reads message content from an in-memory map.
+const messagesByThread: Record<
+  string,
+  Array<{ content: ThreadContent[] }>
+> = {}
+const fetchMessages = vi.fn(async (threadId: string) =>
+  messagesByThread[threadId] ?? []
+)
+
+vi.mock('@/hooks/useServiceHub', () => ({
+  getServiceHub: () => ({
+    messages: () => ({ fetchMessages }),
+  }),
+}))
+
+import {
+  extractTextFromContent,
+  extractSnippet,
+  getThreadSearchIndex,
+  __resetThreadSearchIndexForTests,
+} from '../search-index'
+
+function textContent(value: string): ThreadContent {
+  return { type: ContentType.Text, text: { value, annotations: [] } }
+}
+
+function makeThread(id: string, title: string, updated = 0): Thread {
+  return { id, title, updated } as Thread
+}
+
+beforeEach(() => {
+  __resetThreadSearchIndexForTests()
+  for (const k of Object.keys(messagesByThread)) delete messagesByThread[k]
+  fetchMessages.mockClear()
+})
+
+describe('extractTextFromContent', () => {
+  it('returns empty string for undefined content', () => {
+    expect(extractTextFromContent(undefined)).toBe('')
+  })
+
+  it('joins text parts with a space', () => {
+    const text = extractTextFromContent([textContent('hello'), textContent('world')])
+    expect(text).toBe('hello world')
+  })
+
+  it('ignores non-text content parts', () => {
+    const content: ThreadContent[] = [
+      textContent('keep me'),
+      { type: ContentType.Image, image_url: { url: 'http://x/y.png' } },
+    ]
+    expect(extractTextFromContent(content)).toBe('keep me')
+  })
+
+  it('strips think/reasoning blocks', () => {
+    const content = [
+      textContent('<think>secret reasoning</think>visible answer'),
+    ]
+    expect(extractTextFromContent(content)).toBe('visible answer')
+  })
+
+  it('drops parts that are empty after stripping', () => {
+    const content = [textContent('<thinking>only reasoning</thinking>'), textContent('real')]
+    expect(extractTextFromContent(content)).toBe('real')
+  })
+})
+
+describe('extractSnippet', () => {
+  it('returns undefined when the term is absent', () => {
+    expect(extractSnippet('the quick brown fox', 'zebra')).toBeUndefined()
+  })
+
+  it('is case-insensitive', () => {
+    expect(extractSnippet('Hello World', 'world')).toContain('World')
+  })
+
+  it('adds leading/trailing ellipses when truncating', () => {
+    const long = 'a'.repeat(200) + 'NEEDLE' + 'b'.repeat(200)
+    const snippet = extractSnippet(long, 'NEEDLE')!
+    expect(snippet.startsWith('…')).toBe(true)
+    expect(snippet.endsWith('…')).toBe(true)
+    expect(snippet).toContain('NEEDLE')
+  })
+
+  it('omits ellipses when the match is near the edges', () => {
+    const snippet = extractSnippet('short text', 'short')!
+    expect(snippet).toBe('short text')
+  })
+})
+
+describe('ThreadSearchIndex', () => {
+  it('matches on title only', async () => {
+    const threads = { a: makeThread('a', 'Banana bread recipe') }
+    messagesByThread['a'] = [textContent('unrelated body')].map((c) => ({
+      content: [c],
+    }))
+
+    const index = getThreadSearchIndex()
+    await index.build(threads)
+    const results = index.search('banana')
+
+    expect(results).toHaveLength(1)
+    expect(results[0].matchSource).toBe('title')
+    expect(results[0].snippet).toBeUndefined()
+  })
+
+  it('matches on content only and returns a snippet', async () => {
+    const threads = { a: makeThread('a', 'Untitled chat') }
+    messagesByThread['a'] = [{ content: [textContent('we discussed kubernetes networking')] }]
+
+    const index = getThreadSearchIndex()
+    await index.build(threads)
+    const results = index.search('kubernetes')
+
+    expect(results).toHaveLength(1)
+    expect(results[0].matchSource).toBe('content')
+    expect(results[0].snippet).toContain('kubernetes')
+  })
+
+  it('reports matchSource "both" and still includes a content snippet', async () => {
+    const threads = { a: makeThread('a', 'kubernetes notes') }
+    messagesByThread['a'] = [{ content: [textContent('more kubernetes details here')] }]
+
+    const index = getThreadSearchIndex()
+    await index.build(threads)
+    const results = index.search('kubernetes')
+
+    expect(results[0].matchSource).toBe('both')
+    expect(results[0].snippet).toContain('kubernetes')
+  })
+
+  it('uses strict substring matching (no fuzzy false positives)', async () => {
+    const threads = { a: makeThread('a', 'xylophone buzz') }
+    messagesByThread['a'] = [{ content: [textContent('nothing relevant')] }]
+
+    const index = getThreadSearchIndex()
+    await index.build(threads)
+    expect(index.search('xyz')).toHaveLength(0)
+  })
+
+  it('sorts title matches ahead of content matches', async () => {
+    const threads = {
+      content: makeThread('content', 'Some chat', 100),
+      title: makeThread('title', 'apple pie', 1),
+    }
+    messagesByThread['content'] = [{ content: [textContent('talking about apple')] }]
+    messagesByThread['title'] = [{ content: [textContent('no fruit here')] }]
+
+    const index = getThreadSearchIndex()
+    await index.build(threads)
+    const results = index.search('apple')
+
+    expect(results.map((r) => r.thread.id)).toEqual(['title', 'content'])
+  })
+
+  it('search returns [] before the index is built', () => {
+    const index = getThreadSearchIndex()
+    expect(index.search('anything')).toEqual([])
+  })
+})
+
+describe('ThreadSearchIndex.hasPendingWork', () => {
+  it('is true before the first build', () => {
+    const index = getThreadSearchIndex()
+    expect(index.hasPendingWork({ a: makeThread('a', 'A') })).toBe(true)
+  })
+
+  it('is false right after building the same threads', async () => {
+    const threads = { a: makeThread('a', 'A') }
+    const index = getThreadSearchIndex()
+    await index.build(threads)
+    expect(index.hasPendingWork(threads)).toBe(false)
+  })
+
+  it('detects newly created threads (regression: new threads were unsearchable)', async () => {
+    const threads: Record<string, Thread> = { a: makeThread('a', 'A') }
+    const index = getThreadSearchIndex()
+    await index.build(threads)
+    expect(index.hasPendingWork(threads)).toBe(false)
+
+    // User creates a new thread after the initial build.
+    threads['b'] = makeThread('b', 'B')
+    expect(index.hasPendingWork(threads)).toBe(true)
+
+    messagesByThread['b'] = [{ content: [textContent('brand new content')] }]
+    await index.build(threads)
+    expect(index.search('brand new')).toHaveLength(1)
+  })
+
+  it('detects stale threads after invalidateThread', async () => {
+    const threads = { a: makeThread('a', 'A') }
+    messagesByThread['a'] = [{ content: [textContent('old content')] }]
+    const index = getThreadSearchIndex()
+    await index.build(threads)
+    expect(index.search('updated')).toHaveLength(0)
+
+    messagesByThread['a'] = [{ content: [textContent('updated content')] }]
+    index.invalidateThread('a')
+    expect(index.hasPendingWork(threads)).toBe(true)
+
+    await index.build(threads)
+    expect(index.search('updated')).toHaveLength(1)
+  })
+
+  it('evicts removed threads on the next build', async () => {
+    const threads: Record<string, Thread> = {
+      a: makeThread('a', 'A'),
+      b: makeThread('b', 'B'),
+    }
+    messagesByThread['a'] = [{ content: [textContent('alpha')] }]
+    messagesByThread['b'] = [{ content: [textContent('beta')] }]
+    const index = getThreadSearchIndex()
+    await index.build(threads)
+    expect(index.search('beta')).toHaveLength(1)
+
+    delete threads['b']
+    index.removeThread('b')
+    expect(index.hasPendingWork(threads)).toBe(true)
+
+    await index.build(threads)
+    expect(index.search('beta')).toHaveLength(0)
+  })
+
+  it('invalidate() drops the whole corpus', async () => {
+    const threads = { a: makeThread('a', 'A') }
+    const index = getThreadSearchIndex()
+    await index.build(threads)
+    index.invalidate()
+    expect(index.isReady).toBe(false)
+    expect(index.hasPendingWork(threads)).toBe(true)
+  })
+})
+
+describe('ThreadSearchIndex build lifecycle', () => {
+  it('picks up invalidations that arrive mid-build (race condition)', async () => {
+    const threads = { a: makeThread('a', 'A') }
+    messagesByThread['a'] = [{ content: [textContent('first version')] }]
+
+    let resolveFirst: (() => void) | undefined
+    // Make the first fetch hang so we can invalidate while build() is in flight.
+    fetchMessages.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = () => resolve(messagesByThread['a'])
+        })
+    )
+
+    const index = getThreadSearchIndex()
+    const buildPromise = index.build(threads)
+
+    // Invalidate while the first build is still awaiting the fetch.
+    messagesByThread['a'] = [{ content: [textContent('second version')] }]
+    index.invalidateThread('a')
+
+    resolveFirst!()
+    await buildPromise
+
+    // The mid-build invalidation must have triggered a re-fetch.
+    expect(index.search('second version')).toHaveLength(1)
+  })
+})

--- a/web-app/src/lib/search-index.ts
+++ b/web-app/src/lib/search-index.ts
@@ -1,10 +1,11 @@
 import { getServiceHub } from '@/hooks/useServiceHub'
 import { TEMPORARY_CHAT_ID } from '@/constants/chat'
+import { ContentType, type ThreadContent } from '@janhq/core'
 
 /**
  * Result from a full-text thread search.
  * `matchSource` indicates where the search term was found.
- * `snippet` is a short excerpt around the match (only present for content matches).
+ * `snippet` is a short excerpt around the match (present for any content match).
  */
 export interface ThreadSearchResult {
   thread: Thread
@@ -18,17 +19,29 @@ interface CorpusEntry {
   contentText: string
 }
 
+/** Per-thread content cap to prevent runaway memory use on very long chats. */
+const MAX_CONTENT_CHARS = 5000
+
+/**
+ * Upper bound on the number of threads kept in the in-memory corpus. When a
+ * user has more threads than this, only the most-recently-updated ones are
+ * indexed for content search (older threads still match by title via the fzf
+ * fallback in the search dialog). At the cap the corpus holds roughly
+ * MAX_INDEXED_THREADS * MAX_CONTENT_CHARS chars (~10 MB at the defaults).
+ */
+const MAX_INDEXED_THREADS = 2000
+
 /**
  * Extract plain text from a ThreadMessage's content array.
  * Only pulls text-type content parts and strips XML-like tags (e.g. think blocks).
  */
-function extractTextFromContent(
-  content: Array<{ type: string; text?: { value: string } }> | undefined
+export function extractTextFromContent(
+  content: ThreadContent[] | undefined
 ): string {
   if (!content) return ''
   const parts: string[] = []
   for (const c of content) {
-    if (c.type === 'text' && c.text?.value) {
+    if (c.type === ContentType.Text && c.text?.value) {
       // Strip reasoning blocks that may have been saved with think tags
       const clean = c.text.value
         .replace(/<(think|thinking|reasoning|analysis)[^>]*>[\s\S]*?<\/\1>/gi, '')
@@ -43,7 +56,7 @@ function extractTextFromContent(
  * Extract a short text snippet around the first match of `term` in `text`.
  * Returns a ~120-char window centred on the match.
  */
-function extractSnippet(text: string, term: string): string | undefined {
+export function extractSnippet(text: string, term: string): string | undefined {
   const lower = text.toLowerCase()
   const idx = lower.indexOf(term.toLowerCase())
   if (idx === -1) return undefined
@@ -59,14 +72,14 @@ function extractSnippet(text: string, term: string): string | undefined {
 
 /**
  * Fetch and concatenate the text content for a single thread from disk.
- * Capped at 5000 chars to prevent runaway memory use on very long chats.
+ * Capped at MAX_CONTENT_CHARS to prevent runaway memory use on very long chats.
  */
 async function buildEntryForThread(thread: Thread): Promise<CorpusEntry> {
   const messages = await getServiceHub().messages().fetchMessages(thread.id)
   const contentText = messages
-    .map((m) => extractTextFromContent(m.content as any))
+    .map((m) => extractTextFromContent(m.content))
     .join(' ')
-    .slice(0, 5000)
+    .slice(0, MAX_CONTENT_CHARS)
   return { thread, contentText }
 }
 
@@ -78,7 +91,7 @@ async function buildEntryForThread(thread: Thread): Promise<CorpusEntry> {
  * ```ts
  * const index = getThreadSearchIndex()
  * await index.build(threads)        // loads messages for all threads
- * const results = index.search(...) // fast fzf query
+ * const results = index.search(...) // fast substring query
  * index.invalidateThread(threadId)  // re-fetches just that thread next time
  * ```
  */
@@ -91,21 +104,50 @@ class ThreadSearchIndex {
   private deletedThreadIds = new Set<string>()
 
   private buildPromise: Promise<void> | null = null
+  /** Latest threads record seen by build(), used by in-flight rebuild loop. */
+  private latestThreads: Record<string, Thread> = {}
+
+  /**
+   * The threads eligible for content indexing: real threads with a title,
+   * capped to the MAX_INDEXED_THREADS most-recently-updated. Used by both
+   * doBuild() and hasPendingWork() so they always agree on the target set
+   * (otherwise capped-out threads would look perpetually "new").
+   */
+  private eligibleThreads(threads: Record<string, Thread>): Thread[] {
+    const list = Object.values(threads).filter(
+      (t) => t.id !== TEMPORARY_CHAT_ID && t.title
+    )
+    if (list.length <= MAX_INDEXED_THREADS) return list
+    return [...list]
+      .sort((a, b) => (b.updated ?? 0) - (a.updated ?? 0))
+      .slice(0, MAX_INDEXED_THREADS)
+  }
 
   /**
    * Build (or refresh) the search corpus.  Re-fetches messages for any
    * threads marked stale and for any new threads not yet in the index.
    * Safe to call multiple times — subsequent calls only do incremental work.
+   *
+   * If invalidations or new threads arrive *while* a build is in flight, the
+   * build loops again so that mid-build changes are never dropped.
    */
   async build(threads: Record<string, Thread>): Promise<void> {
+    this.latestThreads = threads
     if (this.buildPromise) return this.buildPromise
 
-    this.buildPromise = this.doBuild(threads)
-    try {
-      await this.buildPromise
-    } finally {
-      this.buildPromise = null
-    }
+    this.buildPromise = (async () => {
+      try {
+        // Keep building until no new work has accumulated. doBuild() consumes
+        // the stale/deleted sets; anything that arrived during the await shows
+        // up as pending work on the next iteration.
+        do {
+          await this.doBuild(this.latestThreads)
+        } while (this.hasPendingWork(this.latestThreads))
+      } finally {
+        this.buildPromise = null
+      }
+    })()
+    return this.buildPromise
   }
 
   private async doBuild(threads: Record<string, Thread>): Promise<void> {
@@ -117,9 +159,7 @@ class ThreadSearchIndex {
     this.deletedThreadIds.clear()
 
     // Determine which threads need (re)fetching
-    const threadList = Object.values(threads).filter(
-      (t) => t.id !== TEMPORARY_CHAT_ID && t.title
-    )
+    const threadList = this.eligibleThreads(threads)
     const toFetch: Thread[] = []
     for (const thread of threadList) {
       const isNew = !this.entriesByThreadId.has(thread.id)
@@ -128,8 +168,15 @@ class ThreadSearchIndex {
     }
     this.staleThreadIds.clear()
 
+    // Evict any threads that are no longer eligible (deleted or pushed past
+    // the cap by more-recent threads).
+    const liveIds = new Set(threadList.map((t) => t.id))
+    for (const id of this.entriesByThreadId.keys()) {
+      if (!liveIds.has(id)) this.entriesByThreadId.delete(id)
+    }
+
     if (toFetch.length === 0 && !isFirstBuild) {
-      // Nothing to do
+      // Nothing left to fetch (eviction above already applied).
       return
     }
 
@@ -144,28 +191,14 @@ class ThreadSearchIndex {
         }
       }
     }
-
-    // Also evict any threads that no longer exist in the threads record
-    const liveIds = new Set(threadList.map((t) => t.id))
-    for (const id of this.entriesByThreadId.keys()) {
-      if (!liveIds.has(id)) this.entriesByThreadId.delete(id)
-    }
-
-    this.rebuildIndex()
-  }
-
-  /** Rebuild after all fetches are complete. */
-  private rebuildIndex(): void {
-    if (!this.entriesByThreadId) return
-    // Entries are already in-place from doBuild(); just mark index as ready.
   }
 
   /**
    * Search both title and message content. Returns de-duplicated results
    * sorted by relevance (title matches first, then content matches).
    *
-   * Title matches use fuzzy matching (good for short text).
-   * Content matches use substring matching (better for prose / code).
+   * Both titles and content use case-insensitive substring matching, so there
+   * are no fuzzy false positives.
    */
   search(term: string): ThreadSearchResult[] {
     if (!term || !this.entriesByThreadId) return []
@@ -173,8 +206,6 @@ class ThreadSearchIndex {
 
     const results: ThreadSearchResult[] = []
 
-    // Substring search — no false positives.
-    // Titles use smart-case (case-insensitive unless the query has uppercase).
     for (const entry of this.entriesByThreadId.values()) {
       const titleMatch = entry.thread.title?.toLowerCase().includes(lowerTerm)
       const contentMatch = entry.contentText.toLowerCase().includes(lowerTerm)
@@ -182,7 +213,9 @@ class ThreadSearchIndex {
       results.push({
         thread: entry.thread,
         matchSource: titleMatch && contentMatch ? 'both' : titleMatch ? 'title' : 'content',
-        snippet: contentMatch && !titleMatch
+        // Show a content snippet whenever the term appears in the body, even
+        // if the title also matched — the snippet adds useful context.
+        snippet: contentMatch
           ? extractSnippet(entry.contentText, term)
           : undefined,
       })
@@ -221,13 +254,23 @@ class ThreadSearchIndex {
     return this.entriesByThreadId !== null
   }
 
-  /** Whether the next build() call would do any work. */
-  get hasPendingWork(): boolean {
-    return (
-      this.entriesByThreadId === null ||
-      this.staleThreadIds.size > 0 ||
-      this.deletedThreadIds.size > 0
-    )
+  /**
+   * Whether the next build() call would do any work for the given threads.
+   * Returns true if the index hasn't been built, if there are stale/deleted
+   * entries, or if `threads` contains eligible threads not yet indexed (or the
+   * indexed set otherwise diverges from the eligible set).
+   */
+  hasPendingWork(threads: Record<string, Thread>): boolean {
+    if (this.entriesByThreadId === null) return true
+    if (this.staleThreadIds.size > 0) return true
+    if (this.deletedThreadIds.size > 0) return true
+
+    const eligible = this.eligibleThreads(threads)
+    for (const t of eligible) {
+      if (!this.entriesByThreadId.has(t.id)) return true
+    }
+    // A size mismatch means some indexed thread is no longer eligible.
+    return this.entriesByThreadId.size !== eligible.length
   }
 }
 
@@ -237,4 +280,9 @@ let instance: ThreadSearchIndex | null = null
 export function getThreadSearchIndex(): ThreadSearchIndex {
   if (!instance) instance = new ThreadSearchIndex()
   return instance
+}
+
+/** Test-only: drop the singleton so each test starts from a clean index. */
+export function __resetThreadSearchIndexForTests(): void {
+  instance = null
 }

--- a/web-app/src/lib/search-index.ts
+++ b/web-app/src/lib/search-index.ts
@@ -1,0 +1,240 @@
+import { getServiceHub } from '@/hooks/useServiceHub'
+import { TEMPORARY_CHAT_ID } from '@/constants/chat'
+
+/**
+ * Result from a full-text thread search.
+ * `matchSource` indicates where the search term was found.
+ * `snippet` is a short excerpt around the match (only present for content matches).
+ */
+export interface ThreadSearchResult {
+  thread: Thread
+  matchSource: 'title' | 'content' | 'both'
+  snippet?: string
+}
+
+interface CorpusEntry {
+  thread: Thread
+  /** Concatenated text content from all messages in this thread. */
+  contentText: string
+}
+
+/**
+ * Extract plain text from a ThreadMessage's content array.
+ * Only pulls text-type content parts and strips XML-like tags (e.g. think blocks).
+ */
+function extractTextFromContent(
+  content: Array<{ type: string; text?: { value: string } }> | undefined
+): string {
+  if (!content) return ''
+  const parts: string[] = []
+  for (const c of content) {
+    if (c.type === 'text' && c.text?.value) {
+      // Strip reasoning blocks that may have been saved with think tags
+      const clean = c.text.value
+        .replace(/<(think|thinking|reasoning|analysis)[^>]*>[\s\S]*?<\/\1>/gi, '')
+        .trim()
+      if (clean) parts.push(clean)
+    }
+  }
+  return parts.join(' ')
+}
+
+/**
+ * Extract a short text snippet around the first match of `term` in `text`.
+ * Returns a ~120-char window centred on the match.
+ */
+function extractSnippet(text: string, term: string): string | undefined {
+  const lower = text.toLowerCase()
+  const idx = lower.indexOf(term.toLowerCase())
+  if (idx === -1) return undefined
+
+  const margin = 55
+  const start = Math.max(0, idx - margin)
+  const end = Math.min(text.length, idx + term.length + margin)
+  let snippet = text.slice(start, end)
+  if (start > 0) snippet = '…' + snippet
+  if (end < text.length) snippet = snippet + '…'
+  return snippet
+}
+
+/**
+ * Fetch and concatenate the text content for a single thread from disk.
+ * Capped at 5000 chars to prevent runaway memory use on very long chats.
+ */
+async function buildEntryForThread(thread: Thread): Promise<CorpusEntry> {
+  const messages = await getServiceHub().messages().fetchMessages(thread.id)
+  const contentText = messages
+    .map((m) => extractTextFromContent(m.content as any))
+    .join(' ')
+    .slice(0, 5000)
+  return { thread, contentText }
+}
+
+/**
+ * A lazily-initialised, cached full-text search index that searches both
+ * thread titles and message content.
+ *
+ * Usage:
+ * ```ts
+ * const index = getThreadSearchIndex()
+ * await index.build(threads)        // loads messages for all threads
+ * const results = index.search(...) // fast fzf query
+ * index.invalidateThread(threadId)  // re-fetches just that thread next time
+ * ```
+ */
+class ThreadSearchIndex {
+  /** Thread ID -> corpus entry. Null until first build() completes. */
+  private entriesByThreadId: Map<string, CorpusEntry> | null = null
+  /** Thread IDs whose content needs to be re-fetched on next search/build. */
+  private staleThreadIds = new Set<string>()
+  /** Thread IDs that have been deleted and should be evicted from the index. */
+  private deletedThreadIds = new Set<string>()
+
+  private buildPromise: Promise<void> | null = null
+
+  /**
+   * Build (or refresh) the search corpus.  Re-fetches messages for any
+   * threads marked stale and for any new threads not yet in the index.
+   * Safe to call multiple times — subsequent calls only do incremental work.
+   */
+  async build(threads: Record<string, Thread>): Promise<void> {
+    if (this.buildPromise) return this.buildPromise
+
+    this.buildPromise = this.doBuild(threads)
+    try {
+      await this.buildPromise
+    } finally {
+      this.buildPromise = null
+    }
+  }
+
+  private async doBuild(threads: Record<string, Thread>): Promise<void> {
+    const isFirstBuild = this.entriesByThreadId === null
+    if (!this.entriesByThreadId) this.entriesByThreadId = new Map()
+
+    // Evict deleted threads
+    for (const id of this.deletedThreadIds) this.entriesByThreadId.delete(id)
+    this.deletedThreadIds.clear()
+
+    // Determine which threads need (re)fetching
+    const threadList = Object.values(threads).filter(
+      (t) => t.id !== TEMPORARY_CHAT_ID && t.title
+    )
+    const toFetch: Thread[] = []
+    for (const thread of threadList) {
+      const isNew = !this.entriesByThreadId.has(thread.id)
+      const isStale = this.staleThreadIds.has(thread.id)
+      if (isNew || isStale) toFetch.push(thread)
+    }
+    this.staleThreadIds.clear()
+
+    if (toFetch.length === 0 && !isFirstBuild) {
+      // Nothing to do
+      return
+    }
+
+    // Fetch missing/stale threads in batches (parallel within batch)
+    const BATCH = 10
+    for (let i = 0; i < toFetch.length; i += BATCH) {
+      const batch = toFetch.slice(i, i + BATCH)
+      const results = await Promise.allSettled(batch.map(buildEntryForThread))
+      for (const r of results) {
+        if (r.status === 'fulfilled') {
+          this.entriesByThreadId.set(r.value.thread.id, r.value)
+        }
+      }
+    }
+
+    // Also evict any threads that no longer exist in the threads record
+    const liveIds = new Set(threadList.map((t) => t.id))
+    for (const id of this.entriesByThreadId.keys()) {
+      if (!liveIds.has(id)) this.entriesByThreadId.delete(id)
+    }
+
+    this.rebuildIndex()
+  }
+
+  /** Rebuild after all fetches are complete. */
+  private rebuildIndex(): void {
+    if (!this.entriesByThreadId) return
+    // Entries are already in-place from doBuild(); just mark index as ready.
+  }
+
+  /**
+   * Search both title and message content. Returns de-duplicated results
+   * sorted by relevance (title matches first, then content matches).
+   *
+   * Title matches use fuzzy matching (good for short text).
+   * Content matches use substring matching (better for prose / code).
+   */
+  search(term: string): ThreadSearchResult[] {
+    if (!term || !this.entriesByThreadId) return []
+    const lowerTerm = term.toLowerCase()
+
+    const results: ThreadSearchResult[] = []
+
+    // Substring search — no false positives.
+    // Titles use smart-case (case-insensitive unless the query has uppercase).
+    for (const entry of this.entriesByThreadId.values()) {
+      const titleMatch = entry.thread.title?.toLowerCase().includes(lowerTerm)
+      const contentMatch = entry.contentText.toLowerCase().includes(lowerTerm)
+      if (!titleMatch && !contentMatch) continue
+      results.push({
+        thread: entry.thread,
+        matchSource: titleMatch && contentMatch ? 'both' : titleMatch ? 'title' : 'content',
+        snippet: contentMatch && !titleMatch
+          ? extractSnippet(entry.contentText, term)
+          : undefined,
+      })
+    }
+
+    // Sort: title matches first (more relevant), then by thread recency
+    results.sort((a, b) => {
+      if (a.matchSource === 'title' && b.matchSource !== 'title') return -1
+      if (a.matchSource !== 'title' && b.matchSource === 'title') return 1
+      return (b.thread.updated ?? 0) - (a.thread.updated ?? 0)
+    })
+
+    return results
+  }
+
+  /** Mark a single thread as stale so its content is re-fetched next build(). */
+  invalidateThread(threadId: string): void {
+    this.staleThreadIds.add(threadId)
+  }
+
+  /** Mark a thread as deleted so it's evicted from the index on next build(). */
+  removeThread(threadId: string): void {
+    this.deletedThreadIds.add(threadId)
+    this.staleThreadIds.delete(threadId)
+  }
+
+  /** Drop the entire corpus.  Useful for "clear all chats" actions. */
+  invalidate(): void {
+    this.entriesByThreadId = null
+    this.staleThreadIds.clear()
+    this.deletedThreadIds.clear()
+  }
+
+  /** Whether the index has been built at least once. */
+  get isReady(): boolean {
+    return this.entriesByThreadId !== null
+  }
+
+  /** Whether the next build() call would do any work. */
+  get hasPendingWork(): boolean {
+    return (
+      this.entriesByThreadId === null ||
+      this.staleThreadIds.size > 0 ||
+      this.deletedThreadIds.size > 0
+    )
+  }
+}
+
+// Singleton instance
+let instance: ThreadSearchIndex | null = null
+
+export function getThreadSearchIndex(): ThreadSearchIndex {
+  if (!instance) instance = new ThreadSearchIndex()
+  return instance
+}

--- a/web-app/src/lib/search-index.ts
+++ b/web-app/src/lib/search-index.ts
@@ -133,6 +133,9 @@ class ThreadSearchIndex {
    */
   async build(threads: Record<string, Thread>): Promise<void> {
     this.latestThreads = threads
+    // Concurrent callers share the same promise. latestThreads is updated
+    // above so the in-flight loop will use the newest threads on its next
+    // iteration — the second caller's changes are not lost.
     if (this.buildPromise) return this.buildPromise
 
     this.buildPromise = (async () => {

--- a/web-app/src/locales/en/common.json
+++ b/web-app/src/locales/en/common.json
@@ -156,6 +156,8 @@
   "temporaryChat": "Temporary Chat",
   "temporaryChatTooltip": "Temporary chat won't appear in your history",
   "noResultsFoundDesc": "We couldn't find any chats matching your search. Try a different keyword.",
+  "searchIndexing": "Still indexing…",
+  "searchIndexingDesc": "We're loading your message history. Matches will appear as soon as indexing finishes.",
   "searchModels": "Search models...",
   "searchStyles": "Search styles...",
   "createAssistant": "Create Assistant",


### PR DESCRIPTION
## Describe Your Changes

Previously, the search bar only searched through chat titles. This meant if you remembered discussing something in a conversation but didn't remember the title, you couldn't find it. Now the search indexes all message content across all your chats, so searching for a topic like "python async" will find any thread where that topic was discussed even if the title is something generic like "Code Help". More specifically:
- Lazy-build full-text search corpus of message content when search dialog opens
- Incremental invalidation on message add/update/delete for near real-time updates
- Loading spinner shown while building index to keep user informed
- Strict substring matching for title and content search (no fuzzy false positives)
- Debounced search input for smooth UI performance


## Self Checklist

- [x ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
