### PR TITLE
feat(settings): move settings/credentials off localStorage to backend store

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6,6 +6,7 @@ version = 3
 name = "Jan"
 version = "0.8.3"
 dependencies = [
+ "aes-gcm",
  "async-trait",
  "base64 0.22.1",
  "chrono",
@@ -30,10 +31,12 @@ dependencies = [
  "hyper-util",
  "indicatif",
  "jan-utils",
+ "keyring",
  "libc",
  "libloading 0.8.9",
  "log",
- "nix",
+ "machine-uid",
+ "nix 0.30.1",
  "once_cell",
  "rand 0.8.5",
  "reqwest",
@@ -70,7 +73,7 @@ dependencies = [
  "url",
  "uuid",
  "windows-sys 0.60.2",
- "zbus",
+ "zbus 5.11.0",
  "zip 0.6.6",
 ]
 
@@ -99,6 +102,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "aes"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +120,20 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -272,7 +299,7 @@ dependencies = [
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
- "zbus",
+ "zbus 5.11.0",
 ]
 
 [[package]]
@@ -1164,6 +1191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1223,6 +1251,15 @@ checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn 2.0.106",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1340,6 +1377,35 @@ name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
+
+[[package]]
+name = "dbus"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2",
+ "zeroize",
+]
 
 [[package]]
 name = "der"
@@ -2257,6 +2323,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gimli"
 version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2738,7 +2814,7 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
+ "windows-registry 0.5.3",
 ]
 
 [[package]]
