### PR TITLE
i18n(ja): update Japanese translations (#8264)

### DIFF
--- a/web-app/src/locales/ja/assistants.json
+++ b/web-app/src/locales/ja/assistants.json
@@ -31,5 +31,11 @@
   "personality": "個性",
   "capabilities": "機能",
   "instructionsDateHint": "ヒント: {{current_date}} を使用して今日の日付を挿入します。",
-  "maxToolSteps": "最大ツールステップ数"
+  "maxToolSteps": "最大ツールステップ数",
+  "setAsDefault": "デフォルトのアシスタントに設定",
+  "isDefault": "デフォルト",
+  "defaultAssistantSection": "デフォルトのアシスタント",
+  "defaultAssistantDesc": "新しいチャットを開始するときに使用されます",
+  "allAssistants": "すべてのアシスタント",
+  "lastUsed": "最終使用"
 }

--- a/web-app/src/locales/ja/chat.json
+++ b/web-app/src/locales/ja/chat.json
@@ -8,5 +8,9 @@
   },
   "sendMessage": "メッセージを送信",
   "newConversation": "新しい会話",
-  "clearHistory": "履歴を消去"
+  "clearHistory": "履歴を消去",
+  "embeddings": {
+    "title": "ドキュメントを準備しています",
+    "description": "添付ファイルを検索・引用できるようにインデックスを作成しています。大きなドキュメントの場合は少し時間がかかることがあります。"
+  }
 }

--- a/web-app/src/locales/ja/hub.json
+++ b/web-app/src/locales/ja/hub.json
@@ -3,6 +3,7 @@
   "sortMostDownloaded": "ダウンロード数順",
   "newChat": "新しいチャット",
   "download": "ダウンロード",
+  "downloadFailed": "ダウンロードを開始できませんでした",
   "downloaded": "ダウンロード済み",
   "loadingModels": "モデルを読み込み中...",
   "noModels": "モデルが見つかりません",

--- a/web-app/src/locales/ja/model-errors.json
+++ b/web-app/src/locales/ja/model-errors.json
@@ -3,5 +3,8 @@
   "description": "このチャットはAIのメモリ制限に近づいています。ホワイトボードがいっぱいになるようなものです。メモリウィンドウ（コンテキストサイズ）を拡張して記憶容量を増やすことができますが、コンピュータのメモリ使用量が増える可能性があります。また、入力を切り詰めることもできます。これは、新しいメッセージのためのスペースを確保するために、チャット履歴の一部を忘れることを意味します。",
   "increaseContextSizeDescription": "コンテキストサイズを増やしますか？",
   "truncateInput": "入力を切り詰める",
-  "increaseContextSize": "コンテキストサイズを増やす"
+  "increaseContextSize": "コンテキストサイズを増やす",
+  "lastRequestOverflowed": "前回のリクエストがコンテキストウィンドウを超過しました。",
+  "contextOverflowDetail": "このリクエストには {{request}} token が必要でしたが、モデルのコンテキストウィンドウは {{context}} token しか保持できません。",
+  "contextOverflowGeneric": "リクエストが利用可能なコンテキストサイズを超えています。"
 }

--- a/web-app/src/locales/ja/provider.json
+++ b/web-app/src/locales/ja/provider.json
@@ -1,5 +1,14 @@
 {
   "addProvider": "プロバイダーを追加",
-  "addOpenAIProvider": "OpenAIプロバイダーを追加",
-  "enterNameForProvider": "プロバイダーの名前を入力してください"
+  "addOpenAIProvider": "カスタムプロバイダーを追加",
+  "enterNameForProvider": "プロバイダー名（例: my-llm-server）",
+  "apiTypeLabel": "API形式",
+  "apiTypeOpenAI": "OpenAI互換",
+  "apiTypeAnthropic": "Anthropic互換",
+  "baseUrlLabel": "ベースURL",
+  "baseUrlPlaceholder": "https://your-endpoint/v1",
+  "baseUrlPlaceholderAnthropic": "https://api.anthropic.com/v1",
+  "apiKeyLabel": "APIキー",
+  "apiKeyPlaceholder": "APIキーを貼り付け",
+  "invalidBaseUrl": "ベースURLは有効なhttp(s) URLである必要があります"
 }

