### PR TITLE
docs: clarify Jan model quick-start flow

### DIFF
--- a/docs/src/pages/docs/desktop/jan-models/jan-code-4b.mdx
+++ b/docs/src/pages/docs/desktop/jan-models/jan-code-4b.mdx
@@ -83,8 +83,10 @@ Jan-Code-4B leads Jan-v3-base-instruct and the Qwen3-4B-Instruct-2507 base model
 ### Quick Start
 
 1. Download Jan Desktop
-2. Select Jan-Code-4B from the model list
-3. Start coding — no additional configuration needed
+2. Click **Open in Jan** above, or open the **Hub** and search for Jan-Code-4B
+3. Choose a variant that fits your hardware, then click **Download**
+4. Once downloaded, select Jan-Code-4B from the model selector in any chat
+5. Start coding — no additional configuration needed
 
 ### Deployment Options
 

--- a/docs/src/pages/docs/desktop/jan-models/jan-v1.mdx
+++ b/docs/src/pages/docs/desktop/jan-models/jan-v1.mdx
@@ -72,8 +72,10 @@ These benchmarks (EQBench, CreativeWriting, and IFBench) measure the model's abi
 ### Quick Start
 
 1. Download Jan Desktop
-2. Select Jan-v1 from the model list
-3. Start chatting - no additional configuration needed
+2. Click **Open in Jan** above, or open the **Hub** and search for Jan-v1
+3. Choose a variant that fits your hardware, then click **Download**
+4. Once downloaded, select Jan-v1 from the model selector in any chat
+5. Start chatting - no additional configuration needed
 
 ### Demo
 

--- a/docs/src/pages/docs/desktop/jan-models/jan-v2-vl-med.mdx
+++ b/docs/src/pages/docs/desktop/jan-models/jan-v2-vl-med.mdx
@@ -96,8 +96,10 @@ Core vision capabilities are fully preserved across all variants:
 ### Quick Start
 
 1. Download Jan Desktop
-2. Select Jan-v2-VL-med (or your preferred variant) from the model list
-3. Start using it for browser automation or visual tasks
+2. Click **Open in Jan** above, or open the **Hub** and search for Jan-v2-VL
+3. Choose Jan-v2-VL-med or another variant that fits your hardware, then click **Download**
+4. Once downloaded, select Jan-v2-VL from the model selector in any chat
+5. Start using it for browser automation or visual tasks
 
 ### Deployment Options
 

--- a/docs/src/pages/docs/desktop/jan-models/jan-v2-vl-med.mdx
+++ b/docs/src/pages/docs/desktop/jan-models/jan-v2-vl-med.mdx
@@ -98,7 +98,7 @@ Core vision capabilities are fully preserved across all variants:
 1. Download Jan Desktop
 2. Click **Open in Jan** above, or open the **Hub** and search for Jan-v2-VL
 3. Choose Jan-v2-VL-med or another variant that fits your hardware, then click **Download**
-4. Once downloaded, select Jan-v2-VL from the model selector in any chat
+4. Once downloaded, select the downloaded Jan-v2-VL variant from the model selector in any chat
 5. Start using it for browser automation or visual tasks
 
 ### Deployment Options

--- a/docs/src/pages/docs/desktop/jan-models/jan-v3-4b-base-instruct.mdx
+++ b/docs/src/pages/docs/desktop/jan-models/jan-v3-4b-base-instruct.mdx
@@ -90,8 +90,10 @@ Jan-v3-4B-base-instruct outperforms Qwen3-4B-Instruct-2507 (its base) across cod
 ### Quick Start
 
 1. Download Jan Desktop
-2. Select Jan-v3-4B-base-instruct from the model list
-3. Start chatting — no additional configuration needed
+2. Click **Open in Jan** above, or open the **Hub** and search for Jan-v3-4B-base-instruct
+3. Choose a variant that fits your hardware, then click **Download**
+4. Once downloaded, select Jan-v3-4B-base-instruct from the model selector in any chat
+5. Start chatting — no additional configuration needed
 
 ### Demo
 


### PR DESCRIPTION
## Summary
- clarify Jan model quick-start steps so users know to open/search the model in Hub, download a hardware-appropriate variant, then select it from the chat model selector
- apply the same flow to related Jan model pages that used the same ambiguous "model list" wording

## Why
Discussion #7981 reports confusion with the previous Jan-Code-4B wording, which said to select the model from the "model list" without explaining where that list is or how the model gets added.

The updated wording matches the current Quickstart and Model Management flow: Hub -> choose/download variant -> model selector.

Refs https://github.com/orgs/janhq/discussions/7981

## Verification
- git diff --check
- rg confirmed no remaining "from the model list" wording under docs/src/pages/docs/desktop/jan-models