### PR TITLE
feat: add Requesty as a remote model provider

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -197,6 +197,7 @@
 /docs/remote-models/nvidia-nim                  /docs/desktop 302
 /docs/remote-models/openai                      /docs/desktop/remote-models/openai 302
 /docs/remote-models/openrouter                  /docs/desktop/remote-models/openrouter 302
+/docs/remote-models/requesty                    /docs/desktop/remote-models/requesty 302
 
 /docs/remote-inference/groq                     /docs/desktop/remote-models/groq 302
 /docs/remote-inference/mistralai                /docs/desktop/remote-models/mistralai 302

--- a/docs/_redirects
+++ b/docs/_redirects
@@ -197,7 +197,6 @@
 /docs/remote-models/nvidia-nim                  /docs/desktop 302
 /docs/remote-models/openai                      /docs/desktop/remote-models/openai 302
 /docs/remote-models/openrouter                  /docs/desktop/remote-models/openrouter 302
-/docs/remote-models/requesty                    /docs/desktop/remote-models/requesty 302
 
 /docs/remote-inference/groq                     /docs/desktop/remote-models/groq 302
 /docs/remote-inference/mistralai                /docs/desktop/remote-models/mistralai 302

--- a/docs/src/pages/docs/desktop/manage-models.mdx
+++ b/docs/src/pages/docs/desktop/manage-models.mdx
@@ -111,4 +111,5 @@ Jan supports connecting to various AI cloud providers. Go to **Settings > Model 
   <DocCard title="Groq" href="/docs/desktop/remote-models/groq" icon={<Zap size={20} />}>Fast inference for open-source models.</DocCard>
   <DocCard title="Mistral" href="/docs/desktop/remote-models/mistralai" icon={<Wind size={20} />}>Use Mistral AI models.</DocCard>
   <DocCard title="OpenRouter" href="/docs/desktop/remote-models/openrouter" icon={<Network size={20} />}>Access hundreds of models via a single API.</DocCard>
+  <DocCard title="Requesty" href="/docs/desktop/remote-models/requesty" icon={<Network size={20} />}>Access models from many providers via a single API.</DocCard>
 </DocCards>

--- a/docs/src/pages/docs/desktop/remote-models/_meta.json
+++ b/docs/src/pages/docs/desktop/remote-models/_meta.json
@@ -20,6 +20,9 @@
   "openrouter": {
     "title": "OpenRouter"
   },
+  "requesty": {
+    "title": "Requesty"
+  },
   "huggingface": {
     "title": "Hugging Face"
   },