--- a/web-app/src/locales/ja/providers.json
+++ b/web-app/src/locales/ja/providers.json
@@ -1,18 +1,29 @@
 {
+  "limitedSupport": "このプロバイダーは完全にはサポートされていない可能性があります。機能（ツール・画像認識・音声）は自動検出されません。モデルを手動で追加し、モデルごとに機能を設定してください。",
+  "mlxExperimental": "MLXのサポートは実験的です。埋め込みは利用できず、推論の切り替えはまだ接続されておらず、一部の新しいモデルアーキテクチャは読み込みに失敗する場合があります。優先順位を付けられるよう、問題はGitHubで報告してください。",
   "refreshModelsError": "モデルを取得するには、プロバイダーにベースURLとAPIキーが設定されている必要があります。",
   "refreshModelsSuccess": "{{provider}}から{{count}}個の新しいモデルを追加しました。",
   "noNewModels": "新しいモデルは見つかりませんでした。利用可能なすべてのモデルは既に追加されています。",
   "refreshModelsFailed": "{{provider}}からのモデルの取得に失敗しました。APIキーとベースURLを確認してください。",
   "models": "モデル",
+  "chatModels": "チャットモデル",
+  "embeddingModels": "埋め込みモデル",
+  "embeddingModelsDesc": "RAGとベクトル検索に使用されます。選択したモデルは、埋め込みを生成する際のデフォルトになります。",
+  "embeddingModelDefault": "デフォルト",
+  "embeddingModelSetDefault": "デフォルトの埋め込みモデルに設定",
+  "embeddingModelIsDefault": "デフォルトの埋め込みモデル",
   "refreshing": "更新中...",
   "refresh": "更新",
   "import": "インポート",
+  "imported": "インポート済み",
+  "importedTooltip": "ローカルファイルからインポートされています。Janから削除しても、ディスク上のファイルは削除されません。",
   "importModelSuccess": "モデル{{provider}}は正常にインポートされました。",
   "importModelError": "モデルのインポートに失敗しました:",
   "stop": "停止",
   "start": "開始",
   "noModelFound": "モデルが見つかりません",
   "noModelFoundDesc": "利用可能なモデルはここにリストされます。まだモデルがない場合は、ハブにアクセスしてダウンロードしてください。",
+  "noModelFoundRemoteDesc": "利用可能なモデルはここにリストされます。上の更新ボタンでプロバイダーからモデルを取得するか、+ボタンで手動で追加してください。",
   "configuration": "設定",
   "apiEndpoint": "APIエンドポイント",
   "testConnection": "接続をテスト",
@@ -29,9 +40,24 @@
   "deleteModel": {
     "title": "モデルを削除: {{modelId}}",
     "description": "本当にこのモデルを削除しますか？この操作は元に戻せません。",
+    "importedDescription": "このインポート済みモデルをJanから削除しますか？ディスク上のローカルファイルは削除されません。",
+    "removeFromJan": "Janから削除",
     "success": "モデル {{modelId}} は完全に削除されました。",
     "cancel": "キャンセル",
     "delete": "削除"
+  },
+  "deleteAllModels": {
+    "button": "すべて削除",
+    "title": "ダウンロードしたすべてのモデルを削除しますか？",
+    "description": "{{count}}個のモデルをディスクから完全に削除します。",
+    "sizeLabel": "解放されるディスク容量:",
+    "calculating": "計算中…",
+    "warning": "この操作は元に戻せません。",
+    "importedExcluded": "{{count}}個のインポート済みモデルは保持されます（これらのファイルはJanによってダウンロードされたものではありません）。",
+    "confirm": "{{count}}個のモデルを削除",
+    "deleting": "削除中…",
+    "success": "{{count}}個のモデルを削除しました。",
+    "partialFailure": "{{count}}個のモデルの削除に失敗しました。詳細はコンソールを確認してください。"
   },
   "deleteProvider": {
     "title": "プロバイダーを削除",
@@ -48,6 +74,9 @@
     "capabilities": "機能",
     "tools": "ツール",
     "vision": "画像認識",
+    "audio": "音声",
+    "video": "動画",
+    "proactive": "プロアクティブ（実験的）",
     "embeddings": "埋め込み",
     "notAvailable": "まだ利用できません",
     "warning": {
@@ -57,5 +86,25 @@
   },
   "addProvider": "プロバイダーを追加",
   "addOpenAIProvider": "OpenAIプロバイダーを追加",
-  "enterNameForProvider": "プロバイダーの名前を入力してください"
+  "enterNameForProvider": "プロバイダーの名前を入力してください",
+  "baseUrl": {
+    "title": "ベースURL",
+    "azureDescription": "あなたのAzure OpenAIエンドポイント。YOUR-RESOURCE-NAMEをAzureリソース名に置き換えてください。"
+  },
+  "apiKeys": {
+    "title": "APIキー",
+    "description": "APIキーを入力してください。詳細設定で追加のキーを登録でき、キーが失敗した場合はJanが自動的に次のキーを試します。",
+    "placeholder": "sk-…\nsk-…",
+    "primaryPlaceholder": "メインのAPIキーを入力",
+    "keyPlaceholder": "APIキーを入力",
+    "primaryBadge": "メイン",
+    "test": "キーをテスト",
+    "testing": "テスト中...",
+    "testHint": "各キーで/modelsを確認し、キーごとのステータスを表示します。",
+    "advanced": "詳細設定",
+    "hideAdvanced": "詳細設定を隠す",
+    "oneKeyHint": "任意のフォールバックキーは詳細設定で構成します。",
+    "addKey": "キーを追加",
+    "removeKey": "キーを削除"
+  }
 }


### PR DESCRIPTION
## Problem

Addresses #8264. The Japanese (`ja`) locale had drifted behind English — missing keys and a few stale strings across several namespaces — so parts of the UI fell back to English for Japanese users.

## Change

A first pass bringing 6 namespaces to key parity with `en`: `assistants`, `chat`, `hub`, `model-errors`, `provider`, `providers`. This covers the custom-provider setup flow, model management / bulk deletion, default-assistant settings, and context-overflow messages (~50 keys). `provider.json` also had two keys whose English source had since changed ("Add Custom Provider", the provider-name placeholder) — the stale Japanese was updated to match the current `en`.

Technical / product names are kept in English (Jan, API, token, RAG, MLX, OpenAI, Anthropic, Azure). All `{{placeholder}}` interpolations are preserved verbatim; existing correct translations are unchanged.

## Testing

- All changed files parse as valid JSON.
- Placeholder set verified against `en` for each updated key.

The remaining namespaces (`common`, `settings`, …) and the terminology-consistency cleanup (e.g. メモリ / RAM) noted in #8264 will follow up in subsequent PRs to keep each review small.
