### PR TITLE
feat(lemonade): native Lemonade server integration

### DIFF
--- a/docs/src/pages/docs/desktop/remote-models/_meta.json
+++ b/docs/src/pages/docs/desktop/remote-models/_meta.json
@@ -1,4 +1,7 @@
 {
+  "lemonade": {
+    "title": "Lemonade"
+  },
   "anthropic": {
     "title": "Anthropic"
   },

--- a/docs/src/pages/docs/desktop/remote-models/lemonade.mdx
+++ b/docs/src/pages/docs/desktop/remote-models/lemonade.mdx
@@ -1,0 +1,77 @@
+---
+title: Lemonade
+description: Learn how to use Lemonade with Jan for local AI inference.
+keywords:
+  [
+    Lemonade,
+    Jan,
+    Jan AI,
+    local AI,
+    local inference,
+    Lemonade integration,
+    AMD,
+    llama.cpp
+  ]
+---
+
+import { Callout, Steps } from 'nextra/components'
+import { Settings } from 'lucide-react'
+
+# Lemonade
+
+Jan supports [Lemonade](https://lemonade-server.ai/), a local AI inference server that runs models on your own hardware. No API key or internet connection is required.
+
+## Integrate Lemonade with Jan
+
+<Steps>
+### Step 1: Start Lemonade
+
+Download and launch [Lemonade](https://lemonade-server.ai/) on your machine. It runs on port **13305** by default.
+
+<Callout type='info'>
+Lemonade must be running before Jan can connect to it.
+</Callout>
+
+### Step 2: Configure Jan
+
+1. Navigate to **Settings** (<Settings width={16} height={16} style={{display:"inline"}}/>)
+2. Under **Model Providers**, select **Lemonade**
+3. The **Base URL** is pre-filled — leave it as-is if Lemonade is running locally
+
+### Step 3: Fetch Your Models
+
+Jan will automatically fetch models the first time you open the Lemonade settings page. You can also click the refresh icon at any time to sync the latest model list from your server.
+
+<Callout type='info'>
+Models are fetched on demand when you visit the Lemonade settings page, not at app startup. If the model picker is empty, open **Settings → Lemonade** once to trigger the fetch.
+</Callout>
+
+### Step 4: Start Chatting
+
+1. Open a **Chat**
+2. Select a Lemonade model from the model selector
+3. Start chatting
+</Steps>
+
+## API Format
+
+Lemonade supports both the OpenAI and Anthropic wire formats. Switch between them in the provider settings — use **OpenAI** for standard chat completions, **Anthropic** for the `/v1/messages` endpoint.
+
+## MCP Server
+
+Lemonade includes an MCP gateway. Enable **Enable MCP Server** in the provider settings to register it with Jan. Once enabled, individual projects can activate it via their MCP settings panel.
+
+## Troubleshooting
+
+**Models not appearing**
+- Confirm Lemonade is running: open `http://localhost:13305/v1/health` in a browser
+- Click the refresh icon on the Lemonade provider page in Jan
+
+**Connection refused**
+- Verify Lemonade is running and listening on port 13305
+- Check the Base URL in Jan's Lemonade settings matches your server address
+
+**API key prompt**
+- A key is only needed if your Lemonade server has authentication enabled (`LEMONADE_API_KEY` environment variable)
+
+Need more help? Visit the [Lemonade documentation](https://lemonade-server.ai/) or join the [Jan Discord](https://discord.gg/FTk2MvZwJH).

--- a/web-app/public/images/model-provider/lemonade.svg
+++ b/web-app/public/images/model-provider/lemonade.svg
@@ -1,0 +1,53 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M7.03604 2.49169L2 5.00962C2.82591 7.34634 5.52523 8.53484 8.04325 7.52763L14.0865 5.00967C13.2606 2.66287 9.85018 1.17686 7.03604 2.49169Z" fill="url(#paint0_linear_18_30102)"/>
+<g filter="url(#filter0_f_18_30102)">
+<path d="M2.64575 5.26035L7.22767 2.96947C8.5803 2.39118 10.05 2.55851 11.2129 2.97773C12.2111 3.33758 12.9907 3.9608 13.418 4.75328L7.85198 7.0724C5.7348 7.91746 3.52324 7.0363 2.64575 5.26035Z" fill="url(#paint1_linear_18_30102)"/>
+</g>
+<g filter="url(#filter1_f_18_30102)">
+<path d="M5.00464 4.17246L7.43032 2.76879C8.78294 2.1905 10.2527 2.35783 11.4155 2.77705C12.4137 3.13689 13.1933 3.76012 13.6206 4.5526C10.4511 2.99575 9.9351 2.43024 5.00464 4.17246Z" fill="url(#paint2_linear_18_30102)"/>
+</g>
+<path d="M14.9236 4.5997C9.51985 6.50701 6.6904 12.4499 8.59216 17.8694L9.84454 21.4282C11.2477 25.4172 14.8309 28.0107 18.7736 28.3363C19.5157 28.3945 20.2115 28.7201 20.7681 29.2202C21.5682 29.9413 22.7162 30.2087 23.7947 29.8249C24.8731 29.4412 25.6037 28.5108 25.7776 27.4525C25.8936 26.7082 26.2299 26.0336 26.7749 25.5103C29.6391 22.7656 30.8103 18.4974 29.4072 14.5084L28.1548 10.9496C26.2531 5.51849 20.3274 2.68077 14.9236 4.5997Z" fill="url(#paint3_radial_18_30102)"/>
+<path d="M14.9236 4.5997C9.51985 6.50701 6.6904 12.4499 8.59216 17.8694L9.84454 21.4282C11.2477 25.4172 14.8309 28.0107 18.7736 28.3363C19.5157 28.3945 20.2115 28.7201 20.7681 29.2202C21.5682 29.9413 22.7162 30.2087 23.7947 29.8249C24.8731 29.4412 25.6037 28.5108 25.7776 27.4525C25.8936 26.7082 26.2299 26.0336 26.7749 25.5103C29.6391 22.7656 30.8103 18.4974 29.4072 14.5084L28.1548 10.9496C26.2531 5.51849 20.3274 2.68077 14.9236 4.5997Z" fill="url(#paint4_radial_18_30102)"/>
+<path d="M14.9236 4.5997C9.51985 6.50701 6.6904 12.4499 8.59216 17.8694L9.84454 21.4282C11.2477 25.4172 14.8309 28.0107 18.7736 28.3363C19.5157 28.3945 20.2115 28.7201 20.7681 29.2202C21.5682 29.9413 22.7162 30.2087 23.7947 29.8249C24.8731 29.4412 25.6037 28.5108 25.7776 27.4525C25.8936 26.7082 26.2299 26.0336 26.7749 25.5103C29.6391 22.7656 30.8103 18.4974 29.4072 14.5084L28.1548 10.9496C26.2531 5.51849 20.3274 2.68077 14.9236 4.5997Z" fill="url(#paint5_radial_18_30102)"/>
+<defs>
+<filter id="filter0_f_18_30102" x="1.89035" y="1.84127" width="12.283" height="6.31025" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.377703" result="effect1_foregroundBlur_18_30102"/>
+</filter>
+<filter id="filter1_f_18_30102" x="4.24923" y="1.64059" width="10.1268" height="3.66743" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="0.377703" result="effect1_foregroundBlur_18_30102"/>
+</filter>
+<linearGradient id="paint0_linear_18_30102" x1="2" y1="5.00899" x2="14.0865" y2="5.00899" gradientUnits="userSpaceOnUse">
+<stop stop-color="#80A338"/>
+<stop offset="1" stop-color="#B3D745"/>
+</linearGradient>
+<linearGradient id="paint1_linear_18_30102" x1="1.99902" y1="5.02002" x2="14.0855" y2="5.02002" gradientUnits="userSpaceOnUse">
+<stop stop-color="#95BD27"/>
+<stop offset="1" stop-color="#BAE038"/>
+</linearGradient>
+<linearGradient id="paint2_linear_18_30102" x1="13.6206" y1="4.2397" x2="6.38307" y2="3.29833" gradientUnits="userSpaceOnUse">
+<stop stop-color="#D1F56E" stop-opacity="0"/>
+<stop offset="0.286062" stop-color="#D1F56E"/>
+<stop offset="1" stop-color="#D1F56E" stop-opacity="0"/>
+</linearGradient>
+<radialGradient id="paint3_radial_18_30102" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(21.2025 10.5724) rotate(115.148) scale(17.6305 14.9181)">
+<stop stop-color="#FFFB98"/>
+<stop offset="0.505208" stop-color="#FFD84C"/>
+<stop offset="1" stop-color="#E6B534"/>
+</radialGradient>
+<radialGradient id="paint4_radial_18_30102" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(14.6238 4.96834) rotate(69.3343) scale(26.7531 22.6372)">
+<stop offset="0.521583" stop-color="#FFDE67" stop-opacity="0"/>
+<stop offset="0.736095" stop-color="#FFA457" stop-opacity="0.2"/>
+<stop offset="0.886173" stop-color="#D5676D" stop-opacity="0.75"/>
+<stop offset="0.917885" stop-color="#E88257"/>
+<stop offset="1" stop-color="#F49754"/>
+</radialGradient>
+<radialGradient id="paint5_radial_18_30102" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(-10.5942 -28.473) rotate(56.1215) scale(51.3589 43.4576)">
+<stop offset="0.707976" stop-color="#D5B638"/>
+<stop offset="0.873737" stop-color="#D5B638" stop-opacity="0"/>
+</radialGradient>
+</defs>
+</svg>

--- a/web-app/src/constants/providers.ts
+++ b/web-app/src/constants/providers.ts
@@ -399,4 +399,63 @@ export const predefinedProviders = [
     ],
     models: [],
   },
+  {
+    active: true,
+    api_key: '',
+    base_url: 'http://127.0.0.1:13305/v1',
+    explore_models_url: 'https://lemonade-server.ai/',
+    provider: 'lemonade',
+    api_type: 'openai',
+    settings: [
+      {
+        key: 'base-url',
+        title: 'Base URL',
+        description:
+          'The Lemonade server endpoint. Defaults to localhost port 13305.',
+        controller_type: 'input',
+        controller_props: {
+          placeholder: 'http://127.0.0.1:13305/v1',
+          value: 'http://127.0.0.1:13305/v1',
+        },
+      },
+      {
+        key: 'api-key',
+        title: 'API Key',
+        description:
+          'Optional. Only required if your Lemonade server requires authentication.',
+        controller_type: 'input',
+        controller_props: {
+          placeholder: 'Leave empty if not configured',
+          value: '',
+          type: 'password',
+          input_actions: ['unobscure', 'copy'],
+        },
+      },
+      {
+        key: 'api-format',
+        title: 'API Format',
+        description:
+          'Wire format for inference requests. Use **OpenAI** for standard chat completions. Use **Anthropic** for the `/v1/messages` compatible endpoint.',
+        controller_type: 'dropdown',
+        controller_props: {
+          value: 'openai',
+          options: [
+            { value: 'openai', name: 'OpenAI' },
+            { value: 'anthropic', name: 'Anthropic' },
+          ],
+        },
+      },
+      {
+        key: 'mcp-enabled',
+        title: 'Enable MCP Server',
+        description:
+          'Register the Lemonade MCP gateway with Jan. Once enabled, individual projects can activate it via the MCP settings panel.',
+        controller_type: 'checkbox',
+        controller_props: {
+          value: false,
+        },
+      },
+    ],
+    models: [],
+  },
 ]

--- a/web-app/src/containers/DropdownModelProvider.tsx
+++ b/web-app/src/containers/DropdownModelProvider.tsx
@@ -21,7 +21,7 @@ import { localStorageKey } from '@/constants/localStorage'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { useFavoriteModel } from '@/hooks/useFavoriteModel'
 import { predefinedProviders } from '@/constants/providers'
-import { providerHasRemoteApiKeys } from '@/lib/provider-api-keys'
+import { providerHasRemoteApiKeys, providerCanFetchWithoutKey } from '@/lib/provider-api-keys'
 import { useServiceHub } from '@/hooks/useServiceHub'
 import { getLastUsedModel } from '@/utils/getModelToStart'
 import { ChevronsUpDown } from 'lucide-react'
@@ -277,6 +277,7 @@ const DropdownModelProvider = memo(function DropdownModelProvider({
           provider &&
           provider.provider !== 'llamacpp' &&
           !providerHasRemoteApiKeys(provider) &&
+          !providerCanFetchWithoutKey(provider.provider) &&
           (isPredefined || provider.models.length === 0)
         )
           return
@@ -361,9 +362,11 @@ const DropdownModelProvider = memo(function DropdownModelProvider({
           )
           const aHasApiKeyOrCustomModel =
             providerHasRemoteApiKeys(a) ||
+            providerCanFetchWithoutKey(a.provider) ||
             (!aIsPredefined && a.models.length > 0)
           const bHasApiKeyOrCustomModel =
             providerHasRemoteApiKeys(b) ||
+            providerCanFetchWithoutKey(b.provider) ||
             (!bIsPredefined && b.models.length > 0)
           // Providers with API keys or custom with models filled second
           if (aHasApiKeyOrCustomModel && !bHasApiKeyOrCustomModel) return -1

--- a/web-app/src/lib/__tests__/provider-api-keys.test.ts
+++ b/web-app/src/lib/__tests__/provider-api-keys.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { providerCanFetchWithoutKey } from '../provider-api-keys'
+
+describe('providerCanFetchWithoutKey', () => {
+  it('returns true for lemonade', () => {
+    expect(providerCanFetchWithoutKey('lemonade')).toBe(true)
+  })
+
+  it('returns false for all standard cloud providers', () => {
+    for (const p of ['openai', 'anthropic', 'gemini', 'groq', 'mistral', 'xai', 'huggingface', 'nvidia']) {
+      expect(providerCanFetchWithoutKey(p)).toBe(false)
+    }
+  })
+})

--- a/web-app/src/lib/__tests__/providerCaps.test.ts
+++ b/web-app/src/lib/__tests__/providerCaps.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { resolveProviderCaps, isPredefinedRemoteProvider } from '../providerCaps'
+
+describe('resolveProviderCaps lemonade', () => {
+  it('returns CUSTOM_PERMISSIVE for lemonade with openai api_type', () => {
+    const caps = resolveProviderCaps({ provider: 'lemonade', api_type: 'openai' })
+    // CUSTOM_PERMISSIVE has an empty supported set (only core/client_only)
+    // and a large maybe set that includes 'penalties'
+    expect(caps.maybe.has('penalties')).toBe(true)
+    expect(caps.maybe.has('top_k')).toBe(true)
+    expect(caps.maybe.has('mirostat')).toBe(true)
+    // CUSTOM_PERMISSIVE: no samplers are in supported (they're all maybe)
+    expect(caps.supported.has('penalties')).toBe(false)
+    expect(caps.supported.has('top_k')).toBe(false)
+  })
+
+  it('returns ANTHROPIC caps for lemonade with anthropic api_type', () => {
+    const caps = resolveProviderCaps({ provider: 'lemonade', api_type: 'anthropic' })
+    // ANTHROPIC supports top_k and has empty maybe
+    expect(caps.supported.has('top_k')).toBe(true)
+    expect(caps.maybe.size).toBe(0)
+  })
+
+  it('isPredefinedRemoteProvider returns false for lemonade (sampler UI stays visible)', () => {
+    expect(isPredefinedRemoteProvider('lemonade')).toBe(false)
+  })
+})

--- a/web-app/src/lib/__tests__/remoteModelCatalog.test.ts
+++ b/web-app/src/lib/__tests__/remoteModelCatalog.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import {
   fetchTopRemoteModels,
   supportsRemoteCatalog,
+  inferLemonadeCapabilities,
 } from '../remoteModelCatalog'
 
 function mkResponse(body: unknown, status = 200): Response {
@@ -39,10 +40,11 @@ function mkGeminiProvider(extra: Record<string, unknown> = {}) {
 }
 
 describe('supportsRemoteCatalog', () => {
-  it('supports openai, anthropic and gemini', () => {
+  it('returns true for built-in catalog providers', () => {
     expect(supportsRemoteCatalog('openai')).toBe(true)
     expect(supportsRemoteCatalog('anthropic')).toBe(true)
     expect(supportsRemoteCatalog('gemini')).toBe(true)
+    expect(supportsRemoteCatalog('lemonade')).toBe(true)
     expect(supportsRemoteCatalog('groq')).toBe(false)
     expect(supportsRemoteCatalog('mistral')).toBe(false)
   })
@@ -240,5 +242,144 @@ describe('fetchTopRemoteModels anthropic', () => {
     expect(headers).not.toHaveProperty(
       'anthropic-dangerous-direct-browser-access'
     )
+  })
+})
+
+function mkLemonadeProvider(extra: Record<string, unknown> = {}) {
+  return {
+    provider: 'lemonade',
+    base_url: 'http://127.0.0.1:13305/v1',
+    api_key: '',
+    ...extra,
+  } as any
+}
+
+describe('fetchTopRemoteModels lemonade', () => {
+  it('carries max_context_window as contextLength and omits it when absent', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      mkResponse({
+        data: [
+          { id: 'Qwen3-0.6B-GGUF', created: 1700000000, labels: [], max_context_window: 40960 },
+          { id: 'Qwen3-8B-GGUF', created: 1700000001, labels: [] },
+        ],
+      })
+    )
+    const result = await fetchTopRemoteModels(mkLemonadeProvider(), fetchImpl)
+    const small = result.find((m) => m.id === 'Qwen3-0.6B-GGUF')!
+    const large = result.find((m) => m.id === 'Qwen3-8B-GGUF')!
+    expect(small.contextLength).toBe(40960)
+    expect(large.contextLength).toBeUndefined()
+  })
+
+  it('maps vision and tool-calling labels to capabilities', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      mkResponse({
+        data: [
+          {
+            id: 'Qwen3-8B-GGUF',
+            created: 1700000000,
+            labels: ['vision', 'tool-calling'],
+          },
+        ],
+      })
+    )
+    const result = await fetchTopRemoteModels(mkLemonadeProvider(), fetchImpl)
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe('Qwen3-8B-GGUF')
+    expect(result[0].capabilities).toContain('completion')
+    expect(result[0].capabilities).toContain('vision')
+    expect(result[0].capabilities).toContain('tools')
+  })
+
+  it('excludes non-chat models (transcription, tts, image, embeddings, reranking, upscaling)', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      mkResponse({
+        data: [
+          { id: 'Whisper-Large', created: 1700000001, labels: ['transcription'] },
+          { id: 'Kokoro-v1', created: 1700000002, labels: ['tts'] },
+          { id: 'SD-Turbo', created: 1700000003, labels: ['image'] },
+          { id: 'bge-large', created: 1700000004, labels: ['embeddings'] },
+          { id: 'cross-encoder', created: 1700000005, labels: ['reranking'] },
+          { id: 'upscaler-model', created: 1700000007, labels: ['upscaling'] },
+          { id: 'Qwen3-0.6B-GGUF', created: 1700000006, labels: [] },
+        ],
+      })
+    )
+    const result = await fetchTopRemoteModels(mkLemonadeProvider(), fetchImpl)
+    const ids = result.map((m) => m.id)
+    expect(ids).not.toContain('Whisper-Large')
+    expect(ids).not.toContain('Kokoro-v1')
+    expect(ids).not.toContain('SD-Turbo')
+    expect(ids).not.toContain('bge-large')
+    expect(ids).not.toContain('cross-encoder')
+    expect(ids).not.toContain('upscaler-model')
+    expect(ids).toContain('Qwen3-0.6B-GGUF')
+  })
+
+  it('maps chat-transcription label to audio capability', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      mkResponse({
+        data: [
+          {
+            id: 'LMX-Omni-5.5B',
+            created: 1700000000,
+            labels: ['vision', 'chat-transcription'],
+          },
+        ],
+      })
+    )
+    const result = await fetchTopRemoteModels(mkLemonadeProvider(), fetchImpl)
+    expect(result[0].capabilities).toContain('audio')
+  })
+
+  it('includes all chat models without TOP_N=10 cap', async () => {
+    const rows = Array.from({ length: 15 }, (_, i) => ({
+      id: `model-${i}`,
+      created: 1700000000 + i,
+      labels: [],
+    }))
+    const fetchImpl = vi.fn().mockResolvedValue(mkResponse({ data: rows }))
+    const result = await fetchTopRemoteModels(mkLemonadeProvider(), fetchImpl)
+    expect(result.length).toBe(15)
+  })
+
+  it('works without an API key (empty string)', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      mkResponse({ data: [{ id: 'Qwen3-0.6B-GGUF', created: 1700000000, labels: [] }] })
+    )
+    const result = await fetchTopRemoteModels(
+      mkLemonadeProvider({ api_key: '' }),
+      fetchImpl
+    )
+    expect(result).toHaveLength(1)
+    // Should not have set Authorization header with empty key
+    const calledHeaders = fetchImpl.mock.calls[0][1]?.headers as Record<string, string>
+    expect(calledHeaders?.Authorization).toBeUndefined()
+  })
+})
+
+describe('inferLemonadeCapabilities', () => {
+  it('returns completion only for empty labels', () => {
+    expect(inferLemonadeCapabilities([])).toEqual(['completion'])
+  })
+
+  it('returns completion only for informational-only labels (hot, reasoning, coding)', () => {
+    expect(inferLemonadeCapabilities(['hot', 'reasoning', 'coding'])).toEqual(['completion'])
+  })
+
+  it('non-chat label wins even when capability labels are also present', () => {
+    expect(inferLemonadeCapabilities(['image', 'vision'])).toBeNull()
+    expect(inferLemonadeCapabilities(['transcription', 'tool-calling'])).toBeNull()
+    expect(inferLemonadeCapabilities(['tts', 'chat-transcription'])).toBeNull()
+    expect(inferLemonadeCapabilities(['embeddings', 'vision', 'tool-calling'])).toBeNull()
+  })
+
+  it('returns all matching capabilities when multiple capability labels present', () => {
+    const caps = inferLemonadeCapabilities(['vision', 'tool-calling', 'chat-transcription'])
+    expect(caps).toContain('completion')
+    expect(caps).toContain('vision')
+    expect(caps).toContain('tools')
+    expect(caps).toContain('audio')
+    expect(caps).toHaveLength(4)
   })
 })