@@ -3150,6 +3226,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "secret-service",
+ "security-framework 2.11.1",
+ "security-framework 3.6.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3208,9 +3300,18 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.176"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libloading"
@@ -3334,6 +3435,17 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "machine-uid"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d7217d573cdb141d6da43113b098172e057d39915d79c4bdedbc3aacd46bd96"
+dependencies = [
+ "libc",
+ "windows-registry 0.6.1",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "malloc_buf"
@@ -3489,7 +3601,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -3532,6 +3644,19 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.9.4",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nix"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
@@ -3568,6 +3693,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3582,6 +3731,15 @@ dependencies = [
  "rand 0.8.5",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3606,6 +3764,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -3985,6 +4154,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
@@ -4472,6 +4647,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
 
 [[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "pom"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4604,7 +4791,7 @@ checksum = "a3ef4f2f0422f23a82ec9f628ea2acd12871c81a9362b02c43c1aa86acfc3ba1"
 dependencies = [
  "futures",
  "indexmap 2.11.4",
- "nix",
+ "nix 0.30.1",
  "tokio",
  "tracing",
  "windows 0.61.3",
@@ -5403,6 +5590,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.5",
+ "serde",
+ "sha2",
+ "zbus 4.4.0",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5416,10 +5622,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "security-framework-sys"
-version = "2.15.0"
+name = "security-framework"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags 2.9.4",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6439,7 +6658,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tracing",
  "url",
- "windows-registry",
+ "windows-registry 0.5.3",
  "windows-result 0.3.4",
 ]
 
@@ -6534,7 +6753,7 @@ dependencies = [
  "jan-utils",
  "lddtree",
  "log",
- "nix",
+ "nix 0.30.1",
  "rand 0.8.5",
  "reqwest",
  "serde",
@@ -6577,7 +6796,7 @@ version = "0.8.3"
 dependencies = [
  "jan-utils",
  "log",
- "nix",
+ "nix 0.30.1",
  "serde",
  "sysinfo",
  "tauri",
@@ -6605,7 +6824,7 @@ dependencies = [
  "thiserror 2.0.17",
  "url",
  "windows 0.61.3",
- "zbus",
+ "zbus 5.11.0",
 ]
 
 [[package]]
@@ -6682,7 +6901,7 @@ dependencies = [
  "thiserror 2.0.17",
  "tracing",
  "windows-sys 0.60.2",
- "zbus",
+ "zbus 5.11.0",
 ]
 
 [[package]]
@@ -7388,6 +7607,16 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"
@@ -8101,6 +8330,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8598,6 +8838,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "xml-rs"
 version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8640,6 +8890,38 @@ dependencies = [
 
 [[package]]
 name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix 0.29.0",
+ "ordered-stream",
+ "rand 0.8.5",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros 4.4.0",
+ "zbus_names 3.0.0",
+ "zvariant 4.2.0",
+]
+
+[[package]]
+name = "zbus"
 version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d07e46d035fb8e375b2ce63ba4e4ff90a7f73cf2ffb0138b29e1158d2eaadf7"
@@ -8658,7 +8940,7 @@ dependencies = [
  "futures-core",
  "futures-lite",
  "hex",
- "nix",
+ "nix 0.30.1",
  "ordered-stream",
  "serde",
  "serde_repr",
@@ -8667,9 +8949,22 @@ dependencies = [
  "uds_windows",
  "windows-sys 0.60.2",
  "winnow 0.7.13",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "zbus_macros 5.11.0",
+ "zbus_names 4.2.0",
+ "zvariant 5.7.0",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -8682,9 +8977,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
+ "zbus_names 4.2.0",
+ "zvariant 5.7.0",
+ "zvariant_utils 3.2.1",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -8696,7 +9002,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "winnow 0.7.13",
- "zvariant",
+ "zvariant 5.7.0",
 ]
 
 [[package]]
@@ -8745,6 +9051,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "zerotrie"
@@ -8848,6 +9168,19 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive 4.2.0",
+]
+
+[[package]]
+name = "zvariant"
 version = "5.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "999dd3be73c52b1fccd109a4a81e4fcd20fab1d3599c8121b38d04e1419498db"
@@ -8857,8 +9190,21 @@ dependencies = [
  "serde",
  "url",
  "winnow 0.7.13",
- "zvariant_derive",
- "zvariant_utils",
+ "zvariant_derive 5.7.0",
+ "zvariant_utils 3.2.1",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -8871,7 +9217,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
- "zvariant_utils",
+ "zvariant_utils 3.2.1",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -139,6 +139,14 @@ dialoguer = { version = "0.11", optional = true }
 env_logger = { version = "0.11", optional = true }
 indicatif = { version = "0.17", optional = true }
 console = { version = "0.15", optional = true }
+keyring = { version = "3", features = [
+    "apple-native",
+    "windows-native",
+    "sync-secret-service",
+    "crypto-rust",
+] }
+aes-gcm = "0.10"
+machine-uid = "0.5"
 
 [dependencies.tauri]
 version = "2.8.5"

--- a/src-tauri/src/core/app/commands.rs
+++ b/src-tauri/src/core/app/commands.rs
@@ -117,6 +117,15 @@ pub fn resolve_config_file_path() -> PathBuf {
 /// Resolve the Jan data folder path without an AppHandle (for CLI use).
 /// Reads AppConfiguration from the config file; falls back to the default location.
 pub fn resolve_jan_data_folder() -> PathBuf {
+    // Explicit override wins on every platform. `dirs::data_dir()` reads
+    // XDG_DATA_HOME only on Linux, so tests/headless consumers need a portable
+    // way to redirect the data folder without relying on OS-specific env.
+    if let Ok(folder) = std::env::var("JAN_DATA_FOLDER") {
+        if !folder.is_empty() {
+            return PathBuf::from(folder);
+        }
+    }
+
     let config_file = resolve_config_file_path();
 
     if config_file.exists() {

--- a/src-tauri/src/core/app/constants.rs
+++ b/src-tauri/src/core/app/constants.rs
@@ -27,8 +27,11 @@ pub const JAN_DATA_DIRS_COMMON: &[&str] = &["extensions", "logs", ".npx", ".uvx"
 /// Cross-category settings file (contains data spanning conversations, models,
 /// and UI preferences). Only deleted during a full wipe — i.e. when the user
 /// keeps neither conversations nor models/configs.
-/// After #7821, zustand stores persist to `settings.json` via @tauri-apps/plugin-store.
-pub const JAN_DATA_FILES_SETTINGS: &[&str] = &["settings.json"];
+/// Written by the backend settings store (`core::app::settings_store`), which
+/// persists webview zustand blobs here keyed by store namespace.
+/// `provider_secrets.enc` is the encrypted OS-keyring fallback for provider API
+/// keys (`core::server::provider_secrets`); it must also be wiped on a full reset.
+pub const JAN_DATA_FILES_SETTINGS: &[&str] = &["settings.json", "provider_secrets.enc"];
 
 /// All known data subdirectories (union of every category above).
 pub const JAN_DATA_SUBDIRS: &[&str] = &[
@@ -45,7 +48,7 @@ pub const JAN_DATA_SUBDIRS: &[&str] = &[
 ];
 
 /// All known data files (union of every file category above).
-pub const JAN_DATA_FILES: &[&str] = &["mcp_config.json", "settings.json"];
+pub const JAN_DATA_FILES: &[&str] = &["mcp_config.json", "settings.json", "provider_secrets.enc"];
 
 #[cfg(test)]
 mod tests {

--- a/src-tauri/src/core/app/mod.rs
+++ b/src-tauri/src/core/app/mod.rs
@@ -2,3 +2,4 @@ pub mod commands;
 pub mod constants;
 pub mod helpers;
 pub mod models;
+pub mod settings_store;

--- a/src-tauri/src/core/app/settings_store.rs
+++ b/src-tauri/src/core/app/settings_store.rs
@@ -1,0 +1,157 @@
+//! Backend-owned settings store for webview Zustand stores.
+//!
+//! Persists non-secret settings to `<jan_data_folder>/settings.json` as a flat
+//! JSON object (`{ "<namespace>": "<serialized-store-blob>" }`). The webview
+//! reaches this via the async `StateStorage` adapter; an out-of-process consumer
+//! (jan-cli) can read the same file without an `AppHandle`. Secrets never land
+//! here — they go to the OS keyring via the provider-config path.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use super::commands::resolve_jan_data_folder;
+use crate::core::app::constants::CONFIGURATION_FILE_NAME;
+
+/// Serializes read-modify-write cycles so concurrent `settings_set`/`_remove`
+/// calls can't clobber each other. The file is the source of truth; this only
+/// guards the in-process critical section.
+static WRITE_LOCK: Mutex<()> = Mutex::new(());
+
+fn settings_file_path() -> PathBuf {
+    resolve_jan_data_folder().join(CONFIGURATION_FILE_NAME)
+}
+
+fn read_map(path: &PathBuf) -> BTreeMap<String, String> {
+    match fs::read_to_string(path) {
+        Ok(content) if !content.trim().is_empty() => {
+            serde_json::from_str(&content).unwrap_or_default()
+        }
+        _ => BTreeMap::new(),
+    }
+}
+
+fn write_map_atomic(path: &PathBuf, map: &BTreeMap<String, String>) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let serialized = serde_json::to_string_pretty(map).map_err(|e| e.to_string())?;
+    let tmp = path.with_extension("json.tmp");
+    fs::write(&tmp, serialized).map_err(|e| e.to_string())?;
+    fs::rename(&tmp, path).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn settings_get(key: String) -> Option<String> {
+    let path = settings_file_path();
+    read_map(&path).get(&key).cloned()
+}
+
+#[tauri::command]
+pub fn settings_set(key: String, value: String) -> Result<(), String> {
+    let _guard = WRITE_LOCK.lock().map_err(|e| e.to_string())?;
+    let path = settings_file_path();
+    let mut map = read_map(&path);
+    map.insert(key, value);
+    write_map_atomic(&path, &map)
+}
+
+#[tauri::command]
+pub fn settings_remove(key: String) -> Result<(), String> {
+    let _guard = WRITE_LOCK.lock().map_err(|e| e.to_string())?;
+    let path = settings_file_path();
+    let mut map = read_map(&path);
+    if map.remove(&key).is_some() {
+        return write_map_atomic(&path, &map);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::MutexGuard;
+
+    /// `resolve_jan_data_folder` reads process-wide env/config, so tests that
+    /// point it at a temp dir must not run concurrently.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct TempDataFolder {
+        _guard: MutexGuard<'static, ()>,
+        prev_app_name: Option<String>,
+        prev_data_dir: Option<String>,
+        dir: tempfile::TempDir,
+    }
+
+    impl TempDataFolder {
+        fn new() -> Self {
+            let guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let dir = tempfile::tempdir().unwrap();
+            let prev_app_name = std::env::var("APP_NAME").ok();
+            let prev_data_dir = std::env::var("XDG_DATA_HOME").ok();
+            // Force resolve_jan_data_folder to the default branch under our temp dir.
+            std::env::set_var("APP_NAME", "JanTest");
+            std::env::set_var("XDG_DATA_HOME", dir.path());
+            Self {
+                _guard: guard,
+                prev_app_name,
+                prev_data_dir,
+                dir,
+            }
+        }
+    }
+
+    impl Drop for TempDataFolder {
+        fn drop(&mut self) {
+            match &self.prev_app_name {
+                Some(v) => std::env::set_var("APP_NAME", v),
+                None => std::env::remove_var("APP_NAME"),
+            }
+            match &self.prev_data_dir {
+                Some(v) => std::env::set_var("XDG_DATA_HOME", v),
+                None => std::env::remove_var("XDG_DATA_HOME"),
+            }
+            let _ = &self.dir;
+        }
+    }
+
+    #[test]
+    fn roundtrip_set_get_remove() {
+        let _tmp = TempDataFolder::new();
+        assert_eq!(settings_get("model-provider".into()), None);
+
+        settings_set("model-provider".into(), "{\"a\":1}".into()).unwrap();
+        assert_eq!(
+            settings_get("model-provider".into()),
+            Some("{\"a\":1}".to_string())
+        );
+
+        settings_set("theme".into(), "\"dark\"".into()).unwrap();
+        assert_eq!(settings_get("theme".into()), Some("\"dark\"".to_string()));
+        assert_eq!(
+            settings_get("model-provider".into()),
+            Some("{\"a\":1}".to_string())
+        );
+
+        settings_remove("model-provider".into()).unwrap();
+        assert_eq!(settings_get("model-provider".into()), None);
+        assert_eq!(settings_get("theme".into()), Some("\"dark\"".to_string()));
+    }
+
+    #[test]
+    fn remove_missing_key_is_ok() {
+        let _tmp = TempDataFolder::new();
+        assert!(settings_remove("nope".into()).is_ok());
+    }
+
+    #[test]
+    fn overwrites_preserve_other_keys() {
+        let _tmp = TempDataFolder::new();
+        settings_set("a".into(), "1".into()).unwrap();
+        settings_set("b".into(), "2".into()).unwrap();
+        settings_set("a".into(), "3".into()).unwrap();
+        assert_eq!(settings_get("a".into()), Some("3".to_string()));
+        assert_eq!(settings_get("b".into()), Some("2".to_string()));
+    }
+}

--- a/src-tauri/src/core/app/settings_store.rs
+++ b/src-tauri/src/core/app/settings_store.rs
@@ -4,20 +4,96 @@
 //! JSON object (`{ "<namespace>": "<serialized-store-blob>" }`). The webview
 //! reaches this via the async `StateStorage` adapter; an out-of-process consumer
 //! (jan-cli) can read the same file without an `AppHandle`. Secrets never land
-//! here — they go to the OS keyring via the provider-config path.
+//! here -- they go to the OS keyring via the provider-config path.
+//!
+//! The map is held in memory and mutated in place; disk writes are coalesced by
+//! a background thread on a short debounce so a burst of `settings_set` calls
+//! (each carrying the whole Zustand store blob) collapses into a single
+//! whole-file rewrite instead of one O(total-size) rewrite per call. A
+//! synchronous [`flush_settings`] drains the debounce on app exit so jan-cli
+//! never reads a stale file.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::PathBuf;
-use std::sync::Mutex;
+use std::sync::{Condvar, Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use super::commands::resolve_jan_data_folder;
 use crate::core::app::constants::CONFIGURATION_FILE_NAME;
 
-/// Serializes read-modify-write cycles so concurrent `settings_set`/`_remove`
-/// calls can't clobber each other. The file is the source of truth; this only
-/// guards the in-process critical section.
-static WRITE_LOCK: Mutex<()> = Mutex::new(());
+/// How long to wait after the last mutation before flushing to disk. Bursts of
+/// writes within this window coalesce into one rewrite.
+const FLUSH_DEBOUNCE: Duration = Duration::from_millis(500);
+
+/// In-memory settings map plus flush bookkeeping.
+struct SettingsMap {
+    map: BTreeMap<String, String>,
+    /// Set on mutation, cleared once the current contents reach disk.
+    dirty: bool,
+    /// Earliest instant at which the background thread may flush; pushed
+    /// forward on each write so rapid successive writes keep coalescing.
+    flush_at: Option<Instant>,
+    /// Keys changed since the last flush, for the dev-build write log. Only
+    /// populated under `debug_assertions`.
+    pending_keys: BTreeSet<String>,
+}
+
+impl SettingsMap {
+    /// Returns true if the value changed (i.e. a flush is warranted).
+    fn set(&mut self, key: String, value: String) -> bool {
+        if self.map.get(&key).is_some_and(|v| *v == value) {
+            return false;
+        }
+        #[cfg(debug_assertions)]
+        self.pending_keys.insert(key.clone());
+        self.map.insert(key, value);
+        true
+    }
+
+    /// Returns true if a key was actually removed.
+    fn remove(&mut self, key: &str) -> bool {
+        if self.map.remove(key).is_none() {
+            return false;
+        }
+        #[cfg(debug_assertions)]
+        self.pending_keys.insert(key.to_string());
+        true
+    }
+
+    fn mark_dirty(&mut self) {
+        self.dirty = true;
+        self.flush_at = Some(Instant::now() + FLUSH_DEBOUNCE);
+    }
+
+    /// Snapshot the contents for disk and clear the dirty/pending state.
+    fn take_flush_batch(&mut self) -> (BTreeMap<String, String>, Vec<String>) {
+        let snapshot = self.map.clone();
+        let keys = std::mem::take(&mut self.pending_keys).into_iter().collect();
+        self.dirty = false;
+        self.flush_at = None;
+        (snapshot, keys)
+    }
+}
+
+/// Dev-only: report which settings keys just hit disk. Compiled out of release
+/// builds (`make dev` / `yarn dev:tauri` build with `debug_assertions`).
+fn log_flushed_keys(keys: &[String]) {
+    #[cfg(debug_assertions)]
+    if !keys.is_empty() {
+        log::debug!(
+            "settings: flushed {} key(s) to disk: {}",
+            keys.len(),
+            keys.join(", ")
+        );
+    }
+    #[cfg(not(debug_assertions))]
+    let _ = keys;
+}
+
+type Store = (Mutex<SettingsMap>, Condvar);
+
+static STORE: OnceLock<Store> = OnceLock::new();
 
 fn settings_file_path() -> PathBuf {
     resolve_jan_data_folder().join(CONFIGURATION_FILE_NAME)
@@ -42,28 +118,103 @@ fn write_map_atomic(path: &PathBuf, map: &BTreeMap<String, String>) -> Result<()
     fs::rename(&tmp, path).map_err(|e| e.to_string())
 }
 
+fn store() -> &'static Store {
+    STORE.get_or_init(|| {
+        let initial = SettingsMap {
+            map: read_map(&settings_file_path()),
+            dirty: false,
+            flush_at: None,
+            pending_keys: BTreeSet::new(),
+        };
+        std::thread::Builder::new()
+            .name("settings-flush".into())
+            .spawn(flush_loop)
+            .ok();
+        (Mutex::new(initial), Condvar::new())
+    })
+}
+
+fn lock(store: &Store) -> std::sync::MutexGuard<'_, SettingsMap> {
+    store.0.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Background thread: waits for dirty state, honors the debounce deadline
+/// (re-waiting if a newer write pushed it forward), then flushes a snapshot
+/// with the lock released during disk I/O.
+fn flush_loop() {
+    let store = store();
+    let cvar = &store.1;
+    loop {
+        let mut guard = lock(store);
+        while !guard.dirty {
+            guard = cvar.wait(guard).unwrap_or_else(|e| e.into_inner());
+        }
+        while let Some(deadline) = guard.flush_at {
+            match deadline.checked_duration_since(Instant::now()) {
+                Some(remaining) if !remaining.is_zero() => {
+                    let (g, _) = cvar
+                        .wait_timeout(guard, remaining)
+                        .unwrap_or_else(|e| e.into_inner());
+                    guard = g;
+                }
+                _ => break,
+            }
+        }
+        let (snapshot, keys) = guard.take_flush_batch();
+        drop(guard);
+        if let Err(e) = write_map_atomic(&settings_file_path(), &snapshot) {
+            log::warn!("settings flush failed: {}", e);
+            // Re-arm so a later write (or exit flush) retries.
+            lock(store).dirty = true;
+        } else {
+            log_flushed_keys(&keys);
+        }
+    }
+}
+
+/// Synchronously write pending changes to disk. Call on app exit so the
+/// debounce window can't drop the last writes or strand jan-cli with a stale
+/// file. No-op when nothing is dirty.
+pub fn flush_settings() {
+    let store = store();
+    let mut guard = lock(store);
+    if !guard.dirty {
+        return;
+    }
+    let (snapshot, keys) = guard.take_flush_batch();
+    drop(guard);
+    if let Err(e) = write_map_atomic(&settings_file_path(), &snapshot) {
+        log::warn!("settings exit flush failed: {}", e);
+        lock(store).dirty = true;
+    } else {
+        log_flushed_keys(&keys);
+    }
+}
+
 #[tauri::command]
 pub fn settings_get(key: String) -> Option<String> {
-    let path = settings_file_path();
-    read_map(&path).get(&key).cloned()
+    let store = store();
+    lock(store).map.get(&key).cloned()
 }
 
 #[tauri::command]
 pub fn settings_set(key: String, value: String) -> Result<(), String> {
-    let _guard = WRITE_LOCK.lock().map_err(|e| e.to_string())?;
-    let path = settings_file_path();
-    let mut map = read_map(&path);
-    map.insert(key, value);
-    write_map_atomic(&path, &map)
+    let store = store();
+    let mut guard = lock(store);
+    if guard.set(key, value) {
+        guard.mark_dirty();
+        store.1.notify_one();
+    }
+    Ok(())
 }
 
 #[tauri::command]
 pub fn settings_remove(key: String) -> Result<(), String> {
-    let _guard = WRITE_LOCK.lock().map_err(|e| e.to_string())?;
-    let path = settings_file_path();
-    let mut map = read_map(&path);
-    if map.remove(&key).is_some() {
-        return write_map_atomic(&path, &map);
+    let store = store();
+    let mut guard = lock(store);
+    if guard.remove(&key) {
+        guard.mark_dirty();
+        store.1.notify_one();
     }
     Ok(())
 }
@@ -71,87 +222,87 @@ pub fn settings_remove(key: String) -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::MutexGuard;
 
-    /// `resolve_jan_data_folder` reads process-wide env/config, so tests that
-    /// point it at a temp dir must not run concurrently.
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    struct TempDataFolder {
-        _guard: MutexGuard<'static, ()>,
-        prev_app_name: Option<String>,
-        prev_data_dir: Option<String>,
-        dir: tempfile::TempDir,
-    }
-
-    impl TempDataFolder {
-        fn new() -> Self {
-            let guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-            let dir = tempfile::tempdir().unwrap();
-            let prev_app_name = std::env::var("APP_NAME").ok();
-            let prev_data_dir = std::env::var("XDG_DATA_HOME").ok();
-            // Force resolve_jan_data_folder to the default branch under our temp dir.
-            std::env::set_var("APP_NAME", "JanTest");
-            std::env::set_var("XDG_DATA_HOME", dir.path());
-            Self {
-                _guard: guard,
-                prev_app_name,
-                prev_data_dir,
-                dir,
-            }
-        }
-    }
-
-    impl Drop for TempDataFolder {
-        fn drop(&mut self) {
-            match &self.prev_app_name {
-                Some(v) => std::env::set_var("APP_NAME", v),
-                None => std::env::remove_var("APP_NAME"),
-            }
-            match &self.prev_data_dir {
-                Some(v) => std::env::set_var("XDG_DATA_HOME", v),
-                None => std::env::remove_var("XDG_DATA_HOME"),
-            }
-            let _ = &self.dir;
+    fn new_map() -> SettingsMap {
+        SettingsMap {
+            map: BTreeMap::new(),
+            dirty: false,
+            flush_at: None,
+            pending_keys: BTreeSet::new(),
         }
     }
 
     #[test]
-    fn roundtrip_set_get_remove() {
-        let _tmp = TempDataFolder::new();
-        assert_eq!(settings_get("model-provider".into()), None);
-
-        settings_set("model-provider".into(), "{\"a\":1}".into()).unwrap();
-        assert_eq!(
-            settings_get("model-provider".into()),
-            Some("{\"a\":1}".to_string())
-        );
-
-        settings_set("theme".into(), "\"dark\"".into()).unwrap();
-        assert_eq!(settings_get("theme".into()), Some("\"dark\"".to_string()));
-        assert_eq!(
-            settings_get("model-provider".into()),
-            Some("{\"a\":1}".to_string())
-        );
-
-        settings_remove("model-provider".into()).unwrap();
-        assert_eq!(settings_get("model-provider".into()), None);
-        assert_eq!(settings_get("theme".into()), Some("\"dark\"".to_string()));
+    fn set_reports_change_and_ignores_noop() {
+        let mut m = new_map();
+        assert!(m.set("a".into(), "1".into()));
+        assert!(!m.set("a".into(), "1".into())); // unchanged -> no flush
+        assert!(m.set("a".into(), "2".into()));
+        assert_eq!(m.map.get("a"), Some(&"2".to_string()));
     }
 
     #[test]
-    fn remove_missing_key_is_ok() {
-        let _tmp = TempDataFolder::new();
-        assert!(settings_remove("nope".into()).is_ok());
+    fn remove_reports_whether_present() {
+        let mut m = new_map();
+        m.set("a".into(), "1".into());
+        assert!(m.remove("a"));
+        assert!(!m.remove("a"));
+        assert!(!m.remove("missing"));
     }
 
     #[test]
-    fn overwrites_preserve_other_keys() {
-        let _tmp = TempDataFolder::new();
-        settings_set("a".into(), "1".into()).unwrap();
-        settings_set("b".into(), "2".into()).unwrap();
-        settings_set("a".into(), "3".into()).unwrap();
-        assert_eq!(settings_get("a".into()), Some("3".to_string()));
-        assert_eq!(settings_get("b".into()), Some("2".to_string()));
+    fn mark_dirty_arms_flush() {
+        let mut m = new_map();
+        assert!(!m.dirty);
+        assert!(m.flush_at.is_none());
+        m.mark_dirty();
+        assert!(m.dirty);
+        assert!(m.flush_at.is_some());
+    }
+
+    #[test]
+    fn take_flush_batch_snapshots_and_clears() {
+        let mut m = new_map();
+        m.set("a".into(), "1".into());
+        m.set("b".into(), "2".into());
+        m.mark_dirty();
+        let (snapshot, keys) = m.take_flush_batch();
+        assert_eq!(snapshot.len(), 2);
+        assert!(!m.dirty);
+        assert!(m.flush_at.is_none());
+        assert!(m.pending_keys.is_empty());
+        // pending_keys only tracked under debug_assertions (tests run debug).
+        assert_eq!(keys, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn set_preserves_other_keys() {
+        let mut m = new_map();
+        m.set("a".into(), "1".into());
+        m.set("b".into(), "2".into());
+        m.set("a".into(), "3".into());
+        assert_eq!(m.map.get("a"), Some(&"3".to_string()));
+        assert_eq!(m.map.get("b"), Some(&"2".to_string()));
+    }
+
+    #[test]
+    fn write_then_read_roundtrips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("settings.json");
+        let mut map = BTreeMap::new();
+        map.insert("model-provider".to_string(), "{\"a\":1}".to_string());
+        map.insert("theme".to_string(), "\"dark\"".to_string());
+        write_map_atomic(&path, &map).unwrap();
+        assert_eq!(read_map(&path), map);
+    }
+
+    #[test]
+    fn read_missing_or_empty_is_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("nope.json");
+        assert!(read_map(&missing).is_empty());
+        let empty = dir.path().join("empty.json");
+        fs::write(&empty, "   ").unwrap();
+        assert!(read_map(&empty).is_empty());
     }
 }

--- a/src-tauri/src/core/server/mod.rs
+++ b/src-tauri/src/core/server/mod.rs
@@ -1,4 +1,5 @@
 pub mod commands;
+pub mod provider_secrets;
 pub mod proxy;
 pub mod remote_provider_commands;
 #[cfg(test)]

--- a/src-tauri/src/core/server/provider_secrets.rs
+++ b/src-tauri/src/core/server/provider_secrets.rs
@@ -264,6 +264,25 @@ mod tests {
         assert!(file_remove("never-stored").is_ok());
     }
 
+    /// A stored key must persist across reloads (restarts) and only disappear on
+    /// an explicit remove — never as a side effect of provider-config churn.
+    /// Regression guard for keys being wiped during boot reconciliation.
+    #[test]
+    fn stored_keys_survive_until_explicit_remove() {
+        let _tmp = TempDataFolder::new();
+        let provider = "custom-router";
+        let keys = vec!["sk-1234".to_string()];
+        file_store(provider, &keys).unwrap();
+
+        // Simulate a restart: re-read from disk without any register/unregister.
+        assert_eq!(file_load(provider), keys, "key must survive a reload");
+        assert_eq!(file_load(provider), keys, "and a second reload");
+
+        // Only an explicit removal clears it.
+        file_remove(provider).unwrap();
+        assert!(file_load(provider).is_empty());
+    }
+
     #[test]
     fn fallback_file_is_encrypted_at_rest() {
         let _tmp = TempDataFolder::new();

--- a/src-tauri/src/core/server/provider_secrets.rs
+++ b/src-tauri/src/core/server/provider_secrets.rs
@@ -18,6 +18,7 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Mutex;
 
 use aes_gcm::aead::{Aead, AeadCore, KeyInit, OsRng};
@@ -34,8 +35,38 @@ const NONCE_LEN: usize = 12;
 /// Serializes read-modify-write on the fallback file.
 static FILE_LOCK: Mutex<()> = Mutex::new(());
 
-fn keyring_entry(provider: &str) -> Result<Entry, String> {
-    Entry::new(KEYRING_SERVICE, provider).map_err(|e| e.to_string())
+/// Latched on the first infrastructure-level keyring failure (D-Bus timeout,
+/// platform/storage-access failure). Once set, every secret op skips the
+/// keyring and goes straight to the encrypted file fallback for the rest of the
+/// session -- otherwise each call re-attempts a dead Secret Service, blocking on
+/// the D-Bus timeout and re-logging every time. A missing entry (`NoEntry`) is
+/// normal and never trips this.
+static KEYRING_DOWN: AtomicBool = AtomicBool::new(false);
+
+fn keyring_down() -> bool {
+    KEYRING_DOWN.load(Ordering::Relaxed)
+}
+
+/// Whether an error means the keyring backend itself is unusable (vs. a normal
+/// "key not stored" or a usage error on our controlled data).
+fn is_infra_failure(err: &keyring::Error) -> bool {
+    matches!(
+        err,
+        keyring::Error::PlatformFailure(_) | keyring::Error::NoStorageAccess(_)
+    )
+}
+
+/// Trip the latch on the first infrastructure failure and warn exactly once.
+fn note_keyring_failure(err: &keyring::Error) {
+    if is_infra_failure(err) && !KEYRING_DOWN.swap(true, Ordering::Relaxed) {
+        log::warn!(
+            "Keyring unavailable ({err}); using encrypted file fallback for the rest of this session"
+        );
+    }
+}
+
+fn keyring_entry(provider: &str) -> keyring::Result<Entry> {
+    Entry::new(KEYRING_SERVICE, provider)
 }
 
 fn secrets_file_path() -> PathBuf {
@@ -137,26 +168,29 @@ pub fn store_provider_keys(provider: &str, keys: &[String]) -> Result<(), String
         return delete_provider_keys(provider);
     }
     let serialized = serde_json::to_string(keys).map_err(|e| e.to_string())?;
-    match keyring_entry(provider).and_then(|e| e.set_password(&serialized).map_err(|e| e.to_string())) {
-        Ok(()) => {
-            // Keyring is authoritative; drop any stale fallback copy.
-            let _ = file_remove(provider);
-            Ok(())
-        }
-        Err(err) => {
-            log::warn!("Keyring unavailable for {provider} ({err}); using file fallback");
-            file_store(provider, keys)
+    if !keyring_down() {
+        match keyring_entry(provider).and_then(|e| e.set_password(&serialized)) {
+            Ok(()) => {
+                // Keyring is authoritative; drop any stale fallback copy.
+                let _ = file_remove(provider);
+                return Ok(());
+            }
+            Err(err) => note_keyring_failure(&err),
         }
     }
+    file_store(provider, keys)
 }
 
 /// Remove a provider's stored keys from both the keyring and the fallback file.
 /// Missing entries are not an error.
 pub fn delete_provider_keys(provider: &str) -> Result<(), String> {
-    if let Ok(entry) = keyring_entry(provider) {
-        match entry.delete_credential() {
+    if !keyring_down() {
+        match keyring_entry(provider).and_then(|e| e.delete_credential()) {
             Ok(()) | Err(keyring::Error::NoEntry) => {}
-            Err(err) => log::warn!("Failed to delete keyring entry for {provider}: {err}"),
+            Err(err) => {
+                note_keyring_failure(&err);
+                log::warn!("Failed to delete keyring entry for {provider}: {err}");
+            }
         }
     }
     file_remove(provider)
@@ -165,13 +199,17 @@ pub fn delete_provider_keys(provider: &str) -> Result<(), String> {
 /// Read a provider's key chain: keyring first, then the fallback file. Returns
 /// an empty vec when neither has it (caller falls back to env/flag).
 pub fn load_provider_keys(provider: &str) -> Vec<String> {
-    if let Ok(entry) = keyring_entry(provider) {
-        if let Ok(serialized) = entry.get_password() {
-            if let Ok(keys) = serde_json::from_str::<Vec<String>>(&serialized) {
-                if !keys.is_empty() {
-                    return keys;
+    if !keyring_down() {
+        match keyring_entry(provider).and_then(|e| e.get_password()) {
+            Ok(serialized) => {
+                if let Ok(keys) = serde_json::from_str::<Vec<String>>(&serialized) {
+                    if !keys.is_empty() {
+                        return keys;
+                    }
                 }
             }
+            Err(keyring::Error::NoEntry) => {}
+            Err(err) => note_keyring_failure(&err),
         }
     }
     file_load(provider)
@@ -258,6 +296,19 @@ mod tests {
         file_remove(provider).unwrap();
         assert!(file_load(provider).is_empty());
         assert_eq!(file_load("anthropic"), vec!["sk-ant".to_string()]);
+    }
+
+    #[test]
+    fn only_infra_errors_latch_the_keyring_off() {
+        // A missing key is normal churn -> must not disable the keyring.
+        assert!(!is_infra_failure(&keyring::Error::NoEntry));
+        // Backend-unusable errors (D-Bus timeout surfaces as PlatformFailure) latch.
+        assert!(is_infra_failure(&keyring::Error::PlatformFailure(Box::new(
+            std::io::Error::other("dbus timeout")
+        ))));
+        assert!(is_infra_failure(&keyring::Error::NoStorageAccess(Box::new(
+            std::io::Error::other("locked")
+        ))));
     }
 
     #[test]

--- a/src-tauri/src/core/server/provider_secrets.rs
+++ b/src-tauri/src/core/server/provider_secrets.rs
@@ -1,0 +1,287 @@
+//! Persistence for remote-provider API keys.
+//!
+//! Secrets never touch the settings file or webview storage. The key chain for
+//! a provider (primary key + fallbacks) is stored as a JSON array under a stable
+//! service/account pair in the OS keyring so an out-of-process consumer
+//! (jan-cli) can read it.
+//!
+//! The Linux Secret Service needs a D-Bus session + an unlocked keyring, which
+//! is often absent on headless/CI/SSH boxes. When the keyring is unavailable we
+//! fall back to an encrypted, permission-restricted file
+//! (`<jan_data>/provider_secrets.enc`, AES-256-GCM, `0600` on unix). The key is
+//! derived from a stable per-machine id + an app salt: this defeats casual disk
+//! or backup inspection, the realistic threat for a headless fallback. It is not
+//! proof against an attacker who already has code + disk access on the box (no
+//! local-key scheme can be). Keyring failure is never fatal; callers additionally
+//! have `--api-key`/env as a last resort.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use aes_gcm::aead::{Aead, AeadCore, KeyInit, OsRng};
+use aes_gcm::{Aes256Gcm, Nonce};
+use keyring::Entry;
+use sha2::{Digest, Sha256};
+
+use crate::core::app::commands::resolve_jan_data_folder;
+
+const KEYRING_SERVICE: &str = "jan-providers";
+const SECRETS_FILE_NAME: &str = "provider_secrets.enc";
+const NONCE_LEN: usize = 12;
+
+/// Serializes read-modify-write on the fallback file.
+static FILE_LOCK: Mutex<()> = Mutex::new(());
+
+fn keyring_entry(provider: &str) -> Result<Entry, String> {
+    Entry::new(KEYRING_SERVICE, provider).map_err(|e| e.to_string())
+}
+
+fn secrets_file_path() -> PathBuf {
+    resolve_jan_data_folder().join(SECRETS_FILE_NAME)
+}
+
+/// Derive a stable 32-byte key from a per-machine id and a versioned app salt.
+fn derive_cipher() -> Result<Aes256Gcm, String> {
+    let machine_id = machine_uid::get().unwrap_or_else(|_| "jan-fallback-machine".to_string());
+    let mut hasher = Sha256::new();
+    hasher.update(b"jan-provider-secrets-v1");
+    hasher.update(machine_id.as_bytes());
+    let key = hasher.finalize();
+    Aes256Gcm::new_from_slice(&key).map_err(|e| e.to_string())
+}
+
+fn read_file_map(path: &PathBuf) -> BTreeMap<String, Vec<String>> {
+    let Ok(bytes) = fs::read(path) else {
+        return BTreeMap::new();
+    };
+    if bytes.len() <= NONCE_LEN {
+        return BTreeMap::new();
+    }
+    let (nonce, ciphertext) = bytes.split_at(NONCE_LEN);
+    let plaintext = match derive_cipher().and_then(|c| {
+        c.decrypt(Nonce::from_slice(nonce), ciphertext)
+            .map_err(|e| e.to_string())
+    }) {
+        Ok(pt) => pt,
+        Err(err) => {
+            log::warn!("Failed to decrypt provider secrets file: {err}");
+            return BTreeMap::new();
+        }
+    };
+    serde_json::from_slice(&plaintext).unwrap_or_default()
+}
+
+fn write_file_map_atomic(path: &PathBuf, map: &BTreeMap<String, Vec<String>>) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let plaintext = serde_json::to_vec(map).map_err(|e| e.to_string())?;
+    let cipher = derive_cipher()?;
+    let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+    let ciphertext = cipher
+        .encrypt(&nonce, plaintext.as_ref())
+        .map_err(|e| e.to_string())?;
+    let mut blob = nonce.to_vec();
+    blob.extend_from_slice(&ciphertext);
+
+    let tmp = path.with_extension("enc.tmp");
+    fs::write(&tmp, &blob).map_err(|e| e.to_string())?;
+    restrict_permissions(&tmp);
+    fs::rename(&tmp, path).map_err(|e| e.to_string())?;
+    restrict_permissions(path);
+    Ok(())
+}
+
+#[cfg(unix)]
+fn restrict_permissions(path: &PathBuf) {
+    use std::os::unix::fs::PermissionsExt;
+    if let Err(err) = fs::set_permissions(path, fs::Permissions::from_mode(0o600)) {
+        log::warn!("Failed to restrict permissions on {}: {err}", path.display());
+    }
+}
+
+#[cfg(not(unix))]
+fn restrict_permissions(_path: &PathBuf) {}
+
+fn file_store(provider: &str, keys: &[String]) -> Result<(), String> {
+    let _guard = FILE_LOCK.lock().map_err(|e| e.to_string())?;
+    let path = secrets_file_path();
+    let mut map = read_file_map(&path);
+    map.insert(provider.to_string(), keys.to_vec());
+    write_file_map_atomic(&path, &map)
+}
+
+fn file_remove(provider: &str) -> Result<(), String> {
+    let _guard = FILE_LOCK.lock().map_err(|e| e.to_string())?;
+    let path = secrets_file_path();
+    let mut map = read_file_map(&path);
+    if map.remove(provider).is_some() {
+        return write_file_map_atomic(&path, &map);
+    }
+    Ok(())
+}
+
+fn file_load(provider: &str) -> Vec<String> {
+    read_file_map(&secrets_file_path())
+        .remove(provider)
+        .unwrap_or_default()
+}
+
+/// Store (or replace) the full key chain for a provider. An empty chain deletes
+/// the entry so we never persist a blank secret. Prefers the OS keyring; on
+/// keyring failure, writes the permission-restricted fallback file.
+pub fn store_provider_keys(provider: &str, keys: &[String]) -> Result<(), String> {
+    if keys.is_empty() {
+        return delete_provider_keys(provider);
+    }
+    let serialized = serde_json::to_string(keys).map_err(|e| e.to_string())?;
+    match keyring_entry(provider).and_then(|e| e.set_password(&serialized).map_err(|e| e.to_string())) {
+        Ok(()) => {
+            // Keyring is authoritative; drop any stale fallback copy.
+            let _ = file_remove(provider);
+            Ok(())
+        }
+        Err(err) => {
+            log::warn!("Keyring unavailable for {provider} ({err}); using file fallback");
+            file_store(provider, keys)
+        }
+    }
+}
+
+/// Remove a provider's stored keys from both the keyring and the fallback file.
+/// Missing entries are not an error.
+pub fn delete_provider_keys(provider: &str) -> Result<(), String> {
+    if let Ok(entry) = keyring_entry(provider) {
+        match entry.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => {}
+            Err(err) => log::warn!("Failed to delete keyring entry for {provider}: {err}"),
+        }
+    }
+    file_remove(provider)
+}
+
+/// Read a provider's key chain: keyring first, then the fallback file. Returns
+/// an empty vec when neither has it (caller falls back to env/flag).
+pub fn load_provider_keys(provider: &str) -> Vec<String> {
+    if let Ok(entry) = keyring_entry(provider) {
+        if let Ok(serialized) = entry.get_password() {
+            if let Ok(keys) = serde_json::from_str::<Vec<String>>(&serialized) {
+                if !keys.is_empty() {
+                    return keys;
+                }
+            }
+        }
+    }
+    file_load(provider)
+}
+
+/// Store a single generic secret (e.g. the Hugging Face token) under `key`.
+/// Empty value deletes it. Backed by the same keyring/encrypted-file store.
+#[tauri::command]
+pub fn set_secret(key: String, value: String) -> Result<(), String> {
+    if value.is_empty() {
+        delete_provider_keys(&key)
+    } else {
+        store_provider_keys(&key, std::slice::from_ref(&value))
+    }
+}
+
+/// Read a single generic secret stored via `set_secret`. None when absent.
+#[tauri::command]
+pub fn get_secret(key: String) -> Option<String> {
+    load_provider_keys(&key).into_iter().next()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::MutexGuard;
+
+    /// `resolve_jan_data_folder` reads process-wide env, so tests that redirect
+    /// it must not run concurrently.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    struct TempDataFolder {
+        _guard: MutexGuard<'static, ()>,
+        prev_app_name: Option<String>,
+        prev_data_dir: Option<String>,
+        _dir: tempfile::TempDir,
+    }
+
+    impl TempDataFolder {
+        fn new() -> Self {
+            let guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            let dir = tempfile::tempdir().unwrap();
+            let prev_app_name = std::env::var("APP_NAME").ok();
+            let prev_data_dir = std::env::var("XDG_DATA_HOME").ok();
+            std::env::set_var("APP_NAME", "JanTest");
+            std::env::set_var("XDG_DATA_HOME", dir.path());
+            Self {
+                _guard: guard,
+                prev_app_name,
+                prev_data_dir,
+                _dir: dir,
+            }
+        }
+    }
+
+    impl Drop for TempDataFolder {
+        fn drop(&mut self) {
+            match &self.prev_app_name {
+                Some(v) => std::env::set_var("APP_NAME", v),
+                None => std::env::remove_var("APP_NAME"),
+            }
+            match &self.prev_data_dir {
+                Some(v) => std::env::set_var("XDG_DATA_HOME", v),
+                None => std::env::remove_var("XDG_DATA_HOME"),
+            }
+        }
+    }
+
+    #[test]
+    fn file_fallback_roundtrip() {
+        let _tmp = TempDataFolder::new();
+        let provider = "openai";
+        assert!(file_load(provider).is_empty());
+
+        let keys = vec!["sk-primary".to_string(), "sk-fallback".to_string()];
+        file_store(provider, &keys).unwrap();
+        assert_eq!(file_load(provider), keys);
+
+        file_store("anthropic", &["sk-ant".to_string()]).unwrap();
+        assert_eq!(file_load(provider), keys);
+
+        file_remove(provider).unwrap();
+        assert!(file_load(provider).is_empty());
+        assert_eq!(file_load("anthropic"), vec!["sk-ant".to_string()]);
+    }
+
+    #[test]
+    fn file_remove_missing_is_ok() {
+        let _tmp = TempDataFolder::new();
+        assert!(file_remove("never-stored").is_ok());
+    }
+
+    #[test]
+    fn fallback_file_is_encrypted_at_rest() {
+        let _tmp = TempDataFolder::new();
+        let secret = "sk-super-secret-value";
+        file_store("openai", &[secret.to_string()]).unwrap();
+        let bytes = fs::read(secrets_file_path()).unwrap();
+        let haystack = String::from_utf8_lossy(&bytes);
+        assert!(!haystack.contains(secret), "secret must not appear in plaintext on disk");
+        assert!(!haystack.contains("openai"), "provider name must not appear in plaintext");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn fallback_file_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let _tmp = TempDataFolder::new();
+        file_store("openai", &["sk-x".to_string()]).unwrap();
+        let mode = fs::metadata(secrets_file_path()).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o600);
+    }
+}

--- a/src-tauri/src/core/server/provider_secrets.rs
+++ b/src-tauri/src/core/server/provider_secrets.rs
@@ -205,8 +205,7 @@ mod tests {
 
     struct TempDataFolder {
         _guard: MutexGuard<'static, ()>,
-        prev_app_name: Option<String>,
-        prev_data_dir: Option<String>,
+        prev_data_folder: Option<String>,
         _dir: tempfile::TempDir,
     }
 
@@ -214,14 +213,13 @@ mod tests {
         fn new() -> Self {
             let guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
             let dir = tempfile::tempdir().unwrap();
-            let prev_app_name = std::env::var("APP_NAME").ok();
-            let prev_data_dir = std::env::var("XDG_DATA_HOME").ok();
-            std::env::set_var("APP_NAME", "JanTest");
-            std::env::set_var("XDG_DATA_HOME", dir.path());
+            let prev_data_folder = std::env::var("JAN_DATA_FOLDER").ok();
+            // Portable override: XDG_DATA_HOME only redirects on Linux, so
+            // relying on it fails the fallback tests on macOS/Windows.
+            std::env::set_var("JAN_DATA_FOLDER", dir.path());
             Self {
                 _guard: guard,
-                prev_app_name,
-                prev_data_dir,
+                prev_data_folder,
                 _dir: dir,
             }
         }
@@ -229,13 +227,9 @@ mod tests {
 
     impl Drop for TempDataFolder {
         fn drop(&mut self) {
-            match &self.prev_app_name {
-                Some(v) => std::env::set_var("APP_NAME", v),
-                None => std::env::remove_var("APP_NAME"),
-            }
-            match &self.prev_data_dir {
-                Some(v) => std::env::set_var("XDG_DATA_HOME", v),
-                None => std::env::remove_var("XDG_DATA_HOME"),
+            match &self.prev_data_folder {
+                Some(v) => std::env::set_var("JAN_DATA_FOLDER", v),
+                None => std::env::remove_var("JAN_DATA_FOLDER"),
             }
         }
     }

--- a/src-tauri/src/core/server/provider_secrets.rs
+++ b/src-tauri/src/core/server/provider_secrets.rs
@@ -180,18 +180,26 @@ pub fn load_provider_keys(provider: &str) -> Vec<String> {
 /// Store a single generic secret (e.g. the Hugging Face token) under `key`.
 /// Empty value deletes it. Backed by the same keyring/encrypted-file store.
 #[tauri::command]
-pub fn set_secret(key: String, value: String) -> Result<(), String> {
-    if value.is_empty() {
-        delete_provider_keys(&key)
-    } else {
-        store_provider_keys(&key, std::slice::from_ref(&value))
-    }
+pub async fn set_secret(key: String, value: String) -> Result<(), String> {
+    // Keyring/file access is blocking; keep it off the main (UI) thread.
+    tauri::async_runtime::spawn_blocking(move || {
+        if value.is_empty() {
+            delete_provider_keys(&key)
+        } else {
+            store_provider_keys(&key, std::slice::from_ref(&value))
+        }
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
 /// Read a single generic secret stored via `set_secret`. None when absent.
 #[tauri::command]
-pub fn get_secret(key: String) -> Option<String> {
-    load_provider_keys(&key).into_iter().next()
+pub async fn get_secret(key: String) -> Option<String> {
+    tauri::async_runtime::spawn_blocking(move || load_provider_keys(&key).into_iter().next())
+        .await
+        .ok()
+        .flatten()
 }
 
 #[cfg(test)]

--- a/src-tauri/src/core/server/remote_provider_commands.rs
+++ b/src-tauri/src/core/server/remote_provider_commands.rs
@@ -51,9 +51,6 @@ pub async fn register_provider_config(
     state: State<'_, AppState>,
     request: RegisterProviderRequest,
 ) -> Result<(), String> {
-    let provider_configs = state.provider_configs.clone();
-    let mut configs = provider_configs.lock().await;
-
     let key_chain = merge_register_api_keys(request.api_key.clone(), request.api_keys.clone());
     let api_key = key_chain.first().cloned();
 
@@ -75,10 +72,17 @@ pub async fn register_provider_config(
 
     // Persist the key chain to the OS keyring so it survives webview storage
     // clears and is readable by out-of-process consumers (jan-cli). Keyring
-    // failure (e.g. headless Linux without an unlocked Secret Service) must not
-    // block registration; the in-memory config still works this session.
-    if let Err(err) =
-        crate::core::server::provider_secrets::store_provider_keys(&request.provider, &config.api_keys)
+    // access is blocking, so run it off-thread and before taking the config
+    // lock. Keyring failure (e.g. headless Linux without an unlocked Secret
+    // Service) must not block registration; the in-memory config still works.
+    let provider_name = request.provider.clone();
+    let keys = config.api_keys.clone();
+    if let Err(err) = tauri::async_runtime::spawn_blocking(move || {
+        crate::core::server::provider_secrets::store_provider_keys(&provider_name, &keys)
+    })
+    .await
+    .map_err(|e| e.to_string())
+    .and_then(|r| r)
     {
         log::warn!(
             "Failed to persist API keys to keyring for {}: {err}",
@@ -86,6 +90,8 @@ pub async fn register_provider_config(
         );
     }
 
+    let provider_configs = state.provider_configs.clone();
+    let mut configs = provider_configs.lock().await;
     let provider_name = request.provider.clone();
     configs.insert(provider_name.clone(), config);
     log::info!("Registered provider config: {provider_name}");
@@ -138,16 +144,26 @@ pub async fn unregister_provider_config(
 /// user removes a custom provider or clears its key, never during boot
 /// reconciliation.
 #[tauri::command]
-pub fn delete_provider_keys(provider: String) -> Result<(), String> {
-    crate::core::server::provider_secrets::delete_provider_keys(&provider)
+pub async fn delete_provider_keys(provider: String) -> Result<(), String> {
+    // Keyring/file access is blocking; keep it off the main (UI) thread.
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::core::server::provider_secrets::delete_provider_keys(&provider)
+    })
+    .await
+    .map_err(|e| e.to_string())?
 }
 
 /// Read a provider's stored API key chain (keyring, then encrypted file
 /// fallback). Used by the frontend to re-seed in-memory keys at boot, since
 /// keys are no longer persisted to webview storage. Empty when none stored.
 #[tauri::command]
-pub fn get_provider_keys(provider: String) -> Vec<String> {
-    crate::core::server::provider_secrets::load_provider_keys(&provider)
+pub async fn get_provider_keys(provider: String) -> Vec<String> {
+    // Keyring/file access is blocking; keep it off the main (UI) thread.
+    tauri::async_runtime::spawn_blocking(move || {
+        crate::core::server::provider_secrets::load_provider_keys(&provider)
+    })
+    .await
+    .unwrap_or_default()
 }
 
 /// Get provider configuration by name

--- a/src-tauri/src/core/server/remote_provider_commands.rs
+++ b/src-tauri/src/core/server/remote_provider_commands.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 use tauri::State;
 
@@ -103,7 +105,20 @@ pub async fn set_model_param_defaults(
     Ok(())
 }
 
-/// Unregister a provider configuration
+/// Drop a provider's in-memory config, reporting whether it was present. Pure:
+/// touches only the map, never the persisted keyring secret.
+fn remove_provider_config(
+    configs: &mut HashMap<String, ProviderConfig>,
+    provider: &str,
+) -> bool {
+    configs.remove(provider).is_some()
+}
+
+/// Unregister a provider's in-memory config. This is called during routine
+/// reconciliation (e.g. deactivating a provider at boot), so it MUST NOT touch
+/// the persisted keyring secret — otherwise a provider whose in-memory key has
+/// not been re-seeded yet would have its stored key destroyed. Deleting the
+/// secret is an explicit user action; see `delete_provider_keys`.
 #[tauri::command]
 pub async fn unregister_provider_config(
     state: State<'_, AppState>,
@@ -112,14 +127,19 @@ pub async fn unregister_provider_config(
     let provider_configs = state.provider_configs.clone();
     let mut configs = provider_configs.lock().await;
 
-    if let Err(err) = crate::core::server::provider_secrets::delete_provider_keys(&provider) {
-        log::warn!("Failed to delete keyring entry for {provider}: {err}");
-    }
-
-    if configs.remove(&provider).is_some() {
+    if remove_provider_config(&mut configs, &provider) {
         log::info!("Unregistered provider config: {provider}");
     }
     Ok(())
+}
+
+/// Permanently delete a provider's stored API key chain from the keyring (and
+/// encrypted-file fallback). Explicit, user-initiated only — invoked when the
+/// user removes a custom provider or clears its key, never during boot
+/// reconciliation.
+#[tauri::command]
+pub fn delete_provider_keys(provider: String) -> Result<(), String> {
+    crate::core::server::provider_secrets::delete_provider_keys(&provider)
 }
 
 /// Read a provider's stored API key chain (keyring, then encrypted file
@@ -151,4 +171,46 @@ pub async fn list_provider_configs(
     let configs = provider_configs.lock().await;
 
     Ok(configs.values().cloned().collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(provider: &str, key: &str) -> ProviderConfig {
+        ProviderConfig {
+            provider: provider.to_string(),
+            api_key: Some(key.to_string()),
+            api_keys: vec![key.to_string()],
+            base_url: None,
+            custom_headers: vec![],
+            models: vec![],
+        }
+    }
+
+    #[test]
+    fn merge_register_api_keys_dedupes_and_trims() {
+        let out = merge_register_api_keys(
+            Some(" sk-a ".to_string()),
+            vec!["sk-a".to_string(), " ".to_string(), "sk-b".to_string()],
+        );
+        assert_eq!(out, vec!["sk-a".to_string(), "sk-b".to_string()]);
+    }
+
+    /// Unregister (boot reconciliation) must only drop the in-memory entry.
+    /// Regression guard: the secret store is a separate concern and is never
+    /// reached from this path, so a not-yet-reseeded provider keeps its key.
+    #[test]
+    fn remove_provider_config_is_in_memory_only() {
+        let mut configs = HashMap::new();
+        configs.insert("openai".to_string(), config("openai", "sk-live"));
+        configs.insert("anthropic".to_string(), config("anthropic", "sk-ant"));
+
+        assert!(remove_provider_config(&mut configs, "openai"));
+        assert!(!configs.contains_key("openai"));
+        // Unrelated provider untouched.
+        assert!(configs.contains_key("anthropic"));
+        // Removing a missing provider is a no-op reported as false.
+        assert!(!remove_provider_config(&mut configs, "openai"));
+    }
 }

--- a/src-tauri/src/core/server/remote_provider_commands.rs
+++ b/src-tauri/src/core/server/remote_provider_commands.rs
@@ -71,6 +71,19 @@ pub async fn register_provider_config(
         models: request.models, // Models will be added when they are configured
     };
 
+    // Persist the key chain to the OS keyring so it survives webview storage
+    // clears and is readable by out-of-process consumers (jan-cli). Keyring
+    // failure (e.g. headless Linux without an unlocked Secret Service) must not
+    // block registration; the in-memory config still works this session.
+    if let Err(err) =
+        crate::core::server::provider_secrets::store_provider_keys(&request.provider, &config.api_keys)
+    {
+        log::warn!(
+            "Failed to persist API keys to keyring for {}: {err}",
+            request.provider
+        );
+    }
+
     let provider_name = request.provider.clone();
     configs.insert(provider_name.clone(), config);
     log::info!("Registered provider config: {provider_name}");
@@ -99,12 +112,22 @@ pub async fn unregister_provider_config(
     let provider_configs = state.provider_configs.clone();
     let mut configs = provider_configs.lock().await;
 
+    if let Err(err) = crate::core::server::provider_secrets::delete_provider_keys(&provider) {
+        log::warn!("Failed to delete keyring entry for {provider}: {err}");
+    }
+
     if configs.remove(&provider).is_some() {
         log::info!("Unregistered provider config: {provider}");
-        Ok(())
-    } else {
-        Ok(())
     }
+    Ok(())
+}
+
+/// Read a provider's stored API key chain (keyring, then encrypted file
+/// fallback). Used by the frontend to re-seed in-memory keys at boot, since
+/// keys are no longer persisted to webview storage. Empty when none stored.
+#[tauri::command]
+pub fn get_provider_keys(provider: String) -> Vec<String> {
+    crate::core::server::provider_secrets::load_provider_keys(&provider)
 }
 
 /// Get provider configuration by name

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -78,6 +78,7 @@ macro_rules! invoke_commands_with_extras {
         // Remote provider commands
         core::server::remote_provider_commands::register_provider_config,
         core::server::remote_provider_commands::unregister_provider_config,
+        core::server::remote_provider_commands::delete_provider_keys,
         core::server::remote_provider_commands::set_model_param_defaults,
         core::server::remote_provider_commands::get_provider_config,
         core::server::remote_provider_commands::get_provider_keys,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -404,6 +404,10 @@ pub fn run() {
         if let RunEvent::Exit = event {
             let app_handle = app.clone();
 
+            // Drain any debounced settings writes before the process dies so
+            // jan-cli never reads a stale settings.json.
+            core::app::settings_store::flush_settings();
+
             #[cfg(not(any(target_os = "ios", target_os = "android")))]
             {
                 if let Some(window) = app_handle.get_webview_window("main") {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -48,6 +48,12 @@ macro_rules! invoke_commands_with_extras {
         core::app::commands::default_data_folder_path,
         core::app::commands::change_app_data_folder,
         core::app::commands::app_token,
+        // Backend-owned settings store (webview zustand persistence)
+        core::app::settings_store::settings_get,
+        core::app::settings_store::settings_set,
+        core::app::settings_store::settings_remove,
+        core::server::provider_secrets::set_secret,
+        core::server::provider_secrets::get_secret,
         // Extension commands
         core::extensions::commands::get_jan_extensions_path,
         core::extensions::commands::install_extensions,
@@ -74,6 +80,7 @@ macro_rules! invoke_commands_with_extras {
         core::server::remote_provider_commands::unregister_provider_config,
         core::server::remote_provider_commands::set_model_param_defaults,
         core::server::remote_provider_commands::get_provider_config,
+        core::server::remote_provider_commands::get_provider_keys,
         core::server::remote_provider_commands::list_provider_configs,
         // MCP commands
         core::mcp::commands::get_tools,

--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -2118,7 +2118,6 @@ const ChatInput = memo(function ChatInput({
                       selectedModelHasTools={
                         selectedModel?.capabilities?.includes('tools') ?? false
                       }
-                      initialMessage={initialMessage}
                       MCPToolComponent={MCPToolComponent}
                     />
                   ) : (
@@ -2140,7 +2139,6 @@ const ChatInput = memo(function ChatInput({
                           }}
                         >
                           <DropdownToolsAvailable
-                            initialMessage={initialMessage}
                             onOpenChange={(isOpen) => {
                               setDropdownToolsAvailable(isOpen)
                               if (isOpen) {

--- a/web-app/src/containers/DropdownToolsAvailable.tsx
+++ b/web-app/src/containers/DropdownToolsAvailable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, memo } from 'react'
+import { useState, memo } from 'react'
 
 import {
   DropDrawer,
@@ -15,7 +15,6 @@ import {
 
 import { Switch } from '@/components/ui/switch'
 
-import { useThreads } from '@/hooks/useThreads'
 import { useToolAvailable } from '@/hooks/useToolAvailable'
 
 import React from 'react'
@@ -25,13 +24,11 @@ import { cn } from '@/lib/utils'
 
 interface DropdownToolsAvailableProps {
   children: (isOpen: boolean, toolsCount: number) => React.ReactNode
-  initialMessage?: boolean
   onOpenChange?: (isOpen: boolean) => void
 }
 
 export default memo(function DropdownToolsAvailable({
   children,
-  initialMessage = false,
   onOpenChange,
 }: DropdownToolsAvailableProps) {
   const allTools = useAppState((state) => state.tools)
@@ -44,53 +41,19 @@ export default memo(function DropdownToolsAvailable({
     setIsOpen(open)
     onOpenChange?.(open)
   }
-  const { getCurrentThread } = useThreads()
-  const {
-    isToolDisabled,
-    setToolDisabledForThread,
-    setDefaultDisabledTools,
-    initializeThreadTools,
-    getDisabledToolsForThread,
-    getDefaultDisabledTools,
-  } = useToolAvailable()
+  const { isToolDisabled, setToolDisabled, getDisabledTools } =
+    useToolAvailable()
 
-  const currentThread = getCurrentThread()
-
-  // Separate effect for thread initialization - only when we have tools and a new thread
-  useEffect(() => {
-    if (tools.length > 0 && currentThread?.id) {
-      initializeThreadTools(currentThread.id, tools)
-    }
-  }, [currentThread?.id, tools, initializeThreadTools])
-
-  const handleToolToggle = (serverName: string, toolName: string, checked: boolean) => {
-    if (initialMessage) {
-      // Update default tools for new threads/index page
-      const currentDefaults = getDefaultDisabledTools()
-      const toolKey = `${serverName}::${toolName}`
-      if (checked) {
-        setDefaultDisabledTools(
-          currentDefaults.filter((key) => key !== toolKey)
-        )
-      } else {
-        setDefaultDisabledTools([...currentDefaults, toolKey])
-      }
-    } else if (currentThread?.id) {
-      // Update tools for specific thread
-      setToolDisabledForThread(currentThread.id, serverName, toolName, checked)
-    }
+  const handleToolToggle = (
+    serverName: string,
+    toolName: string,
+    checked: boolean
+  ) => {
+    setToolDisabled(serverName, toolName, checked)
   }
 
   const isToolChecked = (serverName: string, toolName: string): boolean => {
-    if (initialMessage) {
-      // Use default tools for index page
-      const toolKey = `${serverName}::${toolName}`
-      return !getDefaultDisabledTools().includes(toolKey)
-    } else if (currentThread?.id) {
-      // Use thread-specific tools
-      return !isToolDisabled(currentThread.id, serverName, toolName)
-    }
-    return false
+    return !isToolDisabled(serverName, toolName)
   }
 
   const handleDisableAllServerTools = (
@@ -111,11 +74,7 @@ export default memo(function DropdownToolsAvailable({
   }
 
   const getEnabledToolsCount = (): number => {
-    const disabledToolKeys = initialMessage
-      ? getDefaultDisabledTools()
-      : currentThread?.id
-        ? getDisabledToolsForThread(currentThread.id)
-        : []
+    const disabledToolKeys = getDisabledTools()
     return tools.filter((tool) => {
       const toolKey = `${tool.server}::${tool.name}`
       return !disabledToolKeys.includes(toolKey)
@@ -230,7 +189,6 @@ export default memo(function DropdownToolsAvailable({
                               <Switch
                                 checked={isChecked}
                                 onCheckedChange={(checked) => {
-                                  console.log('checked', checked)
                                   handleToolToggle(tool.server, tool.name, checked)
                                 }}
                                 onClick={(e) => {

--- a/web-app/src/containers/McpExtensionToolLoader.tsx
+++ b/web-app/src/containers/McpExtensionToolLoader.tsx
@@ -1,13 +1,11 @@
 import { ComponentType } from 'react'
 import { MCPTool, MCPToolComponentProps } from '@janhq/core'
 import { useToolAvailable } from '@/hooks/useToolAvailable'
-import { useThreads } from '@/hooks/useThreads'
 
 interface McpExtensionToolLoaderProps {
   tools: MCPTool[]
   hasActiveMCPServers: boolean
   selectedModelHasTools: boolean
-  initialMessage?: boolean
   MCPToolComponent?: ComponentType<MCPToolComponentProps> | null
 }
 
@@ -15,45 +13,20 @@ export const McpExtensionToolLoader = ({
   tools,
   hasActiveMCPServers,
   selectedModelHasTools,
-  initialMessage,
   MCPToolComponent,
 }: McpExtensionToolLoaderProps) => {
-  // Get tool management hooks
-  const { isToolDisabled, setToolDisabledForThread, setDefaultDisabledTools, getDefaultDisabledTools } = useToolAvailable()
-  const { getCurrentThread } = useThreads()
-  const currentThread = getCurrentThread()
+  const { isToolDisabled, setToolDisabled } = useToolAvailable()
 
-  // Handle tool toggle for custom component
   const handleToolToggle = (toolName: string, enabled: boolean) => {
-    const tool = tools.find(t => t.name === toolName)
+    const tool = tools.find((t) => t.name === toolName)
     if (!tool) return
-
-    const toolKey = `${tool.server}::${toolName}`
-
-    if (initialMessage) {
-      const currentDefaults = getDefaultDisabledTools()
-      if (enabled) {
-        setDefaultDisabledTools(currentDefaults.filter((key) => key !== toolKey))
-      } else {
-        setDefaultDisabledTools([...currentDefaults, toolKey])
-      }
-    } else if (currentThread?.id) {
-      setToolDisabledForThread(currentThread.id, tool.server, toolName, enabled)
-    }
+    setToolDisabled(tool.server, toolName, enabled)
   }
 
   const isToolEnabled = (toolName: string): boolean => {
-    const tool = tools.find(t => t.name === toolName)
+    const tool = tools.find((t) => t.name === toolName)
     if (!tool) return false
-
-    const toolKey = `${tool.server}::${toolName}`
-
-    if (initialMessage) {
-      return !getDefaultDisabledTools().includes(toolKey)
-    } else if (currentThread?.id) {
-      return !isToolDisabled(currentThread.id, tool.server, toolName)
-    }
-    return false
+    return !isToolDisabled(tool.server, toolName)
   }
 
   // Only render if we have the custom MCP component and conditions are met

--- a/web-app/src/containers/dialogs/DeleteProvider.tsx
+++ b/web-app/src/containers/dialogs/DeleteProvider.tsx
@@ -14,6 +14,7 @@ import { toast } from 'sonner'
 import { CardItem } from '../Card'
 import { EngineManager } from '@janhq/core'
 import { useModelProvider } from '@/hooks/useModelProvider'
+import { useServiceHub } from '@/hooks/useServiceHub'
 import { useRouter } from '@tanstack/react-router'
 import { route } from '@/constants/routes'
 import { useTranslation } from '@/i18n/react-i18next-compat'
@@ -27,6 +28,7 @@ const DeleteProvider = ({ provider }: Props) => {
   const { t } = useTranslation()
   const { deleteProvider, providers } = useModelProvider()
   const { favoriteModels, removeFavorite } = useFavoriteModel()
+  const serviceHub = useServiceHub()
   const router = useRouter()
   if (
     !provider ||
@@ -45,6 +47,9 @@ const DeleteProvider = ({ provider }: Props) => {
     })
 
     deleteProvider(provider.provider)
+    // Removing a custom provider is an explicit user action, so purge its
+    // stored keyring secret too (boot reconciliation never does this).
+    serviceHub.providers().deleteProviderKeys(provider.provider)
     toast.success(t('providers:deleteProvider.title'), {
       id: `delete-provider-${provider.provider}`,
       description: t('providers:deleteProvider.success', {

--- a/web-app/src/hooks/__tests__/stripProviderSecrets.test.ts
+++ b/web-app/src/hooks/__tests__/stripProviderSecrets.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('@/constants/localStorage', () => ({ localStorageKey: {} }))
+vi.mock('zustand/middleware', () => ({
+  persist: (fn: unknown) => fn,
+  createJSONStorage: () => ({}),
+}))
+vi.mock('@/lib/backendStorage', () => ({ backendStorage: {} }))
+
+import { stripProviderSecrets } from '../useModelProvider'
+
+const SECRET = 'sk-secret-key'
+const FALLBACK = 'sk-fallback-key'
+
+describe('stripProviderSecrets', () => {
+  it('removes the key chain from all four storage locations', () => {
+    const provider = {
+      provider: 'openai',
+      active: true,
+      base_url: 'https://api.openai.com/v1',
+      api_key: SECRET,
+      api_key_fallbacks: [FALLBACK],
+      models: [],
+      settings: [
+        {
+          key: 'api-key',
+          controller_props: { value: SECRET, type: 'password' },
+        },
+        {
+          key: 'api-key-fallbacks',
+          controller_props: { value: `${SECRET}\n${FALLBACK}` },
+        },
+        { key: 'base-url', controller_props: { value: 'https://x' } },
+      ],
+    } as unknown as ModelProvider
+
+    const stripped = stripProviderSecrets(provider)
+
+    expect(stripped.api_key).toBeUndefined()
+    expect(stripped.api_key_fallbacks).toBeUndefined()
+    const serialized = JSON.stringify(stripped)
+    expect(serialized).not.toContain(SECRET)
+    expect(serialized).not.toContain(FALLBACK)
+
+    // Non-secret settings and config are preserved.
+    const baseUrl = stripped.settings?.find((s) => s.key === 'base-url')
+    expect(baseUrl?.controller_props.value).toBe('https://x')
+    expect(stripped.base_url).toBe('https://api.openai.com/v1')
+    expect(stripped.active).toBe(true)
+  })
+
+  it('does not mutate the input provider', () => {
+    const provider = {
+      provider: 'openai',
+      api_key: SECRET,
+      settings: [{ key: 'api-key', controller_props: { value: SECRET } }],
+      models: [],
+    } as unknown as ModelProvider
+
+    stripProviderSecrets(provider)
+    expect(provider.api_key).toBe(SECRET)
+    expect(provider.settings?.[0].controller_props.value).toBe(SECRET)
+  })
+
+  it('handles a provider with no settings array', () => {
+    const provider = {
+      provider: 'custom',
+      api_key: SECRET,
+      models: [],
+    } as unknown as ModelProvider
+    const stripped = stripProviderSecrets(provider)
+    expect(stripped.api_key).toBeUndefined()
+  })
+})

--- a/web-app/src/hooks/__tests__/useGeneralSetting.coverage.test.ts
+++ b/web-app/src/hooks/__tests__/useGeneralSetting.coverage.test.ts
@@ -26,6 +26,12 @@ vi.mock('@/lib/extension', () => ({
   },
 }))
 
+vi.mock('@/hooks/useServiceHub', () => ({
+  getServiceHub: () => ({
+    core: () => ({ invoke: vi.fn().mockResolvedValue(undefined) }),
+  }),
+}))
+
 describe('useGeneralSetting - coverage improvements', () => {
   let mockExtensionManager: any
 

--- a/web-app/src/hooks/__tests__/useGeneralSetting.test.ts
+++ b/web-app/src/hooks/__tests__/useGeneralSetting.test.ts
@@ -26,6 +26,12 @@ vi.mock('@/lib/extension', () => ({
   },
 }))
 
+// Mock ServiceHub (setHuggingfaceToken persists to the keyring via set_secret)
+const mockInvoke = vi.fn().mockResolvedValue(undefined)
+vi.mock('@/hooks/useServiceHub', () => ({
+  getServiceHub: () => ({ core: () => ({ invoke: mockInvoke }) }),
+}))
+
 describe('useGeneralSetting', () => {
   let mockExtensionManager: any
 
@@ -162,6 +168,10 @@ describe('useGeneralSetting', () => {
       })
 
       expect(result.current.huggingfaceToken).toBe('test-token-123')
+      expect(mockInvoke).toHaveBeenCalledWith('set_secret', {
+        key: 'huggingface',
+        value: 'test-token-123',
+      })
     })
 
     it('should update huggingface token', () => {

--- a/web-app/src/hooks/__tests__/useToolAvailable.coverage.test.ts
+++ b/web-app/src/hooks/__tests__/useToolAvailable.coverage.test.ts
@@ -1,14 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 
-vi.mock('@/lib/fileStorage', () => ({
-  fileStorage: {
-    getItem: vi.fn(() => Promise.resolve(null)),
-    setItem: vi.fn(() => Promise.resolve()),
-    removeItem: vi.fn(() => Promise.resolve()),
-  },
-}))
-
 vi.mock('@/constants/localStorage', () => ({
   localStorageKey: {
     toolAvailability: 'tool-availability-settings',
@@ -17,90 +9,58 @@ vi.mock('@/constants/localStorage', () => ({
 
 import { useToolAvailable } from '../useToolAvailable'
 
+type Migrate = (state: unknown, version: number) => any
+
+const getMigrate = (): Migrate | undefined =>
+  (useToolAvailable as any).persist?.getOptions().migrate
+
 describe('useToolAvailable - coverage', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    useToolAvailable.setState({
-      disabledTools: {},
-      defaultDisabledTools: [],
-      defaultsInitialized: false,
-    })
+    useToolAvailable.setState({ disabledTools: [], defaultsInitialized: false })
   })
 
-  it('isDefaultsInitialized should return false initially', () => {
+  it('isDefaultsInitialized starts false; mark flips it', () => {
     const { result } = renderHook(() => useToolAvailable())
     expect(result.current.isDefaultsInitialized()).toBe(false)
-  })
-
-  it('markDefaultsAsInitialized should set flag', () => {
-    const { result } = renderHook(() => useToolAvailable())
-
-    act(() => {
-      result.current.markDefaultsAsInitialized()
-    })
-
+    act(() => result.current.markDefaultsAsInitialized())
     expect(result.current.isDefaultsInitialized()).toBe(true)
   })
 
-  it('should test migrate function with old format keys', () => {
-    const persistApi = (useToolAvailable as any).persist
-    const migrate = persistApi?.getOptions().migrate as
-      | ((state: unknown, version: number) => any)
-      | undefined
-
-    if (migrate) {
-      const oldState = {
-        disabledTools: { 't1': ['oldTool'] },
-        defaultDisabledTools: ['oldDefault'],
-        defaultsInitialized: true,
-      }
-      const migrated = migrate(oldState)
-      expect(migrated.disabledTools).toEqual({})
-      expect(migrated.defaultDisabledTools).toEqual([])
-      expect(migrated.defaultsInitialized).toBe(false)
-    }
-  })
-
-  it('should test migrate function with new format keys', () => {
-    const persistApi = (useToolAvailable as any).persist
-    const migrate = persistApi?.getOptions().migrate as
-      | ((state: unknown, version: number) => any)
-      | undefined
-
-    if (migrate) {
-      const newState = {
-        disabledTools: { 't1': ['server::tool'] },
-        defaultDisabledTools: ['server::default'],
-        defaultsInitialized: true,
-      }
-      const migrated = migrate(newState)
-      expect(migrated.disabledTools).toEqual({ 't1': ['server::tool'] })
-      expect(migrated.defaultDisabledTools).toEqual(['server::default'])
+  describe('v1 -> v2 migration (per-thread -> global)', () => {
+    it('collapses onto the previous global default and drops per-thread overrides', () => {
+      const migrate = getMigrate()!
+      const migrated = migrate(
+        {
+          disabledTools: { t1: ['exa::web_search_exa'] },
+          defaultDisabledTools: ['exa::web_fetch_exa'],
+          defaultsInitialized: true,
+        },
+        1
+      )
+      expect(migrated.disabledTools).toEqual(['exa::web_fetch_exa'])
       expect(migrated.defaultsInitialized).toBe(true)
-    }
-  })
+    })
 
-  it('should test migrate with null state', () => {
-    const persistApi = (useToolAvailable as any).persist
-    const migrate = persistApi?.getOptions().migrate as
-      | ((state: unknown, version: number) => any)
-      | undefined
+    it('re-seeds (defaultsInitialized=false) when old pre-:: keys are dropped', () => {
+      const migrate = getMigrate()!
+      const migrated = migrate(
+        { defaultDisabledTools: ['legacyTool'], defaultsInitialized: true },
+        1
+      )
+      expect(migrated.disabledTools).toEqual([])
+      expect(migrated.defaultsInitialized).toBe(false)
+    })
 
-    if (migrate) {
-      const migrated = migrate(null)
-      expect(migrated).toBeNull()
-    }
-  })
+    it('null/empty persisted state migrates to an empty global set', () => {
+      const migrate = getMigrate()!
+      expect(migrate(null, 1).disabledTools).toEqual([])
+    })
 
-  it('should test migrate with non-object state', () => {
-    const persistApi = (useToolAvailable as any).persist
-    const migrate = persistApi?.getOptions().migrate as
-      | ((state: unknown, version: number) => any)
-      | undefined
-
-    if (migrate) {
-      const migrated = migrate('string')
-      expect(migrated).toBe('string')
-    }
+    it('a v2 state passes through unchanged', () => {
+      const migrate = getMigrate()!
+      const state = { disabledTools: ['a::b'], defaultsInitialized: true }
+      expect(migrate(state, 2)).toEqual(state)
+    })
   })
 })

--- a/web-app/src/hooks/__tests__/useToolAvailable.test.ts
+++ b/web-app/src/hooks/__tests__/useToolAvailable.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
-import { useToolAvailable } from '../useToolAvailable'
-import type { MCPTool } from '@/types/completion'
+import { useToolAvailable, createToolKey } from '../useToolAvailable'
 
 // Mock constants
 vi.mock('@/constants/localStorage', () => ({
@@ -10,7 +9,7 @@ vi.mock('@/constants/localStorage', () => ({
   },
 }))
 
-// Mock zustand persist
+// Mock zustand persist to a passthrough so the store is fully in-memory.
 vi.mock('zustand/middleware', () => ({
   persist: (fn: any) => fn,
   createJSONStorage: () => ({
@@ -20,401 +19,109 @@ vi.mock('zustand/middleware', () => ({
   }),
 }))
 
-describe('useToolAvailable', () => {
+const SERVER = 'exa'
+const TOOL = 'web_search_exa'
+const KEY = createToolKey(SERVER, TOOL)
+
+describe('useToolAvailable (global tool availability)', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    // Reset store state to defaults
-    useToolAvailable.setState({
-      disabledTools: {},
-      defaultDisabledTools: [],
-    })
+    useToolAvailable.setState({ disabledTools: [], defaultsInitialized: false })
   })
 
-  it('should initialize with default values', () => {
+  it('initializes with an empty global disabled set', () => {
     const { result } = renderHook(() => useToolAvailable())
-
-    expect(result.current.disabledTools).toEqual({})
-    expect(result.current.defaultDisabledTools).toEqual([])
-    expect(typeof result.current.setToolDisabledForThread).toBe('function')
+    expect(result.current.disabledTools).toEqual([])
+    expect(typeof result.current.setToolDisabled).toBe('function')
     expect(typeof result.current.isToolDisabled).toBe('function')
-    expect(typeof result.current.getDisabledToolsForThread).toBe('function')
-    expect(typeof result.current.setDefaultDisabledTools).toBe('function')
-    expect(typeof result.current.getDefaultDisabledTools).toBe('function')
-    expect(typeof result.current.initializeThreadTools).toBe('function')
+    expect(typeof result.current.getDisabledTools).toBe('function')
+    expect(typeof result.current.setDisabledTools).toBe('function')
   })
 
-  describe('setToolDisabledForThread', () => {
-    it('should disable a tool for a thread', () => {
+  it('createToolKey builds a server::tool composite key', () => {
+    expect(createToolKey('s', 't')).toBe('s::t')
+  })
+
+  describe('setToolDisabled', () => {
+    it('disables a tool globally', () => {
       const { result } = renderHook(() => useToolAvailable())
-
-      act(() => {
-        result.current.setToolDisabledForThread('thread-1', 'server-1', 'tool-a', false)
-      })
-
-      expect(result.current.disabledTools['thread-1']).toContain('server-1::tool-a')
+      act(() => result.current.setToolDisabled(SERVER, TOOL, false))
+      expect(result.current.disabledTools).toEqual([KEY])
+      expect(result.current.isToolDisabled(SERVER, TOOL)).toBe(true)
     })
 
-    it('should enable a tool for a thread', () => {
+    it('re-enables a disabled tool', () => {
       const { result } = renderHook(() => useToolAvailable())
-
-      // First disable the tool
-      act(() => {
-        result.current.setToolDisabledForThread('thread-1', 'server-1', 'tool-a', false)
-      })
-
-      expect(result.current.disabledTools['thread-1']).toContain('server-1::tool-a')
-
-      // Then enable the tool
-      act(() => {
-        result.current.setToolDisabledForThread('thread-1', 'server-1', 'tool-a', true)
-      })
-
-      expect(result.current.disabledTools['thread-1']).not.toContain('server-1::tool-a')
+      act(() => result.current.setToolDisabled(SERVER, TOOL, false))
+      act(() => result.current.setToolDisabled(SERVER, TOOL, true))
+      expect(result.current.disabledTools).toEqual([])
+      expect(result.current.isToolDisabled(SERVER, TOOL)).toBe(false)
     })
 
-    it('should handle multiple tools for same thread', () => {
+    it('does not duplicate an already-disabled tool', () => {
       const { result } = renderHook(() => useToolAvailable())
-
-      act(() => {
-        result.current.setToolDisabledForThread('thread-1', 'server-1', 'tool-a', false)
-        result.current.setToolDisabledForThread('thread-1', 'server-1', 'tool-b', false)
-        result.current.setToolDisabledForThread('thread-1', 'server-1', 'tool-c', false)
-      })
-
-      expect(result.current.disabledTools['thread-1']).toEqual(['server-1::tool-a', 'server-1::tool-b', 'server-1::tool-c'])
+      act(() => result.current.setToolDisabled(SERVER, TOOL, false))
+      act(() => result.current.setToolDisabled(SERVER, TOOL, false))
+      expect(result.current.disabledTools).toEqual([KEY])
     })
 
-    it('should handle multiple threads independently', () => {
+    it('enabling a tool that was never disabled is a no-op', () => {
       const { result } = renderHook(() => useToolAvailable())
-
-      act(() => {
-        result.current.setToolDisabledForThread('thread-1', 'server-1', 'tool-a', false)
-        result.current.setToolDisabledForThread('thread-2', 'server-1', 'tool-b', false)
-        result.current.setToolDisabledForThread('thread-3', 'server-1', 'tool-c', false)
-      })
-
-      expect(result.current.disabledTools['thread-1']).toEqual(['server-1::tool-a'])
-      expect(result.current.disabledTools['thread-2']).toEqual(['server-1::tool-b'])
-      expect(result.current.disabledTools['thread-3']).toEqual(['server-1::tool-c'])
+      act(() => result.current.setToolDisabled(SERVER, TOOL, true))
+      expect(result.current.disabledTools).toEqual([])
     })
 
-    it('should add duplicate tools when disabling already disabled tool', () => {
+    it('tracks multiple tools independently', () => {
       const { result } = renderHook(() => useToolAvailable())
-
       act(() => {
-        result.current.setToolDisabledForThread('thread-1', 'server-1', 'tool-a', false)
-        result.current.setToolDisabledForThread('thread-1', 'server-1', 'tool-a', false)
+        result.current.setToolDisabled(SERVER, 'a', false)
+        result.current.setToolDisabled(SERVER, 'b', false)
       })
-
-      expect(result.current.disabledTools['thread-1']).toEqual(['server-1::tool-a', 'server-1::tool-a'])
-    })
-
-    it('should handle enabling tool that was not disabled', () => {
-      const { result } = renderHook(() => useToolAvailable())
-
-      act(() => {
-        result.current.setToolDisabledForThread('thread-1', 'server-1', 'tool-a', true)
-      })
-
-      expect(result.current.disabledTools['thread-1']).toEqual([])
+      expect(result.current.disabledTools).toEqual([
+        createToolKey(SERVER, 'a'),
+        createToolKey(SERVER, 'b'),
+      ])
+      act(() => result.current.setToolDisabled(SERVER, 'a', true))
+      expect(result.current.disabledTools).toEqual([createToolKey(SERVER, 'b')])
     })
   })
 
-  describe('isToolDisabled', () => {
-    it('should return false for enabled tools', () => {
+  describe('isToolDisabled / getDisabledTools', () => {
+    it('a tool absent from the set is enabled', () => {
       const { result } = renderHook(() => useToolAvailable())
-
-      const isDisabled = result.current.isToolDisabled('thread-1', 'server-1', 'tool-a')
-      expect(isDisabled).toBe(false)
+      expect(result.current.isToolDisabled(SERVER, TOOL)).toBe(false)
     })
 
-    it('should return true for disabled tools', () => {
+    it('getDisabledTools returns the global array', () => {
       const { result } = renderHook(() => useToolAvailable())
-
-      act(() => {
-        result.current.setToolDisabledForThread('thread-1', 'server-1', 'tool-a', false)
-      })
-
-      const isDisabled = result.current.isToolDisabled('thread-1', 'server-1', 'tool-a')
-      expect(isDisabled).toBe(true)
-    })
-
-    it('should use default disabled tools for new threads', () => {
-      const { result } = renderHook(() => useToolAvailable())
-
-      act(() => {
-        result.current.setDefaultDisabledTools(['server-1::tool-default'])
-      })
-
-      const isDisabled = result.current.isToolDisabled('new-thread', 'server-1', 'tool-default')
-      expect(isDisabled).toBe(true)
-    })
-
-    it('should return false for tools not in default disabled list', () => {
-      const { result } = renderHook(() => useToolAvailable())
-
-      act(() => {
-        result.current.setDefaultDisabledTools(['server-1::tool-default'])
-      })
-
-      const isDisabled = result.current.isToolDisabled('new-thread', 'server-1', 'tool-other')
-      expect(isDisabled).toBe(false)
-    })
-
-    it('should prioritize thread-specific settings over defaults', () => {
-      const { result } = renderHook(() => useToolAvailable())
-
-      act(() => {
-        result.current.setDefaultDisabledTools(['server-1::tool-default'])
-        result.current.setToolDisabledForThread('thread-1', 'server-1', 'tool-default', true)
-      })
-
-      const isDisabled = result.current.isToolDisabled('thread-1', 'server-1', 'tool-default')
-      expect(isDisabled).toBe(false)
+      act(() => result.current.setDisabledTools([KEY]))
+      expect(result.current.getDisabledTools()).toEqual([KEY])
     })
   })
 
-  describe('getDisabledToolsForThread', () => {
-    it('should return empty array for thread with no disabled tools', () => {
+  describe('setDisabledTools (defaults seed)', () => {
+    it('replaces the whole set', () => {
       const { result } = renderHook(() => useToolAvailable())
-
-      const disabledTools = result.current.getDisabledToolsForThread('thread-1')
-      expect(disabledTools).toEqual([])
-    })
-
-    it('should return disabled tools for thread', () => {
-      const { result } = renderHook(() => useToolAvailable())
-
-      act(() => {
-        result.current.setToolDisabledForThread('thread-1', 'server-1', 'tool-a', false)
-        result.current.setToolDisabledForThread('thread-1', 'server-1', 'tool-b', false)
-      })
-
-      const disabledTools = result.current.getDisabledToolsForThread('thread-1')
-      expect(disabledTools).toEqual(['server-1::tool-a', 'server-1::tool-b'])
-    })
-
-    it('should return default disabled tools for new threads', () => {
-      const { result } = renderHook(() => useToolAvailable())
-
-      act(() => {
-        result.current.setDefaultDisabledTools(['server-1::tool-default-1', 'server-1::tool-default-2'])
-      })
-
-      const disabledTools = result.current.getDisabledToolsForThread('new-thread')
-      expect(disabledTools).toEqual(['server-1::tool-default-1', 'server-1::tool-default-2'])
-    })
-
-    it('should return thread-specific tools even when defaults exist', () => {
-      const { result } = renderHook(() => useToolAvailable())
-
-      act(() => {
-        result.current.setDefaultDisabledTools(['server-1::tool-default'])
-        result.current.setToolDisabledForThread('thread-1', 'server-1', 'tool-specific', false)
-      })
-
-      const disabledTools = result.current.getDisabledToolsForThread('thread-1')
-      expect(disabledTools).toEqual(['server-1::tool-specific'])
+      act(() => result.current.setDisabledTools(['a::1', 'b::2']))
+      expect(result.current.disabledTools).toEqual(['a::1', 'b::2'])
+      act(() => result.current.setDisabledTools([]))
+      expect(result.current.disabledTools).toEqual([])
     })
   })
 
-  describe('setDefaultDisabledTools', () => {
-    it('should set default disabled tools', () => {
+  describe('defaults-initialized flag', () => {
+    it('starts false and flips once marked', () => {
       const { result } = renderHook(() => useToolAvailable())
-
-      act(() => {
-        result.current.setDefaultDisabledTools(['server-1::tool-1', 'server-1::tool-2', 'server-1::tool-3'])
-      })
-
-      expect(result.current.defaultDisabledTools).toEqual(['server-1::tool-1', 'server-1::tool-2', 'server-1::tool-3'])
-    })
-
-    it('should replace existing default disabled tools', () => {
-      const { result } = renderHook(() => useToolAvailable())
-
-      act(() => {
-        result.current.setDefaultDisabledTools(['server-1::tool-1', 'server-1::tool-2'])
-      })
-
-      expect(result.current.defaultDisabledTools).toEqual(['server-1::tool-1', 'server-1::tool-2'])
-
-      act(() => {
-        result.current.setDefaultDisabledTools(['server-1::tool-3', 'server-1::tool-4'])
-      })
-
-      expect(result.current.defaultDisabledTools).toEqual(['server-1::tool-3', 'server-1::tool-4'])
-    })
-
-    it('should handle empty array', () => {
-      const { result } = renderHook(() => useToolAvailable())
-
-      act(() => {
-        result.current.setDefaultDisabledTools(['server-1::tool-1'])
-      })
-
-      expect(result.current.defaultDisabledTools).toEqual(['server-1::tool-1'])
-
-      act(() => {
-        result.current.setDefaultDisabledTools([])
-      })
-
-      expect(result.current.defaultDisabledTools).toEqual([])
+      expect(result.current.isDefaultsInitialized()).toBe(false)
+      act(() => result.current.markDefaultsAsInitialized())
+      expect(result.current.isDefaultsInitialized()).toBe(true)
     })
   })
 
-  describe('getDefaultDisabledTools', () => {
-    it('should return default disabled tools', () => {
-      const { result } = renderHook(() => useToolAvailable())
-
-      act(() => {
-        result.current.setDefaultDisabledTools(['server-1::tool-1', 'server-1::tool-2'])
-      })
-
-      const defaultTools = result.current.getDefaultDisabledTools()
-      expect(defaultTools).toEqual(['server-1::tool-1', 'server-1::tool-2'])
-    })
-
-    it('should return empty array when no defaults set', () => {
-      const { result } = renderHook(() => useToolAvailable())
-
-      const defaultTools = result.current.getDefaultDisabledTools()
-      expect(defaultTools).toEqual([])
-    })
-  })
-
-  describe('initializeThreadTools', () => {
-    it('should initialize thread with default tools', () => {
-      const { result } = renderHook(() => useToolAvailable())
-
-      const allTools: MCPTool[] = [
-        { name: 'tool-1', description: 'Tool 1', inputSchema: {}, server: 'server-1' },
-        { name: 'tool-2', description: 'Tool 2', inputSchema: {}, server: 'server-1' },
-        { name: 'tool-3', description: 'Tool 3', inputSchema: {}, server: 'server-1' },
-      ]
-
-      act(() => {
-        result.current.setDefaultDisabledTools(['server-1::tool-1', 'server-1::tool-3'])
-        result.current.initializeThreadTools('new-thread', allTools)
-      })
-
-      expect(result.current.disabledTools['new-thread']).toEqual(['server-1::tool-1', 'server-1::tool-3'])
-    })
-
-    it('should not override existing thread settings', () => {
-      const { result } = renderHook(() => useToolAvailable())
-
-      const allTools: MCPTool[] = [
-        { name: 'tool-1', description: 'Tool 1', inputSchema: {}, server: 'server-1' },
-        { name: 'tool-2', description: 'Tool 2', inputSchema: {}, server: 'server-1' },
-      ]
-
-      act(() => {
-        result.current.setDefaultDisabledTools(['server-1::tool-1'])
-        result.current.setToolDisabledForThread('existing-thread', 'server-1', 'tool-2', false)
-        result.current.initializeThreadTools('existing-thread', allTools)
-      })
-
-      expect(result.current.disabledTools['existing-thread']).toEqual(['server-1::tool-2'])
-    })
-
-    it('should filter default tools to only include existing tools', () => {
-      const { result } = renderHook(() => useToolAvailable())
-
-      const allTools: MCPTool[] = [
-        { name: 'tool-1', description: 'Tool 1', inputSchema: {}, server: 'server-1' },
-        { name: 'tool-2', description: 'Tool 2', inputSchema: {}, server: 'server-1' },
-      ]
-
-      act(() => {
-        result.current.setDefaultDisabledTools(['server-1::tool-1', 'server-1::tool-nonexistent', 'server-1::tool-2'])
-        result.current.initializeThreadTools('new-thread', allTools)
-      })
-
-      expect(result.current.disabledTools['new-thread']).toEqual(['server-1::tool-1', 'server-1::tool-2'])
-    })
-
-    it('should handle empty default tools', () => {
-      const { result } = renderHook(() => useToolAvailable())
-
-      const allTools: MCPTool[] = [
-        { name: 'tool-1', description: 'Tool 1', inputSchema: {}, server: 'server-1' },
-      ]
-
-      act(() => {
-        result.current.setDefaultDisabledTools([])
-        result.current.initializeThreadTools('new-thread', allTools)
-      })
-
-      expect(result.current.disabledTools['new-thread']).toEqual([])
-    })
-
-    it('should handle empty tools array', () => {
-      const { result } = renderHook(() => useToolAvailable())
-
-      act(() => {
-        result.current.setDefaultDisabledTools(['server-1::tool-1'])
-        result.current.initializeThreadTools('new-thread', [])
-      })
-
-      expect(result.current.disabledTools['new-thread']).toEqual([])
-    })
-  })
-
-  describe('state management', () => {
-    it('should maintain state across multiple hook instances', () => {
-      const { result: result1 } = renderHook(() => useToolAvailable())
-      const { result: result2 } = renderHook(() => useToolAvailable())
-
-      act(() => {
-        result1.current.setDefaultDisabledTools(['server-1::tool-default'])
-        result1.current.setToolDisabledForThread('thread-1', 'server-1', 'tool-specific', false)
-      })
-
-      expect(result2.current.defaultDisabledTools).toEqual(['server-1::tool-default'])
-      expect(result2.current.disabledTools['thread-1']).toEqual(['server-1::tool-specific'])
-    })
-  })
-
-  describe('complex scenarios', () => {
-    it('should handle complete tool management workflow', () => {
-      const { result } = renderHook(() => useToolAvailable())
-
-      const allTools: MCPTool[] = [
-        { name: 'tool-a', description: 'Tool A', inputSchema: {}, server: 'test-server' },
-        { name: 'tool-b', description: 'Tool B', inputSchema: {}, server: 'test-server' },
-        { name: 'tool-c', description: 'Tool C', inputSchema: {}, server: 'test-server' },
-      ]
-
-      // Set default disabled tools (using composite keys)
-      act(() => {
-        result.current.setDefaultDisabledTools(['test-server::tool-a', 'test-server::tool-b'])
-      })
-
-      // Initialize thread with defaults
-      act(() => {
-        result.current.initializeThreadTools('thread-1', allTools)
-      })
-
-      expect(result.current.disabledTools['thread-1']).toEqual(['test-server::tool-a', 'test-server::tool-b'])
-
-      // Enable tool-a for thread-1
-      act(() => {
-        result.current.setToolDisabledForThread('thread-1', 'test-server', 'tool-a', true)
-      })
-
-      expect(result.current.disabledTools['thread-1']).toEqual(['test-server::tool-b'])
-
-      // Disable tool-c for thread-1
-      act(() => {
-        result.current.setToolDisabledForThread('thread-1', 'test-server', 'tool-c', false)
-      })
-
-      expect(result.current.disabledTools['thread-1']).toEqual(['test-server::tool-b', 'test-server::tool-c'])
-
-      // Verify tool states
-      expect(result.current.isToolDisabled('thread-1', 'test-server', 'tool-a')).toBe(false)
-      expect(result.current.isToolDisabled('thread-1', 'test-server', 'tool-b')).toBe(true)
-      expect(result.current.isToolDisabled('thread-1', 'test-server', 'tool-c')).toBe(true)
-    })
+  it('shares one global set across hook instances (no per-thread split)', () => {
+    const a = renderHook(() => useToolAvailable())
+    const b = renderHook(() => useToolAvailable())
+    act(() => a.result.current.setToolDisabled(SERVER, TOOL, false))
+    expect(b.result.current.isToolDisabled(SERVER, TOOL)).toBe(true)
   })
 })

--- a/web-app/src/hooks/useAgentMode.ts
+++ b/web-app/src/hooks/useAgentMode.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { localStorageKey } from '@/constants/localStorage'
+import { backendStorage } from '@/lib/backendStorage'
 
 type AgentModeState = {
   /** Map of threadId → agent mode enabled */
@@ -55,7 +56,8 @@ export const useAgentMode = create<AgentModeState>()(
     }),
     {
       name: localStorageKey.agentMode,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => backendStorage),
+      skipHydration: true,
     }
   )
 )

--- a/web-app/src/hooks/useAnalytic.ts
+++ b/web-app/src/hooks/useAnalytic.ts
@@ -1,6 +1,7 @@
 import { localStorageKey } from '@/constants/localStorage'
 import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
+import { backendStorage } from '@/lib/backendStorage'
 
 export const useAnalytic = () => {
   const { productAnalyticPrompt, setProductAnalyticPrompt } =
@@ -46,7 +47,8 @@ export const useProductAnalyticPrompt = create<ProductAnalyticPromptState>()(
     },
     {
       name: localStorageKey.productAnalyticPrompt,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => backendStorage),
+      skipHydration: true,
     }
   )
 )
@@ -70,7 +72,8 @@ export const useProductAnalytic = create<ProductAnalyticState>()(
     },
     {
       name: localStorageKey.productAnalytic,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => backendStorage),
+      skipHydration: true,
     }
   )
 )

--- a/web-app/src/hooks/useDefaultEmbeddingModel.ts
+++ b/web-app/src/hooks/useDefaultEmbeddingModel.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { localStorageKey } from '@/constants/localStorage'
+import { backendStorage } from '@/lib/backendStorage'
 
 interface DefaultEmbeddingModelState {
   defaultByProvider: Record<string, string>
@@ -30,7 +31,8 @@ export const useDefaultEmbeddingModel = create<DefaultEmbeddingModelState>()(
     }),
     {
       name: localStorageKey.defaultEmbeddingModel,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => backendStorage),
+      skipHydration: true,
     }
   )
 )

--- a/web-app/src/hooks/useDownloadStore.ts
+++ b/web-app/src/hooks/useDownloadStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { localStorageKey } from '@/constants/localStorage'
+import { backendStorage } from '@/lib/backendStorage'
 
 export interface DownloadProgressProps {
   id: string
@@ -107,7 +108,8 @@ export const useDownloadStore = create<DownloadState>()(
     }),
     {
       name: localStorageKey.pausedDownloads,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => backendStorage),
+      skipHydration: true,
       partialize: (state) => {
         const downloads: { [id: string]: DownloadProgressProps } = {}
         const resumeParams: { [id: string]: DownloadResumeParams } = {}

--- a/web-app/src/hooks/useFavoriteModel.ts
+++ b/web-app/src/hooks/useFavoriteModel.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { localStorageKey } from '@/constants/localStorage'
+import { backendStorage } from '@/lib/backendStorage'
 
 interface FavoriteModelState {
   favoriteModels: Model[]
@@ -47,7 +48,8 @@ export const useFavoriteModel = create<FavoriteModelState>()(
     }),
     {
       name: localStorageKey.favoriteModels,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => backendStorage),
+      skipHydration: true,
     }
   )
 )

--- a/web-app/src/hooks/useGeneralSetting.ts
+++ b/web-app/src/hooks/useGeneralSetting.ts
@@ -1,7 +1,11 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { localStorageKey } from '@/constants/localStorage'
+import { backendStorage } from '@/lib/backendStorage'
+import { getServiceHub } from '@/hooks/useServiceHub'
 import { ExtensionManager } from '@/lib/extension'
+
+export const HUGGINGFACE_TOKEN_SECRET_KEY = 'huggingface'
 type GeneralSettingState = {
   currentLanguage: Language
   spellCheckChatInput: boolean
@@ -29,6 +33,16 @@ export const useGeneralSetting = create<GeneralSettingState>()(
       setCurrentLanguage: (value) => set({ currentLanguage: value }),
       setHuggingfaceToken: (token) => {
         set({ huggingfaceToken: token })
+        // Canonical secret store is the OS keyring, not settings storage.
+        getServiceHub()
+          .core()
+          .invoke('set_secret', {
+            key: HUGGINGFACE_TOKEN_SECRET_KEY,
+            value: token,
+          })
+          .catch((err) =>
+            console.warn('Failed to persist huggingface token to keyring:', err)
+          )
         ExtensionManager.getInstance()
           .getByName('@janhq/download-extension')
           ?.getSettings()
@@ -52,7 +66,15 @@ export const useGeneralSetting = create<GeneralSettingState>()(
     }),
     {
       name: localStorageKey.settingGeneral,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => backendStorage),
+      skipHydration: true,
+      // huggingfaceToken is a secret — kept in the OS keyring, never persisted here.
+      partialize: (state) => ({
+        currentLanguage: state.currentLanguage,
+        spellCheckChatInput: state.spellCheckChatInput,
+        tokenCounterCompact: state.tokenCounterCompact,
+        autoUpdateCheck: state.autoUpdateCheck,
+      }),
     }
   )
 )

--- a/web-app/src/hooks/useHardware.ts
+++ b/web-app/src/hooks/useHardware.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { localStorageKey } from '@/constants/localStorage'
+import { backendStorage } from '@/lib/backendStorage'
 
 // Hardware data types
 export interface CPU {
@@ -209,7 +210,8 @@ export const useHardware = create<HardwareStore>()(
     }),
     {
       name: localStorageKey.settingHardware,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => backendStorage),
+      skipHydration: true,
     }
   )
 )

--- a/web-app/src/hooks/useInterfaceSettings.ts
+++ b/web-app/src/hooks/useInterfaceSettings.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { localStorageKey } from '@/constants/localStorage'
+import { backendStorage } from '@/lib/backendStorage'
 import { useTheme } from './useTheme'
 import {
   getDefaultNotificationPosition,
@@ -156,8 +157,8 @@ const createDefaultInterfaceValues = (): InterfaceSettingsPersistedSlice => {
   }
 }
 
-const interfaceStorage = createJSONStorage<InterfaceSettingsPersistedSlice>(() =>
-  localStorage
+const interfaceStorage = createJSONStorage<InterfaceSettingsPersistedSlice>(
+  () => backendStorage
 )
 
 export const useInterfaceSettings = create<InterfaceSettingsState>()(
@@ -236,6 +237,7 @@ export const useInterfaceSettings = create<InterfaceSettingsState>()(
     {
       name: localStorageKey.settingInterface,
       storage: interfaceStorage,
+      skipHydration: true,
       partialize: (state) => ({
         fontSize: state.fontSize,
         accentColor: state.accentColor,

--- a/web-app/src/hooks/useJanModelPrompt.ts
+++ b/web-app/src/hooks/useJanModelPrompt.ts
@@ -6,6 +6,7 @@ import { useDownloadStore } from './useDownloadStore'
 import { useLatestJanModel } from './useLatestJanModel'
 import { predefinedProviders } from '@/constants/providers'
 import { providerHasRemoteApiKeys } from '@/lib/provider-api-keys'
+import { backendStorage } from '@/lib/backendStorage'
 
 export type JanModelPromptDismissedState = {
   dismissedModelName: string | null
@@ -22,7 +23,8 @@ export const useJanModelPromptDismissed =
       }),
       {
         name: localStorageKey.janModelPromptDismissed,
-        storage: createJSONStorage(() => localStorage),
+        storage: createJSONStorage(() => backendStorage),
+        skipHydration: true,
         version: 1,
         migrate: (persistedState: unknown) => {
           const state = persistedState as Record<string, unknown>

--- a/web-app/src/hooks/useLatestJanModel.ts
+++ b/web-app/src/hooks/useLatestJanModel.ts
@@ -3,6 +3,7 @@ import { persist, createJSONStorage } from 'zustand/middleware'
 import { localStorageKey, CACHE_EXPIRY_MS } from '@/constants/localStorage'
 import { getServiceHub } from '@/hooks/useServiceHub'
 import type { CatalogModel } from '@/services/models/types'
+import { backendStorage } from '@/lib/backendStorage'
 
 type LatestJanModelState = {
   model: CatalogModel | null
@@ -55,7 +56,8 @@ export const useLatestJanModel = create<LatestJanModelState>()(
     }),
     {
       name: localStorageKey.latestJanModel,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => backendStorage),
+      skipHydration: true,
       partialize: (state) => ({
         model: state.model,
         lastFetchedAt: state.lastFetchedAt,

--- a/web-app/src/hooks/useLeftPanel.ts
+++ b/web-app/src/hooks/useLeftPanel.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { localStorageKey } from '@/constants/localStorage'
+import { backendStorage } from '@/lib/backendStorage'
 
 type LeftPanelStoreState = {
   open: boolean
@@ -23,7 +24,8 @@ export const useLeftPanel = create<LeftPanelStoreState>()(
     }),
     {
       name: localStorageKey.LeftPanel,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => backendStorage),
+      skipHydration: true,
     }
   )
 )

--- a/web-app/src/hooks/useLocalApiServer.ts
+++ b/web-app/src/hooks/useLocalApiServer.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { localStorageKey } from '@/constants/localStorage'
+import { backendStorage } from '@/lib/backendStorage'
 
 type LocalApiServerState = {
   // Run local API server once app opens
@@ -85,7 +86,8 @@ export const useLocalApiServer = create<LocalApiServerState>()(
     }),
     {
       name: localStorageKey.settingLocalApiServer,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => backendStorage),
+      skipHydration: true,
       version: 3,
       migrate: (persistedState: unknown, version: number) => {
         const state = persistedState as Partial<LocalApiServerState>

--- a/web-app/src/hooks/useModelProvider.ts
+++ b/web-app/src/hooks/useModelProvider.ts
@@ -2,16 +2,31 @@ import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { localStorageKey } from '@/constants/localStorage'
 import { getServiceHub } from '@/hooks/useServiceHub'
+import { backendStorage } from '@/lib/backendStorage'
 import { modelSettings } from '@/lib/predefined'
 import { predefinedProviders } from '@/constants/providers'
 import { isLocalProvider } from '@/lib/utils'
-import {
-  API_KEY_FALLBACKS_SETTING_KEY,
-  parseApiKeyFallbacks,
-  serializeApiKeyFallbacks,
-} from '@/lib/provider-api-keys'
+import { API_KEY_FALLBACKS_SETTING_KEY } from '@/lib/provider-api-keys'
 
-const API_KEY_FALLBACKS_MIGRATION_FLAG = 'api_key_fallbacks_migrated_to_settings'
+const API_KEY_SETTING_KEY = 'api-key'
+
+// Secrets live only in the OS keyring (see register_provider_config), never in
+// persisted settings storage. Strip the key chain from every provider before it
+// is written to disk; the in-memory object keeps the keys (re-seeded from the
+// keyring at boot in DataProvider) so synchronous consumers still work.
+export function stripProviderSecrets(provider: ModelProvider): ModelProvider {
+  const settings = provider.settings?.map((s) =>
+    s.key === API_KEY_SETTING_KEY || s.key === API_KEY_FALLBACKS_SETTING_KEY
+      ? { ...s, controller_props: { ...s.controller_props, value: '' } }
+      : s
+  )
+  return {
+    ...provider,
+    api_key: undefined,
+    api_key_fallbacks: undefined,
+    ...(settings ? { settings } : {}),
+  }
+}
 
 type ModelProviderState = {
   providers: ModelProvider[]
@@ -191,43 +206,16 @@ export const useModelProvider = create<ModelProviderState>()(
               }
             })
 
-            // Preserve a zustand-only api-key-fallbacks setting when the
-            // backend doesn't return it, so disk-persisted fallbacks survive
-            // localStorage clears once they round-trip through updateSettings.
-            if (
-              !provider.persist &&
-              !mergedSettings.some((s) => s.key === API_KEY_FALLBACKS_SETTING_KEY)
-            ) {
-              const existingFallbacksSetting = existingProvider?.settings?.find(
-                (s) => s.key === API_KEY_FALLBACKS_SETTING_KEY
-              )
-              if (existingFallbacksSetting) {
-                mergedSettings.push(existingFallbacksSetting)
-              }
-            }
-
-            const fallbacksSetting = mergedSettings.find(
-              (s) => s.key === API_KEY_FALLBACKS_SETTING_KEY
-            )
-            const fallbacksFromSetting = fallbacksSetting
-              ? parseApiKeyFallbacks(
-                  (
-                    fallbacksSetting.controller_props as {
-                      value?: unknown
-                    }
-                  )?.value
-                )
-              : undefined
-
+            // API keys live only in the OS keyring, never in provider settings.
+            // The in-memory chain is preserved from existing state or the
+            // keyring-seeded incoming provider (DataProvider).
             return {
               ...provider,
               models: provider.persist ? updatedModels : mergedModels,
               settings: mergedSettings,
               api_key: existingProvider?.api_key || provider.api_key,
               api_key_fallbacks:
-                existingProvider?.api_key_fallbacks ??
-                fallbacksFromSetting ??
-                provider.api_key_fallbacks,
+                existingProvider?.api_key_fallbacks ?? provider.api_key_fallbacks,
               base_url: existingProvider?.base_url || provider.base_url,
               active: existingProvider ? existingProvider?.active : true,
             }
@@ -238,64 +226,6 @@ export const useModelProvider = create<ModelProviderState>()(
               (e) => !updatedProviders.some((p) => p.provider === e.provider)
             ),
           ]
-
-          // One-shot migration: persist zustand-only fallback keys to disk
-          // via the providers extension so they survive localStorage clears.
-          if (
-            typeof localStorage !== 'undefined' &&
-            localStorage.getItem(API_KEY_FALLBACKS_MIGRATION_FLAG) !== 'true'
-          ) {
-            const toMigrate = nextProviders.filter((p) => {
-              const fallbacks = p.api_key_fallbacks ?? []
-              if (fallbacks.length === 0) return false
-              const setting = p.settings?.find(
-                (s) => s.key === API_KEY_FALLBACKS_SETTING_KEY
-              )
-              const persistedValue = setting
-                ? (setting.controller_props as { value?: unknown })?.value
-                : undefined
-              return (
-                typeof persistedValue !== 'string' || persistedValue.length === 0
-              )
-            })
-            localStorage.setItem(API_KEY_FALLBACKS_MIGRATION_FLAG, 'true')
-            if (toMigrate.length > 0) {
-              queueMicrotask(() => {
-                const svc = getServiceHub().providers()
-                for (const p of toMigrate) {
-                  const value = serializeApiKeyFallbacks(p.api_key_fallbacks ?? [])
-                  const settings = [...(p.settings ?? [])]
-                  const idx = settings.findIndex(
-                    (s) => s.key === API_KEY_FALLBACKS_SETTING_KEY
-                  )
-                  if (idx !== -1) {
-                    const props = settings[idx].controller_props as {
-                      value: string | boolean | number
-                    }
-                    props.value = value
-                  } else {
-                    settings.push({
-                      key: API_KEY_FALLBACKS_SETTING_KEY,
-                      title: 'API Key Fallbacks',
-                      description: '',
-                      controller_type: 'input',
-                      controller_props: {
-                        value,
-                        type: 'password',
-                        placeholder: '',
-                      },
-                    } as (typeof settings)[number])
-                  }
-                  svc.updateSettings(p.provider, settings).catch((err) => {
-                    console.warn(
-                      `[api-key-fallbacks] migration failed for ${p.provider}:`,
-                      err
-                    )
-                  })
-                }
-              })
-            }
-          }
 
           return effectiveDeletedModels === currentDeletedModels
             ? { providers: nextProviders }
@@ -407,7 +337,14 @@ export const useModelProvider = create<ModelProviderState>()(
     }),
     {
       name: localStorageKey.modelProvider,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => backendStorage),
+      // Async backend storage; hydrate explicitly after ServiceHub init.
+      skipHydration: true,
+      // Never persist API keys — they live in the OS keyring only.
+      partialize: (state) => ({
+        ...state,
+        providers: state.providers.map(stripProviderSecrets),
+      }),
       migrate: (persistedState: unknown, version: number) => {
         const state = persistedState as ModelProviderState & {
           providers: Array<

--- a/web-app/src/hooks/useModelSources.ts
+++ b/web-app/src/hooks/useModelSources.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { localStorageKey } from '@/constants/localStorage'
 import { createJSONStorage, persist } from 'zustand/middleware'
 import { getServiceHub } from '@/hooks/useServiceHub'
+import { backendStorage } from '@/lib/backendStorage'
 import type { CatalogModel } from '@/services/models/types'
 import { sanitizeModelId } from '@/lib/utils'
 
@@ -47,7 +48,8 @@ export const useModelSources = create<ModelSourcesState>()(
     }),
     {
       name: localStorageKey.modelSources,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => backendStorage),
+      skipHydration: true,
     }
   )
 )

--- a/web-app/src/hooks/useModelSources.ts
+++ b/web-app/src/hooks/useModelSources.ts
@@ -2,7 +2,6 @@ import { create } from 'zustand'
 import { localStorageKey } from '@/constants/localStorage'
 import { createJSONStorage, persist } from 'zustand/middleware'
 import { getServiceHub } from '@/hooks/useServiceHub'
-import { backendStorage } from '@/lib/backendStorage'
 import type { CatalogModel } from '@/services/models/types'
 import { sanitizeModelId } from '@/lib/utils'
 
@@ -47,9 +46,12 @@ export const useModelSources = create<ModelSourcesState>()(
       },
     }),
     {
+      // Kept in webview localStorage, not the backend settings store: this is a
+      // re-fetchable network cache (the full Hub catalog, ~500 KB), not a user
+      // setting. Persisting it to settings.json rewrote the whole file on every
+      // Hub visit. localStorage is synchronous, so no skipHydration needed.
       name: localStorageKey.modelSources,
-      storage: createJSONStorage(() => backendStorage),
-      skipHydration: true,
+      storage: createJSONStorage(() => localStorage),
     }
   )
 )

--- a/web-app/src/hooks/useProxyConfig.ts
+++ b/web-app/src/hooks/useProxyConfig.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { localStorageKey } from '@/constants/localStorage'
+import { backendStorage } from '@/lib/backendStorage'
 
 type ProxyConfigState = {
   proxyEnabled: boolean
@@ -53,7 +54,8 @@ export const useProxyConfig = create<ProxyConfigState>()(
     }),
     {
       name: localStorageKey.settingProxyConfig,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => backendStorage),
+      skipHydration: true,
     }
   )
 )

--- a/web-app/src/hooks/useTheme.ts
+++ b/web-app/src/hooks/useTheme.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
 import { getServiceHub } from '@/hooks/useServiceHub'
+import { backendStorage } from '@/lib/backendStorage'
 import type { ThemeMode } from '@/services/theme/types'
 import { localStorageKey } from '@/constants/localStorage'
 
@@ -55,7 +56,10 @@ export const useTheme = create<ThemeState>()(
     },
     {
       name: localStorageKey.theme,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => backendStorage),
+      // Backend storage is async; hydrate explicitly after ServiceHub init
+      // (see hydrateBackendStores). getServiceHub() throws before that.
+      skipHydration: true,
       // Persisted isDark from the previous session can be stale (user changed
       // OS theme while the app was closed). Re-derive on hydration so the
       // initial render matches reality; the Tauri portal listener corrects

--- a/web-app/src/hooks/useToolApproval.ts
+++ b/web-app/src/hooks/useToolApproval.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { localStorageKey } from '@/constants/localStorage'
+import { backendStorage } from '@/lib/backendStorage'
 
 export type ToolApprovalModalProps = {
   toolName: string
@@ -160,7 +161,8 @@ export const useToolApproval = create<ToolApprovalState>()(
     }),
     {
       name: localStorageKey.toolApproval,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => backendStorage),
+      skipHydration: true,
       // Only persist approved tools and global permission setting, not modal state
       partialize: (state) => ({
         approvedTools: state.approvedTools,

--- a/web-app/src/hooks/useToolAvailable.ts
+++ b/web-app/src/hooks/useToolAvailable.ts
@@ -2,183 +2,91 @@ import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { localStorageKey } from '@/constants/localStorage'
 import { backendStorage } from '@/lib/backendStorage'
-import { MCPTool } from '@/types/completion'
 
-// Helper function to create composite key for server+tool
-const createToolKey = (serverName: string, toolName: string) => {
-  return `${serverName}::${toolName}`
-}
+// Composite key identifying a tool across servers.
+export const createToolKey = (serverName: string, toolName: string) =>
+  `${serverName}::${toolName}`
 
-const isOldFormatKey = (key: string): boolean => {
-  return !key.includes('::')
-}
-
-const migrateOldFormatIfNeeded = (
-  disabledTools: Record<string, string[]>,
-  defaultDisabledTools: string[]
-): { disabledTools: Record<string, string[]>; defaultDisabledTools: string[] } => {
-  const needsMigration =
-    Object.values(disabledTools).some(tools => tools.some(isOldFormatKey)) ||
-    defaultDisabledTools.some(isOldFormatKey)
-
-  if (!needsMigration) {
-    return { disabledTools, defaultDisabledTools }
-  }
-
-  console.log('[useToolAvailable] Migrating tool availability settings to new format (server::tool)')
-
-  return {
-    disabledTools: {},
-    defaultDisabledTools: [],
-  }
-}
+const isOldFormatKey = (key: string): boolean => !key.includes('::')
 
 type ToolDisabledState = {
-  // Track disabled tools per thread using server::tool composite keys
-  disabledTools: Record<string, string[]> // threadId -> toolKeys[] (server::tool format)
-  // Global default disabled tools (for new threads/index page) using composite keys
-  defaultDisabledTools: string[]
-  // Flag to track if defaults have been initialized from extension
+  // Global set of disabled tools (server::tool keys), shared across every chat.
+  // A tool absent from this list is enabled.
+  disabledTools: string[]
+  // Whether the one-time seed from the MCP extension's defaults has run.
   defaultsInitialized: boolean
 
-  // Actions - now require both server and tool name
-  setToolDisabledForThread: (
-    threadId: string,
+  setToolDisabled: (
     serverName: string,
     toolName: string,
-    available: boolean
+    enabled: boolean
   ) => void
-  isToolDisabled: (threadId: string, serverName: string, toolName: string) => boolean
-  getDisabledToolsForThread: (threadId: string) => string[]
-  setDefaultDisabledTools: (toolKeys: string[]) => void
-  getDefaultDisabledTools: () => string[]
+  isToolDisabled: (serverName: string, toolName: string) => boolean
+  getDisabledTools: () => string[]
+  setDisabledTools: (toolKeys: string[]) => void
   isDefaultsInitialized: () => boolean
   markDefaultsAsInitialized: () => void
-  // Initialize thread tools from default or existing thread settings
-  initializeThreadTools: (threadId: string, allTools: MCPTool[]) => void
 }
 
 export const useToolAvailable = create<ToolDisabledState>()(
   persist(
     (set, get) => ({
-      disabledTools: {},
-      defaultDisabledTools: [],
+      disabledTools: [],
       defaultsInitialized: false,
 
-      setToolDisabledForThread: (
-        threadId: string,
-        serverName: string,
-        toolName: string,
-        available: boolean
-      ) => {
+      setToolDisabled: (serverName, toolName, enabled) => {
+        const toolKey = createToolKey(serverName, toolName)
         set((state) => {
-          const currentTools = state.disabledTools[threadId] || []
-          const toolKey = createToolKey(serverName, toolName)
-          let updatedTools: string[]
-
-          if (available) {
-            // Remove disabled tool
-            updatedTools = [...currentTools.filter((key) => key !== toolKey)]
-          } else {
-            // Disable tool
-            updatedTools = [...currentTools, toolKey]
+          if (enabled) {
+            return {
+              disabledTools: state.disabledTools.filter((k) => k !== toolKey),
+            }
           }
-
-          return {
-            disabledTools: {
-              ...state.disabledTools,
-              [threadId]: updatedTools,
-            },
-          }
+          if (state.disabledTools.includes(toolKey)) return state
+          return { disabledTools: [...state.disabledTools, toolKey] }
         })
       },
 
-      isToolDisabled: (threadId: string, serverName: string, toolName: string) => {
-        const state = get()
-        const toolKey = createToolKey(serverName, toolName)
-        // If no thread-specific settings, use default
-        if (!state.disabledTools[threadId]) {
-          return state.defaultDisabledTools.includes(toolKey)
-        }
-        return state.disabledTools[threadId]?.includes(toolKey) || false
-      },
+      isToolDisabled: (serverName, toolName) =>
+        get().disabledTools.includes(createToolKey(serverName, toolName)),
 
-      getDisabledToolsForThread: (threadId: string) => {
-        const state = get()
-        // If no thread-specific settings, use default
-        if (!state.disabledTools[threadId]) {
-          return state.defaultDisabledTools
-        }
-        return state.disabledTools[threadId] || []
-      },
+      getDisabledTools: () => get().disabledTools,
 
-      setDefaultDisabledTools: (toolKeys: string[]) => {
-        set({ defaultDisabledTools: toolKeys })
-      },
+      setDisabledTools: (toolKeys) => set({ disabledTools: toolKeys }),
 
-      getDefaultDisabledTools: () => {
-        return get().defaultDisabledTools
-      },
-
-      isDefaultsInitialized: () => {
-        return get().defaultsInitialized
-      },
-
-      markDefaultsAsInitialized: () => {
-        set({ defaultsInitialized: true })
-      },
-
-      initializeThreadTools: (threadId: string, allTools: MCPTool[]) => {
-        const state = get()
-        // If thread already has settings, don't override
-        if (state.disabledTools[threadId]) {
-          return
-        }
-
-        // Initialize with default tools only
-        // Don't auto-enable all tools if defaults are explicitly empty
-        const initialTools = state.defaultDisabledTools.filter((toolKey) =>
-          allTools.some((tool) => createToolKey(tool.server, tool.name) === toolKey)
-        )
-
-        set((currentState) => ({
-          disabledTools: {
-            ...currentState.disabledTools,
-            [threadId]: initialTools,
-          },
-        }))
-      },
+      isDefaultsInitialized: () => get().defaultsInitialized,
+      markDefaultsAsInitialized: () => set({ defaultsInitialized: true }),
     }),
     {
       name: localStorageKey.toolAvailability,
       storage: createJSONStorage(() => backendStorage),
       skipHydration: true,
-      // Persist all state
       partialize: (state) => ({
         disabledTools: state.disabledTools,
-        defaultDisabledTools: state.defaultDisabledTools,
         defaultsInitialized: state.defaultsInitialized,
       }),
-      // Migration function to handle old format data
-      migrate: (persistedState: unknown) => {
-        if (persistedState && typeof persistedState === 'object') {
-          const state = persistedState as Record<string, unknown>
-          const migrated = migrateOldFormatIfNeeded(
-            (state.disabledTools as Record<string, string[]>) || {},
-            (state.defaultDisabledTools as string[]) || []
-          )
-
+      // v2: tool availability is global, not per-thread. Collapse the old
+      // { disabledTools: threadId->keys, defaultDisabledTools } shape onto the
+      // previous global default; per-thread overrides are dropped. Any old
+      // pre-`::` keys force a re-seed from the extension on next boot.
+      migrate: (persistedState: unknown, version: number) => {
+        const state = (persistedState ?? {}) as Record<string, unknown>
+        if (version < 2) {
+          const prevDefault = Array.isArray(state.defaultDisabledTools)
+            ? (state.defaultDisabledTools as string[])
+            : []
+          const clean = prevDefault.filter((k) => !isOldFormatKey(k))
           return {
-            ...state,
-            disabledTools: migrated.disabledTools,
-            defaultDisabledTools: migrated.defaultDisabledTools,
-            defaultsInitialized: migrated.disabledTools === state.disabledTools ?
-              state.defaultsInitialized : false,
+            disabledTools: clean,
+            defaultsInitialized:
+              clean.length === prevDefault.length
+                ? Boolean(state.defaultsInitialized)
+                : false,
           }
         }
-        return persistedState
+        return state
       },
-      version: 1, // Increment version to trigger migration
+      version: 2,
     }
   )
 )

--- a/web-app/src/hooks/useToolAvailable.ts
+++ b/web-app/src/hooks/useToolAvailable.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { localStorageKey } from '@/constants/localStorage'
+import { backendStorage } from '@/lib/backendStorage'
 import { MCPTool } from '@/types/completion'
 
 // Helper function to create composite key for server+tool
@@ -150,7 +151,8 @@ export const useToolAvailable = create<ToolDisabledState>()(
     }),
     {
       name: localStorageKey.toolAvailability,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => backendStorage),
+      skipHydration: true,
       // Persist all state
       partialize: (state) => ({
         disabledTools: state.disabledTools,

--- a/web-app/src/hooks/useTools.ts
+++ b/web-app/src/hooks/useTools.ts
@@ -10,7 +10,7 @@ export const useTools = () => {
   const updateTools = useAppState((state) => state.updateTools)
   const updateRagToolNames = useAppState((state) => state.updateRagToolNames)
   const updateMcpToolNames = useAppState((state) => state.updateMcpToolNames)
-  const { isDefaultsInitialized, setDefaultDisabledTools, markDefaultsAsInitialized } = useToolAvailable()
+  const { isDefaultsInitialized, setDisabledTools, markDefaultsAsInitialized } = useToolAvailable()
 
   useEffect(() => {
     async function setTools() {
@@ -45,7 +45,7 @@ export const useTools = () => {
         if (!isDefaultsInitialized() && mcpTools.length > 0 && mcpExtension?.getDefaultDisabledTools) {
           const defaultDisabled = await mcpExtension.getDefaultDisabledTools()
           if (defaultDisabled.length > 0) {
-            setDefaultDisabledTools(defaultDisabled)
+            setDisabledTools(defaultDisabled)
             markDefaultsAsInitialized()
           }
         }

--- a/web-app/src/hooks/useVulkan.ts
+++ b/web-app/src/hooks/useVulkan.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { persist, createJSONStorage } from 'zustand/middleware'
 import { localStorageKey } from '@/constants/localStorage'
+import { backendStorage } from '@/lib/backendStorage'
 
 interface VulkanStore {
   // Vulkan state
@@ -28,7 +29,8 @@ export const useVulkan = create<VulkanStore>()(
     }),
     {
       name: localStorageKey.settingVulkan,
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() => backendStorage),
+      skipHydration: true,
     }
   )
 )

--- a/web-app/src/lib/__tests__/backendStorage.test.ts
+++ b/web-app/src/lib/__tests__/backendStorage.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const isPlatformTauri = vi.fn()
+const invoke = vi.fn()
+
+vi.mock('@/lib/platform/utils', () => ({
+  isPlatformTauri: () => isPlatformTauri(),
+}))
+
+vi.mock('@/hooks/useServiceHub', () => ({
+  getServiceHub: () => ({ core: () => ({ invoke }) }),
+}))
+
+import { backendStorage } from '../backendStorage'
+
+describe('backendStorage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+  })
+
+  describe('web fallback (no Tauri)', () => {
+    beforeEach(() => isPlatformTauri.mockReturnValue(false))
+
+    it('reads/writes/removes via localStorage without touching the backend', async () => {
+      expect(await backendStorage.getItem('k')).toBeNull()
+      await backendStorage.setItem('k', 'v')
+      expect(localStorage.getItem('k')).toBe('v')
+      expect(await backendStorage.getItem('k')).toBe('v')
+      await backendStorage.removeItem('k')
+      expect(await backendStorage.getItem('k')).toBeNull()
+      expect(invoke).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('tauri backend', () => {
+    beforeEach(() => isPlatformTauri.mockReturnValue(true))
+
+    it('routes through settings_* commands', async () => {
+      invoke.mockResolvedValueOnce('stored')
+      expect(await backendStorage.getItem('theme')).toBe('stored')
+      expect(invoke).toHaveBeenCalledWith('settings_get', { key: 'theme' })
+
+      await backendStorage.setItem('theme', '"dark"')
+      expect(invoke).toHaveBeenCalledWith('settings_set', {
+        key: 'theme',
+        value: '"dark"',
+      })
+
+      await backendStorage.removeItem('theme')
+      expect(invoke).toHaveBeenCalledWith('settings_remove', { key: 'theme' })
+    })
+
+    it('maps a missing key (null/undefined) to null', async () => {
+      invoke.mockResolvedValueOnce(null)
+      expect(await backendStorage.getItem('missing')).toBeNull()
+      invoke.mockResolvedValueOnce(undefined)
+      expect(await backendStorage.getItem('missing')).toBeNull()
+    })
+
+    it('degrades to null on backend error rather than throwing', async () => {
+      invoke.mockRejectedValueOnce(new Error('boom'))
+      await expect(backendStorage.getItem('k')).resolves.toBeNull()
+    })
+
+    it('swallows write errors so persistence never crashes the store', async () => {
+      invoke.mockRejectedValueOnce(new Error('boom'))
+      await expect(backendStorage.setItem('k', 'v')).resolves.toBeUndefined()
+    })
+  })
+})

--- a/web-app/src/lib/__tests__/backendStorage.test.ts
+++ b/web-app/src/lib/__tests__/backendStorage.test.ts
@@ -67,5 +67,33 @@ describe('backendStorage', () => {
       invoke.mockRejectedValueOnce(new Error('boom'))
       await expect(backendStorage.setItem('k', 'v')).resolves.toBeUndefined()
     })
+
+    it('skips the invoke when the same value is written again', async () => {
+      invoke.mockResolvedValue(undefined)
+      await backendStorage.setItem('dedup', 'v1')
+      await backendStorage.setItem('dedup', 'v1')
+      await backendStorage.setItem('dedup', 'v2')
+      const sets = invoke.mock.calls.filter(([cmd]) => cmd === 'settings_set')
+      expect(sets).toHaveLength(2)
+      expect(sets.map(([, a]) => a.value)).toEqual(['v1', 'v2'])
+    })
+
+    it('retries after a failed write (cache not poisoned)', async () => {
+      invoke.mockRejectedValueOnce(new Error('boom'))
+      await backendStorage.setItem('retry', 'v')
+      invoke.mockResolvedValueOnce(undefined)
+      await backendStorage.setItem('retry', 'v')
+      const sets = invoke.mock.calls.filter(([cmd]) => cmd === 'settings_set')
+      expect(sets).toHaveLength(2)
+    })
+
+    it('removeItem clears the cache so an identical later write is not skipped', async () => {
+      invoke.mockResolvedValue(undefined)
+      await backendStorage.setItem('rm', 'v')
+      await backendStorage.removeItem('rm')
+      await backendStorage.setItem('rm', 'v')
+      const sets = invoke.mock.calls.filter(([cmd]) => cmd === 'settings_set')
+      expect(sets).toHaveLength(2)
+    })
   })
 })

--- a/web-app/src/lib/__tests__/migrateLocalStorageSettings.test.ts
+++ b/web-app/src/lib/__tests__/migrateLocalStorageSettings.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const isPlatformTauri = vi.fn()
+const invoke = vi.fn()
+const backend = new Map<string, string>()
+
+vi.mock('@/lib/platform/utils', () => ({
+  isPlatformTauri: () => isPlatformTauri(),
+}))
+vi.mock('@/hooks/useServiceHub', () => ({
+  getServiceHub: () => ({ core: () => ({ invoke }) }),
+}))
+vi.mock('@/hooks/useGeneralSetting', () => ({
+  HUGGINGFACE_TOKEN_SECRET_KEY: 'huggingface',
+}))
+
+import { migrateLocalStorageToBackend } from '../migrateLocalStorageSettings'
+
+// invoke mock backed by an in-memory settings map
+function wireInvoke() {
+  invoke.mockImplementation(async (cmd: string, args: any) => {
+    if (cmd === 'settings_get') return backend.get(args.key) ?? null
+    if (cmd === 'settings_set') {
+      backend.set(args.key, args.value)
+      return
+    }
+    return
+  })
+}
+
+describe('migrateLocalStorageToBackend', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    backend.clear()
+    localStorage.clear()
+    isPlatformTauri.mockReturnValue(true)
+    wireInvoke()
+  })
+
+  it('no-ops on web (no Tauri)', async () => {
+    isPlatformTauri.mockReturnValue(false)
+    localStorage.setItem('theme', '{"state":{"activeTheme":"dark"}}')
+    await migrateLocalStorageToBackend()
+    expect(invoke).not.toHaveBeenCalled()
+  })
+
+  it('copies plain store blobs and sets the flag', async () => {
+    localStorage.setItem('theme', '{"state":{"activeTheme":"dark"},"version":0}')
+    localStorage.setItem('left-panel', '{"state":{"open":false}}')
+    await migrateLocalStorageToBackend()
+    expect(backend.get('theme')).toBe('{"state":{"activeTheme":"dark"},"version":0}')
+    expect(backend.get('left-panel')).toBe('{"state":{"open":false}}')
+    expect(backend.get('__settings_migrated_to_backend__')).toBe('true')
+  })
+
+  it('extracts provider keys to keyring and strips them from the blob', async () => {
+    const blob = {
+      state: {
+        providers: [
+          {
+            provider: 'openai',
+            api_key: 'sk-primary',
+            api_key_fallbacks: ['sk-fb'],
+            base_url: 'https://api.openai.com/v1',
+            custom_header: [{ header: 'X', value: 'y' }],
+            models: [{ id: 'gpt-4' }],
+            settings: [
+              { key: 'api-key', controller_props: { value: 'sk-primary' } },
+              { key: 'base-url', controller_props: { value: 'https://x' } },
+            ],
+          },
+          { provider: 'llamacpp', models: [] },
+        ],
+      },
+      version: 17,
+    }
+    localStorage.setItem('model-provider', JSON.stringify(blob))
+
+    await migrateLocalStorageToBackend()
+
+    expect(invoke).toHaveBeenCalledWith('register_provider_config', {
+      request: expect.objectContaining({
+        provider: 'openai',
+        api_key: 'sk-primary',
+        api_keys: ['sk-fb'],
+        base_url: 'https://api.openai.com/v1',
+        models: ['gpt-4'],
+      }),
+    })
+
+    const stored = backend.get('model-provider')!
+    expect(stored).not.toContain('sk-primary')
+    expect(stored).not.toContain('sk-fb')
+    // non-secret config preserved
+    expect(stored).toContain('https://api.openai.com/v1')
+    expect(stored).toContain('gpt-4')
+  })
+
+  it('extracts the HF token to keyring and strips it', async () => {
+    localStorage.setItem(
+      'setting-general',
+      JSON.stringify({ state: { huggingfaceToken: 'hf_secret', autoUpdateCheck: true } })
+    )
+    await migrateLocalStorageToBackend()
+    expect(invoke).toHaveBeenCalledWith('set_secret', {
+      key: 'huggingface',
+      value: 'hf_secret',
+    })
+    const stored = backend.get('setting-general')!
+    expect(stored).not.toContain('hf_secret')
+    expect(stored).toContain('autoUpdateCheck')
+  })
+
+  it('is idempotent: skips entirely when the flag is set', async () => {
+    backend.set('__settings_migrated_to_backend__', 'true')
+    localStorage.setItem('theme', '{"state":{"activeTheme":"dark"}}')
+    await migrateLocalStorageToBackend()
+    expect(backend.has('theme')).toBe(false)
+    expect(invoke).toHaveBeenCalledTimes(1) // only the flag check
+  })
+
+  it('never clobbers existing backend data', async () => {
+    localStorage.setItem('theme', '{"state":{"activeTheme":"dark"}}')
+    backend.set('theme', '{"state":{"activeTheme":"light"}}')
+    await migrateLocalStorageToBackend()
+    expect(backend.get('theme')).toBe('{"state":{"activeTheme":"light"}}')
+  })
+})

--- a/web-app/src/lib/__tests__/migrateLocalStorageSettings.test.ts
+++ b/web-app/src/lib/__tests__/migrateLocalStorageSettings.test.ts
@@ -96,6 +96,43 @@ describe('migrateLocalStorageToBackend', () => {
     expect(stored).toContain('gpt-4')
   })
 
+  it('falls back to the api-key settings value when top-level api_key is absent', async () => {
+    const blob = {
+      state: {
+        providers: [
+          {
+            provider: 'openai',
+            base_url: 'https://api.openai.com/v1',
+            models: [{ id: 'gpt-4' }],
+            settings: [
+              { key: 'api-key', controller_props: { value: 'sk-from-settings' } },
+              {
+                key: 'api-key-fallbacks',
+                controller_props: { value: 'sk-fb1\nsk-fb2' },
+              },
+            ],
+          },
+        ],
+      },
+      version: 17,
+    }
+    localStorage.setItem('model-provider', JSON.stringify(blob))
+
+    await migrateLocalStorageToBackend()
+
+    expect(invoke).toHaveBeenCalledWith('register_provider_config', {
+      request: expect.objectContaining({
+        provider: 'openai',
+        api_key: 'sk-from-settings',
+        api_keys: ['sk-fb1', 'sk-fb2'],
+      }),
+    })
+
+    const stored = backend.get('model-provider')!
+    expect(stored).not.toContain('sk-from-settings')
+    expect(stored).not.toContain('sk-fb1')
+  })
+
   it('extracts the HF token to keyring and strips it', async () => {
     localStorage.setItem(
       'setting-general',
@@ -119,10 +156,39 @@ describe('migrateLocalStorageToBackend', () => {
     expect(invoke).toHaveBeenCalledTimes(1) // only the flag check
   })
 
-  it('never clobbers existing backend data', async () => {
+  it('overwrites a pre-feature fossil when the flag is unset (localStorage wins)', async () => {
+    // #7821 shipped and was reverted within v0.8.0, but nightly testers can have
+    // a stale model-provider/theme blob in settings.json with no migration flag.
+    // localStorage is authoritative, so migration must overwrite the fossil.
     localStorage.setItem('theme', '{"state":{"activeTheme":"dark"}}')
     backend.set('theme', '{"state":{"activeTheme":"light"}}')
     await migrateLocalStorageToBackend()
-    expect(backend.get('theme')).toBe('{"state":{"activeTheme":"light"}}')
+    expect(backend.get('theme')).toBe('{"state":{"activeTheme":"dark"}}')
+  })
+
+  it('extracts keys from a fossil model-provider blob (flag unset, backend present)', async () => {
+    backend.set('model-provider', '{"state":{"providers":[]},"version":17}')
+    const blob = {
+      state: {
+        providers: [
+          {
+            provider: 'openai',
+            api_key: 'sk-real',
+            models: [{ id: 'gpt-4' }],
+          },
+        ],
+      },
+      version: 17,
+    }
+    localStorage.setItem('model-provider', JSON.stringify(blob))
+
+    await migrateLocalStorageToBackend()
+
+    expect(invoke).toHaveBeenCalledWith('register_provider_config', {
+      request: expect.objectContaining({ provider: 'openai', api_key: 'sk-real' }),
+    })
+    const stored = backend.get('model-provider')!
+    expect(stored).not.toContain('sk-real')
+    expect(stored).toContain('gpt-4')
   })
 })

--- a/web-app/src/lib/backendStorage.ts
+++ b/web-app/src/lib/backendStorage.ts
@@ -13,6 +13,12 @@ import { getServiceHub } from '@/hooks/useServiceHub'
  * `skipHydration: true` and be rehydrated via `hydrateBackendStores()` only
  * after the ServiceHub is initialized (`getServiceHub()` throws before that).
  */
+// Last value known to be on the backend, per key. Lets setItem skip the
+// serialization + IPC round-trip when Zustand persist re-writes an unchanged
+// blob (it fires setItem on every set(), without diffing). Only updated on a
+// confirmed backend write/read so a failed invoke still retries next time.
+const lastWritten = new Map<string, string>()
+
 export const backendStorage: StateStorage = {
   getItem: async (name) => {
     if (!isPlatformTauri()) return localStorage.getItem(name)
@@ -21,6 +27,7 @@ export const backendStorage: StateStorage = {
         'settings_get',
         { key: name }
       )
+      if (value != null) lastWritten.set(name, value)
       return value ?? null
     } catch (error) {
       console.error(`settings_get failed for '${name}':`, error)
@@ -32,8 +39,10 @@ export const backendStorage: StateStorage = {
       localStorage.setItem(name, value)
       return
     }
+    if (lastWritten.get(name) === value) return
     try {
       await getServiceHub().core().invoke('settings_set', { key: name, value })
+      lastWritten.set(name, value)
     } catch (error) {
       console.error(`settings_set failed for '${name}':`, error)
     }
@@ -45,6 +54,7 @@ export const backendStorage: StateStorage = {
     }
     try {
       await getServiceHub().core().invoke('settings_remove', { key: name })
+      lastWritten.delete(name)
     } catch (error) {
       console.error(`settings_remove failed for '${name}':`, error)
     }

--- a/web-app/src/lib/backendStorage.ts
+++ b/web-app/src/lib/backendStorage.ts
@@ -1,0 +1,52 @@
+import type { StateStorage } from 'zustand/middleware'
+import { isPlatformTauri } from '@/lib/platform/utils'
+import { getServiceHub } from '@/hooks/useServiceHub'
+
+/**
+ * Async Zustand `StateStorage` backed by the Rust settings store
+ * (`settings_get`/`settings_set`/`settings_remove`), which persists to
+ * `<jan_data>/settings.json`. This keeps user settings off webview
+ * localStorage so out-of-process consumers (jan-cli) can read them.
+ *
+ * On web (`dev:web`, no Tauri shell) there is no backend, so it degrades to
+ * localStorage. The async boundary is honest: stores using this must set
+ * `skipHydration: true` and be rehydrated via `hydrateBackendStores()` only
+ * after the ServiceHub is initialized (`getServiceHub()` throws before that).
+ */
+export const backendStorage: StateStorage = {
+  getItem: async (name) => {
+    if (!isPlatformTauri()) return localStorage.getItem(name)
+    try {
+      const value = await getServiceHub().core().invoke<string | null>(
+        'settings_get',
+        { key: name }
+      )
+      return value ?? null
+    } catch (error) {
+      console.error(`settings_get failed for '${name}':`, error)
+      return null
+    }
+  },
+  setItem: async (name, value) => {
+    if (!isPlatformTauri()) {
+      localStorage.setItem(name, value)
+      return
+    }
+    try {
+      await getServiceHub().core().invoke('settings_set', { key: name, value })
+    } catch (error) {
+      console.error(`settings_set failed for '${name}':`, error)
+    }
+  },
+  removeItem: async (name) => {
+    if (!isPlatformTauri()) {
+      localStorage.removeItem(name)
+      return
+    }
+    try {
+      await getServiceHub().core().invoke('settings_remove', { key: name })
+    } catch (error) {
+      console.error(`settings_remove failed for '${name}':`, error)
+    }
+  },
+}

--- a/web-app/src/lib/custom-chat-transport.ts
+++ b/web-app/src/lib/custom-chat-transport.ts
@@ -648,13 +648,8 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
 
     const toolsRecord: Record<string, Tool> = {}
 
-    // Get disabled tools for this thread
-    const getDisabledToolsForThread =
-      useToolAvailable.getState().getDisabledToolsForThread
-    const disabledToolKeys = this.threadId
-      ? getDisabledToolsForThread(this.threadId)
-      : useToolAvailable.getState().getDefaultDisabledTools()
-    // Helper to check if a tool is disabled
+    // Tool availability is global (shared across all chats).
+    const disabledToolKeys = useToolAvailable.getState().getDisabledTools()
     const isToolDisabled = (serverName: string, toolName: string): boolean => {
       const toolKey = `${serverName}::${toolName}`
       return disabledToolKeys.includes(toolKey)

--- a/web-app/src/lib/hydrateStores.ts
+++ b/web-app/src/lib/hydrateStores.ts
@@ -11,7 +11,6 @@ import { useHardware } from '@/hooks/useHardware'
 import { useLocalApiServer } from '@/hooks/useLocalApiServer'
 import { useToolApproval } from '@/hooks/useToolApproval'
 import { useToolAvailable } from '@/hooks/useToolAvailable'
-import { useModelSources } from '@/hooks/useModelSources'
 import { useDownloadStore } from '@/hooks/useDownloadStore'
 import { useProxyConfig } from '@/hooks/useProxyConfig'
 import { useVulkan } from '@/hooks/useVulkan'
@@ -42,7 +41,6 @@ const secondaryStores = [
   useLocalApiServer,
   useToolApproval,
   useToolAvailable,
-  useModelSources,
   useDownloadStore,
   useProxyConfig,
   useVulkan,

--- a/web-app/src/lib/hydrateStores.ts
+++ b/web-app/src/lib/hydrateStores.ts
@@ -1,0 +1,61 @@
+import { useTheme } from '@/hooks/useTheme'
+import { useInterfaceSettings } from '@/hooks/useInterfaceSettings'
+import { useGeneralSetting } from '@/hooks/useGeneralSetting'
+import { useLeftPanel } from '@/hooks/useLeftPanel'
+import { useModelProvider } from '@/hooks/useModelProvider'
+import {
+  useProductAnalytic,
+  useProductAnalyticPrompt,
+} from '@/hooks/useAnalytic'
+import { useHardware } from '@/hooks/useHardware'
+import { useLocalApiServer } from '@/hooks/useLocalApiServer'
+import { useToolApproval } from '@/hooks/useToolApproval'
+import { useToolAvailable } from '@/hooks/useToolAvailable'
+import { useModelSources } from '@/hooks/useModelSources'
+import { useDownloadStore } from '@/hooks/useDownloadStore'
+import { useProxyConfig } from '@/hooks/useProxyConfig'
+import { useVulkan } from '@/hooks/useVulkan'
+import { useFavoriteModel } from '@/hooks/useFavoriteModel'
+import { useLatestJanModel } from '@/hooks/useLatestJanModel'
+import { useJanModelPromptDismissed } from '@/hooks/useJanModelPrompt'
+import { useDefaultEmbeddingModel } from '@/hooks/useDefaultEmbeddingModel'
+import { useAgentMode } from '@/hooks/useAgentMode'
+
+/**
+ * Stores persisted through `backendStorage` set `skipHydration: true` so they
+ * never hit the backend before the ServiceHub is initialized. This runs their
+ * rehydration explicitly, once, after init. Called from `ServiceHubProvider`
+ * before it renders children, so no component ever sees pre-hydration defaults.
+ *
+ * Add each migrated store here as it is switched to `backendStorage`.
+ */
+// useInterfaceSettings' onRehydrateStorage reads useTheme.getState().isDark, so
+// theme must hydrate first.
+const secondaryStores = [
+  useInterfaceSettings,
+  useGeneralSetting,
+  useLeftPanel,
+  useModelProvider,
+  useProductAnalytic,
+  useProductAnalyticPrompt,
+  useHardware,
+  useLocalApiServer,
+  useToolApproval,
+  useToolAvailable,
+  useModelSources,
+  useDownloadStore,
+  useProxyConfig,
+  useVulkan,
+  useFavoriteModel,
+  useLatestJanModel,
+  useJanModelPromptDismissed,
+  useDefaultEmbeddingModel,
+  useAgentMode,
+] as const
+
+export async function hydrateBackendStores(): Promise<void> {
+  await Promise.resolve(useTheme.persist.rehydrate())
+  await Promise.all(
+    secondaryStores.map((store) => Promise.resolve(store.persist.rehydrate()))
+  )
+}

--- a/web-app/src/lib/migrateLocalStorageSettings.ts
+++ b/web-app/src/lib/migrateLocalStorageSettings.ts
@@ -60,12 +60,28 @@ async function transformModelProviderBlob(
     : []
 
   for (const p of providers) {
-    const primary = typeof p.api_key === 'string' ? p.api_key : ''
+    // Keys historically lived either at the top level (`api_key`) or, in older
+    // builds, only in the `api-key` settings controller value. Read the
+    // top-level first, then fall back to the settings entries so no key is
+    // stranded during migration.
+    const settingValue = (key: string): string => {
+      if (!Array.isArray(p.settings)) return ''
+      const entry = (p.settings as Array<Record<string, unknown>>).find(
+        (s) => s.key === key
+      )
+      const props = entry?.controller_props as
+        | { value?: unknown }
+        | undefined
+      return typeof props?.value === 'string' ? props.value : ''
+    }
+
+    const primary =
+      (typeof p.api_key === 'string' && p.api_key) || settingValue('api-key')
     const fallbacks = Array.isArray(p.api_key_fallbacks)
       ? (p.api_key_fallbacks as unknown[]).filter(
           (k): k is string => typeof k === 'string'
         )
-      : []
+      : settingValue('api-key-fallbacks').split(/\r?\n/)
     const chain = [primary, ...fallbacks]
       .map((k) => k.trim())
       .filter((k) => k.length > 0)
@@ -147,10 +163,13 @@ export async function migrateLocalStorageToBackend(): Promise<void> {
     for (const key of MIGRATED_KEYS) {
       const local = localStorage.getItem(key)
       if (local == null) continue
-      // Never clobber existing backend data (e.g. a downgrade/re-upgrade round).
-      const existing = await invoke<string | null>('settings_get', { key })
-      if (existing != null) continue
-
+      // Gate solely on MIGRATION_FLAG_KEY (checked above), never on per-key
+      // presence. The only way backend data exists while the flag is unset is a
+      // pre-feature fossil (the #7821 build persisted a model-provider blob into
+      // settings.json before being reverted in the same v0.8.0 release) or a
+      // crashed prior run — in both cases localStorage is authoritative, so we
+      // overwrite. Once the flag is set migration short-circuits entirely, so
+      // steady-state store writes are never clobbered.
       let value = local
       if (key === localStorageKey.modelProvider) {
         value = await transformModelProviderBlob(local, invoke)

--- a/web-app/src/lib/migrateLocalStorageSettings.ts
+++ b/web-app/src/lib/migrateLocalStorageSettings.ts
@@ -1,0 +1,168 @@
+import { isPlatformTauri } from '@/lib/platform/utils'
+import { getServiceHub } from '@/hooks/useServiceHub'
+import { localStorageKey } from '@/constants/localStorage'
+import { HUGGINGFACE_TOKEN_SECRET_KEY } from '@/hooks/useGeneralSetting'
+
+/**
+ * One-time migration of settings from webview localStorage to the backend
+ * settings store (+ OS keyring for secrets). Runs once, before store
+ * hydration, guarded by a flag stored in the BACKEND (not localStorage) so a
+ * downgrade -> re-upgrade never re-imports the stale localStorage fossil over
+ * newer backend data. Per the migration-snapshot policy, localStorage is NOT
+ * cleared: a downgraded (pre-feature) build can still read it.
+ */
+const MIGRATION_FLAG_KEY = '__settings_migrated_to_backend__'
+
+// Every store key persisted through backendStorage. Plain copy unless listed in
+// the secret-handling transforms below.
+const MIGRATED_KEYS: string[] = [
+  localStorageKey.theme,
+  localStorageKey.settingInterface,
+  localStorageKey.settingGeneral,
+  localStorageKey.LeftPanel,
+  localStorageKey.modelProvider,
+  localStorageKey.productAnalyticPrompt,
+  localStorageKey.productAnalytic,
+  localStorageKey.settingHardware,
+  localStorageKey.settingLocalApiServer,
+  localStorageKey.toolApproval,
+  localStorageKey.toolAvailability,
+  localStorageKey.modelSources,
+  localStorageKey.pausedDownloads,
+  localStorageKey.settingProxyConfig,
+  localStorageKey.settingVulkan,
+  localStorageKey.favoriteModels,
+  localStorageKey.latestJanModel,
+  localStorageKey.janModelPromptDismissed,
+  localStorageKey.defaultEmbeddingModel,
+  localStorageKey.agentMode,
+]
+
+type Invoke = <T = unknown>(cmd: string, args?: Record<string, unknown>) => Promise<T>
+
+// zustand persist wraps state as { state, version }; unwrap defensively.
+function getStateSlice(parsed: unknown): Record<string, unknown> | undefined {
+  if (!parsed || typeof parsed !== 'object') return undefined
+  const obj = parsed as Record<string, unknown>
+  const inner = (obj.state ?? obj) as Record<string, unknown>
+  return typeof inner === 'object' ? inner : undefined
+}
+
+// Move each provider's key chain into the keyring, then strip it from the blob.
+async function transformModelProviderBlob(
+  raw: string,
+  invoke: Invoke
+): Promise<string> {
+  const parsed = JSON.parse(raw)
+  const state = getStateSlice(parsed)
+  const providers = Array.isArray(state?.providers)
+    ? (state!.providers as Array<Record<string, unknown>>)
+    : []
+
+  for (const p of providers) {
+    const primary = typeof p.api_key === 'string' ? p.api_key : ''
+    const fallbacks = Array.isArray(p.api_key_fallbacks)
+      ? (p.api_key_fallbacks as unknown[]).filter(
+          (k): k is string => typeof k === 'string'
+        )
+      : []
+    const chain = [primary, ...fallbacks]
+      .map((k) => k.trim())
+      .filter((k) => k.length > 0)
+
+    if (p.provider !== 'llamacpp' && chain.length > 0) {
+      const customHeaders = Array.isArray(p.custom_header)
+        ? (p.custom_header as Array<{ header: string; value: string }>).map(
+            (h) => ({ header: h.header, value: h.value })
+          )
+        : []
+      const models = Array.isArray(p.models)
+        ? (p.models as Array<{ id: string }>).map((m) => m.id)
+        : []
+      await invoke('register_provider_config', {
+        request: {
+          provider: p.provider,
+          api_key: chain[0],
+          api_keys: chain.slice(1),
+          base_url: p.base_url,
+          custom_headers: customHeaders,
+          models,
+        },
+      })
+    }
+
+    delete p.api_key
+    delete p.api_key_fallbacks
+    if (Array.isArray(p.settings)) {
+      for (const s of p.settings as Array<Record<string, unknown>>) {
+        if (
+          (s.key === 'api-key' || s.key === 'api-key-fallbacks') &&
+          s.controller_props &&
+          typeof s.controller_props === 'object'
+        ) {
+          const props = s.controller_props as Record<string, unknown>
+          props.value = ''
+        }
+      }
+    }
+  }
+
+  return JSON.stringify(parsed)
+}
+
+// Move the HF token into the keyring, then strip it from the blob.
+async function transformGeneralBlob(
+  raw: string,
+  invoke: Invoke
+): Promise<string> {
+  const parsed = JSON.parse(raw)
+  const state = getStateSlice(parsed)
+  const token = state && typeof state.huggingfaceToken === 'string'
+    ? (state.huggingfaceToken as string)
+    : ''
+  if (token.trim().length > 0) {
+    await invoke('set_secret', {
+      key: HUGGINGFACE_TOKEN_SECRET_KEY,
+      value: token,
+    })
+  }
+  if (state) delete state.huggingfaceToken
+  return JSON.stringify(parsed)
+}
+
+export async function migrateLocalStorageToBackend(): Promise<void> {
+  // On web there is no backend; localStorage IS the store, nothing to migrate.
+  if (!isPlatformTauri() || typeof localStorage === 'undefined') return
+
+  const invoke = getServiceHub().core().invoke.bind(
+    getServiceHub().core()
+  ) as Invoke
+
+  try {
+    const alreadyMigrated = await invoke<string | null>('settings_get', {
+      key: MIGRATION_FLAG_KEY,
+    })
+    if (alreadyMigrated === 'true') return
+
+    for (const key of MIGRATED_KEYS) {
+      const local = localStorage.getItem(key)
+      if (local == null) continue
+      // Never clobber existing backend data (e.g. a downgrade/re-upgrade round).
+      const existing = await invoke<string | null>('settings_get', { key })
+      if (existing != null) continue
+
+      let value = local
+      if (key === localStorageKey.modelProvider) {
+        value = await transformModelProviderBlob(local, invoke)
+      } else if (key === localStorageKey.settingGeneral) {
+        value = await transformGeneralBlob(local, invoke)
+      }
+      await invoke('settings_set', { key, value })
+    }
+
+    await invoke('settings_set', { key: MIGRATION_FLAG_KEY, value: 'true' })
+  } catch (error) {
+    // Leave the flag unset so migration retries on the next launch.
+    console.error('Settings localStorage->backend migration failed:', error)
+  }
+}

--- a/web-app/src/lib/migrateLocalStorageSettings.ts
+++ b/web-app/src/lib/migrateLocalStorageSettings.ts
@@ -27,7 +27,6 @@ const MIGRATED_KEYS: string[] = [
   localStorageKey.settingLocalApiServer,
   localStorageKey.toolApproval,
   localStorageKey.toolAvailability,
-  localStorageKey.modelSources,
   localStorageKey.pausedDownloads,
   localStorageKey.settingProxyConfig,
   localStorageKey.settingVulkan,

--- a/web-app/src/providers/DataProvider.tsx
+++ b/web-app/src/providers/DataProvider.tsx
@@ -1,7 +1,10 @@
 import { useModelProvider } from '@/hooks/useModelProvider'
 
 import { useAppUpdater } from '@/hooks/useAppUpdater'
-import { useGeneralSetting } from '@/hooks/useGeneralSetting'
+import {
+  useGeneralSetting,
+  HUGGINGFACE_TOKEN_SECRET_KEY,
+} from '@/hooks/useGeneralSetting'
 import { useServiceHub } from '@/hooks/useServiceHub'
 import { useEffect } from 'react'
 import { useMCPServers, DEFAULT_MCP_SETTINGS } from '@/hooks/useMCPServers'
@@ -59,6 +62,37 @@ async function registerRemoteProvider(provider: ModelProvider) {
   } catch (error) {
     console.error(`Failed to register provider ${provider.provider}:`, error)
   }
+}
+
+// Re-seed in-memory provider keys from the OS keyring. Keys are no longer
+// persisted to settings storage (stripped by useModelProvider.partialize), so
+// after a reload the store has none; synchronous consumers (model-factory,
+// presence checks) read provider.api_key, so we repopulate the runtime objects.
+async function seedProviderKeysFromKeyring(
+  providers: ModelProvider[]
+): Promise<ModelProvider[]> {
+  return Promise.all(
+    providers.map(async (provider) => {
+      if (provider.provider === 'llamacpp') return provider
+      try {
+        const keys = await invoke<string[]>('get_provider_keys', {
+          provider: provider.provider,
+        })
+        if (!keys || keys.length === 0) return provider
+        return {
+          ...provider,
+          api_key: keys[0],
+          api_key_fallbacks: keys.slice(1),
+        }
+      } catch (error) {
+        console.warn(
+          `Failed to load keyring keys for ${provider.provider}:`,
+          error
+        )
+        return provider
+      }
+    })
+  )
 }
 
 // Track which providers have been registered so we can unregister stale ones
@@ -155,16 +189,26 @@ export function DataProvider() {
 
   useEffect(() => {
     console.log('Initializing DataProvider...')
-    serviceHub.providers().getProviders().then((providers) => {
-      setProviders(providers)
+    serviceHub.providers().getProviders().then(async (providers) => {
+      const seeded = await seedProviderKeysFromKeyring(providers)
+      setProviders(seeded)
       // Register active remote providers with the backend
-      providers.forEach((provider) => {
+      seeded.forEach((provider) => {
         if (provider.active) {
           registerRemoteProvider(provider)
           registeredProviderNames.add(provider.provider)
         }
       })
     })
+    // Re-seed the Hugging Face token from the keyring (no longer persisted to
+    // settings storage) into the store + download extension for this session.
+    invoke<string | null>('get_secret', {
+      key: HUGGINGFACE_TOKEN_SECRET_KEY,
+    })
+      .then((token) => {
+        if (token) useGeneralSetting.getState().setHuggingfaceToken(token)
+      })
+      .catch(() => {})
     serviceHub
       .mcp()
       .getMCPConfig()
@@ -263,8 +307,9 @@ export function DataProvider() {
 
   useEffect(() => {
     const handler = () => {
-      serviceHub.providers().getProviders().then((providers) => {
-        setProviders(providers)
+      serviceHub.providers().getProviders().then(async (providers) => {
+        const seeded = await seedProviderKeysFromKeyring(providers)
+        setProviders(seeded)
         syncRemoteProviders()
         syncModelParamDefaults()
       })

--- a/web-app/src/providers/DataProvider.tsx
+++ b/web-app/src/providers/DataProvider.tsx
@@ -95,6 +95,24 @@ async function seedProviderKeysFromKeyring(
   )
 }
 
+// Re-seed keyring keys into the store for EVERY provider, including
+// user-added custom ones (getProviders() only returns predefined + engine
+// providers, so custom providers would otherwise stay keyless after a reload).
+// Applies via updateProvider so it merges over the already-hydrated state.
+async function applyKeyringKeys(): Promise<void> {
+  const store = useModelProvider.getState()
+  const seeded = await seedProviderKeysFromKeyring(store.providers)
+  for (const p of seeded) {
+    const current = store.providers.find((x) => x.provider === p.provider)
+    if (p.api_key && p.api_key !== current?.api_key) {
+      store.updateProvider(p.provider, {
+        api_key: p.api_key,
+        api_key_fallbacks: p.api_key_fallbacks,
+      })
+    }
+  }
+}
+
 // Track which providers have been registered so we can unregister stale ones
 let registeredProviderNames = new Set<string>()
 
@@ -189,11 +207,12 @@ export function DataProvider() {
 
   useEffect(() => {
     console.log('Initializing DataProvider...')
-    serviceHub.providers().getProviders().then(async (providers) => {
-      const seeded = await seedProviderKeysFromKeyring(providers)
-      setProviders(seeded)
-      // Register active remote providers with the backend
-      seeded.forEach((provider) => {
+    serviceHub.providers().getProviders().then(async (fetched) => {
+      setProviders(fetched)
+      // Seed keyring keys into the merged store (predefined + engine + custom).
+      await applyKeyringKeys()
+      // Register active remote providers with the backend, keys now in place.
+      useModelProvider.getState().providers.forEach((provider) => {
         if (provider.active) {
           registerRemoteProvider(provider)
           registeredProviderNames.add(provider.provider)
@@ -307,9 +326,9 @@ export function DataProvider() {
 
   useEffect(() => {
     const handler = () => {
-      serviceHub.providers().getProviders().then(async (providers) => {
-        const seeded = await seedProviderKeysFromKeyring(providers)
-        setProviders(seeded)
+      serviceHub.providers().getProviders().then(async (fetched) => {
+        setProviders(fetched)
+        await applyKeyringKeys()
         syncRemoteProviders()
         syncModelParamDefaults()
       })

--- a/web-app/src/providers/ServiceHubProvider.tsx
+++ b/web-app/src/providers/ServiceHubProvider.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react'
 import { initializeServiceHub } from '@/services'
 import { initializeServiceHubStore } from '@/hooks/useServiceHub'
+import { hydrateBackendStores } from '@/lib/hydrateStores'
+import { migrateLocalStorageToBackend } from '@/lib/migrateLocalStorageSettings'
 
 interface ServiceHubProviderProps {
   children: React.ReactNode
@@ -11,9 +13,15 @@ export function ServiceHubProvider({ children }: ServiceHubProviderProps) {
 
   useEffect(() => {
     initializeServiceHub()
-      .then((hub) => {
+      .then(async (hub) => {
         console.log('Services initialized, initializing Zustand store')
         initializeServiceHubStore(hub)
+        // One-time localStorage -> backend migration must run before hydration
+        // so the backend store is populated before any store reads it.
+        await migrateLocalStorageToBackend()
+        // Settings stores use async backend storage; hydrate before rendering
+        // children so no component reads pre-hydration defaults.
+        await hydrateBackendStores()
         setIsReady(true)
       })
       .catch((error) => {

--- a/web-app/src/providers/__tests__/DataProvider.test.tsx
+++ b/web-app/src/providers/__tests__/DataProvider.test.tsx
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 const h = vi.hoisted(() => {
   return {
     setProviders: vi.fn(),
+    updateProvider: vi.fn(),
     getProviderByName: vi.fn(),
     providers: [] as Array<Record<string, unknown>>,
     checkForUpdate: vi.fn(),
@@ -46,8 +47,14 @@ vi.mock('@/hooks/useModelProvider', () => {
   const useModelProvider = vi.fn(() => ({
     setProviders: h.setProviders,
     getProviderByName: h.getProviderByName,
-  })) as unknown as { (): unknown; getState: () => { providers: unknown[] } }
-  useModelProvider.getState = () => ({ providers: h.providers })
+  })) as unknown as {
+    (): unknown
+    getState: () => { providers: unknown[]; updateProvider: () => void }
+  }
+  useModelProvider.getState = () => ({
+    providers: h.providers,
+    updateProvider: h.updateProvider,
+  })
   return { useModelProvider }
 })
 
@@ -275,7 +282,7 @@ describe('DataProvider', () => {
   })
 
   it('registers remote providers with the backend for active providers', async () => {
-    hubState.getProviders.mockResolvedValue([
+    const fetched = [
       {
         provider: 'openai',
         active: true,
@@ -289,7 +296,10 @@ describe('DataProvider', () => {
         models: [],
         custom_header: [],
       },
-    ])
+    ]
+    hubState.getProviders.mockResolvedValue(fetched)
+    // Registration reads the store after setProviders merges the fetched list.
+    h.providers = fetched
     render(<DataProvider />)
     await waitFor(() => {
       expect(h.invoke).toHaveBeenCalledWith(
@@ -326,9 +336,11 @@ describe('DataProvider', () => {
   it('logs provider registration failures without throwing', async () => {
     const err = vi.spyOn(console, 'error').mockImplementation(() => {})
     h.invoke.mockRejectedValue(new Error('nope'))
-    hubState.getProviders.mockResolvedValue([
+    const fetched = [
       { provider: 'openai', active: true, models: [], custom_header: [] },
-    ])
+    ]
+    hubState.getProviders.mockResolvedValue(fetched)
+    h.providers = fetched
     render(<DataProvider />)
     await waitFor(() => {
       expect(err).toHaveBeenCalledWith(

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -346,6 +346,12 @@ function ProviderDetail() {
       api_key: nextPrimary,
       api_key_fallbacks: nextFallbacks,
     })
+    // Clearing the key is an explicit user action: purge the keyring secret so
+    // it isn't re-seeded into memory on the next launch. (register handles the
+    // non-empty case via boot sync -> register_provider_config.)
+    if (nextPrimary.length === 0 && nextFallbacks.length === 0) {
+      serviceHub.providers().deleteProviderKeys(providerName)
+    }
   }, [apiKeysDraft, provider, providerName, serviceHub, updateProvider])
 
   const commitBaseUrlDraft = useCallback(() => {

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -569,10 +569,8 @@ function ThreadDetail() {
   const hasBannerError = !!(oomError || backendError || contextLimitError)
   const effectiveStatus = hasBannerError ? 'ready' : status
 
-  // Get disabled tools for this thread to trigger re-render when they change
-  const disabledTools = useToolAvailable((state) =>
-    state.getDisabledToolsForThread(threadId)
-  )
+  // Global disabled-tools set; re-run the effect below when it changes.
+  const disabledTools = useToolAvailable((state) => state.disabledTools)
 
   // Update RAG tools availability when documents, model, or tool availability changes
   useEffect(() => {

--- a/web-app/src/services/app/tauri.ts
+++ b/web-app/src/services/app/tauri.ts
@@ -12,16 +12,17 @@ export class TauriAppService extends DefaultAppService {
   /**
    * Factory reset with optional data preservation.
    *
-   * User settings are persisted to `settings.json` via @tauri-apps/plugin-store
-   * (see #7821). The Rust `factory_reset` command conditionally deletes
-   * directories, config files, and `settings.json` based on the keep flags.
-   * No frontend snapshot/restore is needed — the file store is preserved or
-   * wiped on disk by the Rust side.
+   * User settings are persisted to `<jan_data>/settings.json` by the Rust
+   * settings store (`core::app::settings_store`), and secrets to the OS keyring
+   * (encrypted-file fallback `provider_secrets.enc`). The Rust `factory_reset`
+   * command conditionally deletes directories, config files, `settings.json`,
+   * and `provider_secrets.enc` based on the keep flags — no frontend
+   * snapshot/restore is needed.
    *
-   * Persisted UI state (selected model, provider list, threads) lives in the
-   * webview localStorage, not the data folder. The reliable clear happens on
-   * next startup via a Rust sentinel (see `main.tsx`) — renderer-side removal
-   * here is a best-effort supplement that races the restart flush.
+   * localStorage still holds a frozen pre-migration snapshot (kept so a
+   * downgraded build can read it). The reliable clear happens on next startup
+   * via a Rust sentinel (see `main.tsx`) — renderer-side removal here is a
+   * best-effort supplement that races the restart flush.
    */
   async factoryReset(options?: FactoryResetOptions): Promise<void> {
     const { EngineManager } = await import('@janhq/core')

--- a/web-app/src/services/providers/__tests__/tauri.test.ts
+++ b/web-app/src/services/providers/__tests__/tauri.test.ts
@@ -5,6 +5,10 @@ vi.mock('@tauri-apps/plugin-http', () => ({
   fetch: vi.fn(),
 }))
 
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+
 vi.mock('@/constants/providers', () => ({
   predefinedProviders: [
     {
@@ -67,6 +71,7 @@ vi.mock('@/lib/provider-api-keys', () => ({
 }))
 
 import { fetch as fetchTauri } from '@tauri-apps/plugin-http'
+import { invoke } from '@tauri-apps/api/core'
 import { EngineManager } from '@janhq/core'
 import { ExtensionManager } from '@/lib/extension'
 import { providerRemoteApiKeyChain } from '@/lib/provider-api-keys'
@@ -453,6 +458,24 @@ describe('TauriProvidersService', () => {
 
       const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       await expect(svc.updateSettings('test', [])).rejects.toThrow('fail')
+      errSpy.mockRestore()
+    })
+  })
+
+  describe('deleteProviderKeys', () => {
+    it('invokes delete_provider_keys with the provider name', async () => {
+      vi.mocked(invoke).mockResolvedValueOnce(undefined)
+      await svc.deleteProviderKeys('openai')
+      expect(invoke).toHaveBeenCalledWith('delete_provider_keys', {
+        provider: 'openai',
+      })
+    })
+
+    it('swallows and logs errors so a failed delete never throws', async () => {
+      vi.mocked(invoke).mockRejectedValueOnce(new Error('keyring down'))
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      await expect(svc.deleteProviderKeys('openai')).resolves.toBeUndefined()
+      expect(errSpy).toHaveBeenCalled()
       errSpy.mockRestore()
     })
   })

--- a/web-app/src/services/providers/__tests__/tauri.test.ts
+++ b/web-app/src/services/providers/__tests__/tauri.test.ts
@@ -63,6 +63,7 @@ vi.mock('@/lib/models', () => ({
 
 vi.mock('@/lib/provider-api-keys', () => ({
   providerRemoteApiKeyChain: vi.fn().mockReturnValue([]),
+  API_KEY_FALLBACKS_SETTING_KEY: 'api-key-fallbacks',
 }))
 
 import { fetch as fetchTauri } from '@tauri-apps/plugin-http'
@@ -423,6 +424,24 @@ describe('TauriProvidersService', () => {
           controllerProps: { value: '' },
         }),
       ])
+    })
+
+    it('blanks api-key and api-key-fallbacks so keys never reach settings.json', async () => {
+      const mockUpdate = vi.fn()
+      vi.mocked(ExtensionManager.getInstance).mockReturnValue({
+        getEngine: vi.fn().mockReturnValue({ updateSettings: mockUpdate }),
+      } as any)
+
+      await svc.updateSettings('openai', [
+        { key: 'api-key', controller_type: 'input', controller_props: { value: 'sk-secret' } } as any,
+        { key: 'api-key-fallbacks', controller_type: 'input', controller_props: { value: 'sk-a\nsk-b' } } as any,
+        { key: 'base-url', controller_type: 'input', controller_props: { value: 'https://x' } } as any,
+      ])
+
+      const persisted = mockUpdate.mock.calls[0][0]
+      expect(persisted.find((s: any) => s.key === 'api-key').controllerProps.value).toBe('')
+      expect(persisted.find((s: any) => s.key === 'api-key-fallbacks').controllerProps.value).toBe('')
+      expect(persisted.find((s: any) => s.key === 'base-url').controllerProps.value).toBe('https://x')
     })
 
     it('rethrows on error', async () => {

--- a/web-app/src/services/providers/default.ts
+++ b/web-app/src/services/providers/default.ts
@@ -19,6 +19,11 @@ export class DefaultProvidersService implements ProvidersService {
     // No-op - not implemented in default service
   }
 
+  async deleteProviderKeys(providerName: string): Promise<void> {
+    console.log('deleteProviderKeys called:', { providerName })
+    // No-op - no keyring on the default (web) service
+  }
+
   fetch(): typeof fetch {
     return fetch
   }

--- a/web-app/src/services/providers/tauri.ts
+++ b/web-app/src/services/providers/tauri.ts
@@ -11,7 +11,10 @@ import { ExtensionManager } from '@/lib/extension'
 import { fetch as fetchTauri } from '@tauri-apps/plugin-http'
 import { DefaultProvidersService } from './default'
 import { getModelCapabilities } from '@/lib/models'
-import { providerRemoteApiKeyChain } from '@/lib/provider-api-keys'
+import {
+  API_KEY_FALLBACKS_SETTING_KEY,
+  providerRemoteApiKeyChain,
+} from '@/lib/provider-api-keys'
 
 export class TauriProvidersService extends DefaultProvidersService {
   fetch(): typeof fetch {
@@ -269,6 +272,11 @@ export class TauriProvidersService extends DefaultProvidersService {
     settings: ProviderSetting[]
   ): Promise<void> {
     try {
+      // API keys are persisted to the OS keyring only (via
+      // register_provider_config), never to the extension's settings.json.
+      // Blank the key entries at this single chokepoint regardless of caller.
+      const isSecretKey = (key: string) =>
+        key === 'api-key' || key === API_KEY_FALLBACKS_SETTING_KEY
       return ExtensionManager.getInstance()
         .getEngine(providerName)
         ?.updateSettings(
@@ -276,8 +284,9 @@ export class TauriProvidersService extends DefaultProvidersService {
             ...setting,
             controllerProps: {
               ...setting.controller_props,
-              value:
-                setting.controller_props.value !== undefined
+              value: isSecretKey(setting.key)
+                ? ''
+                : setting.controller_props.value !== undefined
                   ? setting.controller_props.value
                   : '',
             },

--- a/web-app/src/services/providers/tauri.ts
+++ b/web-app/src/services/providers/tauri.ts
@@ -9,6 +9,7 @@ import { ModelCapabilities } from '@/types/models'
 import { modelSettings } from '@/lib/predefined'
 import { ExtensionManager } from '@/lib/extension'
 import { fetch as fetchTauri } from '@tauri-apps/plugin-http'
+import { invoke } from '@tauri-apps/api/core'
 import { DefaultProvidersService } from './default'
 import { getModelCapabilities } from '@/lib/models'
 import {
@@ -129,6 +130,14 @@ export class TauriProvidersService extends DefaultProvidersService {
     } catch (error: unknown) {
       console.error('Error getting providers in Tauri:', error)
       return []
+    }
+  }
+
+  async deleteProviderKeys(providerName: string): Promise<void> {
+    try {
+      await invoke('delete_provider_keys', { provider: providerName })
+    } catch (error) {
+      console.error(`Failed to delete keyring keys for ${providerName}:`, error)
     }
   }
 

--- a/web-app/src/services/providers/types.ts
+++ b/web-app/src/services/providers/types.ts
@@ -6,5 +6,11 @@ export interface ProvidersService {
   getProviders(): Promise<ModelProvider[]>
   fetchModelsFromProvider(provider: ModelProvider): Promise<string[]>
   updateSettings(providerName: string, settings: ProviderSetting[]): Promise<void>
+  /**
+   * Permanently delete a provider's stored API key chain from the OS keyring.
+   * Explicit, user-initiated only (provider removal / key clear) — never called
+   * during boot reconciliation, which must not destroy stored secrets.
+   */
+  deleteProviderKeys(providerName: string): Promise<void>
   fetch(): typeof fetch
 }


### PR DESCRIPTION
## Describe Your Changes

- Persist provider settings and secrets to the backend settings store with
OS keyring (encrypted-file fallback), plus localStorage migration and
store hydration. Adds settings_store.rs and provider_secrets.rs on the
Rust side and backendStorage/hydrateStores/migrateLocalStorageSettings on
the web side, wiring all settings hooks through the new storage layer.

## Fixes Issues

- Closes https://github.com/janhq/jan-internal/issues/167
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
