### PR TITLE
ci: grant actions:write to stale workflow for state persistence

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   issues: write
+  actions: write
 
 jobs:
   stale:


### PR DESCRIPTION
## Describe Your Changes

- The lack of "write" permission was causing the workflow to fail to close issues whose grace period has been expired.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