--- a/web-app/src/lib/custom-chat-transport.ts
+++ b/web-app/src/lib/custom-chat-transport.ts
@@ -1244,7 +1244,11 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
 
     const maxContextTokens = (() => {
       const raw = inferenceParams.max_context_tokens
-      return typeof raw === 'number' ? raw : (Number(raw) || 0)
+      const explicit = typeof raw === 'number' ? raw : (Number(raw) || 0)
+      if (explicit > 0) return explicit
+      // Fall back to the model's advertised context window when the user has not
+      // set an explicit budget — prevents silently overflowing small-context models.
+      return selectedModel?.contextLength ?? 0
     })()
     const autoCompact =
       inferenceParams.auto_compact === true ||

--- a/web-app/src/lib/custom-chat-transport.ts
+++ b/web-app/src/lib/custom-chat-transport.ts
@@ -1345,7 +1345,11 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
 
     const configuredContextTokens = (() => {
       const raw = inferenceParams.max_context_tokens
-      return typeof raw === 'number' ? raw : (Number(raw) || 0)
+      const explicit = typeof raw === 'number' ? raw : (Number(raw) || 0)
+      if (explicit > 0) return explicit
+      // Fall back to the model's advertised context window when the user has not
+      // set an explicit budget — prevents silently overflowing small-context models.
+      return selectedModel?.contextLength ?? 0
     })()
     const contextShiftEnabled =
       providerId === 'llamacpp' &&

