### PR TITLE
fix(chat): render media on first-message send

### DIFF
--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -920,7 +920,9 @@ function ThreadDetail() {
       }
       addMessage(userMessage)
 
-      // Build parts for AI SDK (only images are sent as file parts)
+      // Build parts for AI SDK. Derive media file parts from the resolved
+      // attachments (not the raw `files` arg) so the first-message flow — where
+      // media lives in the store and `files` is empty — still renders live.
       const parts: Array<
         | { type: 'text'; text: string }
         | { type: 'file'; mediaType: string; url: string }
@@ -931,15 +933,15 @@ function ThreadDetail() {
         },
       ]
 
-      if (files) {
-        files.forEach((file) => {
+      mediaAttachments.forEach((a) => {
+        if (a.dataUrl && a.mimeType) {
           parts.push({
             type: 'file',
-            mediaType: file.mediaType,
-            url: file.url,
+            mediaType: a.mimeType,
+            url: a.dataUrl,
           })
-        })
-      }
+        }
+      })
 
       sendMessage({
         parts,


### PR DESCRIPTION
## Describe Your Changes

- The live UI message's file parts were built from the raw `files` arg, which is empty on the new-thread (first-message) flow where media lives in the attachments store. Derive parts from the resolved `mediaAttachments` instead, so video/image/audio render live on the first message instead of only after a reload.


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
