### PR TITLE
fix(security): bump handlebars to 4.7.9 to clear RCE advisory

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -63,5 +63,8 @@
     "prettier": "^3.2.5",
     "typescript": "^5"
   },
+  "resolutions": {
+    "handlebars": "^4.7.9"
+  },
   "packageManager": "yarn@1.22.22"
 }

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -4686,10 +4686,10 @@ hachure-fill@^0.5.2:
   resolved "https://registry.yarnpkg.com/hachure-fill/-/hachure-fill-0.5.2.tgz#d19bc4cc8750a5962b47fb1300557a85fcf934cc"
   integrity sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==
 
-handlebars@^4.7.8:
-  version "4.7.8"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.8.tgz#41c42c18b1be2365439188c77c6afae71c0cd9e9"
-  integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
+handlebars@^4.7.8, handlebars@^4.7.9:
+  version "4.7.9"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.9.tgz#6f139082ab58dc4e5a0e51efe7db5ae890d56a0f"
+  integrity sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==
   dependencies:
     minimist "^1.2.5"
     neo-async "^2.6.2"


### PR DESCRIPTION
## Describe Your Changes

- handlebars 4.7.8 (transitive via the plop devDependency) is flagged by GHSA for JavaScript injection via AST type confusion in Handlebars.compile(). Not reachable in Jan (docs is a static Nextra site with no runtime Handlebars.compile of untrusted input; plop runs only locally for blog-post scaffolding), but pin the patched version via a yarn resolution to clear the 8 open Dependabot alerts.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
