### PR TITLE
fix: ignore IME composition Enter in rename and project dialogs

### DIFF
--- a/web-app/src/containers/dialogs/AddProjectDialog.tsx
+++ b/web-app/src/containers/dialogs/AddProjectDialog.tsx
@@ -118,7 +118,12 @@ export default function AddProjectDialog({
               className="mt-1"
               autoFocus
               onKeyDown={(e) => {
-                if (e.key === 'Enter' && !isButtonDisabled) {
+                // e.keyCode 229 / isComposing means an IME (e.g.
+                // Chinese/Japanese) is composing; the Enter that confirms a
+                // candidate must not create the project.
+                const isComposing =
+                  e.nativeEvent.isComposing || e.keyCode === 229
+                if (e.key === 'Enter' && !isComposing && !isButtonDisabled) {
                   handleSave()
                 }
               }}

--- a/web-app/src/containers/dialogs/RenameThreadDialog.tsx
+++ b/web-app/src/containers/dialogs/RenameThreadDialog.tsx
@@ -80,7 +80,10 @@ export function RenameThreadDialog({
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     e.stopPropagation()
-    if (e.key === 'Enter' && title.trim()) {
+    // e.keyCode 229 / isComposing means an IME (e.g. Chinese/Japanese) is
+    // composing; the Enter that confirms a candidate must not rename.
+    const isComposing = e.nativeEvent.isComposing || e.keyCode === 229
+    if (e.key === 'Enter' && !isComposing && title.trim()) {
       handleRename()
     }
   }


### PR DESCRIPTION
## What

When an IME (Input Method Editor) user types Chinese or Japanese, they press Enter to confirm a composition candidate. Two dialogs treat that Enter as a submit:

- `RenameThreadDialog`: the confirming Enter renames the thread, so it can fire before the title is finished.
- `AddProjectDialog`: the confirming Enter creates the project the same way.

`ChatInput` already fixed exactly this in #6109 by ignoring Enter while `e.nativeEvent.isComposing || e.keyCode === 229` is true, but these dialogs were missed. The IME QA item in #7036 ("when using IME keyboard to type Chinese and Japanese character and they press Enter, the Send button doesn't trigger automatically") only covers the chat input.

## Fix

Apply the same `isComposing` guard to both `handleKeyDown` functions. When no IME is composing, `isComposing` is false, so behavior is unchanged for everyone else.

## Left out on purpose

`SearchDialog` and `EditModel` have the same gap, but they are being reworked in #8288 / #8287 / #8039, so I left them untouched here to avoid conflicts. The same guard applies there.

## How to test

With the OS input set to a Japanese or Chinese IME, open the rename-thread or new-project dialog, type a word, and press Enter to pick a candidate. Before this change the dialog submits mid-composition; after it, it waits for a real Enter. This is the behavior `ChatInput.test.tsx` already covers ("does not submit if isComposing (IME) is true"); I can add equivalent dialog tests if you would like them.
