### PR TITLE
fix: use Windows copy command in build-cli Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ ifeq ($(DETECTED_OS),Darwin)
 	cp src-tauri/resources/bin/jan-cli src-tauri/target/universal-apple-darwin/release/jan-cli
 else ifeq ($(DETECTED_OS),Windows)
 	cd src-tauri && cargo build --release --features cli --bin jan-cli
-	cp src-tauri/target/release/jan-cli.exe src-tauri/resources/bin/jan-cli.exe
+	copy src-tauri\target\release\jan-cli.exe src-tauri\resources\bin\jan-cli.exe
 else
 	cd src-tauri && cargo build --release --features cli --bin jan-cli
 	cp src-tauri/target/release/jan-cli src-tauri/resources/bin/jan-cli


### PR DESCRIPTION
## Describe Your Changes
- build-cli Makefile target uses cp on the Windows branch, but cp doesn't exist on Windows. Changed to copy, consistent with the build-cli-dev target directly below it which already does this correctly (see line 234).

## Fixes Issues

- no issue: self-contained fix

## Self Checklist

- No docs update needed for a build script fix