--- a/docs/src/pages/docs/desktop/remote-models/requesty.mdx
+++ b/docs/src/pages/docs/desktop/remote-models/requesty.mdx
@@ -1,0 +1,91 @@
+---
+title: Requesty
+description: A step-by-step guide on integrating Jan with Requesty.
+keywords:
+  [
+    Jan,
+    Customizable Intelligence, LLM,
+    local AI,
+    privacy focus,
+    free and open source,
+    private and offline,
+    conversational AI,
+    no-subscription fee,
+    large language models,
+    Requesty integration,
+    Requesty,
+  ]
+---
+
+import { Callout, Steps } from 'nextra/components'
+import { Settings, Plus } from 'lucide-react'
+
+# Requesty
+
+## Integrate Requesty with Jan
+
+[Requesty](https://requesty.ai/) is an OpenAI-compatible LLM gateway that provides access to
+models from many providers through a single unified API. You can use the same API to interact
+with models from OpenAI, Anthropic, Google, Meta and more without managing a separate key for
+each provider.
+
+Jan supports the Requesty API, allowing you to use models from various providers and helping you
+avoid having to get an API key from all of your favorite ones.
+
+## Integrate Requesty with Jan
+
+<Steps>
+
+### Step 1: Get Your API Key
+1. Visit [Requesty API Keys](https://app.requesty.ai/api-keys) and sign in
+2. Create & copy a new API key or copy your existing one
+
+<Callout type='info'>
+Ensure your API key has sufficient credits. Requesty credits work across all available models.
+</Callout>
+
+### Step 2: Configure Jan
+
+1. Navigate to the **Settings** page (<Settings width={16} height={16} style={{display:"inline"}}/>)
+2. Under **Model Providers**, select **Requesty**
+3. Insert your **API Key**
+
+### Step 3: Start Using Requesty Models
+
+1. Pick any existing **Chat** or create a new one
+2. Select any model from **model selector** under Requesty
+3. Start chatting
+</Steps>
+
+## Available Models Through Requesty
+
+Jan automatically uses your Requesty account's available models. For custom configurations:
+
+**Model Field Settings:**
+- Specify a model using the format: `provider/model-name`
+- Available options can be found in [Requesty's Model List](https://app.requesty.ai/router/list)
+
+**Examples of Model IDs:**
+- OpenAI GPT-4o mini: `openai/gpt-4o-mini`
+- Anthropic Claude: `anthropic/claude-opus-4`
+- Google Gemini 2.5 Pro: `google/gemini-2.5-pro`
+
+## Troubleshooting
+
+Common issues and solutions:
+
+**1. API Key Issues**
+- Verify your API key is correct and not expired
+- Check if you have sufficient credits in your Requesty account
+- Ensure you have access to the model you're trying to use
+
+**2. Connection Problems**
+- Check your internet connection
+- Look for error messages in [Jan's logs](/docs/desktop/troubleshooting#how-to-get-error-logs)
+
+**3. Model Unavailable**
+- Confirm the model is currently available on Requesty
+- Check if you're using the correct model ID format
+- Verify the model provider is currently operational
+
+Need more help? Join our [Discord community](https://discord.gg/FTk2MvZwJH) or check the [Requesty documentation](https://docs.requesty.ai).

--- a/docs/src/pages/docs/desktop/remote-models/requesty.mdx
+++ b/docs/src/pages/docs/desktop/remote-models/requesty.mdx
@@ -22,8 +22,6 @@ import { Settings, Plus } from 'lucide-react'
 
 # Requesty
 
-## Integrate Requesty with Jan
-
 [Requesty](https://requesty.ai/) is an OpenAI-compatible LLM gateway that provides access to
 models from many providers through a single unified API. You can use the same API to interact
 with models from OpenAI, Anthropic, Google, Meta and more without managing a separate key for

--- a/web-app/public/images/model-provider/requesty.svg
+++ b/web-app/public/images/model-provider/requesty.svg
@@ -1,0 +1,4 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="512" height="512" fill="white"/>
+<text x="256" y="256" font-family="Arial, Helvetica, sans-serif" font-size="320" font-weight="700" fill="black" text-anchor="middle" dominant-baseline="central">R</text>
+</svg>

--- a/web-app/src/constants/models.ts
+++ b/web-app/src/constants/models.ts
@@ -126,6 +126,15 @@ export const providerModels = {
     supportsToolCalls: true,
     supportsN: true,
   },
+  requesty: {
+    models: true,
+    supportsCompletion: true,
+    supportsStreaming: true,
+    supportsJSON: true,
+    supportsImages: true,
+    supportsToolCalls: true,
+    supportsN: true,
+  },
   nvidia: {
     models: ['moonshotai/kimi-k2.5', 'minimaxai/minimax-m2.5', 'z-ai/glm5'],
     supportsCompletion: true,

--- a/web-app/src/constants/providers.ts
+++ b/web-app/src/constants/providers.ts
@@ -174,6 +174,29 @@ export const predefinedProviders = [
   {
     active: true,
     api_key: '',
+    base_url: 'https://router.requesty.ai/v1',
+    explore_models_url: 'https://app.requesty.ai/router/list',
+    provider: 'requesty',
+    settings: [
+      {
+        key: 'api-key',
+        title: 'API Key',
+        description:
+          "The Requesty API uses API keys for authentication. Visit your [API Keys](https://app.requesty.ai/api-keys) page to retrieve the API key you'll use in your requests.",
+        controller_type: 'input',
+        controller_props: {
+          placeholder: 'Insert API Key',
+          value: '',
+          type: 'password',
+          input_actions: ['unobscure', 'copy'],
+        },
+      },
+    ],
+    models: [],
+  },
+  {
+    active: true,
+    api_key: '',
     base_url: 'https://api.mistral.ai/v1',
     explore_models_url:
       'https://docs.mistral.ai/getting-started/models/models_overview/',

--- a/web-app/src/constants/providers.ts
+++ b/web-app/src/constants/providers.ts
@@ -185,6 +185,29 @@ export const predefinedProviders = [
   {
     active: true,
     api_key: '',
+    base_url: 'https://router.requesty.ai/v1',
+    explore_models_url: 'https://app.requesty.ai/router/list',
+    provider: 'requesty',
+    settings: [
+      {
+        key: 'api-key',
+        title: 'API Key',
+        description:
+          "The Requesty API uses API keys for authentication. Visit your [API Keys](https://app.requesty.ai/api-keys) page to retrieve the API key you'll use in your requests.",
+        controller_type: 'input',
+        controller_props: {
+          placeholder: 'Insert API Key',
+          value: '',
+          type: 'password',
+          input_actions: ['unobscure', 'copy'],
+        },
+      },
+    ],
+    models: [],
+  },
+  {
+    active: true,
+    api_key: '',
     base_url: 'https://api.mistral.ai/v1',
     explore_models_url:
       'https://docs.mistral.ai/getting-started/models/models_overview/',

--- a/web-app/src/lib/ai-model.ts
+++ b/web-app/src/lib/ai-model.ts
@@ -136,6 +136,13 @@ export function createLanguageModel(
             'X-Title': 'Jan',
           }
         : {}),
+      // Requesty identification headers
+      ...(provider.provider === 'requesty'
+        ? {
+            'HTTP-Referer': 'https://jan.ai',
+            'X-Title': 'Jan',
+          }
+        : {}),
     },
     // Include usage data in streaming responses for token speed calculation
     includeUsage: true,

--- a/web-app/src/lib/ai-model.ts
+++ b/web-app/src/lib/ai-model.ts
@@ -129,15 +129,8 @@ export function createLanguageModel(
       provider.base_url?.includes('127.0.0.1:')
         ? { Origin: 'tauri://localhost' }
         : {}),
-      // OpenRouter identification headers
-      ...(provider.provider === 'openrouter'
-        ? {
-            'HTTP-Referer': 'https://jan.ai',
-            'X-Title': 'Jan',
-          }
-        : {}),
-      // Requesty identification headers
-      ...(provider.provider === 'requesty'
+      // Identification headers for gateway providers (OpenRouter, Requesty)
+      ...(['openrouter', 'requesty'].includes(provider.provider)
         ? {
             'HTTP-Referer': 'https://jan.ai',
             'X-Title': 'Jan',

--- a/web-app/src/lib/providerCaps.ts
+++ b/web-app/src/lib/providerCaps.ts
@@ -61,6 +61,11 @@ const OPENROUTER: ProviderCaps = {
   maybe: new Set(['typical_p']),
 }
 
+const REQUESTY: ProviderCaps = {
+  supported: set('penalties', 'top_k', 'min_p', 'repetition'),
+  maybe: new Set(['typical_p']),
+}
+
 const XAI: ProviderCaps = {
   supported: set(),
   maybe: new Set(['penalties']),
@@ -149,6 +154,7 @@ const BUILTIN_CAPS: Record<string, ProviderCaps> = {
   mistral: MISTRAL,
   groq: GROQ,
   openrouter: OPENROUTER,
+  requesty: REQUESTY,
   xai: XAI,
   huggingface: HUGGINGFACE,
   nvidia: NVIDIA,

--- a/web-app/src/lib/providerCaps.ts
+++ b/web-app/src/lib/providerCaps.ts
@@ -61,6 +61,11 @@ const OPENROUTER: ProviderCaps = {
   maybe: new Set(['typical_p']),
 }
 
+const REQUESTY: ProviderCaps = {
+  supported: set('penalties', 'top_k', 'min_p', 'repetition'),
+  maybe: new Set(['typical_p']),
+}
+
 const XAI: ProviderCaps = {
   supported: set(),
   maybe: new Set(['penalties']),
@@ -155,6 +160,7 @@ const BUILTIN_CAPS: Record<string, ProviderCaps> = {
   mistral: MISTRAL,
   groq: GROQ,
   openrouter: OPENROUTER,
+  requesty: REQUESTY,
   xai: XAI,
   huggingface: HUGGINGFACE,
   nvidia: NVIDIA,

--- a/web-app/src/lib/utils.ts
+++ b/web-app/src/lib/utils.ts
@@ -124,6 +124,8 @@ export function getProviderLogo(provider: string) {
       return '/images/model-provider/mistral.svg'
     case 'openrouter':
       return '/images/model-provider/open-router.svg'
+    case 'requesty':
+      return '/images/model-provider/requesty.svg'
     case 'groq':
       return '/images/model-provider/groq.svg'
     case 'cohere':
@@ -157,6 +159,8 @@ export const getProviderTitle = (provider: string) => {
       return 'OpenAI'
     case 'openrouter':
       return 'OpenRouter'
+    case 'requesty':
+      return 'Requesty'
     case 'gemini':
       return 'Gemini'
     case 'huggingface':

--- a/web-app/src/lib/utils.ts
+++ b/web-app/src/lib/utils.ts
@@ -143,6 +143,8 @@ export function getProviderLogo(provider: string) {
       return '/images/model-provider/mistral.svg'
     case 'openrouter':
       return '/images/model-provider/open-router.svg'
+    case 'requesty':
+      return '/images/model-provider/requesty.svg'
     case 'groq':
       return '/images/model-provider/groq.svg'
     case 'cohere':
@@ -176,6 +178,8 @@ export const getProviderTitle = (provider: string) => {
       return 'OpenAI'
     case 'openrouter':
       return 'OpenRouter'
+    case 'requesty':
+      return 'Requesty'
     case 'gemini':
       return 'Gemini'
     case 'huggingface':


### PR DESCRIPTION
## Summary

Adds Requesty as a remote model provider in Jan. Requesty is an OpenAI-compatible LLM gateway (base URL `https://router.requesty.ai/v1`) that exposes models from multiple providers using the `provider/model` naming convention, the same shape Jan already uses for OpenRouter.

This change mirrors the existing OpenRouter provider registration. No new code paths were introduced; Requesty reuses the generic OpenAI-compatible request flow.

## Changes

- `web-app/src/constants/providers.ts`: add the `requesty` provider entry (base_url, explore_models_url, api-key setting), mirroring the OpenRouter object.
- `web-app/src/constants/models.ts`: add the `requesty` capability flags entry.
- `web-app/src/lib/providerCaps.ts`: add `REQUESTY` sampling caps and register it.
- `web-app/src/lib/ai-model.ts`: send the same `HTTP-Referer` / `X-Title` identification headers used for OpenRouter.
- `web-app/src/lib/utils.ts`: add provider logo path and display title (`Requesty`).
- `web-app/public/images/model-provider/requesty.svg`: placeholder logo. This is a generic "R" mark, not the official brand asset; maintainers are welcome to drop in the official Requesty logo.
- `docs/src/pages/docs/desktop/remote-models/requesty.mdx`: provider docs page mirroring `openrouter.mdx`.
- `docs/src/pages/docs/desktop/remote-models/_meta.json`, `docs/src/pages/docs/desktop/manage-models.mdx`, `docs/_redirects`: docs nav entry, cloud-provider card, and redirect.

## Testing

Verified a live request against the Requesty endpoint with `POST https://router.requesty.ai/v1/chat/completions`, model `openai/gpt-4o-mini`, returned HTTP 200 with a valid completion. This confirms the base URL, auth scheme, and `provider/model` naming used in the provider entry are correct.

A full monorepo install was not run locally, so I have not produced a UI screenshot. The edits are data/constant additions that match the existing OpenRouter entry's shape exactly; happy to add a screenshot if a maintainer can point me at the lightest way to build the web-app, or if you'd prefer I adjust anything.

Disclosure: I work at Requesty. This mirrors the existing OpenRouter provider entry; happy to adjust wording/placement or close if it's not a fit.