--- a/web-app/src/lib/provider-api-keys.ts
+++ b/web-app/src/lib/provider-api-keys.ts
@@ -38,3 +38,9 @@ export function providerHasRemoteApiKeys(provider: {
 }): boolean {
   return providerRemoteApiKeyChain(provider).length > 0
 }
+
+const KEY_OPTIONAL_PROVIDERS = new Set(['lemonade'])
+
+export function providerCanFetchWithoutKey(providerName: string): boolean {
+  return KEY_OPTIONAL_PROVIDERS.has(providerName)
+}

--- a/web-app/src/lib/providerCaps.ts
+++ b/web-app/src/lib/providerCaps.ts
@@ -159,6 +159,8 @@ const BUILTIN_CAPS: Record<string, ProviderCaps> = {
   huggingface: HUGGINGFACE,
   nvidia: NVIDIA,
   minimax: MINIMAX,
+  // CUSTOM_PERMISSIVE (not LLAMACPP): Lemonade may back any runtime, so extended samplers are optional rather than guaranteed.
+  lemonade: CUSTOM_PERMISSIVE,
   llamacpp: LLAMACPP,
   mlx: MLX,
 }
@@ -182,7 +184,7 @@ export function getProviderApiType(
   return provider.provider === 'anthropic' ? 'anthropic' : 'openai'
 }
 
