### PR TITLE
fix(markdown): force code blocks LTR in RTL language context

### DIFF
--- a/web-app/src/components/ai-elements/code-block.tsx
+++ b/web-app/src/components/ai-elements/code-block.tsx
@@ -100,6 +100,7 @@ export const CodeBlock = ({
   return (
     <CodeBlockContext.Provider value={{ code }}>
       <div
+        dir="ltr"
         className={cn(
           "group relative w-full overflow-hidden bg-background text-foreground",
           className,


### PR DESCRIPTION
## Describe Your Changes

- Code blocks inherited RTL direction from RenderMarkdown's dir="auto" container when the surrounding response was predominantly RTL. Pin the CodeBlock root to dir="ltr" so code always renders left-to-right while prose keeps dir="auto".

## Fixes Issues

- Closes #8346
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
