### PR TITLE
Add TrustedRouter as a built-in cloud provider

### DIFF
--- a/docs/src/pages/docs/desktop/remote-models/_meta.json
+++ b/docs/src/pages/docs/desktop/remote-models/_meta.json
@@ -20,6 +20,9 @@
   "openrouter": {
     "title": "OpenRouter"
   },
+  "trustedrouter": {
+    "title": "TrustedRouter"
+  },
   "huggingface": {
     "title": "Hugging Face"
   },

--- a/docs/src/pages/docs/desktop/remote-models/trustedrouter.mdx
+++ b/docs/src/pages/docs/desktop/remote-models/trustedrouter.mdx
@@ -1,0 +1,56 @@
+---
+title: TrustedRouter
+description: A step-by-step guide on connecting Jan to TrustedRouter.
+keywords:
+  [
+    Jan,
+    local AI,
+    privacy focus,
+    remote AI,
+    OpenAI-compatible API,
+    TrustedRouter,
+  ]
+---
+
+import { Callout, Steps } from 'nextra/components'
+import { Settings } from 'lucide-react'
+
+# TrustedRouter
+
+## Integrate TrustedRouter with Jan
+
+[TrustedRouter](https://trustedrouter.com) is an OpenAI-compatible router for
+accessing multiple model providers through one API. It uses an open-source and
+verifiable attested router with zero prompt and output logging by default,
+which can be useful when chats contain private project context, code, or
+customer data.
+
+<Steps>
+
+### Step 1: Get Your API Key
+
+1. Visit [TrustedRouter](https://trustedrouter.com/console/api-keys)
+2. Create and copy a new API key
+
+<Callout type='info'>
+TrustedRouter keys work with the OpenAI-compatible base URL
+`https://api.trustedrouter.com/v1`.
+</Callout>
+
+### Step 2: Configure Jan
+
+1. Navigate to the **Settings** page (<Settings width={16} height={16} style={{display:"inline"}}/>)
+2. Add a custom OpenAI-compatible provider
+3. Set the base URL to `https://api.trustedrouter.com/v1`
+4. Insert your **API Key**
+
+### Step 3: Start Using TrustedRouter Models
+
+Use a TrustedRouter routing alias or any model ID exposed by your account:
+
+- `trustedrouter/auto` for automatic routing
+- `trustedrouter/zdr` for zero data retention routing
+- `trustedrouter/e2e` for end-to-end encrypted routing where available
+
+</Steps>
+

--- a/web-app/public/images/model-provider/trusted-router.svg
+++ b/web-app/public/images/model-provider/trusted-router.svg
@@ -1,0 +1,8 @@
+<svg fill="none" height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg">
+  <title>TrustedRouter</title>
+  <g stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2">
+    <path d="M1.4 7.5h5.1L11 12M1.4 16.5H4L8.5 12M1.4 12h14.1"/>
+    <circle cx="15.5" cy="12" fill="currentColor" r="1.9" stroke="none"/>
+    <path d="M17.4 12h5.2"/>
+  </g>
+</svg>

--- a/web-app/src/constants/models.ts
+++ b/web-app/src/constants/models.ts
@@ -126,6 +126,15 @@ export const providerModels = {
     supportsToolCalls: true,
     supportsN: true,
   },
+  trustedrouter: {
+    models: true,
+    supportsCompletion: true,
+    supportsStreaming: true,
+    supportsJSON: true,
+    supportsImages: true,
+    supportsToolCalls: true,
+    supportsN: true,
+  },
   nvidia: {
     models: ['moonshotai/kimi-k2.5', 'minimaxai/minimax-m2.5', 'z-ai/glm5'],
     supportsCompletion: true,

--- a/web-app/src/constants/providers.ts
+++ b/web-app/src/constants/providers.ts
@@ -185,6 +185,51 @@ export const predefinedProviders = [
   {
     active: true,
     api_key: '',
+    base_url: 'https://api.trustedrouter.com/v1',
+    explore_models_url: 'https://trustedrouter.com/models',
+    provider: 'trustedrouter',
+    settings: [
+      {
+        key: 'api-key',
+        title: 'API Key',
+        description:
+          "The TrustedRouter API uses API keys for authentication. Visit your [API Keys](https://trustedrouter.com/console/api-keys) page to retrieve the API key you'll use in your requests.",
+        controller_type: 'input',
+        controller_props: {
+          placeholder: 'Insert API Key',
+          value: '',
+          type: 'password',
+          input_actions: ['unobscure', 'copy'],
+        },
+      },
+    ],
+    models: [
+      {
+        id: 'trustedrouter/auto',
+        name: 'TrustedRouter Auto',
+        version: '1.0',
+        description: 'Routes each request across healthy supported providers',
+        capabilities: ['completion', 'tools'],
+      },
+      {
+        id: 'trustedrouter/zdr',
+        name: 'TrustedRouter ZDR',
+        version: '1.0',
+        description: 'Prefers zero-data-retention routes',
+        capabilities: ['completion', 'tools'],
+      },
+      {
+        id: 'trustedrouter/e2e',
+        name: 'TrustedRouter E2E',
+        version: '1.0',
+        description: 'Uses end-to-end encrypted routes where available',
+        capabilities: ['completion', 'tools'],
+      },
+    ],
+  },
+  {
+    active: true,
+    api_key: '',
     base_url: 'https://api.mistral.ai/v1',
     explore_models_url:
       'https://docs.mistral.ai/getting-started/models/models_overview/',

--- a/web-app/src/lib/providerCaps.ts
+++ b/web-app/src/lib/providerCaps.ts
@@ -61,6 +61,11 @@ const OPENROUTER: ProviderCaps = {
   maybe: new Set(['typical_p']),
 }
 
+const TRUSTEDROUTER: ProviderCaps = {
+  supported: set('penalties'),
+  maybe: new Set(['top_k', 'min_p', 'repetition', 'typical_p']),
+}
+
 const XAI: ProviderCaps = {
   supported: set(),
   maybe: new Set(['penalties']),
@@ -155,6 +160,7 @@ const BUILTIN_CAPS: Record<string, ProviderCaps> = {
   mistral: MISTRAL,
   groq: GROQ,
   openrouter: OPENROUTER,
+  trustedrouter: TRUSTEDROUTER,
   xai: XAI,
   huggingface: HUGGINGFACE,
   nvidia: NVIDIA,

--- a/web-app/src/lib/utils.ts
+++ b/web-app/src/lib/utils.ts
@@ -143,6 +143,8 @@ export function getProviderLogo(provider: string) {
       return '/images/model-provider/mistral.svg'
     case 'openrouter':
       return '/images/model-provider/open-router.svg'
+    case 'trustedrouter':
+      return '/images/model-provider/trusted-router.svg'
     case 'groq':
       return '/images/model-provider/groq.svg'
     case 'cohere':
@@ -176,6 +178,8 @@ export const getProviderTitle = (provider: string) => {
       return 'OpenAI'
     case 'openrouter':
       return 'OpenRouter'
+    case 'trustedrouter':
+      return 'TrustedRouter'
     case 'gemini':
       return 'Gemini'
     case 'huggingface':


### PR DESCRIPTION
Adds TrustedRouter (attested OpenAI-compatible router) as a built-in cloud provider, mirroring the OpenRouter treatment:

- provider entry in `web-app/src/constants/providers.ts` (base URL `https://api.trustedrouter.com/v1`, API-key setting, router-alias starter models `trustedrouter/auto`, `zdr`, `e2e`)
- capability entries in `web-app/src/constants/models.ts` (dynamic `/models` listing) and `web-app/src/lib/providerCaps.ts`
- icon + display-name wiring in `web-app/src/lib/utils.ts` and `web-app/public/images/model-provider/trusted-router.svg`
- remote-models docs page (updated from the earlier docs-only revision of this PR)

Verified: `tsc --noEmit` clean in web-app and the lib/constants vitest suites pass (109 tests).

This reworks the earlier docs-only version of this PR into a code integration.