### PR TITLE
fix: invoke Windows copy through cmd in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ ifeq ($(DETECTED_OS),Darwin)
 	cp src-tauri/resources/bin/jan-cli src-tauri/target/universal-apple-darwin/release/jan-cli
 else ifeq ($(DETECTED_OS),Windows)
 	cd src-tauri && cargo build --release --features cli --bin jan-cli
-	copy src-tauri\target\release\jan-cli.exe src-tauri\resources\bin\jan-cli.exe
+	cmd /C copy /Y "src-tauri\target\release\jan-cli.exe" "src-tauri\resources\bin\jan-cli.exe"
 else
 	cd src-tauri && cargo build --release --features cli --bin jan-cli
 	cp src-tauri/target/release/jan-cli src-tauri/resources/bin/jan-cli
@@ -231,7 +231,7 @@ build-cli-dev:
 	$(call MKDIR,'src-tauri/resources/bin')	
 	cd src-tauri && cargo build --features cli --bin jan-cli
 ifeq ($(DETECTED_OS),Windows)
-	copy src-tauri\target\debug\jan-cli.exe src-tauri\resources\bin\jan-cli.exe
+	cmd /C copy /Y "src-tauri\target\debug\jan-cli.exe" "src-tauri\resources\bin\jan-cli.exe"
 else
 	install -m755 src-tauri/target/debug/jan-cli src-tauri/resources/bin/jan-cli
 endif

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ ifeq ($(DETECTED_OS),Darwin)
 	cp src-tauri/resources/bin/jan-cli src-tauri/target/universal-apple-darwin/release/jan-cli
 else ifeq ($(DETECTED_OS),Windows)
 	cd src-tauri && cargo build --release --features cli --bin jan-cli
-	cmd /C copy /Y "src-tauri\target\release\jan-cli.exe" "src-tauri\resources\bin\jan-cli.exe"
+	powershell -NoLogo -NoProfile -NonInteractive -Command "Copy-Item -Force -ErrorAction Stop -LiteralPath 'src-tauri/target/release/jan-cli.exe' -Destination 'src-tauri/resources/bin/jan-cli.exe'"
 else
 	cd src-tauri && cargo build --release --features cli --bin jan-cli
 	cp src-tauri/target/release/jan-cli src-tauri/resources/bin/jan-cli
@@ -231,7 +231,7 @@ build-cli-dev:
 	$(call MKDIR,'src-tauri/resources/bin')	
 	cd src-tauri && cargo build --features cli --bin jan-cli
 ifeq ($(DETECTED_OS),Windows)
-	cmd /C copy /Y "src-tauri\target\debug\jan-cli.exe" "src-tauri\resources\bin\jan-cli.exe"
+	powershell -NoLogo -NoProfile -NonInteractive -Command "Copy-Item -Force -ErrorAction Stop -LiteralPath 'src-tauri/target/debug/jan-cli.exe' -Destination 'src-tauri/resources/bin/jan-cli.exe'"
 else
 	install -m755 src-tauri/target/debug/jan-cli src-tauri/resources/bin/jan-cli
 endif


### PR DESCRIPTION
## Describe Your Changes

Follow-up to #8293.

That change replaced `cp` with Windows `copy` for the `jan-cli.exe` copy step. This worked in local Windows builds, but the self-hosted Windows CI runners invoke the Make recipe differently: GNU Make tried to launch `copy` directly via `CreateProcess`.

On Windows, `copy` is a `cmd.exe` built-in, not a standalone executable, so both Windows `Linter & Test` pipelines failed after the Rust build succeeded:

- `test-on-windows (mcafee)`
- `test-on-windows (bit-defender)`

The failure was:

process_begin: CreateProcess(NULL, copy src-tauri\target\release\jan-cli.exe src-tauri\resources\bin\jan-cli.exe, ...) failed.
make (e=2): The system cannot find the file specified.
make[1]: *** [Makefile:223: build-cli] Error 2

## Fixes Issues

- Fixes the Windows `Linter & Test` push failures on `test-on-windows (mcafee)` and `test-on-windows (bit-defender)` after #8293.