-const LOCAL_PROVIDER_IDS = new Set<string>(['llamacpp', 'mlx'])
+const LOCAL_PROVIDER_IDS = new Set<string>(['llamacpp', 'mlx', 'lemonade'])
 
 /**
  * Predefined remote providers ship locked base_urls and expose only a fixed

--- a/web-app/src/lib/remoteModelCatalog.ts
+++ b/web-app/src/lib/remoteModelCatalog.ts
@@ -4,6 +4,7 @@ export type RemoteCatalogModel = {
   id: string
   capabilities: string[]
   createdMs: number
+  contextLength?: number
 }
 
 type ProviderLike = {
@@ -64,7 +65,7 @@ export function ensureAnthropicHeaders(
   setDefaultHeader(headers, ANTHROPIC_BROWSER_ACCESS_HEADER, 'true')
 }
 
-type CatalogKind = 'openai' | 'anthropic' | 'gemini'
+type CatalogKind = 'openai' | 'anthropic' | 'gemini' | 'lemonade'
 
 /// Resolve which catalog shape a provider speaks. `api_type` is authoritative
 /// (a custom-named Anthropic gateway still lists Claude models), falling back
@@ -75,7 +76,7 @@ function resolveCatalogKind(
   const name = typeof provider === 'string' ? provider : provider.provider
   const apiType = typeof provider === 'string' ? undefined : provider.api_type
   if (apiType === 'anthropic') return 'anthropic'
-  if (name === 'openai' || name === 'anthropic' || name === 'gemini') {
+  if (name === 'openai' || name === 'anthropic' || name === 'gemini' || name === 'lemonade') {
     return name
   }
   return null
@@ -160,6 +161,47 @@ function inferAnthropicCapabilities(id: string): string[] | null {
   return ['completion', 'tools', 'vision']
 }
 
+const NON_CHAT_LABELS = new Set([
+  'transcription',
+  'tts',
+  'image',
+  'embeddings',
+  'reranking',
+  'upscaling',
+])
+
+export function inferLemonadeCapabilities(labels: string[]): string[] | null {
+  if (labels.some((l) => NON_CHAT_LABELS.has(l))) return null
+  const caps: string[] = ['completion']
+  if (labels.includes('vision')) caps.push('vision')
+  if (labels.includes('tool-calling')) caps.push('tools')
+  if (labels.includes('chat-transcription')) caps.push('audio')
+  return caps
+}
+
+function normalizeLemonadeCatalog(rows: unknown[]): RemoteCatalogModel[] {
+  const parsed: RemoteCatalogModel[] = []
+  for (const raw of rows) {
+    if (!raw || typeof raw !== 'object') continue
+    const row = raw as Record<string, unknown>
+    const id = typeof row.id === 'string' ? row.id : null
+    if (!id) continue
+    const labels = Array.isArray(row.labels)
+      ? (row.labels as unknown[]).filter((l): l is string => typeof l === 'string')
+      : []
+    const caps = inferLemonadeCapabilities(labels)
+    if (!caps) continue
+    const createdMs = parseCreated(row.created, row.created_at)
+    const contextLength =
+      typeof row.max_context_window === 'number' && row.max_context_window > 0
+        ? row.max_context_window
+        : undefined
+    parsed.push({ id, capabilities: caps, createdMs, contextLength })
+  }
+  parsed.sort((a, b) => b.createdMs - a.createdMs || a.id.localeCompare(b.id))
+  return parsed
+}
+
 function buildHeaders(p: ProviderLike, key: string | undefined): Record<string, string> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' }
   if (key) {
@@ -232,6 +274,9 @@ export async function fetchTopRemoteModels(
 }
 
 function normalizeCatalog(kind: CatalogKind, rows: unknown[]): RemoteCatalogModel[] {
+  if (kind === 'lemonade') {
+    return normalizeLemonadeCatalog(rows)
+  }
   const inferCaps =
     kind === 'openai'
       ? inferOpenAICapabilities

--- a/web-app/src/lib/utils.ts
+++ b/web-app/src/lib/utils.ts
@@ -159,6 +159,8 @@ export function getProviderLogo(provider: string) {
       return '/images/model-provider/minimax.svg'
     case 'nvidia':
       return '/images/model-provider/nvidia.svg'
+    case 'lemonade':
+      return '/images/model-provider/lemonade.svg'
     default:
       return undefined
   }
@@ -186,6 +188,8 @@ export const getProviderTitle = (provider: string) => {
       return 'MiniMax'
     case 'nvidia':
       return 'NVIDIA NIM'
+    case 'lemonade':
+      return 'Lemonade'
     default:
       return provider.charAt(0).toUpperCase() + provider.slice(1)
   }

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -46,13 +46,23 @@ import { DialogAddModel } from '@/containers/dialogs/AddModel'
 import {
   providerHasRemoteApiKeys,
   providerRemoteApiKeyChain,
+  providerCanFetchWithoutKey,
   API_KEY_FALLBACKS_SETTING_KEY,
   serializeApiKeyFallbacks,
 } from '@/lib/provider-api-keys'
+import { useMCPServers } from '@/hooks/useMCPServers'
 import {
   supportsRemoteCatalog,
   fetchTopRemoteModels,
 } from '@/lib/remoteModelCatalog'
+
+function lemonadeMcpUrl(baseUrl: string): string {
+  try {
+    return new URL(baseUrl).origin + '/mcp'
+  } catch {
+    return 'http://127.0.0.1:13305/mcp'
+  }
+}
 
 // as route.threadsDetail
 export const Route = createFileRoute('/settings/providers/$providerName')({
@@ -283,7 +293,7 @@ function ProviderDetail() {
     if (!provider) return
     if (!supportsRemoteCatalog(provider)) return
     if (provider.models.length > 0) return
-    if (!providerHasRemoteApiKeys(provider)) return
+    if (!providerHasRemoteApiKeys(provider) && !providerCanFetchWithoutKey(provider.provider)) return
     if (autoCatalogAttempted.current.has(provider.provider)) return
     autoCatalogAttempted.current.add(provider.provider)
     handleRefreshModels()
@@ -521,7 +531,7 @@ function ProviderDetail() {
   // This ensures all screens receive the event intermediately
 
   const handleRefreshModels = async () => {
-    if (!provider || !provider.base_url || !providerHasRemoteApiKeys(provider)) {
+    if (!provider || !provider.base_url || (!providerHasRemoteApiKeys(provider) && !providerCanFetchWithoutKey(provider.provider))) {
       toast.error(t('providers:models'), {
         description: t('providers:refreshModelsError'),
       })
@@ -539,6 +549,7 @@ function ProviderDetail() {
           name: m.id,
           capabilities: m.capabilities,
           version: '1.0',
+          ...(m.contextLength ? { contextLength: m.contextLength } : {}),
         }))
       } else {
         const modelIds = await serviceHub
@@ -643,7 +654,6 @@ function ProviderDetail() {
   }
 
   const handleStopModel = (modelId: string) => {
-    // Original: stopModel(modelId).then(() => { setActiveModels((prevModels) => prevModels.filter((model) => model !== modelId)) })
     serviceHub
       .models()
       .stopModel(modelId, provider?.provider)
@@ -828,14 +838,16 @@ function ProviderDetail() {
               {!(
                 isPredefinedProvider &&
                 provider?.provider !== 'llamacpp' &&
-                provider?.provider !== 'mlx'
+                provider?.provider !== 'mlx' &&
+                provider?.provider !== 'lemonade'
               ) && (
               <Card>
                 {provider?.settings.map((setting, settingIndex) => {
                   if (
                     setting.key === 'api-key' &&
                     provider?.provider !== 'llamacpp' &&
-                    provider?.provider !== 'mlx'
+                    provider?.provider !== 'mlx' &&
+                    provider?.provider !== 'lemonade'
                   ) {
                     return null
                   }
@@ -888,6 +900,60 @@ function ProviderDetail() {
                                 typeof newValue === 'string'
                               ) {
                                 updateObj.base_url = newValue
+                                if (provider.provider === 'lemonade') {
+                                  const mcpEnabled =
+                                    newSettings.find((s) => s.key === 'mcp-enabled')
+                                      ?.controller_props?.value === true
+                                  if (mcpEnabled) {
+                                    try {
+                                      const mcpUrl = lemonadeMcpUrl(newValue)
+                                      // useMCPServers.getState() — Zustand store singleton, not a React hook
+                                      const mcpStore = useMCPServers.getState()
+                                      mcpStore.addServer('lemonade', {
+                                        command: '',
+                                        args: [],
+                                        env: {},
+                                        type: 'http',
+                                        url: mcpUrl,
+                                        active: true,
+                                        description: 'Lemonade local AI server',
+                                      })
+                                      mcpStore.syncServersAndRestart().catch(console.error)
+                                    } catch {
+                                      // invalid URL
+                                    }
+                                  }
+                                }
+                              } else if (
+                                provider.provider === 'lemonade' &&
+                                settingKey === 'api-format' &&
+                                typeof newValue === 'string'
+                              ) {
+                                if (newValue === 'openai' || newValue === 'anthropic') {
+                                  updateObj.api_type = newValue
+                                }
+                              } else if (
+                                provider.provider === 'lemonade' &&
+                                settingKey === 'mcp-enabled'
+                              ) {
+                                // useMCPServers.getState() — Zustand store singleton, not a React hook
+                                const mcpStore = useMCPServers.getState()
+                                const baseUrl = provider.base_url ?? 'http://127.0.0.1:13305/v1'
+                                const mcpUrl = lemonadeMcpUrl(baseUrl)
+                                if (newValue === true) {
+                                  mcpStore.addServer('lemonade', {
+                                    command: '',
+                                    args: [],
+                                    env: {},
+                                    type: 'http',
+                                    url: mcpUrl,
+                                    active: true,
+                                    description: 'Lemonade local AI server',
+                                  })
+                                } else {
+                                  mcpStore.deleteServer('lemonade')
+                                }
+                                mcpStore.syncServersAndRestart().catch(console.error)
                               }
 
                               // Reset device setting to empty when backend or version changes
@@ -1064,7 +1130,8 @@ function ProviderDetail() {
 
               {provider &&
                 provider.provider !== 'llamacpp' &&
-                provider.provider !== 'mlx' && (
+                provider.provider !== 'mlx' &&
+                provider.provider !== 'lemonade' && (
                   <Card>
                     {provider.provider === 'azure' && (
                       <div className="space-y-2 mb-4">
@@ -1388,7 +1455,7 @@ function ProviderDetail() {
                                 predefinedProviders.some(
                                   (p) => p.provider === provider.provider
                                 ) &&
-                                providerHasRemoteApiKeys(provider))) && (
+                                (providerHasRemoteApiKeys(provider) || providerCanFetchWithoutKey(provider.provider)))) && (
                               <FavoriteModelAction model={model} />
                             )}
                             <DialogDeleteModel

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -41,13 +41,23 @@ import { DialogAddModel } from '@/containers/dialogs/AddModel'
 import {
   providerHasRemoteApiKeys,
   providerRemoteApiKeyChain,
+  providerCanFetchWithoutKey,
   API_KEY_FALLBACKS_SETTING_KEY,
   serializeApiKeyFallbacks,
 } from '@/lib/provider-api-keys'
+import { useMCPServers } from '@/hooks/useMCPServers'
 import {
   supportsRemoteCatalog,
   fetchTopRemoteModels,
 } from '@/lib/remoteModelCatalog'
+
+function lemonadeMcpUrl(baseUrl: string): string {
+  try {
+    return new URL(baseUrl).origin + '/mcp'
+  } catch {
+    return 'http://127.0.0.1:13305/mcp'
+  }
+}
 
 // as route.threadsDetail
 export const Route = createFileRoute('/settings/providers/$providerName')({
@@ -258,7 +268,7 @@ function ProviderDetail() {
     if (!provider) return
     if (!supportsRemoteCatalog(provider)) return
     if (provider.models.length > 0) return
-    if (!providerHasRemoteApiKeys(provider)) return
+    if (!providerHasRemoteApiKeys(provider) && !providerCanFetchWithoutKey(provider.provider)) return
     if (autoCatalogAttempted.current.has(provider.provider)) return
     autoCatalogAttempted.current.add(provider.provider)
     handleRefreshModels()
@@ -474,7 +484,7 @@ function ProviderDetail() {
   // This ensures all screens receive the event intermediately
 
   const handleRefreshModels = async () => {
-    if (!provider || !provider.base_url || !providerHasRemoteApiKeys(provider)) {
+    if (!provider || !provider.base_url || (!providerHasRemoteApiKeys(provider) && !providerCanFetchWithoutKey(provider.provider))) {
       toast.error(t('providers:models'), {
         description: t('providers:refreshModelsError'),
       })
@@ -492,6 +502,7 @@ function ProviderDetail() {
           name: m.id,
           capabilities: m.capabilities,
           version: '1.0',
+          ...(m.contextLength ? { contextLength: m.contextLength } : {}),
         }))
       } else {
         const modelIds = await serviceHub
@@ -596,7 +607,6 @@ function ProviderDetail() {
   }
 
   const handleStopModel = (modelId: string) => {
-    // Original: stopModel(modelId).then(() => { setActiveModels((prevModels) => prevModels.filter((model) => model !== modelId)) })
     serviceHub
       .models()
       .stopModel(modelId, provider?.provider)
@@ -675,14 +685,16 @@ function ProviderDetail() {
               {!(
                 isPredefinedProvider &&
                 provider?.provider !== 'llamacpp' &&
-                provider?.provider !== 'mlx'
+                provider?.provider !== 'mlx' &&
+                provider?.provider !== 'lemonade'
               ) && (
               <Card>
                 {provider?.settings.map((setting, settingIndex) => {
                   if (
                     setting.key === 'api-key' &&
                     provider?.provider !== 'llamacpp' &&
-                    provider?.provider !== 'mlx'
+                    provider?.provider !== 'mlx' &&
+                    provider?.provider !== 'lemonade'
                   ) {
                     return null
                   }
@@ -729,6 +741,60 @@ function ProviderDetail() {
                                 typeof newValue === 'string'
                               ) {
                                 updateObj.base_url = newValue
+                                if (provider.provider === 'lemonade') {
+                                  const mcpEnabled =
+                                    newSettings.find((s) => s.key === 'mcp-enabled')
+                                      ?.controller_props?.value === true
+                                  if (mcpEnabled) {
+                                    try {
+                                      const mcpUrl = lemonadeMcpUrl(newValue)
+                                      // useMCPServers.getState() — Zustand store singleton, not a React hook
+                                      const mcpStore = useMCPServers.getState()
+                                      mcpStore.addServer('lemonade', {
+                                        command: '',
+                                        args: [],
+                                        env: {},
+                                        type: 'http',
+                                        url: mcpUrl,
+                                        active: true,
+                                        description: 'Lemonade local AI server',
+                                      })
+                                      mcpStore.syncServersAndRestart().catch(console.error)
+                                    } catch {
+                                      // invalid URL
+                                    }
+                                  }
+                                }
+                              } else if (
+                                provider.provider === 'lemonade' &&
+                                settingKey === 'api-format' &&
+                                typeof newValue === 'string'
+                              ) {
+                                if (newValue === 'openai' || newValue === 'anthropic') {
+                                  updateObj.api_type = newValue
+                                }
+                              } else if (
+                                provider.provider === 'lemonade' &&
+                                settingKey === 'mcp-enabled'
+                              ) {
+                                // useMCPServers.getState() — Zustand store singleton, not a React hook
+                                const mcpStore = useMCPServers.getState()
+                                const baseUrl = provider.base_url ?? 'http://127.0.0.1:13305/v1'
+                                const mcpUrl = lemonadeMcpUrl(baseUrl)
+                                if (newValue === true) {
+                                  mcpStore.addServer('lemonade', {
+                                    command: '',
+                                    args: [],
+                                    env: {},
+                                    type: 'http',
+                                    url: mcpUrl,
+                                    active: true,
+                                    description: 'Lemonade local AI server',
+                                  })
+                                } else {
+                                  mcpStore.deleteServer('lemonade')
+                                }
+                                mcpStore.syncServersAndRestart().catch(console.error)
                               }
 
                               serviceHub
@@ -800,7 +866,8 @@ function ProviderDetail() {
 
               {provider &&
                 provider.provider !== 'llamacpp' &&
-                provider.provider !== 'mlx' && (
+                provider.provider !== 'mlx' &&
+                provider.provider !== 'lemonade' && (
                   <Card>
                     {provider.provider === 'azure' && (
                       <div className="space-y-2 mb-4">
@@ -1124,7 +1191,7 @@ function ProviderDetail() {
                                 predefinedProviders.some(
                                   (p) => p.provider === provider.provider
                                 ) &&
-                                providerHasRemoteApiKeys(provider))) && (
+                                (providerHasRemoteApiKeys(provider) || providerCanFetchWithoutKey(provider.provider)))) && (
                               <FavoriteModelAction model={model} />
                             )}
                             <DialogDeleteModel

--- a/web-app/src/routes/settings/providers/__tests__/$providerName.test.tsx
+++ b/web-app/src/routes/settings/providers/__tests__/$providerName.test.tsx
@@ -70,9 +70,52 @@ const h = vi.hoisted(() => {
     ],
   }
 
+  const lemonadeProvider: any = {
+    provider: 'lemonade',
+    active: true,
+    api_key: '',
+    base_url: 'http://127.0.0.1:13305/v1',
+    api_type: 'openai',
+    models: [],
+    settings: [
+      {
+        key: 'base-url',
+        title: 'Base URL',
+        description: 'The Lemonade server endpoint.',
+        controller_type: 'input',
+        controller_props: { value: 'http://127.0.0.1:13305/v1' },
+      },
+      {
+        key: 'api-key',
+        title: 'API Key',
+        description: 'Optional.',
+        controller_type: 'input',
+        controller_props: { value: '', type: 'password', input_actions: ['unobscure', 'copy'] },
+      },
+      {
+        key: 'api-format',
+        title: 'API Format',
+        description: 'Wire format.',
+        controller_type: 'dropdown',
+        controller_props: {
+          value: 'openai',
+          options: [{ value: 'openai', name: 'OpenAI' }, { value: 'anthropic', name: 'Anthropic' }],
+        },
+      },
+      {
+        key: 'mcp-enabled',
+        title: 'Enable MCP Server',
+        description: 'Register MCP gateway.',
+        controller_type: 'checkbox',
+        controller_props: { value: false },
+      },
+    ],
+  }
+
   const providerMap: Record<string, any> = {
     openai: openaiProvider,
     llamacpp: llamacppProvider,
+    lemonade: lemonadeProvider,
   }
 
   const updateProvider = vi.fn()
@@ -135,6 +178,7 @@ const h = vi.hoisted(() => {
     toastInfo,
     openaiProvider,
     llamacppProvider,
+    lemonadeProvider,
     providerMap,
     modelProviderStore,
     updateProvider,
@@ -203,15 +247,24 @@ vi.mock('@/containers/Capabilities', () => ({
   ),
 }))
 
+// Registry so tests can invoke a specific DynamicControllerSetting's onChange
+// with an arbitrary value rather than the hardcoded 'new-value'.
+const dynamicCtrlRegistry: Map<string, (v: any) => void> = new Map()
+
 vi.mock('@/containers/dynamicControllerSetting', () => ({
-  DynamicControllerSetting: ({ onChange, controllerProps }: any) => (
-    <button
-      data-testid="dynamic-ctrl"
-      onClick={() => onChange('new-value')}
-    >
-      {String(controllerProps?.value ?? '')}
-    </button>
-  ),
+  DynamicControllerSetting: ({ onChange, controllerProps }: any) => {
+    const key = String(controllerProps?.value ?? '')
+    dynamicCtrlRegistry.set(key, onChange)
+    return (
+      <button
+        data-testid="dynamic-ctrl"
+        data-ctrl-value={key}
+        onClick={() => onChange('new-value')}
+      >
+        {key}
+      </button>
+    )
+  },
 }))
 
 vi.mock('@/containers/RenderMarkdown', () => ({
@@ -336,12 +389,24 @@ vi.mock('@/hooks/useBackendUpdater', () => ({
 
 vi.mock('@/hooks/useAppState', () => ({ useAppState: h.useAppStateMock }))
 
+vi.mock('@/hooks/useMCPServers', () => {
+  const addServer = vi.fn()
+  const deleteServer = vi.fn()
+  const syncServersAndRestart = vi.fn().mockResolvedValue(undefined)
+  return {
+    useMCPServers: {
+      getState: () => ({ addServer, deleteServer, syncServersAndRestart }),
+    },
+  }
+})
+
 vi.mock('zustand/shallow', () => ({
   useShallow: (fn: any) => fn,
 }))
 
 // Import AFTER mocks
 import { Route } from '../$providerName'
+import { useMCPServers } from '@/hooks/useMCPServers'
 
 const renderComponent = () => {
   const Component = Route.component as React.ComponentType
@@ -379,6 +444,43 @@ beforeEach(() => {
   ]
   h.providerMap.openai = h.openaiProvider
   h.providerMap.llamacpp = h.llamacppProvider
+  h.lemonadeProvider.api_type = 'openai'
+  h.lemonadeProvider.base_url = 'http://127.0.0.1:13305/v1'
+  h.lemonadeProvider.settings = [
+    {
+      key: 'base-url',
+      title: 'Base URL',
+      description: 'The Lemonade server endpoint.',
+      controller_type: 'input',
+      controller_props: { value: 'http://127.0.0.1:13305/v1' },
+    },
+    {
+      key: 'api-key',
+      title: 'API Key',
+      description: 'Optional.',
+      controller_type: 'input',
+      controller_props: { value: '', type: 'password', input_actions: ['unobscure', 'copy'] },
+    },
+    {
+      key: 'api-format',
+      title: 'API Format',
+      description: 'Wire format.',
+      controller_type: 'dropdown',
+      controller_props: {
+        value: 'openai',
+        options: [{ value: 'openai', name: 'OpenAI' }, { value: 'anthropic', name: 'Anthropic' }],
+      },
+    },
+    {
+      key: 'mcp-enabled',
+      title: 'Enable MCP Server',
+      description: 'Register MCP gateway.',
+      controller_type: 'checkbox',
+      controller_props: { value: false },
+    },
+  ]
+  h.providerMap.lemonade = h.lemonadeProvider
+  dynamicCtrlRegistry.clear()
 
   // Reset services to default behavior
   h.providersSvc.getProviders = vi.fn().mockResolvedValue([])
@@ -811,6 +913,63 @@ describe('ProviderDetail route', () => {
         fireEvent.click(dyns[0]) // llamacpp_version
       })
       expect(h.modelsSvc.stopAllModels).toHaveBeenCalled()
+    })
+  })
+
+  describe('Lemonade provider', () => {
+    beforeEach(() => {
+      h.params.providerName = 'lemonade'
+    })
+
+    it('changing api-format updates provider api_type', () => {
+      renderComponent()
+      // The api-format setting renders with current value 'openai' as button text
+      const onChange = dynamicCtrlRegistry.get('openai')
+      expect(onChange).toBeDefined()
+      act(() => {
+        onChange!('anthropic')
+      })
+      expect(h.updateProvider).toHaveBeenCalledWith(
+        'lemonade',
+        expect.objectContaining({ api_type: 'anthropic' })
+      )
+    })
+
+    it('toggling mcp-enabled ON calls addServer with correct HTTP MCP config', () => {
+      renderComponent()
+      const { addServer } = useMCPServers.getState()
+      // The mcp-enabled setting renders with current value 'false' as button text
+      const onChange = dynamicCtrlRegistry.get('false')
+      expect(onChange).toBeDefined()
+      act(() => {
+        onChange!(true)
+      })
+      expect(addServer).toHaveBeenCalledWith(
+        'lemonade',
+        expect.objectContaining({
+          type: 'http',
+          url: 'http://127.0.0.1:13305/mcp',
+          active: true,
+        })
+      )
+    })
+
+    it('toggling mcp-enabled OFF calls deleteServer with lemonade', () => {
+      // Set up the lemonade provider with mcp-enabled: true
+      h.lemonadeProvider.settings = h.lemonadeProvider.settings.map((s: any) =>
+        s.key === 'mcp-enabled'
+          ? { ...s, controller_props: { ...s.controller_props, value: true } }
+          : s
+      )
+      renderComponent()
+      const { deleteServer } = useMCPServers.getState()
+      // The mcp-enabled setting renders with current value 'true' as button text
+      const onChange = dynamicCtrlRegistry.get('true')
+      expect(onChange).toBeDefined()
+      act(() => {
+        onChange!(false)
+      })
+      expect(deleteServer).toHaveBeenCalledWith('lemonade')
     })
   })
 })

--- a/web-app/src/routes/settings/providers/__tests__/$providerName.test.tsx
+++ b/web-app/src/routes/settings/providers/__tests__/$providerName.test.tsx
@@ -63,9 +63,52 @@ const h = vi.hoisted(() => {
     ],
   }
 
+  const lemonadeProvider: any = {
+    provider: 'lemonade',
+    active: true,
+    api_key: '',
+    base_url: 'http://127.0.0.1:13305/v1',
+    api_type: 'openai',
+    models: [],
+    settings: [
+      {
+        key: 'base-url',
+        title: 'Base URL',
+        description: 'The Lemonade server endpoint.',
+        controller_type: 'input',
+        controller_props: { value: 'http://127.0.0.1:13305/v1' },
+      },
+      {
+        key: 'api-key',
+        title: 'API Key',
+        description: 'Optional.',
+        controller_type: 'input',
+        controller_props: { value: '', type: 'password', input_actions: ['unobscure', 'copy'] },
+      },
+      {
+        key: 'api-format',
+        title: 'API Format',
+        description: 'Wire format.',
+        controller_type: 'dropdown',
+        controller_props: {
+          value: 'openai',
+          options: [{ value: 'openai', name: 'OpenAI' }, { value: 'anthropic', name: 'Anthropic' }],
+        },
+      },
+      {
+        key: 'mcp-enabled',
+        title: 'Enable MCP Server',
+        description: 'Register MCP gateway.',
+        controller_type: 'checkbox',
+        controller_props: { value: false },
+      },
+    ],
+  }
+
   const providerMap: Record<string, any> = {
     openai: openaiProvider,
     llamacpp: llamacppProvider,
+    lemonade: lemonadeProvider,
   }
 
   const updateProvider = vi.fn()
@@ -123,6 +166,7 @@ const h = vi.hoisted(() => {
     toastInfo,
     openaiProvider,
     llamacppProvider,
+    lemonadeProvider,
     providerMap,
     modelProviderStore,
     updateProvider,
@@ -190,15 +234,24 @@ vi.mock('@/containers/Capabilities', () => ({
   ),
 }))
 
+// Registry so tests can invoke a specific DynamicControllerSetting's onChange
+// with an arbitrary value rather than the hardcoded 'new-value'.
+const dynamicCtrlRegistry: Map<string, (v: any) => void> = new Map()
+
 vi.mock('@/containers/dynamicControllerSetting', () => ({
-  DynamicControllerSetting: ({ onChange, controllerProps }: any) => (
-    <button
-      data-testid="dynamic-ctrl"
-      onClick={() => onChange('new-value')}
-    >
-      {String(controllerProps?.value ?? '')}
-    </button>
-  ),
+  DynamicControllerSetting: ({ onChange, controllerProps }: any) => {
+    const key = String(controllerProps?.value ?? '')
+    dynamicCtrlRegistry.set(key, onChange)
+    return (
+      <button
+        data-testid="dynamic-ctrl"
+        data-ctrl-value={key}
+        onClick={() => onChange('new-value')}
+      >
+        {key}
+      </button>
+    )
+  },
 }))
 
 vi.mock('@/containers/RenderMarkdown', () => ({
@@ -319,12 +372,24 @@ vi.mock('@/hooks/useLlamacppDevices', () => {
 
 vi.mock('@/hooks/useAppState', () => ({ useAppState: h.useAppStateMock }))
 
+vi.mock('@/hooks/useMCPServers', () => {
+  const addServer = vi.fn()
+  const deleteServer = vi.fn()
+  const syncServersAndRestart = vi.fn().mockResolvedValue(undefined)
+  return {
+    useMCPServers: {
+      getState: () => ({ addServer, deleteServer, syncServersAndRestart }),
+    },
+  }
+})
+
 vi.mock('zustand/shallow', () => ({
   useShallow: (fn: any) => fn,
 }))
 
 // Import AFTER mocks
 import { Route } from '../$providerName'
+import { useMCPServers } from '@/hooks/useMCPServers'
 
 const renderComponent = () => {
   const Component = Route.component as React.ComponentType
@@ -362,6 +427,43 @@ beforeEach(() => {
   ]
   h.providerMap.openai = h.openaiProvider
   h.providerMap.llamacpp = h.llamacppProvider
+  h.lemonadeProvider.api_type = 'openai'
+  h.lemonadeProvider.base_url = 'http://127.0.0.1:13305/v1'
+  h.lemonadeProvider.settings = [
+    {
+      key: 'base-url',
+      title: 'Base URL',
+      description: 'The Lemonade server endpoint.',
+      controller_type: 'input',
+      controller_props: { value: 'http://127.0.0.1:13305/v1' },
+    },
+    {
+      key: 'api-key',
+      title: 'API Key',
+      description: 'Optional.',
+      controller_type: 'input',
+      controller_props: { value: '', type: 'password', input_actions: ['unobscure', 'copy'] },
+    },
+    {
+      key: 'api-format',
+      title: 'API Format',
+      description: 'Wire format.',
+      controller_type: 'dropdown',
+      controller_props: {
+        value: 'openai',
+        options: [{ value: 'openai', name: 'OpenAI' }, { value: 'anthropic', name: 'Anthropic' }],
+      },
+    },
+    {
+      key: 'mcp-enabled',
+      title: 'Enable MCP Server',
+      description: 'Register MCP gateway.',
+      controller_type: 'checkbox',
+      controller_props: { value: false },
+    },
+  ]
+  h.providerMap.lemonade = h.lemonadeProvider
+  dynamicCtrlRegistry.clear()
 
   // Reset services to default behavior
   h.providersSvc.getProviders = vi.fn().mockResolvedValue([])
@@ -724,6 +826,63 @@ describe('ProviderDetail route', () => {
         fireEvent.click(dyns[0])
       })
       expect(h.modelsSvc.stopAllModels).toHaveBeenCalled()
+    })
+  })
+
+  describe('Lemonade provider', () => {
+    beforeEach(() => {
+      h.params.providerName = 'lemonade'
+    })
+
+    it('changing api-format updates provider api_type', () => {
+      renderComponent()
+      // The api-format setting renders with current value 'openai' as button text
+      const onChange = dynamicCtrlRegistry.get('openai')
+      expect(onChange).toBeDefined()
+      act(() => {
+        onChange!('anthropic')
+      })
+      expect(h.updateProvider).toHaveBeenCalledWith(
+        'lemonade',
+        expect.objectContaining({ api_type: 'anthropic' })
+      )
+    })
+
+    it('toggling mcp-enabled ON calls addServer with correct HTTP MCP config', () => {
+      renderComponent()
+      const { addServer } = useMCPServers.getState()
+      // The mcp-enabled setting renders with current value 'false' as button text
+      const onChange = dynamicCtrlRegistry.get('false')
+      expect(onChange).toBeDefined()
+      act(() => {
+        onChange!(true)
+      })
+      expect(addServer).toHaveBeenCalledWith(
+        'lemonade',
+        expect.objectContaining({
+          type: 'http',
+          url: 'http://127.0.0.1:13305/mcp',
+          active: true,
+        })
+      )
+    })
+
+    it('toggling mcp-enabled OFF calls deleteServer with lemonade', () => {
+      // Set up the lemonade provider with mcp-enabled: true
+      h.lemonadeProvider.settings = h.lemonadeProvider.settings.map((s: any) =>
+        s.key === 'mcp-enabled'
+          ? { ...s, controller_props: { ...s.controller_props, value: true } }
+          : s
+      )
+      renderComponent()
+      const { deleteServer } = useMCPServers.getState()
+      // The mcp-enabled setting renders with current value 'true' as button text
+      const onChange = dynamicCtrlRegistry.get('true')
+      expect(onChange).toBeDefined()
+      act(() => {
+        onChange!(false)
+      })
+      expect(deleteServer).toHaveBeenCalledWith('lemonade')
     })
   })
 })

--- a/web-app/src/types/modelProviders.d.ts
+++ b/web-app/src/types/modelProviders.d.ts
@@ -49,6 +49,8 @@ type Model = {
   /** Chat-template kwargs the model's template accepts (llamacpp only). */
   template_kwargs?: TemplateKwarg[]
   settings?: Record<string, ProviderSetting>
+  /** Maximum context window in tokens as reported by the provider at catalog fetch time. */
+  contextLength?: number
   /** Whether this model is an embedding model (e.g., BERT-based) */
   embedding?: boolean
   /** Whether this model was imported from a user-supplied local file


### PR DESCRIPTION
## Describe Your Changes

Adds [Lemonade](https://lemonade-server.ai/) as a built-in model provider for local AI inference. Models and their capabilities (vision, tools, audio) are discovered automatically from the running server. Supports both [OpenAI](https://lemonade-server.ai/docs/api/openai/) and [Anthropic](https://lemonade-server.ai/docs/api/anthropic/) wire formats, and optionally registers Lemonade's [MCP gateway](https://lemonade-server.ai/docs/api/mcp/) per project.

https://github.com/user-attachments/assets/440136ac-0d8d-487a-9554-bfabb2f2eb0f

PS: Hope this is a welcome addition, happy to field any review comments.

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [x] Updated docs (for bug fixes / features)
- [ ] ~Created issues for follow-up changes or refactoring needed~ (N/A)
