### PR TITLE
feat: OpenAI-compatible translating gateway + Responses API + unified reasoning

### DIFF
--- a/extensions/llamacpp-extension/settings.json
+++ b/extensions/llamacpp-extension/settings.json
@@ -222,7 +222,7 @@
   {
     "key": "parallel",
     "title": "Parallel Sequences",
-    "description": "Number of parallel sequences to decode (0 = llama.cpp default of 1). Set to 1 to also enable -kvu for optimized single-request serving.",
+    "description": "Number of parallel sequences to decode for your own chat requests (0 = llama.cpp default of 4). Jan reserves one additional internal slot beyond this for background requests (e.g. thread auto-titling), so they don't evict your chat's KV cache.",
     "controllerType": "input",
     "controllerProps": {
       "value": 1,
@@ -257,6 +257,15 @@
     "controllerType": "checkbox",
     "controllerProps": {
       "value": false
+    }
+  },
+  {
+    "key": "strip_reasoning_from_context",
+    "title": "Strip reasoning from context",
+    "description": "Remove prior turns' thinking/reasoning content before resending history. Improves KV-cache reuse across turns, but some models (e.g. newer Qwen releases) recommend keeping it for better multi-turn reasoning.",
+    "controllerType": "checkbox",
+    "controllerProps": {
+      "value": true
     }
   },
   {
@@ -381,7 +390,7 @@
   {
     "key": "swa_full",
     "title": "Full SWA Cache",
-    "description": "Use full-size SWA cache. May improve quality at the cost of memory.",
+    "description": "Use full-size KV cache for sliding-window-attention models (e.g. Gemma). Enable this if such a model reprocesses the entire prompt every turn instead of reusing cache; costs more memory.",
     "controllerType": "checkbox",
     "controllerProps": {
       "value": false

--- a/extensions/llamacpp-extension/settings.json
+++ b/extensions/llamacpp-extension/settings.json
@@ -102,7 +102,7 @@
   {
     "key": "fit_ctx",
     "title": "Fit Minimum Context Size",
-    "description": "Minimum context size (tokens) that can be set by --fit option. (env: LLAMA_ARG_FIT_CTX)",
+    "description": "Minimum context size (tokens) that can be set by the auto-fit option.",
     "controllerType": "input",
     "controllerProps": {
       "value": 4096,
@@ -356,7 +356,7 @@
   {
     "key": "cache_ram",
     "title": "Prompt Cache RAM (MiB)",
-    "description": "Maximum prompt cache size in MiB (--cache-ram). -1 = unlimited, 0 = disabled.",
+    "description": "Maximum prompt cache size in MiB. -1 = unlimited, 0 = disabled.",
     "controllerType": "input",
     "controllerProps": {
       "value": -1,
@@ -368,7 +368,7 @@
   {
     "key": "cache_reuse",
     "title": "Cache Reuse",
-    "description": "Min chunk size of matching prefix tokens to reuse from cache (--cache-reuse). 0 = disabled.",
+    "description": "Min chunk size of matching prefix tokens to reuse from cache. 0 = disabled.",
     "controllerType": "input",
     "controllerProps": {
       "value": 0,
@@ -381,7 +381,7 @@
   {
     "key": "swa_full",
     "title": "Full SWA Cache",
-    "description": "Use full-size SWA cache (--swa-full). May improve quality at the cost of memory.",
+    "description": "Use full-size SWA cache. May improve quality at the cost of memory.",
     "controllerType": "checkbox",
     "controllerProps": {
       "value": false
@@ -399,7 +399,7 @@
   {
     "key": "keep",
     "title": "Keep First N Tokens",
-    "description": "Number of tokens from the initial prompt to keep when context is shifted (--keep). -1 = keep all.",
+    "description": "Number of tokens from the initial prompt to keep when context is shifted. -1 = keep all.",
     "controllerType": "input",
     "controllerProps": {
       "value": 0,

--- a/extensions/llamacpp-extension/settings.json
+++ b/extensions/llamacpp-extension/settings.json
@@ -388,6 +388,15 @@
     }
   },
   {
+    "key": "kv_unified",
+    "title": "Unified KV Cache",
+    "description": "Use a single unified KV buffer shared across all slots. Saves memory when running multiple parallel slots; default is auto.",
+    "controllerType": "checkbox",
+    "controllerProps": {
+      "value": false
+    }
+  },
+  {
     "key": "keep",
     "title": "Keep First N Tokens",
     "description": "Number of tokens from the initial prompt to keep when context is shifted (--keep). -1 = keep all.",

--- a/extensions/llamacpp-extension/settings.json
+++ b/extensions/llamacpp-extension/settings.json
@@ -390,10 +390,15 @@
   {
     "key": "kv_unified",
     "title": "Unified KV Cache",
-    "description": "Use a single unified KV buffer shared across all slots. Saves memory when running multiple parallel slots; default is auto.",
-    "controllerType": "checkbox",
+    "description": "Use a single unified KV buffer shared across all slots. Saves memory when running multiple parallel slots.",
+    "controllerType": "dropdown",
     "controllerProps": {
-      "value": false
+      "value": "auto",
+      "options": [
+        { "value": "auto", "name": "Auto" },
+        { "value": "on", "name": "On" },
+        { "value": "off", "name": "Off" }
+      ]
     }
   },
   {

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -3050,6 +3050,9 @@ export default class llamacpp_extension extends AIEngine {
     // (chunk.prompt_progress?.processed / chunk.prompt_progress?.total) * 100
     // chunk.prompt_progress?.cache is for past tokens already in kv cache
     opts.return_progress = true
+    // Per-chunk timings so callers can track live token counts during
+    // generation instead of only once the stream finishes.
+    opts.timings_per_token = true
 
     const body = JSON.stringify(opts)
     if (opts.stream) {

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -3386,7 +3386,13 @@ export default class llamacpp_extension extends AIEngine {
     }
   }
 
-  async embed(text: string[]): Promise<EmbeddingResponse> {
+  /**
+   * Resolves the default/preferred embedding model, importing and loading
+   * sentence-transformer-mini as the fallback, then ensures a session exists.
+   * Shared by embed() and getEmbeddingContextSize() so both agree on which
+   * model is "the" embedding model.
+   */
+  private async ensureEmbeddingModelLoaded(): Promise<SessionInfo> {
     const downloadedModelList = await this.list()
     const installedEmbedding = downloadedModelList.filter(
       (m) => (m as any).embedding === true
@@ -3394,11 +3400,11 @@ export default class llamacpp_extension extends AIEngine {
     const hasMini = downloadedModelList.some(
       (m) => m.id === 'sentence-transformer-mini'
     )
-    let preferred = getDefaultEmbeddingModelId('llamacpp')
+    let preferred = await getDefaultEmbeddingModelId('llamacpp')
 
     if (!preferred && installedEmbedding.length === 1 && !hasMini) {
       preferred = installedEmbedding[0].id
-      setDefaultEmbeddingModelId('llamacpp', preferred)
+      await setDefaultEmbeddingModelId('llamacpp', preferred)
       logger.info(
         `Auto-promoted "${preferred}" as default embedding model (single installed model, sentence-transformer-mini not present)`
       )
@@ -3427,6 +3433,51 @@ export default class llamacpp_extension extends AIEngine {
       }
       sInfo = await this.load(targetModelId, undefined, true)
     }
+    return sInfo as SessionInfo
+  }
+
+  /**
+   * Actual post-fit context window of the embedding model, read from the
+   * router's /props endpoint (the same source getModelProps uses for chat
+   * models). Used by RAG ingestion to size chunks so they don't exceed the
+   * model's n_ctx (e.g. sentence-transformer-mini natively caps at 256).
+   */
+  async getEmbeddingContextSize(): Promise<number | undefined> {
+    const sInfo = await this.ensureEmbeddingModelLoaded()
+    const props = await this.getModelProps(sInfo.model_id)
+    return props?.nCtx
+  }
+
+  /**
+   * Real token counts from the embedding model's own tokenizer via /tokenize
+   * on its session port. Char-based chunking can't reliably predict token
+   * count (subword tokenizers vary widely by content), so callers that need
+   * a hard guarantee against exceed_context_size_error should verify with
+   * this rather than estimating from character length.
+   */
+  async countEmbeddingTokens(texts: string[]): Promise<number[]> {
+    const sInfo = await this.ensureEmbeddingModelLoaded()
+    const counts: number[] = []
+    for (const text of texts) {
+      const res = await fetch(`http://localhost:${sInfo.port}/tokenize`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${sInfo.api_key}`,
+        },
+        body: JSON.stringify({ content: text }),
+      })
+      if (!res.ok) {
+        throw new Error(`Tokenize request failed with status ${res.status}`)
+      }
+      const json = (await res.json()) as { tokens?: unknown[] }
+      counts.push(Array.isArray(json.tokens) ? json.tokens.length : 0)
+    }
+    return counts
+  }
+
+  async embed(text: string[]): Promise<EmbeddingResponse> {
+    const sInfo = await this.ensureEmbeddingModelLoaded()
 
     const ubatchSize =
       (this.config?.ubatch_size && this.config.ubatch_size > 0
@@ -3457,7 +3508,7 @@ export default class llamacpp_extension extends AIEngine {
     }
 
     const sendBatch = async (batchInput: string[]) => {
-      const response = await attemptRequest(sInfo as SessionInfo, batchInput)
+      const response = await attemptRequest(sInfo, batchInput)
       if (!response.ok) {
         const errorData = await response.json().catch(() => null)
         throw new Error(
@@ -3474,7 +3525,7 @@ export default class llamacpp_extension extends AIEngine {
     }
 
     return mergeEmbedResponses(
-      (sInfo as SessionInfo).model_id,
+      sInfo.model_id,
       batchResults
     ) as EmbeddingResponse
   }

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -120,6 +120,7 @@ const PRESET_AFFECTING_KEYS = new Set<string>([
   'cache_reuse',
   'swa_full',
   'keep',
+  'kv_unified',
 ])
 
 /**

--- a/extensions/llamacpp-extension/src/preset.test.ts
+++ b/extensions/llamacpp-extension/src/preset.test.ts
@@ -159,6 +159,31 @@ describe('generatePreset MTP emission', () => {
   })
 })
 
+describe('generatePreset parallel reservation', () => {
+  it('adds one reserved background slot on top of the global parallel value', async () => {
+    setupModel('llama', {})
+    await generatePreset('/p', '/jan', { parallel: 1 } as any, {
+      supportsMtp: false,
+    })
+    const ini = writtenFiles['/p/router.preset.ini']
+    expect(ini).toContain('parallel = 2')
+  })
+
+  it('adds one reserved background slot on top of a per-model parallel override', async () => {
+    setupModel('llama', { parallel: 3 })
+    await generatePreset('/p', '/jan', {} as any, { supportsMtp: false })
+    const ini = writtenFiles['/p/router.preset.ini']
+    expect(ini).toContain('parallel = 4')
+  })
+
+  it('omits parallel when unset, leaving llama.cpp auto-default untouched', async () => {
+    setupModel('llama', {})
+    await generatePreset('/p', '/jan', {} as any, { supportsMtp: false })
+    const ini = writtenFiles['/p/router.preset.ini']
+    expect(ini).not.toContain('parallel =')
+  })
+})
+
 describe('generatePreset ctx-size default', () => {
   it('emits ctx-size = 8192 in [*] when fit is off and no ctx_size is set', async () => {
     setupModel('llama', {})

--- a/extensions/llamacpp-extension/src/preset.test.ts
+++ b/extensions/llamacpp-extension/src/preset.test.ts
@@ -210,6 +210,26 @@ describe('generatePreset ctx-size default', () => {
   })
 })
 
+describe('generatePreset context-shift', () => {
+  it('emits context-shift = true when ctx_shift is enabled', async () => {
+    setupModel('llama', {})
+    await generatePreset('/p', '/jan', { ctx_shift: true } as any, {
+      supportsMtp: false,
+    })
+    const ini = writtenFiles['/p/router.preset.ini']
+    expect(ini).toContain('context-shift = true')
+  })
+
+  it('omits context-shift when disabled, matching llama.cpp own default', async () => {
+    setupModel('llama', {})
+    await generatePreset('/p', '/jan', { ctx_shift: false } as any, {
+      supportsMtp: false,
+    })
+    const ini = writtenFiles['/p/router.preset.ini']
+    expect(ini).not.toContain('context-shift')
+  })
+})
+
 describe('generatePreset embedding ctx-size', () => {
   it('pins embedders to native ctx-size = 0 so they do not inherit the global 8192', async () => {
     setupModel('minilm', { embedding: true })

--- a/extensions/llamacpp-extension/src/preset.ts
+++ b/extensions/llamacpp-extension/src/preset.ts
@@ -307,6 +307,11 @@ export async function generatePreset(
   if (config.swa_full === true) {
     lines.push('swa-full = true')
   }
+  // kv-unified default = auto (enabled when slot count is auto); explicit
+  // opt-in only, since the auto default already covers the common case.
+  if (config.kv_unified === true) {
+    lines.push('kv-unified = true')
+  }
   // keep default = 0
   if (
     typeof config.keep === 'number' &&

--- a/extensions/llamacpp-extension/src/preset.ts
+++ b/extensions/llamacpp-extension/src/preset.ts
@@ -47,6 +47,12 @@ type ModelYaml = ModelConfig & {
   mmproj_offload?: boolean
 }
 
+// One extra llama-server slot beyond the user-visible "Parallel Sequences"
+// count, reserved for background requests (e.g. thread auto-titling) that
+// must never be able to evict the user's own chat KV cache from its slot.
+// Hidden from the setting's UI value; see reservedSlotId in thread-title-summarizer.ts.
+export const RESERVED_BACKGROUND_SLOTS = 1
+
 export const MTP_MIN_BUILD = 9193
 
 const DEFAULT_EMBEDDING_UBATCH = 2048
@@ -182,9 +188,10 @@ export async function generatePreset(
   ) {
     lines.push(`cache-type-v = ${escapeIniValue(config.cache_type_v)}`)
   }
-  // parallel default = -1 (auto); positive user value is intent.
+  // parallel default = -1 (auto); positive user value is intent. The reserved
+  // slot is added on top and never exposed in the setting's own value.
   if (typeof config.parallel === 'number' && config.parallel > 0) {
-    lines.push(`parallel = ${config.parallel}`)
+    lines.push(`parallel = ${config.parallel + RESERVED_BACKGROUND_SLOTS}`)
   }
   // cont-batching default = true; emit only the explicit-off case.
   if (config.cont_batching === false) {
@@ -387,7 +394,7 @@ export async function generatePreset(
       lines.push(`cache-type-v = ${escapeIniValue(mc.cache_type_v)}`)
     }
     if (typeof mc.parallel === 'number' && mc.parallel > 0) {
-      lines.push(`parallel = ${mc.parallel}`)
+      lines.push(`parallel = ${mc.parallel + RESERVED_BACKGROUND_SLOTS}`)
     }
     if (mc.cont_batching === false) {
       lines.push('cont-batching = false')

--- a/extensions/llamacpp-extension/src/preset.ts
+++ b/extensions/llamacpp-extension/src/preset.ts
@@ -307,10 +307,11 @@ export async function generatePreset(
   if (config.swa_full === true) {
     lines.push('swa-full = true')
   }
-  // kv-unified default = auto (enabled when slot count is auto); explicit
-  // opt-in only, since the auto default already covers the common case.
-  if (config.kv_unified === true) {
+  // auto = omit the flag, let llama.cpp decide based on slot count
+  if (config.kv_unified === 'on') {
     lines.push('kv-unified = true')
+  } else if (config.kv_unified === 'off') {
+    lines.push('kv-unified = false')
   }
   // keep default = 0
   if (

--- a/extensions/llamacpp-extension/src/preset.ts
+++ b/extensions/llamacpp-extension/src/preset.ts
@@ -284,9 +284,9 @@ export async function generatePreset(
   ) {
     lines.push(`rope-freq-scale = ${config.rope_freq_scale}`)
   }
-  // context-shift default = enabled
-  if (config.ctx_shift === false) {
-    lines.push('context-shift = false')
+  // context-shift default = disabled
+  if (config.ctx_shift === true) {
+    lines.push('context-shift = true')
   }
   // cache-ram default = 8192 MiB
   if (

--- a/extensions/llamacpp-extension/src/util.ts
+++ b/extensions/llamacpp-extension/src/util.ts
@@ -1,3 +1,5 @@
+import { invoke } from '@tauri-apps/api/core'
+
 // File path utilities
 export function basenameNoExt(filePath: string): string {
   const VALID_EXTENSIONS = [".tar.gz", ".zip"];
@@ -32,11 +34,34 @@ interface ProxyState {
   noProxy: string
 }
 
-export function getDefaultEmbeddingModelId(
-  provider: string = 'llamacpp'
-): string | undefined {
+const DEFAULT_EMBEDDING_MODEL_KEY = 'default-embedding-model'
+
+// The web-app's useDefaultEmbeddingModel store persists this key through
+// the Rust settings backend (settings_get/settings_set -> settings.json),
+// not webview localStorage, on desktop. Read/write the same backend so this
+// extension sees the model the user actually picked in Settings; localStorage
+// is only a fallback for `dev:web` (no Tauri shell).
+async function readDefaultEmbeddingModelRaw(): Promise<string | null> {
   try {
-    const raw = localStorage.getItem('default-embedding-model')
+    const value = await invoke<string | null>('settings_get', {
+      key: DEFAULT_EMBEDDING_MODEL_KEY,
+    })
+    if (value != null) return value
+  } catch {
+    /* not running under Tauri, or command unavailable */
+  }
+  try {
+    return localStorage.getItem(DEFAULT_EMBEDDING_MODEL_KEY)
+  } catch {
+    return null
+  }
+}
+
+export async function getDefaultEmbeddingModelId(
+  provider: string = 'llamacpp'
+): Promise<string | undefined> {
+  try {
+    const raw = await readDefaultEmbeddingModelRaw()
     if (!raw) return undefined
     const parsed = JSON.parse(raw)
     const map = parsed?.state?.defaultByProvider
@@ -47,18 +72,31 @@ export function getDefaultEmbeddingModelId(
   }
 }
 
-export function setDefaultEmbeddingModelId(provider: string, modelId: string) {
+export async function setDefaultEmbeddingModelId(
+  provider: string,
+  modelId: string
+) {
   try {
-    const raw = localStorage.getItem('default-embedding-model')
+    const raw = await readDefaultEmbeddingModelRaw()
     const parsed = raw ? JSON.parse(raw) : { state: {}, version: 0 }
     const state = parsed.state ?? {}
     const map = state.defaultByProvider ?? {}
     map[provider] = modelId
     parsed.state = { ...state, defaultByProvider: map }
     if (parsed.version === undefined) parsed.version = 0
-    localStorage.setItem('default-embedding-model', JSON.stringify(parsed))
+    const serialized = JSON.stringify(parsed)
+    try {
+      await invoke('settings_set', {
+        key: DEFAULT_EMBEDDING_MODEL_KEY,
+        value: serialized,
+      })
+      return
+    } catch {
+      /* not running under Tauri, or command unavailable */
+    }
+    localStorage.setItem(DEFAULT_EMBEDDING_MODEL_KEY, serialized)
   } catch {
-    /* localStorage write failed; non-fatal */
+    /* non-fatal */
   }
 }
 

--- a/extensions/mlx-extension/settings.json
+++ b/extensions/mlx-extension/settings.json
@@ -5,5 +5,12 @@
     "description": "Automatically unload other models when loading a new one",
     "controllerType": "checkbox",
     "controllerProps": { "value": true }
+  },
+  {
+    "key": "strip_reasoning_from_context",
+    "title": "Strip reasoning from context",
+    "description": "Remove prior turns' thinking/reasoning content before resending history. Improves KV-cache reuse across turns, but some models (e.g. newer Qwen releases) recommend keeping it for better multi-turn reasoning.",
+    "controllerType": "checkbox",
+    "controllerProps": { "value": true }
   }
 ]

--- a/extensions/vector-db-extension/src/index.ts
+++ b/extensions/vector-db-extension/src/index.ts
@@ -2,6 +2,15 @@ import { VectorDBExtension, type SearchMode, type VectorDBStatus, type VectorChu
 import * as vecdb from '@janhq/tauri-plugin-vector-db-api'
 import * as ragApi from '@janhq/tauri-plugin-rag-api'
 
+// Conservative average for English/dense text; real tokenizers vary (CJK
+// runs closer to 1-2 chars/token), so this stays a deliberate underestimate
+// rather than an exact conversion.
+const CHARS_PER_TOKEN_ESTIMATE = 3
+const CONTEXT_SAFETY_MARGIN = 0.8
+const MIN_CHUNK_SIZE_CHARS = 64
+// Reserves room for BOS/special tokens the tokenizer adds beyond raw content.
+const EMBEDDING_CONTEXT_SAFETY_TOKENS = 8
+
 export default class VectorDBExt extends VectorDBExtension {
   async onLoad(): Promise<void> {
     // no-op
@@ -144,13 +153,74 @@ export default class VectorDBExt extends VectorDBExtension {
 
   // Optional helper for chunking
   private async chunkText(text: string, chunkSize: number, chunkOverlap: number): Promise<string[]> {
-    return await vecdb.chunkText(text, chunkSize, chunkOverlap)
+    const safeChunkSize = await this.clampToEmbeddingContext(chunkSize, chunkOverlap)
+    const rawChunks = await vecdb.chunkText(text, safeChunkSize, chunkOverlap)
+    return await this.ensureChunksFitEmbeddingContext(rawChunks)
+  }
+
+  /**
+   * chunk_text (Rust) splits by raw character count with no tokenizer
+   * awareness. Clamp the char budget to the embedding model's real n_ctx so
+   * most chunks fit on the first try (cheap, but only an estimate).
+   */
+  private async clampToEmbeddingContext(chunkSize: number, chunkOverlap: number): Promise<number> {
+    const llm = this.getEmbeddingEngine()
+    if (!llm?.getEmbeddingContextSize) return chunkSize
+    const ctxSize = await llm.getEmbeddingContextSize().catch(() => undefined)
+    if (!ctxSize || ctxSize <= 0) return chunkSize
+    const safeMaxChars = Math.floor(
+      ctxSize * CHARS_PER_TOKEN_ESTIMATE * CONTEXT_SAFETY_MARGIN
+    )
+    const budget = Math.max(MIN_CHUNK_SIZE_CHARS, safeMaxChars - chunkOverlap)
+    return Math.min(chunkSize, budget)
+  }
+
+  /**
+   * Character-based estimates can't be trusted for every tokenizer/content
+   * mix (subword tokenizers on dense text can run well under the assumed
+   * chars-per-token ratio). Verify each chunk against the embedding model's
+   * real tokenizer and recursively halve any chunk that still doesn't fit,
+   * so ingestion can never hit exceed_context_size_error.
+   */
+  private async ensureChunksFitEmbeddingContext(chunks: string[]): Promise<string[]> {
+    const llm = this.getEmbeddingEngine()
+    if (!llm?.getEmbeddingContextSize || !llm?.countEmbeddingTokens) return chunks
+    const ctxSize = await llm.getEmbeddingContextSize().catch(() => undefined)
+    if (!ctxSize || ctxSize <= 0) return chunks
+    const budget = Math.max(1, ctxSize - EMBEDDING_CONTEXT_SAFETY_TOKENS)
+
+    const out: string[] = []
+    for (const chunk of chunks) {
+      out.push(...(await this.splitChunkToFit(chunk, budget, llm)))
+    }
+    return out
+  }
+
+  private async splitChunkToFit(
+    text: string,
+    budget: number,
+    llm: { countEmbeddingTokens: (texts: string[]) => Promise<number[]> }
+  ): Promise<string[]> {
+    if (!text) return []
+    const [count] = await llm.countEmbeddingTokens([text]).catch(() => [0])
+    if (count <= budget || text.length <= MIN_CHUNK_SIZE_CHARS) return [text]
+    const mid = Math.floor(text.length / 2)
+    return [
+      ...(await this.splitChunkToFit(text.slice(0, mid), budget, llm)),
+      ...(await this.splitChunkToFit(text.slice(mid), budget, llm)),
+    ]
+  }
+
+  private getEmbeddingEngine() {
+    return window.core?.extensionManager.getByName('@janhq/llamacpp-extension') as AIEngine & {
+      embed?: (texts: string[]) => Promise<{ data: Array<{ embedding: number[]; index: number }> }>
+      getEmbeddingContextSize?: () => Promise<number | undefined>
+      countEmbeddingTokens?: (texts: string[]) => Promise<number[]>
+    }
   }
 
   private async embedTexts(texts: string[]): Promise<number[][]> {
-    const llm = window.core?.extensionManager.getByName('@janhq/llamacpp-extension') as AIEngine & {
-      embed?: (texts: string[]) => Promise<{ data: Array<{ embedding: number[]; index: number }> }>
-    }
+    const llm = this.getEmbeddingEngine()
     if (!llm?.embed) throw new Error('llamacpp extension not available')
 
     const res = await llm.embed(texts)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -6749,6 +6749,7 @@ version = "0.8.3"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
+ "futures-util",
  "hmac",
  "jan-utils",
  "lddtree",

--- a/src-tauri/plugins/tauri-plugin-llamacpp/Cargo.lock
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/Cargo.lock
@@ -3418,6 +3418,7 @@ version = "0.8.3"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
+ "futures-util",
  "hmac",
  "jan-utils",
  "lddtree",

--- a/src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = "2.0.12"
 tokio = { version = "1", features = ["full"] }
 tauri-plugin-hardware = { path = "../tauri-plugin-hardware" }
 serde_json = "1.0.149"
+futures-util = "0.3"
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 reqwest = { version = "0.12", features = ["json", "blocking", "stream", "native-tls"] }

--- a/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/index.ts
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/index.ts
@@ -116,6 +116,7 @@ export function normalizeLlamacppConfig(config: any): LlamacppConfig {
     cache_reuse: asI32(config.cache_reuse, 0),
     swa_full: asBool(config.swa_full),
     keep: asI32(config.keep, 0),
+    kv_unified: asBool(config.kv_unified),
   }
 }
 

--- a/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/index.ts
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/index.ts
@@ -116,7 +116,7 @@ export function normalizeLlamacppConfig(config: any): LlamacppConfig {
     cache_reuse: asI32(config.cache_reuse, 0),
     swa_full: asBool(config.swa_full),
     keep: asI32(config.keep, 0),
-    kv_unified: asBool(config.kv_unified),
+    kv_unified: asString(config.kv_unified, 'auto'),
   }
 }
 

--- a/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/types.ts
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/types.ts
@@ -80,6 +80,7 @@ export type LlamacppConfig = {
   cache_reuse: number
   swa_full: boolean
   keep: number
+  kv_unified: boolean
 }
 
 export type ModelPlan = {

--- a/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/types.ts
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/guest-js/types.ts
@@ -80,7 +80,7 @@ export type LlamacppConfig = {
   cache_reuse: number
   swa_full: boolean
   keep: number
-  kv_unified: boolean
+  kv_unified: string
 }
 
 export type ModelPlan = {

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/commands.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/commands.rs
@@ -137,6 +137,118 @@ fn spawn_load_progress_listener<R: Runtime>(
     })
 }
 
+/// Payload for the `llamacpp-model-unloaded` event: any model transition to
+/// `status: "unloaded"` seen on `/models/sse`, regardless of cause (explicit
+/// unload, LRU eviction under `models_max`, or a crash - `exit_code` is 0 for
+/// the first two, nonzero for a crash). Forwarded unconditionally; the
+/// frontend already knows about unloads it requested itself, so reconciling
+/// already-correct state is a harmless no-op.
+#[derive(serde::Serialize, Clone)]
+pub struct UnloadEventPayload {
+    pub model: String,
+    pub exit_code: Option<i64>,
+}
+
+/// Parses one SSE event block, returning an unload payload only for a
+/// `status_change` event whose `data.status` is `"unloaded"`. `None` for any
+/// other event/status or malformed input.
+fn parse_unload_event(block: &str) -> Option<UnloadEventPayload> {
+    for line in block.lines() {
+        let data = line
+            .strip_prefix("data: ")
+            .or_else(|| line.strip_prefix("data:"))?;
+        let json: serde_json::Value = serde_json::from_str(data).ok()?;
+        if json.get("event").and_then(|v| v.as_str()) != Some("status_change") {
+            continue;
+        }
+        let model = json.get("model").and_then(|v| v.as_str())?;
+        let status = json
+            .get("data")
+            .and_then(|d| d.get("status"))
+            .and_then(|v| v.as_str())?;
+        if status != "unloaded" {
+            continue;
+        }
+        let exit_code = json
+            .get("data")
+            .and_then(|d| d.get("exit_code"))
+            .and_then(|v| v.as_i64());
+        return Some(UnloadEventPayload {
+            model: model.to_string(),
+            exit_code,
+        });
+    }
+    None
+}
+
+/// Subscribes to the router's `/models/sse` feed for the router's entire
+/// lifetime, re-emitting every model-unload transition (explicit unload, LRU
+/// eviction, crash) as `llamacpp-model-unloaded`. Unlike
+/// `spawn_load_progress_listener` (per-model, aborted once loading finishes)
+/// this runs continuously and reconnects with backoff on a dropped
+/// connection, since the router process can outlive many individual loads.
+///
+/// `/models/sse` itself was introduced upstream in build b9688 (#23976); on
+/// an older backend the initial connection succeeds at the TCP/HTTP layer
+/// but the route 404s, so we give up permanently after the first failed
+/// connection instead of retrying forever against a route that will never
+/// exist. A transient connection error (router mid-restart) is retried with
+/// exponential backoff instead, since that's recoverable.
+fn spawn_unload_watcher<R: Runtime>(
+    app_handle: tauri::AppHandle<R>,
+    port: u16,
+    api_key: String,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        use futures_util::StreamExt;
+
+        let client = http_client().await;
+        let url = format!("http://127.0.0.1:{}/models/sse", port);
+        let mut backoff = Duration::from_millis(500);
+        const MAX_BACKOFF: Duration = Duration::from_secs(30);
+
+        loop {
+            let resp = match client.get(&url).bearer_auth(&api_key).send().await {
+                Ok(r) => r,
+                Err(e) => {
+                    log::debug!(
+                        "model unload watcher: failed to connect to /models/sse: {}; retrying in {:?}",
+                        e,
+                        backoff
+                    );
+                    tokio::time::sleep(backoff).await;
+                    backoff = (backoff * 2).min(MAX_BACKOFF);
+                    continue;
+                }
+            };
+            if !resp.status().is_success() {
+                log::debug!(
+                    "model unload watcher: /models/sse returned {} (backend predates b9688?); giving up",
+                    resp.status()
+                );
+                return;
+            }
+            backoff = Duration::from_millis(500);
+
+            let mut stream = resp.bytes_stream();
+            let mut buf = String::new();
+            while let Some(chunk) = stream.next().await {
+                let Ok(bytes) = chunk else { break };
+                buf.push_str(&String::from_utf8_lossy(&bytes));
+                while let Some(pos) = buf.find("\n\n") {
+                    let event_block: String = buf.drain(..pos + 2).collect();
+                    if let Some(payload) = parse_unload_event(&event_block) {
+                        let _ = app_handle.emit("llamacpp-model-unloaded", payload);
+                    }
+                }
+            }
+            // Stream ended (router restarted or connection dropped); briefly
+            // pause then reconnect.
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+    })
+}
+
 async fn post_load<R: Runtime>(
     app_handle: &tauri::AppHandle<R>,
     port: u16,
@@ -611,12 +723,23 @@ pub async fn start_router<R: Runtime>(
         .router_pid
         .store(handle.pid, std::sync::atomic::Ordering::SeqCst);
     *guard = Some(handle);
+
+    let watcher = spawn_unload_watcher(app_handle.clone(), info.port, info.api_key.clone());
+    *state.unload_watcher.lock().await = Some(watcher);
+
     Ok(info)
+}
+
+async fn stop_unload_watcher(state: &LlamacppState) {
+    if let Some(handle) = state.unload_watcher.lock().await.take() {
+        handle.abort();
+    }
 }
 
 #[tauri::command]
 pub async fn stop_router<R: Runtime>(app_handle: tauri::AppHandle<R>) -> Result<(), String> {
     let state: State<Arc<LlamacppState>> = app_handle.state();
+    stop_unload_watcher(&state).await;
     let mut guard = state.router.lock().await;
     if let Some(handle) = guard.take() {
         state
@@ -725,6 +848,7 @@ pub async fn try_graceful_stop_router<R: Runtime>(
             state
                 .router_pid
                 .store(0, std::sync::atomic::Ordering::SeqCst);
+            stop_unload_watcher(&state).await;
             Ok(None)
         }
         Err((h, busy)) => {
@@ -799,6 +923,7 @@ pub async fn force_kill_router_tree<R: Runtime>(
         let mut guard = state.router.lock().await;
         guard.take()
     };
+    stop_unload_watcher(&state).await;
     match (maybe_handle, pid) {
         (Some(handle), _) => crate::router::force_kill_router_tree(handle).await,
         (None, p) if p != 0 => crate::router::force_kill_router_tree_by_pid(p),
@@ -901,5 +1026,88 @@ mod load_progress_tests {
         );
         let payload = parse_load_progress_event(&block, "model-1").expect("should parse");
         assert!(payload.stage.is_none());
+    }
+}
+
+#[cfg(test)]
+mod unload_watcher_tests {
+    use super::parse_unload_event;
+
+    fn sse_block(model: &str, event: &str, data: serde_json::Value) -> String {
+        let payload = serde_json::json!({ "model": model, "event": event, "data": data });
+        format!("data: {}\n\n", payload)
+    }
+
+    #[test]
+    fn parses_an_unload_event_with_exit_code() {
+        let block = sse_block(
+            "model-1",
+            "status_change",
+            serde_json::json!({ "status": "unloaded", "exit_code": 137 }),
+        );
+        let payload = parse_unload_event(&block).expect("should parse");
+        assert_eq!(payload.model, "model-1");
+        assert_eq!(payload.exit_code, Some(137));
+    }
+
+    #[test]
+    fn parses_a_clean_unload_with_zero_exit_code() {
+        // LRU eviction / explicit unload: clean stop, exit_code 0.
+        let block = sse_block(
+            "model-1",
+            "status_change",
+            serde_json::json!({ "status": "unloaded", "exit_code": 0 }),
+        );
+        let payload = parse_unload_event(&block).expect("should parse");
+        assert_eq!(payload.exit_code, Some(0));
+    }
+
+    #[test]
+    fn ignores_non_unloaded_status() {
+        let block = sse_block(
+            "model-1",
+            "status_change",
+            serde_json::json!({ "status": "loading" }),
+        );
+        assert!(parse_unload_event(&block).is_none());
+    }
+
+    #[test]
+    fn ignores_non_status_change_events() {
+        let block = sse_block(
+            "model-1",
+            "model_remove",
+            serde_json::json!({}),
+        );
+        assert!(parse_unload_event(&block).is_none());
+    }
+
+    #[test]
+    fn defaults_missing_exit_code_to_none() {
+        let block = sse_block(
+            "model-1",
+            "status_change",
+            serde_json::json!({ "status": "unloaded" }),
+        );
+        let payload = parse_unload_event(&block).expect("should parse");
+        assert_eq!(payload.exit_code, None);
+    }
+
+    #[test]
+    fn ignores_malformed_json() {
+        let block = "data: not json\n\n".to_string();
+        assert!(parse_unload_event(&block).is_none());
+    }
+
+    #[test]
+    fn ignores_missing_status_field() {
+        let block = sse_block("model-1", "status_change", serde_json::json!({}));
+        assert!(parse_unload_event(&block).is_none());
+    }
+
+    #[test]
+    fn ignores_blocks_with_no_data_line() {
+        let block = "event: ping\n\n".to_string();
+        assert!(parse_unload_event(&block).is_none());
     }
 }

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/commands.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/commands.rs
@@ -41,10 +41,18 @@ async fn http_client() -> reqwest::Client {
 
 /// Payload for the `llamacpp-model-load-progress` event, mirrored from the
 /// router's `/models/sse` `status_change` events (`progress.value` is 0.0-1.0).
+/// `stage` is the upstream stage identifier being loaded right now
+/// (`text_model` | `mmproj_model` | `spec_model`); `stages` is the full set
+/// for this load - always includes `text_model`, plus `mmproj_model` for a
+/// vision-capable model and/or `spec_model` for speculative decoding. A
+/// plain text-only load (the common case) has exactly one stage, so the
+/// frontend uses `stages.len() > 1` to decide whether naming the stage is
+/// worth surfacing at all.
 #[derive(serde::Serialize, Clone)]
 pub struct LoadProgressPayload {
     pub model: String,
     pub stage: Option<String>,
+    pub stages: Vec<String>,
     pub value: f64,
 }
 
@@ -74,9 +82,19 @@ fn parse_load_progress_event(block: &str, model_id: &str) -> Option<LoadProgress
             .get("current")
             .and_then(|v| v.as_str())
             .map(|s| s.to_string());
+        let stages = progress
+            .get("stages")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|s| s.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
         return Some(LoadProgressPayload {
             model: model_id.to_string(),
             stage,
+            stages,
             value,
         });
     }
@@ -954,7 +972,41 @@ mod load_progress_tests {
         let payload = parse_load_progress_event(&block, "model-1").expect("should parse");
         assert_eq!(payload.model, "model-1");
         assert_eq!(payload.stage.as_deref(), Some("text_model"));
+        assert_eq!(payload.stages, vec!["text_model".to_string()]);
         assert!((payload.value - 0.42).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn parses_a_multi_stage_vision_model_load() {
+        let block = sse_block(
+            "model-1",
+            "status_change",
+            serde_json::json!({
+                "status": "loading",
+                "progress": {
+                    "stages": ["text_model", "mmproj_model"],
+                    "current": "mmproj_model",
+                    "value": 0.8
+                }
+            }),
+        );
+        let payload = parse_load_progress_event(&block, "model-1").expect("should parse");
+        assert_eq!(payload.stage.as_deref(), Some("mmproj_model"));
+        assert_eq!(
+            payload.stages,
+            vec!["text_model".to_string(), "mmproj_model".to_string()]
+        );
+    }
+
+    #[test]
+    fn defaults_missing_stages_array_to_empty() {
+        let block = sse_block(
+            "model-1",
+            "status_change",
+            serde_json::json!({ "progress": { "current": "text_model", "value": 0.5 } }),
+        );
+        let payload = parse_load_progress_event(&block, "model-1").expect("should parse");
+        assert!(payload.stages.is_empty());
     }
 
     #[test]

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/commands.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/commands.rs
@@ -39,7 +39,110 @@ async fn http_client() -> reqwest::Client {
         .unwrap_or_else(|_| reqwest::Client::new())
 }
 
-async fn post_load(port: u16, api_key: &str, model_id: &str) -> ServerResult<()> {
+/// Payload for the `llamacpp-model-load-progress` event, mirrored from the
+/// router's `/models/sse` `status_change` events (`progress.value` is 0.0-1.0).
+#[derive(serde::Serialize, Clone)]
+pub struct LoadProgressPayload {
+    pub model: String,
+    pub stage: Option<String>,
+    pub value: f64,
+}
+
+/// Parses one SSE "event block" (text up to and including a `\n\n`
+/// separator) and returns a progress payload if it's a `status_change` event
+/// for `model_id` carrying a non-null `progress` field. Returns `None` for
+/// any other event, a different model, or malformed input - callers should
+/// simply skip the block.
+fn parse_load_progress_event(block: &str, model_id: &str) -> Option<LoadProgressPayload> {
+    for line in block.lines() {
+        let data = line
+            .strip_prefix("data: ")
+            .or_else(|| line.strip_prefix("data:"))?;
+        let json: serde_json::Value = serde_json::from_str(data).ok()?;
+        if json.get("model").and_then(|v| v.as_str()) != Some(model_id) {
+            continue;
+        }
+        if json.get("event").and_then(|v| v.as_str()) != Some("status_change") {
+            continue;
+        }
+        let progress = json.get("data").and_then(|d| d.get("progress"))?;
+        if progress.is_null() {
+            continue;
+        }
+        let value = progress.get("value").and_then(|v| v.as_f64()).unwrap_or(0.0);
+        let stage = progress
+            .get("current")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        return Some(LoadProgressPayload {
+            model: model_id.to_string(),
+            stage,
+            value,
+        });
+    }
+    None
+}
+
+/// Subscribes to the router's `/models/sse` feed and re-emits `progress`
+/// updates for `model_id` as Tauri events, until the connection drops or the
+/// task is aborted by the caller once loading finishes.
+///
+/// `/models/sse` was introduced upstream in build b9747 (server: real-time
+/// model load progress tracking, #24828); this plugin doesn't track backend
+/// build numbers, so rather than gating ahead of time we just check the
+/// response here. Older backends 404 (or otherwise fail) and we return
+/// immediately without emitting anything - the UI already has a workaround,
+/// falling back to its plain "Loading model..." spinner (`loadingModel`,
+/// entirely unaffected by this listener) in `PromptProgress.tsx`.
+fn spawn_load_progress_listener<R: Runtime>(
+    app_handle: tauri::AppHandle<R>,
+    port: u16,
+    api_key: String,
+    model_id: String,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        use futures_util::StreamExt;
+
+        let client = http_client().await;
+        let url = format!("http://127.0.0.1:{}/models/sse", port);
+        let resp = match client.get(&url).bearer_auth(&api_key).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                log::debug!("model load progress: failed to connect to /models/sse: {}", e);
+                return;
+            }
+        };
+        if !resp.status().is_success() {
+            log::debug!(
+                "model load progress unavailable on this backend (/models/sse returned {}); \
+                 falling back to the plain loading indicator",
+                resp.status()
+            );
+            return;
+        }
+
+        let mut stream = resp.bytes_stream();
+        let mut buf = String::new();
+        while let Some(chunk) = stream.next().await {
+            let Ok(bytes) = chunk else { break };
+            buf.push_str(&String::from_utf8_lossy(&bytes));
+
+            while let Some(pos) = buf.find("\n\n") {
+                let event_block: String = buf.drain(..pos + 2).collect();
+                if let Some(payload) = parse_load_progress_event(&event_block, &model_id) {
+                    let _ = app_handle.emit("llamacpp-model-load-progress", payload);
+                }
+            }
+        }
+    })
+}
+
+async fn post_load<R: Runtime>(
+    app_handle: &tauri::AppHandle<R>,
+    port: u16,
+    api_key: &str,
+    model_id: &str,
+) -> ServerResult<()> {
     let client = http_client().await;
     let url = format!("http://127.0.0.1:{}/models/load", port);
     let resp = client
@@ -67,9 +170,18 @@ async fn post_load(port: u16, api_key: &str, model_id: &str) -> ServerResult<()>
         }
     }
 
+    let progress_task = spawn_load_progress_listener(
+        app_handle.clone(),
+        port,
+        api_key.to_string(),
+        model_id.to_string(),
+    );
+
     // /models/load returns success once loading is *initiated*; poll /models
     // until the entry transitions from "loading" to "loaded" (or fails).
-    wait_until_loaded(port, api_key, model_id, Duration::from_secs(600)).await
+    let result = wait_until_loaded(port, api_key, model_id, Duration::from_secs(600)).await;
+    progress_task.abort();
+    result
 }
 
 async fn wait_until_loaded(
@@ -336,7 +448,7 @@ pub async fn load_llama_model<R: Runtime>(
     let (port, api_key, pid) = router_endpoint(&app_handle)
         .await
         .map_err(ServerError::InvalidArgument)?;
-    post_load(port, &api_key, &model_id).await?;
+    post_load(&app_handle, port, &api_key, &model_id).await?;
     Ok(SessionInfo {
         pid: pid as i32,
         port: port as i32,
@@ -386,7 +498,7 @@ pub async fn ensure_session_ready<R: Runtime>(
     is_embedding: bool,
 ) -> Result<SessionInfo, String> {
     let (port, api_key, pid) = router_endpoint(&app_handle).await?;
-    post_load(port, &api_key, &model_id)
+    post_load(&app_handle, port, &api_key, &model_id)
         .await
         .map_err(|e| e.to_string())?;
     Ok(SessionInfo {
@@ -693,4 +805,101 @@ pub async fn force_kill_router_tree<R: Runtime>(
         _ => {}
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod load_progress_tests {
+    use super::parse_load_progress_event;
+
+    fn sse_block(model: &str, event: &str, data: serde_json::Value) -> String {
+        let payload = serde_json::json!({ "model": model, "event": event, "data": data });
+        format!("data: {}\n\n", payload)
+    }
+
+    #[test]
+    fn parses_a_matching_progress_event() {
+        let block = sse_block(
+            "model-1",
+            "status_change",
+            serde_json::json!({
+                "status": "loading",
+                "progress": { "stages": ["text_model"], "current": "text_model", "value": 0.42 }
+            }),
+        );
+        let payload = parse_load_progress_event(&block, "model-1").expect("should parse");
+        assert_eq!(payload.model, "model-1");
+        assert_eq!(payload.stage.as_deref(), Some("text_model"));
+        assert!((payload.value - 0.42).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn ignores_events_for_a_different_model() {
+        let block = sse_block(
+            "other-model",
+            "status_change",
+            serde_json::json!({ "progress": { "current": "text_model", "value": 0.5 } }),
+        );
+        assert!(parse_load_progress_event(&block, "model-1").is_none());
+    }
+
+    #[test]
+    fn ignores_non_status_change_events() {
+        let block = sse_block(
+            "model-1",
+            "download_progress",
+            serde_json::json!({ "done": 10, "total": 100 }),
+        );
+        assert!(parse_load_progress_event(&block, "model-1").is_none());
+    }
+
+    #[test]
+    fn ignores_status_change_without_progress() {
+        let block = sse_block("model-1", "status_change", serde_json::json!({ "status": "loaded" }));
+        assert!(parse_load_progress_event(&block, "model-1").is_none());
+    }
+
+    #[test]
+    fn ignores_null_progress() {
+        let block = sse_block(
+            "model-1",
+            "status_change",
+            serde_json::json!({ "status": "loaded", "progress": null }),
+        );
+        assert!(parse_load_progress_event(&block, "model-1").is_none());
+    }
+
+    #[test]
+    fn ignores_malformed_json() {
+        let block = "data: not json at all\n\n".to_string();
+        assert!(parse_load_progress_event(&block, "model-1").is_none());
+    }
+
+    #[test]
+    fn ignores_blocks_with_no_data_line() {
+        let block = "event: ping\n\n".to_string();
+        assert!(parse_load_progress_event(&block, "model-1").is_none());
+    }
+
+    #[test]
+    fn defaults_missing_value_to_zero() {
+        let block = sse_block(
+            "model-1",
+            "status_change",
+            serde_json::json!({ "progress": { "current": "text_model" } }),
+        );
+        let payload = parse_load_progress_event(&block, "model-1").expect("should parse");
+        assert_eq!(payload.value, 0.0);
+        assert_eq!(payload.stage.as_deref(), Some("text_model"));
+    }
+
+    #[test]
+    fn defaults_missing_stage_to_none() {
+        let block = sse_block(
+            "model-1",
+            "status_change",
+            serde_json::json!({ "progress": { "value": 0.9 } }),
+        );
+        let payload = parse_load_progress_event(&block, "model-1").expect("should parse");
+        assert!(payload.stage.is_none());
+    }
 }

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/router.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/router.rs
@@ -19,6 +19,22 @@ use tokio::time::Instant;
 
 pub type ErrorCallback = Arc<dyn Fn(&'static str, String) + Send + Sync + 'static>;
 
+/// Matches the various phrasings llama-server has used for its
+/// ready-to-serve log line across versions. `line_lower` must already be
+/// lowercased by the caller. Router mode logs `"llama_server: listening on
+/// http://<host>:<port>"` - note the colon between "server" and "listening"
+/// (`"server: listening on"`), which does NOT match the older
+/// `"server listening on"` (no colon) wording still used elsewhere, so both
+/// must be checked explicitly rather than relying on one subsuming the
+/// other.
+fn is_ready_line(line_lower: &str) -> bool {
+    line_lower.contains("http server listening")
+        || line_lower.contains("server is listening on")
+        || line_lower.contains("server listening on")
+        || line_lower.contains("server: listening on")
+        || line_lower.contains("starting the main loop")
+}
+
 fn is_oom_line(line_lower: &str) -> bool {
     if line_lower.contains("erroroutofdevicememory")
         || line_lower.contains("erroroutofhostmemory")
@@ -217,11 +233,7 @@ pub async fn start_router(
                         log::info!("[llamacpp-router stdout] {}", line);
                     }
                     let line_lower = line.to_lowercase();
-                    if line_lower.contains("http server listening")
-                        || line_lower.contains("server is listening on")
-                        || line_lower.contains("server listening on")
-                        || line_lower.contains("starting the main loop")
-                    {
+                    if is_ready_line(&line_lower) {
                         let _ = stdout_ready_tx.send(true).await;
                     }
                     if let Some(cb) = &stdout_on_error {
@@ -270,11 +282,7 @@ pub async fn start_router(
                         stderr_buffer.push('\n');
                         log::info!("[llamacpp-router] {}", line);
                         let line_lower = line.to_lowercase();
-                        if line_lower.contains("server is listening on")
-                            || line_lower.contains("server listening on")
-                            || line_lower.contains("starting the main loop")
-                            || line_lower.contains("http server listening")
-                        {
+                        if is_ready_line(&line_lower) {
                             let _ = ready_tx.send(true).await;
                         }
                         if let Some(cb) = &stderr_on_error {
@@ -682,6 +690,31 @@ mod tests {
         let envs = with_api_key_env(initial, "secret-key");
         assert_eq!(envs.get("LLAMA_ARG_TIMEOUT"), Some(&"60".to_string()));
         assert_eq!(envs.get("LLAMA_API_KEY"), Some(&"secret-key".to_string()));
+    }
+
+    #[test]
+    fn is_ready_line_matches_router_mode_wording() {
+        // Regression: router mode logs "llama_server: listening on
+        // http://host:port" (colon before "listening"), which the older
+        // "server listening on" (no colon) pattern does not match -
+        // readiness was never detected and start_router hung for the full
+        // 600s timeout despite the server already serving requests.
+        let line = "0.00.021.026 i srv  llama_server: listening on http://127.0.0.1:55707";
+        assert!(is_ready_line(line));
+    }
+
+    #[test]
+    fn is_ready_line_still_matches_older_wordings() {
+        assert!(is_ready_line("http server listening on 127.0.0.1:8080"));
+        assert!(is_ready_line("server is listening on http://127.0.0.1:8080"));
+        assert!(is_ready_line("server listening on 127.0.0.1:8080"));
+        assert!(is_ready_line("starting the main loop"));
+    }
+
+    #[test]
+    fn is_ready_line_rejects_unrelated_lines() {
+        assert!(!is_ready_line("srv log_server_r: request: post /v1/chat/completions"));
+        assert!(!is_ready_line("loaded 5 custom model presets"));
     }
 
     #[test]

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/router.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/router.rs
@@ -86,10 +86,18 @@ pub struct RouterHandle {
 ///
 /// `models_max == 0` is forwarded as-is; the upstream README documents 0 as
 /// "unlimited" — we let the server interpret that.
+///
+/// The API key is deliberately NOT passed here as `--api-key`: argv is
+/// visible to any other process on the machine (`ps`/Task Manager, `/proc`),
+/// and we already log the full argv at startup. It's set as the
+/// `LLAMA_API_KEY` env var instead (`start_router`, env-only, not inherited
+/// by child processes the same way a command-line arg would show up in
+/// process listings) - llama-server reads either, preferring the CLI flag
+/// when both are present (hence the "will be overwritten" warning it used to
+/// print when we set both).
 pub fn router_args(
     preset_path: &Path,
     port: u16,
-    api_key: &str,
     models_max: u32,
     default_args: &[String],
 ) -> Vec<String> {
@@ -102,14 +110,20 @@ pub fn router_args(
         "127.0.0.1".to_string(),
         "--port".to_string(),
         port.to_string(),
-        "--api-key".to_string(),
-        api_key.to_string(),
     ];
     // Web-UI disable flag (`--no-webui` pre-b9222, `--no-ui` from b9222) is
     // appended by the TS caller via `default_args` because the spelling
     // depends on the backend build number.
     args.extend(default_args.iter().cloned());
     args
+}
+
+/// Merges `LLAMA_API_KEY` into `envs`, always overwriting any prior value.
+/// Pure / unit-testable - authoritative so this invariant holds even if a
+/// future call site forgets to set it or sets a stale one.
+fn with_api_key_env(mut envs: HashMap<String, String>, api_key: &str) -> HashMap<String, String> {
+    envs.insert("LLAMA_API_KEY".to_string(), api_key.to_string());
+    envs
 }
 
 /// Spawn `llama-server` in router mode and wait for it to become ready.
@@ -135,7 +149,11 @@ pub async fn start_router(
         models_max
     );
 
-    let args = router_args(&preset_path, port, &api_key, models_max, &default_args);
+    // Authoritative: always carry the key via env, never argv (see
+    // `router_args`'s doc comment).
+    let envs = with_api_key_env(envs, &api_key);
+
+    let args = router_args(&preset_path, port, models_max, &default_args);
     log::info!("Router argv: {:?}", args);
 
     // Resolve readiness timeout (seconds). Match existing convention by
@@ -627,7 +645,7 @@ mod tests {
     #[test]
     fn router_args_contains_required_flags() {
         let preset = PathBuf::from("/tmp/preset.ini");
-        let args = router_args(&preset, 1337, "secret-key", 4, &[]);
+        let args = router_args(&preset, 1337, 4, &[]);
 
         // Required flags present
         let joined = args.join(" ");
@@ -636,7 +654,6 @@ mod tests {
         assert!(joined.contains("--models-max 4"));
         assert!(joined.contains("--host 127.0.0.1"));
         assert!(joined.contains("--port 1337"));
-        assert!(joined.contains("--api-key secret-key"));
         // Web-UI disable flag is now appended by the caller (it's
         // build-number-dependent: --no-webui vs --no-ui), so it must NOT be
         // baked into the base argv.
@@ -645,10 +662,44 @@ mod tests {
     }
 
     #[test]
+    fn with_api_key_env_sets_the_key() {
+        let envs = with_api_key_env(HashMap::new(), "secret-key");
+        assert_eq!(envs.get("LLAMA_API_KEY"), Some(&"secret-key".to_string()));
+    }
+
+    #[test]
+    fn with_api_key_env_overwrites_a_stale_value() {
+        let mut initial = HashMap::new();
+        initial.insert("LLAMA_API_KEY".to_string(), "stale-key".to_string());
+        let envs = with_api_key_env(initial, "fresh-key");
+        assert_eq!(envs.get("LLAMA_API_KEY"), Some(&"fresh-key".to_string()));
+    }
+
+    #[test]
+    fn with_api_key_env_preserves_other_vars() {
+        let mut initial = HashMap::new();
+        initial.insert("LLAMA_ARG_TIMEOUT".to_string(), "60".to_string());
+        let envs = with_api_key_env(initial, "secret-key");
+        assert_eq!(envs.get("LLAMA_ARG_TIMEOUT"), Some(&"60".to_string()));
+        assert_eq!(envs.get("LLAMA_API_KEY"), Some(&"secret-key".to_string()));
+    }
+
+    #[test]
+    fn router_args_never_carries_the_api_key() {
+        // The key must travel via the LLAMA_API_KEY env var only - argv is
+        // visible to any other process on the machine (ps/Task Manager) and
+        // gets logged verbatim at startup.
+        let preset = PathBuf::from("/tmp/preset.ini");
+        let args = router_args(&preset, 1337, 4, &[]);
+        assert!(!args.iter().any(|a| a == "--api-key"));
+        assert!(!args.join(" ").to_lowercase().contains("api-key"));
+    }
+
+    #[test]
     fn router_args_appends_default_args_in_order() {
         let preset = PathBuf::from("/tmp/p.ini");
         let extras = vec!["--threads".to_string(), "8".to_string(), "--metrics".to_string()];
-        let args = router_args(&preset, 8080, "k", 2, &extras);
+        let args = router_args(&preset, 8080, 2, &extras);
 
         // The defaults must appear after our base flags, preserving order.
         let last_three: Vec<&String> = args.iter().rev().take(3).collect::<Vec<_>>().into_iter().rev().collect();
@@ -659,7 +710,7 @@ mod tests {
     fn router_args_passes_through_models_max_zero() {
         // README: 0 means unlimited; we forward as-is.
         let preset = PathBuf::from("/tmp/p.ini");
-        let args = router_args(&preset, 8080, "k", 0, &[]);
+        let args = router_args(&preset, 8080, 0, &[]);
         let joined = args.join(" ");
         assert!(joined.contains("--models-max 0"));
     }

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/state.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/state.rs
@@ -16,6 +16,9 @@ pub struct LlamacppState {
     /// Mirror of the router PID for emergency lookup (e.g. force-kill while
     /// the handle is temporarily owned by the watcher loop). 0 = no router.
     pub router_pid: AtomicU32,
+    /// Persistent `/models/sse` subscriber (router-side unload notifications),
+    /// alive for the router's lifetime. Aborted whenever the router stops.
+    pub unload_watcher: Mutex<Option<tokio::task::JoinHandle<()>>>,
 }
 
 impl Default for LlamacppState {
@@ -23,6 +26,7 @@ impl Default for LlamacppState {
         Self {
             router: Mutex::new(None),
             router_pid: AtomicU32::new(0),
+            unload_watcher: Mutex::new(None),
         }
     }
 }

--- a/src-tauri/src/core/mcp/commands.rs
+++ b/src-tauri/src/core/mcp/commands.rs
@@ -25,10 +25,17 @@ async fn tool_call_timeout(state: &AppState) -> Duration {
 
 /// Shared implementation for listing MCP tools.
 ///
-/// - `server_filter: None` — every connected server (same behavior as `get_tools`).
-/// - `server_filter: Some(names)` — only connected servers in that set; unknown or
-///   disconnected names are skipped (logged). Transport / list failures use the same
-///   cleanup as `get_tools` (remove stale entry, emit `mcp-update` when needed).
+/// - `server_filter: None` — every enabled server (same behavior as `get_tools`).
+/// - `server_filter: Some(names)` — only enabled servers in that set; unknown names
+///   are skipped (logged).
+///
+/// A server counts as "enabled" if it's in `mcp_active_servers`, regardless of
+/// whether it's currently connected — a transiently disconnected server still
+/// contributes its last successfully listed tools (`mcp_last_known_tools`), so
+/// the tool schema Jan sends stays present and stable across reconnects instead
+/// of shrinking/growing and invalidating the downstream KV-cache prefix.
+/// `mcp_last_known_tools` is only cleared by explicit user deactivation
+/// (`deactivate_mcp_server`), never by a transient list-tools failure here.
 async fn collect_mcp_tools<R: Runtime>(
     app: &AppHandle<R>,
     state: &AppState,
@@ -39,20 +46,20 @@ async fn collect_mcp_tools<R: Runtime>(
     let mut removed_any = false;
 
     let server_names: Vec<String> = {
-        let servers = state.mcp_servers.lock().await;
+        let active_servers = state.mcp_active_servers.lock().await;
         match &server_filter {
-            None => servers.keys().cloned().collect(),
+            None => active_servers.keys().cloned().collect(),
             Some(filter) => {
                 for name in filter {
-                    if !servers.contains_key(name) {
+                    if !active_servers.contains_key(name) {
                         log::debug!(
-                            "collect_mcp_tools: requested server {name:?} is not connected (removed or never started); skipping"
+                            "collect_mcp_tools: requested server {name:?} is not enabled; skipping"
                         );
                     }
                 }
                 filter
                     .iter()
-                    .filter(|n| servers.contains_key(*n))
+                    .filter(|n| active_servers.contains_key(*n))
                     .cloned()
                     .collect()
             }
@@ -60,30 +67,33 @@ async fn collect_mcp_tools<R: Runtime>(
     };
 
     for server_name in server_names {
-        let list_result = {
+        // Snapshot the live service's list_all_tools() future while holding the
+        // lock, but resolve it after dropping the guard so a slow/hanging
+        // server doesn't hold `mcp_servers` locked for other callers.
+        let maybe_list_result = {
             let servers = state.mcp_servers.lock().await;
-            if let Some(service) = servers.get(&server_name) {
-                timeout(timeout_duration, service.list_all_tools()).await
-            } else {
-                log::debug!(
-                    "collect_mcp_tools: server {server_name:?} disappeared before list_tools; skipping"
-                );
-                continue;
+            match servers.get(&server_name) {
+                Some(service) => Some(timeout(timeout_duration, service.list_all_tools()).await),
+                None => None,
             }
         };
 
-        match list_result {
-            Ok(Ok(tools)) => {
-                for tool in tools {
-                    all_tools.push(ToolWithServer {
+        let fresh_tools = match maybe_list_result {
+            Some(Ok(Ok(tools))) => {
+                let mapped: Vec<ToolWithServer> = tools
+                    .into_iter()
+                    .map(|tool| ToolWithServer {
                         name: tool.name.to_string(),
                         description: tool.description.as_ref().map(|d| d.to_string()),
                         input_schema: serde_json::Value::Object((*tool.input_schema).clone()),
                         server: server_name.clone(),
-                    });
-                }
+                    })
+                    .collect();
+                let mut last_known = state.mcp_last_known_tools.lock().await;
+                last_known.insert(server_name.clone(), mapped.clone());
+                Some(mapped)
             }
-            Ok(Err(e)) => {
+            Some(Ok(Err(e))) => {
                 let err_str = e.to_string();
                 log::warn!("MCP server {server_name} failed to list tools: {err_str}");
                 if is_transport_error(&err_str) {
@@ -92,14 +102,31 @@ async fn collect_mcp_tools<R: Runtime>(
                 if remove_mcp_server_entry(&state.mcp_servers, &server_name).await {
                     removed_any = true;
                 }
+                None
             }
-            Err(_) => {
+            Some(Err(_)) => {
                 log::warn!(
                     "MCP server {server_name}: listing tools timed out after {} seconds",
                     timeout_duration.as_secs()
                 );
+                None
             }
-        }
+            None => {
+                log::debug!(
+                    "collect_mcp_tools: server {server_name:?} not connected; using last-known tools if any"
+                );
+                None
+            }
+        };
+
+        let tools = match fresh_tools {
+            Some(tools) => tools,
+            None => {
+                let last_known = state.mcp_last_known_tools.lock().await;
+                last_known.get(&server_name).cloned().unwrap_or_default()
+            }
+        };
+        all_tools.extend(tools);
     }
 
     if removed_any {
@@ -171,6 +198,14 @@ pub async fn deactivate_mcp_server<R: Runtime>(
         let mut active_servers = state.mcp_active_servers.lock().await;
         active_servers.remove(&name);
         log::info!("Removed MCP server {name} from active servers list");
+    }
+
+    // Explicit deactivation is the only thing that should drop the last-known
+    // tool schema — a transient disconnect must not (collect_mcp_tools keeps
+    // serving it until the server is actually turned off).
+    {
+        let mut last_known = state.mcp_last_known_tools.lock().await;
+        last_known.remove(&name);
     }
 
     // Now remove and stop the server
@@ -324,20 +359,16 @@ pub async fn get_tools_for_servers<R: Runtime>(
     collect_mcp_tools(&app, &state, Some(filter)).await
 }
 
-/// Returns name, capability tags, and description for all connected MCP servers
+/// Returns name, capability tags, and description for all enabled MCP servers
+/// (regardless of live connection state — see `collect_mcp_tools`).
 #[tauri::command]
 pub async fn get_server_summaries(
     state: State<'_, AppState>,
 ) -> Result<Vec<ServerSummary>, String> {
-    let connected_servers: Vec<String> = {
-        let servers = state.mcp_servers.lock().await;
-        servers.keys().cloned().collect()
-    };
-
     let active_servers = state.mcp_active_servers.lock().await;
     let mut summaries = Vec::new();
 
-    for name in &connected_servers {
+    for name in active_servers.keys() {
         let config = active_servers.get(name);
 
         let capabilities: Vec<String> = config

--- a/src-tauri/src/core/mcp/tests.rs
+++ b/src-tauri/src/core/mcp/tests.rs
@@ -288,12 +288,16 @@ async fn test_get_server_summaries_with_capabilities_in_active_config() {
         );
     }
 
-    // Summaries are derived from the intersection of connected servers and active config.
-    // With no entries in mcp_servers the result should still be empty.
+    // Summaries are derived from enabled (active_servers) config, independent of
+    // live connection state, so a transiently disconnected server still appears
+    // and keeps contributing a stable tool schema.
     let result = get_server_summaries(state).await;
     assert!(result.is_ok());
     let summaries = result.unwrap();
-    assert!(summaries.is_empty(), "No connected servers → no summaries");
+    assert_eq!(summaries.len(), 1, "enabled server appears even when disconnected");
+    assert_eq!(summaries[0].name, "filesystem");
+    assert_eq!(summaries[0].capabilities, vec!["filesystem", "files"]);
+    assert_eq!(summaries[0].description, "Read and write local files");
 }
 
 #[tokio::test]
@@ -318,10 +322,93 @@ async fn test_get_server_summaries_missing_metadata_defaults() {
         );
     }
 
-    // No entries in mcp_servers → summaries list is empty
+    // Enabled server with no metadata still appears, with defaulted fields.
     let result = get_server_summaries(state).await;
     assert!(result.is_ok());
-    assert!(result.unwrap().is_empty());
+    let summaries = result.unwrap();
+    assert_eq!(summaries.len(), 1);
+    assert_eq!(summaries[0].name, "minimal_server");
+    assert!(summaries[0].capabilities.is_empty());
+    assert_eq!(summaries[0].description, "");
+}
+
+// ============================================================================
+// get_tools last-known-tools fallback tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_get_tools_falls_back_to_last_known_when_server_enabled_but_disconnected() {
+    use super::commands::get_tools;
+    use super::models::ToolWithServer;
+
+    let app = mock_app();
+    let servers_state: SharedMcpServers = Arc::new(Mutex::new(HashMap::new()));
+    app.manage(AppState {
+        mcp_servers: servers_state.clone(),
+        ..Default::default()
+    });
+
+    let state = app.state::<AppState>();
+
+    // Enabled (in active_servers) but not present in mcp_servers — simulates a
+    // transient disconnect of a remote MCP server.
+    {
+        let mut active = state.mcp_active_servers.lock().await;
+        active.insert("exa".to_string(), serde_json::json!({ "type": "http" }));
+    }
+    {
+        let mut last_known = state.mcp_last_known_tools.lock().await;
+        last_known.insert(
+            "exa".to_string(),
+            vec![ToolWithServer {
+                name: "web_search_exa".to_string(),
+                description: Some("search the web".to_string()),
+                input_schema: serde_json::json!({}),
+                server: "exa".to_string(),
+            }],
+        );
+    }
+
+    let result = get_tools(app.handle().clone(), state).await;
+    assert!(result.is_ok());
+    let tools = result.unwrap();
+    assert_eq!(tools.len(), 1, "disconnected-but-enabled server's last-known tools still present");
+    assert_eq!(tools[0].name, "web_search_exa");
+    assert_eq!(tools[0].server, "exa");
+}
+
+#[tokio::test]
+async fn test_get_tools_omits_disabled_server_even_with_stale_last_known_entry() {
+    use super::commands::get_tools;
+    use super::models::ToolWithServer;
+
+    let app = mock_app();
+    let servers_state: SharedMcpServers = Arc::new(Mutex::new(HashMap::new()));
+    app.manage(AppState {
+        mcp_servers: servers_state.clone(),
+        ..Default::default()
+    });
+
+    let state = app.state::<AppState>();
+
+    // Not in active_servers (disabled/never enabled this session) but a stale
+    // last-known entry lingers — must not leak into the tool list.
+    {
+        let mut last_known = state.mcp_last_known_tools.lock().await;
+        last_known.insert(
+            "old_server".to_string(),
+            vec![ToolWithServer {
+                name: "stale_tool".to_string(),
+                description: None,
+                input_schema: serde_json::json!({}),
+                server: "old_server".to_string(),
+            }],
+        );
+    }
+
+    let result = get_tools(app.handle().clone(), state).await;
+    assert!(result.is_ok());
+    assert!(result.unwrap().is_empty(), "disabled server must not contribute stale tools");
 }
 
 // ============================================================================

--- a/src-tauri/src/core/server/converters.rs
+++ b/src-tauri/src/core/server/converters.rs
@@ -83,6 +83,425 @@ fn parse_event(raw: &str) -> Option<SseEvent> {
     Some(ev)
 }
 
+use serde_json::{json, Value};
+use std::collections::HashMap;
+
+/// Translates an OpenAI chat/completions request to a provider's native wire
+/// API and its response back. Implementors front a provider whose native API is
+/// not chat/completions (OpenAI `/v1/responses`, Google `generateContent`,
+/// Anthropic `/v1/messages`); the proxy selects one by `ProviderConfig.api_type`
+/// and otherwise forwards verbatim.
+pub trait UpstreamConverter: Send + Sync {
+    /// Path suffix appended to the provider `base_url` (e.g. `/responses`).
+    fn upstream_path(&self) -> &'static str;
+
+    /// Rewrite the inbound chat/completions body into the native request body.
+    fn convert_request(&self, body: &Value) -> Value;
+
+    /// Translate a non-streaming native response into a chat.completion object.
+    fn convert_response(&self, upstream: &Value) -> Value;
+
+    /// Translate one native SSE event into zero or more chat/completions SSE
+    /// `data:` payloads (each a JSON chunk string, or the literal `[DONE]`).
+    fn convert_stream_event(&self, event: &SseEvent, state: &mut StreamState) -> Vec<String>;
+}
+
+/// Select the converter for a provider's `api_type`. `None`, `"openai"`, and
+/// unknown values keep the verbatim chat/completions passthrough.
+pub fn converter_for(api_type: Option<&str>) -> Option<Box<dyn UpstreamConverter>> {
+    match api_type {
+        Some("openai-responses") => Some(Box::new(OpenAIResponsesConverter::new())),
+        _ => None,
+    }
+}
+
+/// Per-stream translation state threaded across `convert_stream_event` calls.
+#[derive(Debug, Default)]
+pub struct StreamState {
+    pub id: String,
+    pub model: String,
+    pub created: i64,
+    pub role_sent: bool,
+    pub saw_tool_call: bool,
+    /// native item/call id -> chat tool_calls array index.
+    pub tool_index: HashMap<String, usize>,
+    pub next_tool_index: usize,
+    pub finished: bool,
+}
+
+/// Fronts OpenAI's `/v1/responses` API, exposing it as chat/completions so the
+/// proxy's OpenAI-SDK clients get reasoning summaries (`reasoning_content`)
+/// without switching wire formats.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct OpenAIResponsesConverter;
+
+impl OpenAIResponsesConverter {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// Extract plain text from a chat message `content` (string or content-part array).
+fn message_text(content: &Value) -> String {
+    match content {
+        Value::String(s) => s.clone(),
+        Value::Array(parts) => parts
+            .iter()
+            .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
+            .collect::<Vec<_>>()
+            .join(""),
+        _ => String::new(),
+    }
+}
+
+impl UpstreamConverter for OpenAIResponsesConverter {
+    fn upstream_path(&self) -> &'static str {
+        "/responses"
+    }
+
+    fn convert_request(&self, body: &Value) -> Value {
+        let mut out = json!({});
+        if let Some(model) = body.get("model") {
+            out["model"] = model.clone();
+        }
+
+        // Split system/developer messages into `instructions`; the rest become
+        // `input` items (Responses accepts chat-shaped {role, content}).
+        let mut instructions: Vec<String> = Vec::new();
+        let mut input_items: Vec<Value> = Vec::new();
+        if let Some(messages) = body.get("messages").and_then(|m| m.as_array()) {
+            for msg in messages {
+                let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("user");
+                let content = msg.get("content").cloned().unwrap_or(Value::Null);
+                match role {
+                    "system" | "developer" => instructions.push(message_text(&content)),
+                    "tool" => {
+                        // Chat tool result -> Responses function_call_output item.
+                        input_items.push(json!({
+                            "type": "function_call_output",
+                            "call_id": msg.get("tool_call_id").cloned().unwrap_or(Value::Null),
+                            "output": message_text(&content),
+                        }));
+                    }
+                    "assistant" if msg.get("tool_calls").is_some() => {
+                        if let Some(calls) = msg.get("tool_calls").and_then(|c| c.as_array()) {
+                            for call in calls {
+                                let func = call.get("function");
+                                input_items.push(json!({
+                                    "type": "function_call",
+                                    "call_id": call.get("id").cloned().unwrap_or(Value::Null),
+                                    "name": func.and_then(|f| f.get("name")).cloned().unwrap_or(Value::Null),
+                                    "arguments": func.and_then(|f| f.get("arguments")).cloned().unwrap_or(Value::String(String::new())),
+                                }));
+                            }
+                        }
+                        let text = message_text(&content);
+                        if !text.is_empty() {
+                            input_items.push(json!({"role": "assistant", "content": text}));
+                        }
+                    }
+                    _ => input_items.push(json!({"role": role, "content": message_text(&content)})),
+                }
+            }
+        }
+        if !instructions.is_empty() {
+            out["instructions"] = json!(instructions.join("\n\n"));
+        }
+        out["input"] = json!(input_items);
+
+        for (src, dst) in [
+            ("max_tokens", "max_output_tokens"),
+            ("max_completion_tokens", "max_output_tokens"),
+        ] {
+            if let Some(v) = body.get(src) {
+                out[dst] = v.clone();
+            }
+        }
+        for key in ["temperature", "top_p", "stream"] {
+            if let Some(v) = body.get(key) {
+                out[key] = v.clone();
+            }
+        }
+
+        if let Some(effort) = body.get("reasoning_effort").and_then(|e| e.as_str()) {
+            out["reasoning"] = json!({"effort": effort, "summary": "auto"});
+        }
+
+        if let Some(tools) = body.get("tools").and_then(|t| t.as_array()) {
+            let flattened: Vec<Value> = tools
+                .iter()
+                .filter_map(|t| {
+                    let func = t.get("function")?;
+                    Some(json!({
+                        "type": "function",
+                        "name": func.get("name").cloned().unwrap_or(Value::Null),
+                        "description": func.get("description").cloned().unwrap_or(Value::Null),
+                        "parameters": func.get("parameters").cloned().unwrap_or(json!({})),
+                    }))
+                })
+                .collect();
+            out["tools"] = json!(flattened);
+        }
+        if let Some(tc) = body.get("tool_choice") {
+            out["tool_choice"] = tc.clone();
+        }
+
+        out
+    }
+
+    fn convert_response(&self, upstream: &Value) -> Value {
+        let mut content = String::new();
+        let mut reasoning = String::new();
+        let mut tool_calls: Vec<Value> = Vec::new();
+
+        if let Some(output) = upstream.get("output").and_then(|o| o.as_array()) {
+            for item in output {
+                match item.get("type").and_then(|t| t.as_str()) {
+                    Some("message") => {
+                        if let Some(parts) = item.get("content").and_then(|c| c.as_array()) {
+                            for part in parts {
+                                if let Some(t) = part.get("text").and_then(|t| t.as_str()) {
+                                    content.push_str(t);
+                                }
+                            }
+                        }
+                    }
+                    Some("reasoning") => {
+                        if let Some(parts) = item.get("summary").and_then(|s| s.as_array()) {
+                            for part in parts {
+                                if let Some(t) = part.get("text").and_then(|t| t.as_str()) {
+                                    reasoning.push_str(t);
+                                }
+                            }
+                        }
+                    }
+                    Some("function_call") => {
+                        tool_calls.push(json!({
+                            "id": item.get("call_id").cloned().unwrap_or(Value::Null),
+                            "type": "function",
+                            "function": {
+                                "name": item.get("name").cloned().unwrap_or(Value::Null),
+                                "arguments": item.get("arguments").cloned().unwrap_or(Value::String(String::new())),
+                            }
+                        }));
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        let mut message = json!({"role": "assistant"});
+        message["content"] = if content.is_empty() && !tool_calls.is_empty() {
+            Value::Null
+        } else {
+            json!(content)
+        };
+        if !reasoning.is_empty() {
+            message["reasoning_content"] = json!(reasoning);
+        }
+        let finish_reason = if !tool_calls.is_empty() {
+            message["tool_calls"] = json!(tool_calls);
+            "tool_calls"
+        } else {
+            "stop"
+        };
+
+        json!({
+            "id": upstream.get("id").cloned().unwrap_or_else(|| json!("chatcmpl-proxy")),
+            "object": "chat.completion",
+            "created": upstream.get("created_at").cloned().unwrap_or_else(|| json!(0)),
+            "model": upstream.get("model").cloned().unwrap_or(Value::Null),
+            "choices": [{
+                "index": 0,
+                "message": message,
+                "finish_reason": finish_reason,
+            }],
+            "usage": convert_usage(upstream.get("usage")),
+        })
+    }
+
+    fn convert_stream_event(&self, event: &SseEvent, state: &mut StreamState) -> Vec<String> {
+        if event.data == "[DONE]" || state.finished {
+            return Vec::new();
+        }
+        let data: Value = match serde_json::from_str(&event.data) {
+            Ok(v) => v,
+            Err(_) => return Vec::new(),
+        };
+        let kind = if event.event.is_empty() {
+            data.get("type").and_then(|t| t.as_str()).unwrap_or("")
+        } else {
+            event.event.as_str()
+        };
+
+        let mut out: Vec<String> = Vec::new();
+        match kind {
+            "response.created" | "response.in_progress" => {
+                if let Some(resp) = data.get("response") {
+                    if let Some(id) = resp.get("id").and_then(|v| v.as_str()) {
+                        state.id = id.to_string();
+                    }
+                    if let Some(model) = resp.get("model").and_then(|v| v.as_str()) {
+                        state.model = model.to_string();
+                    }
+                    if let Some(created) = resp.get("created_at").and_then(|v| v.as_i64()) {
+                        state.created = created;
+                    }
+                }
+            }
+            "response.output_text.delta" => {
+                if let Some(text) = data.get("delta").and_then(|d| d.as_str()) {
+                    push_role_chunk(state, &mut out);
+                    out.push(chunk_str(state, json!({"content": text}), None));
+                }
+            }
+            "response.reasoning_summary_text.delta" => {
+                if let Some(text) = data.get("delta").and_then(|d| d.as_str()) {
+                    push_role_chunk(state, &mut out);
+                    out.push(chunk_str(state, json!({"reasoning_content": text}), None));
+                }
+            }
+            "response.output_item.added" => {
+                if let Some(item) = data.get("item") {
+                    if item.get("type").and_then(|t| t.as_str()) == Some("function_call") {
+                        let key = item
+                            .get("id")
+                            .and_then(|v| v.as_str())
+                            .or_else(|| item.get("call_id").and_then(|v| v.as_str()))
+                            .unwrap_or("")
+                            .to_string();
+                        let idx = state.next_tool_index;
+                        state.next_tool_index += 1;
+                        state.tool_index.insert(key, idx);
+                        state.saw_tool_call = true;
+                        push_role_chunk(state, &mut out);
+                        out.push(chunk_str(
+                            state,
+                            json!({"tool_calls": [{
+                                "index": idx,
+                                "id": item.get("call_id").cloned().unwrap_or(Value::Null),
+                                "type": "function",
+                                "function": {
+                                    "name": item.get("name").cloned().unwrap_or(Value::Null),
+                                    "arguments": "",
+                                }
+                            }]}),
+                            None,
+                        ));
+                    }
+                }
+            }
+            "response.function_call_arguments.delta" => {
+                let key = data
+                    .get("item_id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                if let Some(delta) = data.get("delta").and_then(|d| d.as_str()) {
+                    let idx = *state.tool_index.get(&key).unwrap_or(&0);
+                    out.push(chunk_str(
+                        state,
+                        json!({"tool_calls": [{
+                            "index": idx,
+                            "function": {"arguments": delta}
+                        }]}),
+                        None,
+                    ));
+                }
+            }
+            "response.completed" | "response.incomplete" => {
+                let finish = if state.saw_tool_call { "tool_calls" } else { "stop" };
+                out.push(chunk_str_with_usage(
+                    state,
+                    json!({}),
+                    Some(finish),
+                    data.get("response").and_then(|r| r.get("usage")),
+                ));
+                out.push("[DONE]".to_string());
+                state.finished = true;
+            }
+            "response.failed" | "error" => {
+                let message = data
+                    .get("response")
+                    .and_then(|r| r.get("error"))
+                    .or_else(|| data.get("error"))
+                    .and_then(|e| e.get("message"))
+                    .and_then(|m| m.as_str())
+                    .unwrap_or("upstream error");
+                out.push(json!({"error": {"message": message}}).to_string());
+                out.push("[DONE]".to_string());
+                state.finished = true;
+            }
+            _ => {}
+        }
+        out
+    }
+}
+
+fn push_role_chunk(state: &mut StreamState, out: &mut Vec<String>) {
+    if !state.role_sent {
+        state.role_sent = true;
+        out.push(chunk_str(state, json!({"role": "assistant"}), None));
+    }
+}
+
+fn chunk_str(state: &StreamState, delta: Value, finish: Option<&str>) -> String {
+    json!({
+        "id": non_empty(&state.id, "chatcmpl-proxy"),
+        "object": "chat.completion.chunk",
+        "created": state.created,
+        "model": state.model,
+        "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+    })
+    .to_string()
+}
+
+fn chunk_str_with_usage(
+    state: &StreamState,
+    delta: Value,
+    finish: Option<&str>,
+    usage: Option<&Value>,
+) -> String {
+    let mut chunk = json!({
+        "id": non_empty(&state.id, "chatcmpl-proxy"),
+        "object": "chat.completion.chunk",
+        "created": state.created,
+        "model": state.model,
+        "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+    });
+    if let Some(u) = usage {
+        chunk["usage"] = convert_usage(Some(u));
+    }
+    chunk.to_string()
+}
+
+fn non_empty(s: &str, fallback: &str) -> String {
+    if s.is_empty() {
+        fallback.to_string()
+    } else {
+        s.to_string()
+    }
+}
+
+/// Map Responses `usage` (`input_tokens`/`output_tokens`) to chat/completions
+/// (`prompt_tokens`/`completion_tokens`).
+fn convert_usage(usage: Option<&Value>) -> Value {
+    let Some(u) = usage else {
+        return Value::Null;
+    };
+    let prompt = u.get("input_tokens").and_then(|v| v.as_i64()).unwrap_or(0);
+    let completion = u.get("output_tokens").and_then(|v| v.as_i64()).unwrap_or(0);
+    let total = u
+        .get("total_tokens")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(prompt + completion);
+    json!({
+        "prompt_tokens": prompt,
+        "completion_tokens": completion,
+        "total_tokens": total,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -158,5 +577,236 @@ mod tests {
         let mut acc = SseAccumulator::new();
         acc.push("data: done\n\n");
         assert_eq!(acc.finish(), None);
+    }
+}
+
+#[cfg(test)]
+mod openai_responses_tests {
+    use super::*;
+
+    fn conv() -> OpenAIResponsesConverter {
+        OpenAIResponsesConverter::new()
+    }
+
+    #[test]
+    fn request_splits_system_into_instructions_and_maps_input() {
+        let body = json!({
+            "model": "gpt-5",
+            "messages": [
+                {"role": "system", "content": "be brief"},
+                {"role": "user", "content": "hi"}
+            ],
+            "max_tokens": 128,
+            "temperature": 0.4,
+            "stream": true,
+            "reasoning_effort": "high"
+        });
+        let out = conv().convert_request(&body);
+        assert_eq!(out["model"], json!("gpt-5"));
+        assert_eq!(out["instructions"], json!("be brief"));
+        assert_eq!(out["input"], json!([{"role": "user", "content": "hi"}]));
+        assert_eq!(out["max_output_tokens"], json!(128));
+        assert_eq!(out["temperature"], json!(0.4));
+        assert_eq!(out["stream"], json!(true));
+        assert_eq!(out["reasoning"], json!({"effort": "high", "summary": "auto"}));
+    }
+
+    #[test]
+    fn request_flattens_tools_and_maps_tool_messages() {
+        let body = json!({
+            "model": "gpt-5",
+            "messages": [
+                {"role": "user", "content": "weather?"},
+                {"role": "assistant", "content": "", "tool_calls": [
+                    {"id": "call_1", "type": "function", "function": {"name": "getw", "arguments": "{}"}}
+                ]},
+                {"role": "tool", "tool_call_id": "call_1", "content": "sunny"}
+            ],
+            "tools": [
+                {"type": "function", "function": {"name": "getw", "description": "d", "parameters": {"type": "object"}}}
+            ]
+        });
+        let out = conv().convert_request(&body);
+        assert_eq!(
+            out["tools"],
+            json!([{"type": "function", "name": "getw", "description": "d", "parameters": {"type": "object"}}])
+        );
+        let input = out["input"].as_array().unwrap();
+        assert_eq!(input[0], json!({"role": "user", "content": "weather?"}));
+        assert_eq!(
+            input[1],
+            json!({"type": "function_call", "call_id": "call_1", "name": "getw", "arguments": "{}"})
+        );
+        assert_eq!(
+            input[2],
+            json!({"type": "function_call_output", "call_id": "call_1", "output": "sunny"})
+        );
+    }
+
+    #[test]
+    fn response_maps_text_reasoning_and_usage() {
+        let upstream = json!({
+            "id": "resp_1",
+            "model": "gpt-5",
+            "created_at": 123,
+            "output": [
+                {"type": "reasoning", "summary": [{"type": "summary_text", "text": "thinking"}]},
+                {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "hello"}]}
+            ],
+            "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+        });
+        let out = conv().convert_response(&upstream);
+        assert_eq!(out["object"], json!("chat.completion"));
+        assert_eq!(out["id"], json!("resp_1"));
+        assert_eq!(out["created"], json!(123));
+        let choice = &out["choices"][0];
+        assert_eq!(choice["message"]["content"], json!("hello"));
+        assert_eq!(choice["message"]["reasoning_content"], json!("thinking"));
+        assert_eq!(choice["finish_reason"], json!("stop"));
+        assert_eq!(out["usage"], json!({"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}));
+    }
+
+    #[test]
+    fn response_maps_function_call_to_tool_calls() {
+        let upstream = json!({
+            "id": "resp_2",
+            "model": "gpt-5",
+            "output": [
+                {"type": "function_call", "call_id": "c1", "name": "getw", "arguments": "{\"x\":1}"}
+            ]
+        });
+        let out = conv().convert_response(&upstream);
+        let choice = &out["choices"][0];
+        assert_eq!(choice["finish_reason"], json!("tool_calls"));
+        assert_eq!(choice["message"]["content"], Value::Null);
+        assert_eq!(
+            choice["message"]["tool_calls"],
+            json!([{"id": "c1", "type": "function", "function": {"name": "getw", "arguments": "{\"x\":1}"}}])
+        );
+    }
+
+    fn ev(event: &str, data: Value) -> SseEvent {
+        SseEvent {
+            event: event.to_string(),
+            data: data.to_string(),
+        }
+    }
+
+    #[test]
+    fn stream_text_deltas_emit_role_then_content() {
+        let c = conv();
+        let mut state = StreamState::default();
+        assert!(c
+            .convert_stream_event(
+                &ev("response.created", json!({"response": {"id": "r1", "model": "gpt-5", "created_at": 9}})),
+                &mut state
+            )
+            .is_empty());
+        let first = c.convert_stream_event(&ev("response.output_text.delta", json!({"delta": "he"})), &mut state);
+        assert_eq!(first.len(), 2);
+        let role: Value = serde_json::from_str(&first[0]).unwrap();
+        assert_eq!(role["choices"][0]["delta"]["role"], json!("assistant"));
+        assert_eq!(role["id"], json!("r1"));
+        assert_eq!(role["model"], json!("gpt-5"));
+        let content: Value = serde_json::from_str(&first[1]).unwrap();
+        assert_eq!(content["choices"][0]["delta"]["content"], json!("he"));
+
+        let second = c.convert_stream_event(&ev("response.output_text.delta", json!({"delta": "llo"})), &mut state);
+        assert_eq!(second.len(), 1);
+        let content2: Value = serde_json::from_str(&second[0]).unwrap();
+        assert_eq!(content2["choices"][0]["delta"]["content"], json!("llo"));
+    }
+
+    #[test]
+    fn stream_reasoning_delta_maps_to_reasoning_content() {
+        let c = conv();
+        let mut state = StreamState::default();
+        let out = c.convert_stream_event(
+            &ev("response.reasoning_summary_text.delta", json!({"delta": "hmm"})),
+            &mut state,
+        );
+        // role chunk + reasoning chunk
+        assert_eq!(out.len(), 2);
+        let reasoning: Value = serde_json::from_str(&out[1]).unwrap();
+        assert_eq!(reasoning["choices"][0]["delta"]["reasoning_content"], json!("hmm"));
+    }
+
+    #[test]
+    fn stream_function_call_emits_header_and_argument_deltas() {
+        let c = conv();
+        let mut state = StreamState::default();
+        let added = c.convert_stream_event(
+            &ev(
+                "response.output_item.added",
+                json!({"item": {"id": "fc_1", "type": "function_call", "call_id": "c1", "name": "getw"}}),
+            ),
+            &mut state,
+        );
+        // role chunk + tool header
+        assert_eq!(added.len(), 2);
+        let header: Value = serde_json::from_str(&added[1]).unwrap();
+        let tc = &header["choices"][0]["delta"]["tool_calls"][0];
+        assert_eq!(tc["index"], json!(0));
+        assert_eq!(tc["id"], json!("c1"));
+        assert_eq!(tc["function"]["name"], json!("getw"));
+
+        let arg = c.convert_stream_event(
+            &ev("response.function_call_arguments.delta", json!({"item_id": "fc_1", "delta": "{\"x\""})),
+            &mut state,
+        );
+        assert_eq!(arg.len(), 1);
+        let arg_chunk: Value = serde_json::from_str(&arg[0]).unwrap();
+        let atc = &arg_chunk["choices"][0]["delta"]["tool_calls"][0];
+        assert_eq!(atc["index"], json!(0));
+        assert_eq!(atc["function"]["arguments"], json!("{\"x\""));
+    }
+
+    #[test]
+    fn stream_completed_emits_finish_usage_and_done() {
+        let c = conv();
+        let mut state = StreamState {
+            saw_tool_call: true,
+            ..Default::default()
+        };
+        let out = c.convert_stream_event(
+            &ev(
+                "response.completed",
+                json!({"response": {"usage": {"input_tokens": 3, "output_tokens": 4, "total_tokens": 7}}}),
+            ),
+            &mut state,
+        );
+        assert_eq!(out.len(), 2);
+        let finish: Value = serde_json::from_str(&out[0]).unwrap();
+        assert_eq!(finish["choices"][0]["finish_reason"], json!("tool_calls"));
+        assert_eq!(finish["usage"]["prompt_tokens"], json!(3));
+        assert_eq!(out[1], "[DONE]");
+        assert!(state.finished);
+        // Events after completion are ignored.
+        assert!(c
+            .convert_stream_event(&ev("response.output_text.delta", json!({"delta": "x"})), &mut state)
+            .is_empty());
+    }
+
+    #[test]
+    fn stream_dispatches_on_data_type_when_event_field_absent() {
+        let c = conv();
+        let mut state = StreamState::default();
+        let out = c.convert_stream_event(
+            &ev("", json!({"type": "response.output_text.delta", "delta": "hi"})),
+            &mut state,
+        );
+        assert_eq!(out.len(), 2);
+    }
+
+    #[test]
+    fn stream_ignores_done_sentinel_and_bad_json() {
+        let c = conv();
+        let mut state = StreamState::default();
+        assert!(c
+            .convert_stream_event(&SseEvent { event: String::new(), data: "[DONE]".into() }, &mut state)
+            .is_empty());
+        assert!(c
+            .convert_stream_event(&SseEvent { event: String::new(), data: "not json".into() }, &mut state)
+            .is_empty());
     }
 }

--- a/src-tauri/src/core/server/converters.rs
+++ b/src-tauri/src/core/server/converters.rs
@@ -104,6 +104,11 @@ pub trait UpstreamConverter: Send + Sync {
         ("authorization", format!("Bearer {key}"))
     }
 
+    /// Fixed headers the native API requires (Anthropic: `anthropic-version`).
+    fn extra_headers(&self) -> Vec<(&'static str, &'static str)> {
+        Vec::new()
+    }
+
     /// Rewrite the inbound chat/completions body into the native request body.
     fn convert_request(&self, body: &Value) -> Value;
 
@@ -121,6 +126,7 @@ pub fn converter_for(api_type: Option<&str>) -> Option<Box<dyn UpstreamConverter
     match api_type {
         Some("openai-responses") => Some(Box::new(OpenAIResponsesConverter::new())),
         Some("google") => Some(Box::new(GoogleGenerateContentConverter::new())),
+        Some("anthropic") => Some(Box::new(AnthropicMessagesConverter::new())),
         _ => None,
     }
 }
@@ -137,6 +143,8 @@ pub struct StreamState {
     pub tool_index: HashMap<String, usize>,
     pub next_tool_index: usize,
     pub finished: bool,
+    /// Prompt tokens captured early (Anthropic sends them in `message_start`).
+    pub input_tokens: i64,
 }
 
 /// Fronts OpenAI's `/v1/responses` API, exposing it as chat/completions so the
@@ -777,6 +785,355 @@ impl UpstreamConverter for GoogleGenerateContentConverter {
     }
 }
 
+/// Anthropic requires a `max_tokens`; chat/completions may omit it.
+const ANTHROPIC_DEFAULT_MAX_TOKENS: i64 = 4096;
+
+/// Fronts Anthropic's `/v1/messages` API. Auth is `x-api-key` plus a fixed
+/// `anthropic-version` header. The registered provider `base_url` should include
+/// the version prefix, e.g. `https://api.anthropic.com/v1`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct AnthropicMessagesConverter;
+
+impl AnthropicMessagesConverter {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+fn map_anthropic_finish(reason: &str, saw_tool: bool) -> &'static str {
+    if saw_tool {
+        return "tool_calls";
+    }
+    match reason {
+        "max_tokens" => "length",
+        "tool_use" => "tool_calls",
+        "refusal" => "content_filter",
+        _ => "stop",
+    }
+}
+
+fn anthropic_usage(input_tokens: i64, output_tokens: i64) -> Value {
+    json!({
+        "prompt_tokens": input_tokens,
+        "completion_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens,
+    })
+}
+
+/// Append `blocks` to the last message when it shares `role`, else start a new
+/// one. Anthropic rejects consecutive same-role messages, so tool results and
+/// adjacent turns must be merged.
+fn push_merged(messages: &mut Vec<Value>, role: &str, blocks: Vec<Value>) {
+    if blocks.is_empty() {
+        return;
+    }
+    if let Some(last) = messages.last_mut() {
+        if last.get("role").and_then(|r| r.as_str()) == Some(role) {
+            if let Some(arr) = last.get_mut("content").and_then(|c| c.as_array_mut()) {
+                arr.extend(blocks);
+                return;
+            }
+        }
+    }
+    messages.push(json!({"role": role, "content": blocks}));
+}
+
+impl UpstreamConverter for AnthropicMessagesConverter {
+    fn upstream_path(&self, _body: &Value) -> String {
+        "/messages".to_string()
+    }
+
+    fn auth_header(&self, key: &str) -> (&'static str, String) {
+        ("x-api-key", key.to_string())
+    }
+
+    fn extra_headers(&self) -> Vec<(&'static str, &'static str)> {
+        vec![("anthropic-version", "2023-06-01")]
+    }
+
+    fn convert_request(&self, body: &Value) -> Value {
+        let mut out = json!({});
+        if let Some(model) = body.get("model") {
+            out["model"] = model.clone();
+        }
+        let max_tokens = body
+            .get("max_tokens")
+            .or_else(|| body.get("max_completion_tokens"))
+            .and_then(|v| v.as_i64())
+            .unwrap_or(ANTHROPIC_DEFAULT_MAX_TOKENS);
+        out["max_tokens"] = json!(max_tokens);
+        for key in ["temperature", "top_p", "stream"] {
+            if let Some(v) = body.get(key) {
+                out[key] = v.clone();
+            }
+        }
+
+        let mut system: Vec<String> = Vec::new();
+        let mut messages: Vec<Value> = Vec::new();
+        if let Some(msgs) = body.get("messages").and_then(|m| m.as_array()) {
+            for msg in msgs {
+                let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("user");
+                let content = msg.get("content").cloned().unwrap_or(Value::Null);
+                match role {
+                    "system" | "developer" => system.push(message_text(&content)),
+                    "assistant" => {
+                        let mut blocks: Vec<Value> = Vec::new();
+                        let text = message_text(&content);
+                        if !text.is_empty() {
+                            blocks.push(json!({"type": "text", "text": text}));
+                        }
+                        if let Some(calls) = msg.get("tool_calls").and_then(|c| c.as_array()) {
+                            for call in calls {
+                                let func = call.get("function");
+                                let args_str = func
+                                    .and_then(|f| f.get("arguments"))
+                                    .and_then(|a| a.as_str())
+                                    .unwrap_or("{}");
+                                let input: Value = serde_json::from_str(args_str).unwrap_or_else(|_| json!({}));
+                                blocks.push(json!({
+                                    "type": "tool_use",
+                                    "id": call.get("id").cloned().unwrap_or(Value::Null),
+                                    "name": func.and_then(|f| f.get("name")).cloned().unwrap_or(Value::Null),
+                                    "input": input,
+                                }));
+                            }
+                        }
+                        push_merged(&mut messages, "assistant", blocks);
+                    }
+                    "tool" => {
+                        push_merged(
+                            &mut messages,
+                            "user",
+                            vec![json!({
+                                "type": "tool_result",
+                                "tool_use_id": msg.get("tool_call_id").cloned().unwrap_or(Value::Null),
+                                "content": message_text(&content),
+                            })],
+                        );
+                    }
+                    _ => push_merged(
+                        &mut messages,
+                        "user",
+                        vec![json!({"type": "text", "text": message_text(&content)})],
+                    ),
+                }
+            }
+        }
+        out["messages"] = json!(messages);
+        if !system.is_empty() {
+            out["system"] = json!(system.join("\n\n"));
+        }
+
+        if let Some(tools) = body.get("tools").and_then(|t| t.as_array()) {
+            let mapped: Vec<Value> = tools
+                .iter()
+                .filter_map(|t| {
+                    let func = t.get("function")?;
+                    Some(json!({
+                        "name": func.get("name").cloned().unwrap_or(Value::Null),
+                        "description": func.get("description").cloned().unwrap_or(Value::Null),
+                        "input_schema": func.get("parameters").cloned().unwrap_or(json!({"type": "object"})),
+                    }))
+                })
+                .collect();
+            if !mapped.is_empty() {
+                out["tools"] = json!(mapped);
+            }
+        }
+        if let Some(tc) = body.get("tool_choice") {
+            out["tool_choice"] = match tc.as_str() {
+                Some("none") => json!({"type": "none"}),
+                Some("required") => json!({"type": "any"}),
+                Some("auto") => json!({"type": "auto"}),
+                _ => {
+                    // {"type":"function","function":{"name":...}} -> {"type":"tool","name":...}
+                    match tc.get("function").and_then(|f| f.get("name")) {
+                        Some(name) => json!({"type": "tool", "name": name}),
+                        None => json!({"type": "auto"}),
+                    }
+                }
+            };
+        }
+
+        out
+    }
+
+    fn convert_response(&self, upstream: &Value) -> Value {
+        let mut content = String::new();
+        let mut reasoning = String::new();
+        let mut tool_calls: Vec<Value> = Vec::new();
+
+        if let Some(blocks) = upstream.get("content").and_then(|c| c.as_array()) {
+            for block in blocks {
+                match block.get("type").and_then(|t| t.as_str()) {
+                    Some("text") => {
+                        if let Some(t) = block.get("text").and_then(|t| t.as_str()) {
+                            content.push_str(t);
+                        }
+                    }
+                    Some("thinking") => {
+                        if let Some(t) = block.get("thinking").and_then(|t| t.as_str()) {
+                            reasoning.push_str(t);
+                        }
+                    }
+                    Some("tool_use") => {
+                        let input = block.get("input").cloned().unwrap_or_else(|| json!({}));
+                        tool_calls.push(json!({
+                            "id": block.get("id").cloned().unwrap_or(Value::Null),
+                            "type": "function",
+                            "function": {
+                                "name": block.get("name").cloned().unwrap_or(Value::Null),
+                                "arguments": serde_json::to_string(&input).unwrap_or_default(),
+                            }
+                        }));
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        let mut message = json!({"role": "assistant"});
+        let saw_tool = !tool_calls.is_empty();
+        message["content"] = if content.is_empty() && saw_tool {
+            Value::Null
+        } else {
+            json!(content)
+        };
+        if !reasoning.is_empty() {
+            message["reasoning_content"] = json!(reasoning);
+        }
+        if saw_tool {
+            message["tool_calls"] = json!(tool_calls);
+        }
+        let finish_reason = map_anthropic_finish(
+            upstream.get("stop_reason").and_then(|r| r.as_str()).unwrap_or("end_turn"),
+            saw_tool,
+        );
+        let usage = upstream.get("usage");
+        let input_tokens = usage.and_then(|u| u.get("input_tokens")).and_then(|v| v.as_i64()).unwrap_or(0);
+        let output_tokens = usage.and_then(|u| u.get("output_tokens")).and_then(|v| v.as_i64()).unwrap_or(0);
+
+        json!({
+            "id": upstream.get("id").cloned().unwrap_or_else(|| json!("chatcmpl-proxy")),
+            "object": "chat.completion",
+            "created": 0,
+            "model": upstream.get("model").cloned().unwrap_or(Value::Null),
+            "choices": [{
+                "index": 0,
+                "message": message,
+                "finish_reason": finish_reason,
+            }],
+            "usage": anthropic_usage(input_tokens, output_tokens),
+        })
+    }
+
+    fn convert_stream_event(&self, event: &SseEvent, state: &mut StreamState) -> Vec<String> {
+        if event.data == "[DONE]" || state.finished {
+            return Vec::new();
+        }
+        let data: Value = match serde_json::from_str(&event.data) {
+            Ok(v) => v,
+            Err(_) => return Vec::new(),
+        };
+        let kind = if event.event.is_empty() {
+            data.get("type").and_then(|t| t.as_str()).unwrap_or("")
+        } else {
+            event.event.as_str()
+        };
+
+        let mut out: Vec<String> = Vec::new();
+        match kind {
+            "message_start" => {
+                if let Some(msg) = data.get("message") {
+                    if let Some(id) = msg.get("id").and_then(|v| v.as_str()) {
+                        state.id = id.to_string();
+                    }
+                    if let Some(model) = msg.get("model").and_then(|v| v.as_str()) {
+                        state.model = model.to_string();
+                    }
+                    if let Some(t) = msg.get("usage").and_then(|u| u.get("input_tokens")).and_then(|v| v.as_i64()) {
+                        state.input_tokens = t;
+                    }
+                }
+            }
+            "content_block_start" => {
+                let block = data.get("content_block");
+                let block_type = block.and_then(|b| b.get("type")).and_then(|t| t.as_str());
+                push_role_chunk(state, &mut out);
+                if block_type == Some("tool_use") {
+                    let block_index = data.get("index").and_then(|v| v.as_i64()).unwrap_or(0).to_string();
+                    let idx = state.next_tool_index;
+                    state.next_tool_index += 1;
+                    state.tool_index.insert(block_index, idx);
+                    state.saw_tool_call = true;
+                    out.push(chunk_str(
+                        state,
+                        json!({"tool_calls": [{
+                            "index": idx,
+                            "id": block.and_then(|b| b.get("id")).cloned().unwrap_or(Value::Null),
+                            "type": "function",
+                            "function": {
+                                "name": block.and_then(|b| b.get("name")).cloned().unwrap_or(Value::Null),
+                                "arguments": "",
+                            }
+                        }]}),
+                        None,
+                    ));
+                }
+            }
+            "content_block_delta" => {
+                let delta = data.get("delta");
+                match delta.and_then(|d| d.get("type")).and_then(|t| t.as_str()) {
+                    Some("text_delta") => {
+                        if let Some(text) = delta.and_then(|d| d.get("text")).and_then(|t| t.as_str()) {
+                            push_role_chunk(state, &mut out);
+                            out.push(chunk_str(state, json!({"content": text}), None));
+                        }
+                    }
+                    Some("thinking_delta") => {
+                        if let Some(text) = delta.and_then(|d| d.get("thinking")).and_then(|t| t.as_str()) {
+                            push_role_chunk(state, &mut out);
+                            out.push(chunk_str(state, json!({"reasoning_content": text}), None));
+                        }
+                    }
+                    Some("input_json_delta") => {
+                        let block_index = data.get("index").and_then(|v| v.as_i64()).unwrap_or(0).to_string();
+                        let idx = *state.tool_index.get(&block_index).unwrap_or(&0);
+                        if let Some(partial) = delta.and_then(|d| d.get("partial_json")).and_then(|t| t.as_str()) {
+                            out.push(chunk_str(
+                                state,
+                                json!({"tool_calls": [{"index": idx, "function": {"arguments": partial}}]}),
+                                None,
+                            ));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            "message_delta" => {
+                // Carries the terminal stop_reason + cumulative output tokens.
+                let reason = data
+                    .get("delta")
+                    .and_then(|d| d.get("stop_reason"))
+                    .and_then(|r| r.as_str())
+                    .unwrap_or("end_turn");
+                let finish = map_anthropic_finish(reason, state.saw_tool_call);
+                let output_tokens = data
+                    .get("usage")
+                    .and_then(|u| u.get("output_tokens"))
+                    .and_then(|v| v.as_i64())
+                    .unwrap_or(0);
+                let usage = anthropic_usage(state.input_tokens, output_tokens);
+                out.push(chunk_str_with_usage(state, json!({}), Some(finish), Some(&usage)));
+                out.push("[DONE]".to_string());
+                state.finished = true;
+            }
+            _ => {}
+        }
+        out
+    }
+}
+
 fn push_role_chunk(state: &mut StreamState, out: &mut Vec<String>) {
     if !state.role_sent {
         state.role_sent = true;
@@ -1366,5 +1723,205 @@ mod google_generate_content_tests {
         let finish: Value = serde_json::from_str(&out[2]).unwrap();
         assert_eq!(finish["choices"][0]["finish_reason"], json!("tool_calls"));
         assert_eq!(out[3], "[DONE]");
+    }
+}
+
+#[cfg(test)]
+mod anthropic_messages_tests {
+    use super::*;
+
+    fn conv() -> AnthropicMessagesConverter {
+        AnthropicMessagesConverter::new()
+    }
+
+    #[test]
+    fn auth_and_headers() {
+        let c = conv();
+        assert_eq!(c.auth_header("k"), ("x-api-key", "k".to_string()));
+        assert_eq!(c.extra_headers(), vec![("anthropic-version", "2023-06-01")]);
+        assert_eq!(c.upstream_path(&json!({})), "/messages");
+    }
+
+    #[test]
+    fn request_maps_system_messages_and_default_max_tokens() {
+        let body = json!({
+            "model": "claude-sonnet-4",
+            "messages": [
+                {"role": "system", "content": "be brief"},
+                {"role": "user", "content": "hi"}
+            ]
+        });
+        let out = conv().convert_request(&body);
+        assert_eq!(out["model"], json!("claude-sonnet-4"));
+        assert_eq!(out["system"], json!("be brief"));
+        assert_eq!(out["max_tokens"], json!(ANTHROPIC_DEFAULT_MAX_TOKENS));
+        assert_eq!(
+            out["messages"],
+            json!([{"role": "user", "content": [{"type": "text", "text": "hi"}]}])
+        );
+    }
+
+    #[test]
+    fn request_merges_consecutive_tool_results_into_one_user_message() {
+        let body = json!({
+            "model": "claude-sonnet-4",
+            "max_tokens": 256,
+            "messages": [
+                {"role": "user", "content": "go"},
+                {"role": "assistant", "content": "", "tool_calls": [
+                    {"id": "a", "type": "function", "function": {"name": "f1", "arguments": "{\"x\":1}"}},
+                    {"id": "b", "type": "function", "function": {"name": "f2", "arguments": "{}"}}
+                ]},
+                {"role": "tool", "tool_call_id": "a", "content": "r1"},
+                {"role": "tool", "tool_call_id": "b", "content": "r2"}
+            ]
+        });
+        let out = conv().convert_request(&body);
+        assert_eq!(out["max_tokens"], json!(256));
+        let msgs = out["messages"].as_array().unwrap();
+        assert_eq!(msgs.len(), 3);
+        assert_eq!(msgs[1]["role"], json!("assistant"));
+        assert_eq!(
+            msgs[1]["content"],
+            json!([
+                {"type": "tool_use", "id": "a", "name": "f1", "input": {"x": 1}},
+                {"type": "tool_use", "id": "b", "name": "f2", "input": {}}
+            ])
+        );
+        // Both tool results merged into a single user message.
+        assert_eq!(msgs[2]["role"], json!("user"));
+        assert_eq!(
+            msgs[2]["content"],
+            json!([
+                {"type": "tool_result", "tool_use_id": "a", "content": "r1"},
+                {"type": "tool_result", "tool_use_id": "b", "content": "r2"}
+            ])
+        );
+    }
+
+    #[test]
+    fn request_maps_tools_and_tool_choice() {
+        let body = json!({
+            "model": "c",
+            "messages": [],
+            "tools": [{"type": "function", "function": {"name": "f", "description": "d", "parameters": {"type": "object"}}}],
+            "tool_choice": "required"
+        });
+        let out = conv().convert_request(&body);
+        assert_eq!(
+            out["tools"],
+            json!([{"name": "f", "description": "d", "input_schema": {"type": "object"}}])
+        );
+        assert_eq!(out["tool_choice"], json!({"type": "any"}));
+    }
+
+    #[test]
+    fn request_maps_named_tool_choice() {
+        let body = json!({
+            "model": "c",
+            "messages": [],
+            "tool_choice": {"type": "function", "function": {"name": "pick"}}
+        });
+        let out = conv().convert_request(&body);
+        assert_eq!(out["tool_choice"], json!({"type": "tool", "name": "pick"}));
+    }
+
+    #[test]
+    fn response_maps_text_thinking_tool_use_and_usage() {
+        let upstream = json!({
+            "id": "msg_1",
+            "model": "claude-sonnet-4",
+            "content": [
+                {"type": "thinking", "thinking": "hmm"},
+                {"type": "text", "text": "hello"},
+                {"type": "tool_use", "id": "tu_1", "name": "f", "input": {"a": 1}}
+            ],
+            "stop_reason": "tool_use",
+            "usage": {"input_tokens": 12, "output_tokens": 6}
+        });
+        let out = conv().convert_response(&upstream);
+        let choice = &out["choices"][0];
+        assert_eq!(choice["message"]["content"], json!("hello"));
+        assert_eq!(choice["message"]["reasoning_content"], json!("hmm"));
+        assert_eq!(choice["finish_reason"], json!("tool_calls"));
+        let tc = &choice["message"]["tool_calls"][0];
+        assert_eq!(tc["id"], json!("tu_1"));
+        assert_eq!(tc["function"]["arguments"], json!("{\"a\":1}"));
+        assert_eq!(out["usage"], json!({"prompt_tokens": 12, "completion_tokens": 6, "total_tokens": 18}));
+    }
+
+    fn ev(event: &str, data: Value) -> SseEvent {
+        SseEvent { event: event.to_string(), data: data.to_string() }
+    }
+
+    #[test]
+    fn stream_full_sequence() {
+        let c = conv();
+        let mut state = StreamState::default();
+        c.convert_stream_event(
+            &ev("message_start", json!({"message": {"id": "msg_1", "model": "claude-sonnet-4", "usage": {"input_tokens": 10}}})),
+            &mut state,
+        );
+        let block = c.convert_stream_event(
+            &ev("content_block_start", json!({"index": 0, "content_block": {"type": "text"}})),
+            &mut state,
+        );
+        // role chunk on first content block
+        assert_eq!(block.len(), 1);
+        let role: Value = serde_json::from_str(&block[0]).unwrap();
+        assert_eq!(role["choices"][0]["delta"]["role"], json!("assistant"));
+        assert_eq!(role["id"], json!("msg_1"));
+
+        let text = c.convert_stream_event(
+            &ev("content_block_delta", json!({"index": 0, "delta": {"type": "text_delta", "text": "hi"}})),
+            &mut state,
+        );
+        assert_eq!(text.len(), 1);
+        let content: Value = serde_json::from_str(&text[0]).unwrap();
+        assert_eq!(content["choices"][0]["delta"]["content"], json!("hi"));
+
+        let reasoning = c.convert_stream_event(
+            &ev("content_block_delta", json!({"index": 0, "delta": {"type": "thinking_delta", "thinking": "why"}})),
+            &mut state,
+        );
+        let r: Value = serde_json::from_str(&reasoning[0]).unwrap();
+        assert_eq!(r["choices"][0]["delta"]["reasoning_content"], json!("why"));
+
+        let done = c.convert_stream_event(
+            &ev("message_delta", json!({"delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 5}})),
+            &mut state,
+        );
+        assert_eq!(done.len(), 2);
+        let finish: Value = serde_json::from_str(&done[0]).unwrap();
+        assert_eq!(finish["choices"][0]["finish_reason"], json!("stop"));
+        assert_eq!(finish["usage"], json!({"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}));
+        assert_eq!(done[1], "[DONE]");
+        assert!(state.finished);
+    }
+
+    #[test]
+    fn stream_tool_use_emits_header_and_argument_deltas() {
+        let c = conv();
+        let mut state = StreamState::default();
+        let start = c.convert_stream_event(
+            &ev("content_block_start", json!({"index": 1, "content_block": {"type": "tool_use", "id": "tu_1", "name": "f"}})),
+            &mut state,
+        );
+        // role chunk + tool header
+        assert_eq!(start.len(), 2);
+        let header: Value = serde_json::from_str(&start[1]).unwrap();
+        let tc = &header["choices"][0]["delta"]["tool_calls"][0];
+        assert_eq!(tc["index"], json!(0));
+        assert_eq!(tc["id"], json!("tu_1"));
+        assert_eq!(tc["function"]["name"], json!("f"));
+
+        let arg = c.convert_stream_event(
+            &ev("content_block_delta", json!({"index": 1, "delta": {"type": "input_json_delta", "partial_json": "{\"a\""}})),
+            &mut state,
+        );
+        let arg_chunk: Value = serde_json::from_str(&arg[0]).unwrap();
+        let atc = &arg_chunk["choices"][0]["delta"]["tool_calls"][0];
+        assert_eq!(atc["index"], json!(0));
+        assert_eq!(atc["function"]["arguments"], json!("{\"a\""));
     }
 }

--- a/src-tauri/src/core/server/converters.rs
+++ b/src-tauri/src/core/server/converters.rs
@@ -1,0 +1,162 @@
+//! Translating-gateway support for the proxy.
+//!
+//! Jan's proxy accepts OpenAI chat/completions and, for OpenAI-compatible
+//! upstreams, forwards verbatim. To also front providers with a different
+//! native wire API (OpenAI `/v1/responses`, Google `generateContent`,
+//! Anthropic `/v1/messages`), each such provider gets a converter that rewrites
+//! the request and translates the response back to chat/completions.
+//!
+//! This module currently provides the shared primitive every converter needs:
+//! an [`SseAccumulator`] that reassembles complete Server-Sent Events across
+//! network chunk boundaries. The existing inline proxy parser splits each chunk
+//! on lines and drops partial lines, which only survives because upstreams tend
+//! to flush whole events; a real translator cannot rely on that.
+
+/// One parsed Server-Sent Event.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SseEvent {
+    /// The `event:` field value, empty when absent (chat/completions omits it;
+    /// OpenAI `/responses` and Anthropic set it).
+    pub event: String,
+    /// Concatenated `data:` payload (multiple `data:` lines joined by `\n`),
+    /// with sentinels like `[DONE]` preserved verbatim.
+    pub data: String,
+}
+
+/// Accumulates raw response text and yields complete SSE events, buffering any
+/// partial trailing event until its terminating blank line arrives in a later
+/// chunk.
+#[derive(Debug, Default)]
+pub struct SseAccumulator {
+    buf: String,
+}
+
+impl SseAccumulator {
+    pub fn new() -> Self {
+        Self { buf: String::new() }
+    }
+
+    /// Feed a chunk of the response body; returns every event completed by it.
+    pub fn push(&mut self, chunk: &str) -> Vec<SseEvent> {
+        // Normalize CRLF so boundary detection only has to look for "\n\n".
+        self.buf.push_str(&chunk.replace("\r\n", "\n"));
+        let mut events = Vec::new();
+        while let Some(idx) = self.buf.find("\n\n") {
+            let raw: String = self.buf.drain(..idx + 2).collect();
+            if let Some(ev) = parse_event(&raw) {
+                events.push(ev);
+            }
+        }
+        events
+    }
+
+    /// Flush a final event that arrived without a terminating blank line (some
+    /// servers omit it before closing the connection).
+    pub fn finish(&mut self) -> Option<SseEvent> {
+        let raw = std::mem::take(&mut self.buf);
+        parse_event(&raw)
+    }
+}
+
+fn parse_event(raw: &str) -> Option<SseEvent> {
+    let mut ev = SseEvent::default();
+    let mut data_lines: Vec<&str> = Vec::new();
+    let mut has_field = false;
+    for line in raw.lines() {
+        // Blank lines separate events; lines starting with ':' are comments.
+        if line.is_empty() || line.starts_with(':') {
+            continue;
+        }
+        if let Some(rest) = line.strip_prefix("data:") {
+            data_lines.push(rest.strip_prefix(' ').unwrap_or(rest));
+            has_field = true;
+        } else if let Some(rest) = line.strip_prefix("event:") {
+            ev.event = rest.strip_prefix(' ').unwrap_or(rest).to_string();
+            has_field = true;
+        }
+        // `id:`, `retry:`, and unknown fields are irrelevant to translation.
+    }
+    if !has_field {
+        return None;
+    }
+    ev.data = data_lines.join("\n");
+    Some(ev)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_single_event_in_one_chunk() {
+        let mut acc = SseAccumulator::new();
+        let events = acc.push("data: {\"a\":1}\n\n");
+        assert_eq!(
+            events,
+            vec![SseEvent {
+                event: String::new(),
+                data: "{\"a\":1}".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn buffers_an_event_split_across_chunks() {
+        let mut acc = SseAccumulator::new();
+        assert!(acc.push("data: {\"a\":").is_empty());
+        assert!(acc.push("1}").is_empty());
+        let events = acc.push("\n\n");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].data, "{\"a\":1}");
+    }
+
+    #[test]
+    fn yields_multiple_events_from_one_chunk() {
+        let mut acc = SseAccumulator::new();
+        let events = acc.push("data: 1\n\ndata: 2\n\n");
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].data, "1");
+        assert_eq!(events[1].data, "2");
+    }
+
+    #[test]
+    fn joins_multiline_data_and_reads_event_field() {
+        let mut acc = SseAccumulator::new();
+        let events = acc.push("event: response.delta\ndata: line1\ndata: line2\n\n");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event, "response.delta");
+        assert_eq!(events[0].data, "line1\nline2");
+    }
+
+    #[test]
+    fn normalizes_crlf_boundaries() {
+        let mut acc = SseAccumulator::new();
+        let events = acc.push("data: x\r\n\r\n");
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].data, "x");
+    }
+
+    #[test]
+    fn ignores_comment_lines_and_preserves_done_sentinel() {
+        let mut acc = SseAccumulator::new();
+        let events = acc.push(": keep-alive\n\ndata: [DONE]\n\n");
+        // The comment-only block yields no event; [DONE] is preserved verbatim.
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].data, "[DONE]");
+    }
+
+    #[test]
+    fn finish_flushes_a_trailing_event_without_blank_line() {
+        let mut acc = SseAccumulator::new();
+        assert!(acc.push("data: tail").is_empty());
+        let last = acc.finish();
+        assert_eq!(last.map(|e| e.data), Some("tail".to_string()));
+    }
+
+    #[test]
+    fn finish_is_empty_when_buffer_has_no_fields() {
+        let mut acc = SseAccumulator::new();
+        acc.push("data: done\n\n");
+        assert_eq!(acc.finish(), None);
+    }
+}

--- a/src-tauri/src/core/server/converters.rs
+++ b/src-tauri/src/core/server/converters.rs
@@ -92,8 +92,17 @@ use std::collections::HashMap;
 /// Anthropic `/v1/messages`); the proxy selects one by `ProviderConfig.api_type`
 /// and otherwise forwards verbatim.
 pub trait UpstreamConverter: Send + Sync {
-    /// Path suffix appended to the provider `base_url` (e.g. `/responses`).
-    fn upstream_path(&self) -> &'static str;
+    /// Path suffix appended to the provider `base_url`. Derived from the request
+    /// body because some APIs encode the model and action in the URL (Google:
+    /// `/models/{model}:streamGenerateContent?alt=sse`).
+    fn upstream_path(&self, body: &Value) -> String;
+
+    /// Authorization header for the upstream request. Defaults to OpenAI-style
+    /// `Authorization: Bearer`; providers using a different scheme (Google:
+    /// `x-goog-api-key`) override this.
+    fn auth_header(&self, key: &str) -> (&'static str, String) {
+        ("authorization", format!("Bearer {key}"))
+    }
 
     /// Rewrite the inbound chat/completions body into the native request body.
     fn convert_request(&self, body: &Value) -> Value;
@@ -111,6 +120,7 @@ pub trait UpstreamConverter: Send + Sync {
 pub fn converter_for(api_type: Option<&str>) -> Option<Box<dyn UpstreamConverter>> {
     match api_type {
         Some("openai-responses") => Some(Box::new(OpenAIResponsesConverter::new())),
+        Some("google") => Some(Box::new(GoogleGenerateContentConverter::new())),
         _ => None,
     }
 }
@@ -155,8 +165,8 @@ fn message_text(content: &Value) -> String {
 }
 
 impl UpstreamConverter for OpenAIResponsesConverter {
-    fn upstream_path(&self) -> &'static str {
-        "/responses"
+    fn upstream_path(&self, _body: &Value) -> String {
+        "/responses".to_string()
     }
 
     fn convert_request(&self, body: &Value) -> Value {
@@ -411,12 +421,12 @@ impl UpstreamConverter for OpenAIResponsesConverter {
             }
             "response.completed" | "response.incomplete" => {
                 let finish = if state.saw_tool_call { "tool_calls" } else { "stop" };
-                out.push(chunk_str_with_usage(
-                    state,
-                    json!({}),
-                    Some(finish),
-                    data.get("response").and_then(|r| r.get("usage")),
-                ));
+                let usage = data
+                    .get("response")
+                    .and_then(|r| r.get("usage"))
+                    .map(|u| convert_usage(Some(u)))
+                    .filter(|u| !u.is_null());
+                out.push(chunk_str_with_usage(state, json!({}), Some(finish), usage.as_ref()));
                 out.push("[DONE]".to_string());
                 state.finished = true;
             }
@@ -433,6 +443,335 @@ impl UpstreamConverter for OpenAIResponsesConverter {
                 state.finished = true;
             }
             _ => {}
+        }
+        out
+    }
+}
+
+/// Fronts Google's Gemini `generateContent` API. The model and action are
+/// encoded in the URL and streaming uses `?alt=sse`; auth is `x-goog-api-key`.
+/// The registered provider `base_url` must include the API version, e.g.
+/// `https://generativelanguage.googleapis.com/v1beta`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct GoogleGenerateContentConverter;
+
+impl GoogleGenerateContentConverter {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+/// Map a Gemini `finishReason` to a chat/completions `finish_reason`.
+fn map_gemini_finish(reason: &str, saw_tool: bool) -> &'static str {
+    if saw_tool {
+        return "tool_calls";
+    }
+    match reason {
+        "MAX_TOKENS" => "length",
+        "SAFETY" | "RECITATION" | "PROHIBITED_CONTENT" | "BLOCKLIST" => "content_filter",
+        _ => "stop",
+    }
+}
+
+/// Map Gemini `usageMetadata` to chat/completions usage.
+fn convert_gemini_usage(usage: Option<&Value>) -> Value {
+    let Some(u) = usage else {
+        return Value::Null;
+    };
+    let prompt = u.get("promptTokenCount").and_then(|v| v.as_i64()).unwrap_or(0);
+    let candidates = u
+        .get("candidatesTokenCount")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(0);
+    let thoughts = u.get("thoughtsTokenCount").and_then(|v| v.as_i64()).unwrap_or(0);
+    let completion = candidates + thoughts;
+    let total = u
+        .get("totalTokenCount")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(prompt + completion);
+    json!({
+        "prompt_tokens": prompt,
+        "completion_tokens": completion,
+        "total_tokens": total,
+    })
+}
+
+impl UpstreamConverter for GoogleGenerateContentConverter {
+    fn upstream_path(&self, body: &Value) -> String {
+        let model = body.get("model").and_then(|m| m.as_str()).unwrap_or("");
+        let streaming = body.get("stream").and_then(|s| s.as_bool()).unwrap_or(false);
+        if streaming {
+            format!("/models/{model}:streamGenerateContent?alt=sse")
+        } else {
+            format!("/models/{model}:generateContent")
+        }
+    }
+
+    fn auth_header(&self, key: &str) -> (&'static str, String) {
+        ("x-goog-api-key", key.to_string())
+    }
+
+    fn convert_request(&self, body: &Value) -> Value {
+        // tool_call_id -> function name, so tool results become functionResponse
+        // parts (Gemini keys them by name, not call id).
+        let mut call_names: HashMap<String, String> = HashMap::new();
+        if let Some(messages) = body.get("messages").and_then(|m| m.as_array()) {
+            for msg in messages {
+                if let Some(calls) = msg.get("tool_calls").and_then(|c| c.as_array()) {
+                    for call in calls {
+                        if let (Some(id), Some(name)) = (
+                            call.get("id").and_then(|v| v.as_str()),
+                            call.get("function").and_then(|f| f.get("name")).and_then(|n| n.as_str()),
+                        ) {
+                            call_names.insert(id.to_string(), name.to_string());
+                        }
+                    }
+                }
+            }
+        }
+
+        let mut contents: Vec<Value> = Vec::new();
+        let mut system_parts: Vec<Value> = Vec::new();
+        if let Some(messages) = body.get("messages").and_then(|m| m.as_array()) {
+            for msg in messages {
+                let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("user");
+                let content = msg.get("content").cloned().unwrap_or(Value::Null);
+                match role {
+                    "system" | "developer" => {
+                        system_parts.push(json!({"text": message_text(&content)}));
+                    }
+                    "assistant" => {
+                        let mut parts: Vec<Value> = Vec::new();
+                        let text = message_text(&content);
+                        if !text.is_empty() {
+                            parts.push(json!({"text": text}));
+                        }
+                        if let Some(calls) = msg.get("tool_calls").and_then(|c| c.as_array()) {
+                            for call in calls {
+                                let func = call.get("function");
+                                let name = func.and_then(|f| f.get("name")).cloned().unwrap_or(Value::Null);
+                                let args_str = func
+                                    .and_then(|f| f.get("arguments"))
+                                    .and_then(|a| a.as_str())
+                                    .unwrap_or("{}");
+                                let args: Value = serde_json::from_str(args_str).unwrap_or_else(|_| json!({}));
+                                parts.push(json!({"functionCall": {"name": name, "args": args}}));
+                            }
+                        }
+                        if !parts.is_empty() {
+                            contents.push(json!({"role": "model", "parts": parts}));
+                        }
+                    }
+                    "tool" => {
+                        let call_id = msg.get("tool_call_id").and_then(|v| v.as_str()).unwrap_or("");
+                        let name = call_names.get(call_id).cloned().unwrap_or_else(|| call_id.to_string());
+                        let text = message_text(&content);
+                        // Gemini requires the functionResponse `response` to be an object.
+                        let response: Value = serde_json::from_str(&text)
+                            .ok()
+                            .filter(|v: &Value| v.is_object())
+                            .unwrap_or_else(|| json!({"result": text}));
+                        contents.push(json!({
+                            "role": "user",
+                            "parts": [{"functionResponse": {"name": name, "response": response}}]
+                        }));
+                    }
+                    _ => contents.push(json!({"role": "user", "parts": [{"text": message_text(&content)}]})),
+                }
+            }
+        }
+
+        let mut out = json!({"contents": contents});
+        if !system_parts.is_empty() {
+            out["systemInstruction"] = json!({"parts": system_parts});
+        }
+
+        let mut gen_config = json!({});
+        if let Some(v) = body.get("temperature") {
+            gen_config["temperature"] = v.clone();
+        }
+        if let Some(v) = body.get("top_p") {
+            gen_config["topP"] = v.clone();
+        }
+        if let Some(v) = body.get("max_tokens").or_else(|| body.get("max_completion_tokens")) {
+            gen_config["maxOutputTokens"] = v.clone();
+        }
+        if body.get("reasoning_effort").and_then(|e| e.as_str()).is_some() {
+            gen_config["thinkingConfig"] = json!({"thinkingBudget": -1, "includeThoughts": true});
+        }
+        if gen_config.as_object().is_some_and(|o| !o.is_empty()) {
+            out["generationConfig"] = gen_config;
+        }
+
+        if let Some(tools) = body.get("tools").and_then(|t| t.as_array()) {
+            let decls: Vec<Value> = tools
+                .iter()
+                .filter_map(|t| {
+                    let func = t.get("function")?;
+                    Some(json!({
+                        "name": func.get("name").cloned().unwrap_or(Value::Null),
+                        "description": func.get("description").cloned().unwrap_or(Value::Null),
+                        "parameters": func.get("parameters").cloned().unwrap_or(json!({})),
+                    }))
+                })
+                .collect();
+            if !decls.is_empty() {
+                out["tools"] = json!([{"functionDeclarations": decls}]);
+            }
+        }
+        if let Some(mode) = body.get("tool_choice").and_then(|c| c.as_str()) {
+            let g_mode = match mode {
+                "none" => "NONE",
+                "required" => "ANY",
+                _ => "AUTO",
+            };
+            out["toolConfig"] = json!({"functionCallingConfig": {"mode": g_mode}});
+        }
+
+        out
+    }
+
+    fn convert_response(&self, upstream: &Value) -> Value {
+        let candidate = upstream
+            .get("candidates")
+            .and_then(|c| c.as_array())
+            .and_then(|c| c.first());
+        let mut content = String::new();
+        let mut reasoning = String::new();
+        let mut tool_calls: Vec<Value> = Vec::new();
+
+        if let Some(parts) = candidate
+            .and_then(|c| c.get("content"))
+            .and_then(|c| c.get("parts"))
+            .and_then(|p| p.as_array())
+        {
+            for part in parts {
+                if let Some(fc) = part.get("functionCall") {
+                    let args = fc.get("args").cloned().unwrap_or_else(|| json!({}));
+                    tool_calls.push(json!({
+                        "id": format!("call_{}", tool_calls.len()),
+                        "type": "function",
+                        "function": {
+                            "name": fc.get("name").cloned().unwrap_or(Value::Null),
+                            "arguments": serde_json::to_string(&args).unwrap_or_default(),
+                        }
+                    }));
+                } else if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
+                    if part.get("thought").and_then(|t| t.as_bool()).unwrap_or(false) {
+                        reasoning.push_str(text);
+                    } else {
+                        content.push_str(text);
+                    }
+                }
+            }
+        }
+
+        let mut message = json!({"role": "assistant"});
+        message["content"] = if content.is_empty() && !tool_calls.is_empty() {
+            Value::Null
+        } else {
+            json!(content)
+        };
+        if !reasoning.is_empty() {
+            message["reasoning_content"] = json!(reasoning);
+        }
+        let saw_tool = !tool_calls.is_empty();
+        if saw_tool {
+            message["tool_calls"] = json!(tool_calls);
+        }
+        let finish_reason = map_gemini_finish(
+            candidate
+                .and_then(|c| c.get("finishReason"))
+                .and_then(|r| r.as_str())
+                .unwrap_or("STOP"),
+            saw_tool,
+        );
+
+        json!({
+            "id": upstream.get("responseId").cloned().unwrap_or_else(|| json!("chatcmpl-proxy")),
+            "object": "chat.completion",
+            "created": 0,
+            "model": upstream.get("modelVersion").cloned().unwrap_or(Value::Null),
+            "choices": [{
+                "index": 0,
+                "message": message,
+                "finish_reason": finish_reason,
+            }],
+            "usage": convert_gemini_usage(upstream.get("usageMetadata")),
+        })
+    }
+
+    fn convert_stream_event(&self, event: &SseEvent, state: &mut StreamState) -> Vec<String> {
+        if event.data == "[DONE]" || state.finished {
+            return Vec::new();
+        }
+        let data: Value = match serde_json::from_str(&event.data) {
+            Ok(v) => v,
+            Err(_) => return Vec::new(),
+        };
+        if let Some(model) = data.get("modelVersion").and_then(|v| v.as_str()) {
+            if state.model.is_empty() {
+                state.model = model.to_string();
+            }
+        }
+        if let Some(id) = data.get("responseId").and_then(|v| v.as_str()) {
+            if state.id.is_empty() {
+                state.id = id.to_string();
+            }
+        }
+
+        let mut out: Vec<String> = Vec::new();
+        let candidate = data
+            .get("candidates")
+            .and_then(|c| c.as_array())
+            .and_then(|c| c.first());
+
+        if let Some(parts) = candidate
+            .and_then(|c| c.get("content"))
+            .and_then(|c| c.get("parts"))
+            .and_then(|p| p.as_array())
+        {
+            for part in parts {
+                if let Some(fc) = part.get("functionCall") {
+                    let idx = state.next_tool_index;
+                    state.next_tool_index += 1;
+                    state.saw_tool_call = true;
+                    push_role_chunk(state, &mut out);
+                    let args = fc.get("args").cloned().unwrap_or_else(|| json!({}));
+                    out.push(chunk_str(
+                        state,
+                        json!({"tool_calls": [{
+                            "index": idx,
+                            "id": format!("call_{idx}"),
+                            "type": "function",
+                            "function": {
+                                "name": fc.get("name").cloned().unwrap_or(Value::Null),
+                                "arguments": serde_json::to_string(&args).unwrap_or_default(),
+                            }
+                        }]}),
+                        None,
+                    ));
+                } else if let Some(text) = part.get("text").and_then(|t| t.as_str()) {
+                    push_role_chunk(state, &mut out);
+                    let key = if part.get("thought").and_then(|t| t.as_bool()).unwrap_or(false) {
+                        "reasoning_content"
+                    } else {
+                        "content"
+                    };
+                    out.push(chunk_str(state, json!({ key: text }), None));
+                }
+            }
+        }
+
+        if let Some(reason) = candidate.and_then(|c| c.get("finishReason")).and_then(|r| r.as_str()) {
+            let finish = map_gemini_finish(reason, state.saw_tool_call);
+            let usage = data
+                .get("usageMetadata")
+                .map(|u| convert_gemini_usage(Some(u)))
+                .filter(|u| !u.is_null());
+            out.push(chunk_str_with_usage(state, json!({}), Some(finish), usage.as_ref()));
+            out.push("[DONE]".to_string());
+            state.finished = true;
         }
         out
     }
@@ -456,6 +795,7 @@ fn chunk_str(state: &StreamState, delta: Value, finish: Option<&str>) -> String 
     .to_string()
 }
 
+/// Build a finish chunk. `usage` is already chat-shaped (`prompt_tokens` etc.).
 fn chunk_str_with_usage(
     state: &StreamState,
     delta: Value,
@@ -470,7 +810,7 @@ fn chunk_str_with_usage(
         "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
     });
     if let Some(u) = usage {
-        chunk["usage"] = convert_usage(Some(u));
+        chunk["usage"] = u.clone();
     }
     chunk.to_string()
 }
@@ -808,5 +1148,223 @@ mod openai_responses_tests {
         assert!(c
             .convert_stream_event(&SseEvent { event: String::new(), data: "not json".into() }, &mut state)
             .is_empty());
+    }
+}
+
+#[cfg(test)]
+mod google_generate_content_tests {
+    use super::*;
+
+    fn conv() -> GoogleGenerateContentConverter {
+        GoogleGenerateContentConverter::new()
+    }
+
+    #[test]
+    fn path_encodes_model_and_action() {
+        let c = conv();
+        assert_eq!(
+            c.upstream_path(&json!({"model": "gemini-2.5-pro"})),
+            "/models/gemini-2.5-pro:generateContent"
+        );
+        assert_eq!(
+            c.upstream_path(&json!({"model": "gemini-2.5-pro", "stream": true})),
+            "/models/gemini-2.5-pro:streamGenerateContent?alt=sse"
+        );
+    }
+
+    #[test]
+    fn auth_uses_goog_api_key() {
+        assert_eq!(conv().auth_header("k"), ("x-goog-api-key", "k".to_string()));
+    }
+
+    #[test]
+    fn request_maps_roles_system_and_thinking() {
+        let body = json!({
+            "model": "gemini-2.5-pro",
+            "messages": [
+                {"role": "system", "content": "be brief"},
+                {"role": "user", "content": "hi"},
+                {"role": "assistant", "content": "hello"}
+            ],
+            "temperature": 0.5,
+            "top_p": 0.9,
+            "max_tokens": 100,
+            "reasoning_effort": "high"
+        });
+        let out = conv().convert_request(&body);
+        assert_eq!(out["systemInstruction"], json!({"parts": [{"text": "be brief"}]}));
+        assert_eq!(
+            out["contents"],
+            json!([
+                {"role": "user", "parts": [{"text": "hi"}]},
+                {"role": "model", "parts": [{"text": "hello"}]}
+            ])
+        );
+        assert_eq!(out["generationConfig"]["temperature"], json!(0.5));
+        assert_eq!(out["generationConfig"]["topP"], json!(0.9));
+        assert_eq!(out["generationConfig"]["maxOutputTokens"], json!(100));
+        assert_eq!(
+            out["generationConfig"]["thinkingConfig"],
+            json!({"thinkingBudget": -1, "includeThoughts": true})
+        );
+    }
+
+    #[test]
+    fn request_maps_tool_calls_and_results() {
+        let body = json!({
+            "model": "gemini-2.5-pro",
+            "messages": [
+                {"role": "user", "content": "weather?"},
+                {"role": "assistant", "content": "", "tool_calls": [
+                    {"id": "call_1", "type": "function", "function": {"name": "getw", "arguments": "{\"city\":\"NYC\"}"}}
+                ]},
+                {"role": "tool", "tool_call_id": "call_1", "content": "{\"temp\":20}"}
+            ],
+            "tools": [
+                {"type": "function", "function": {"name": "getw", "description": "d", "parameters": {"type": "object"}}}
+            ],
+            "tool_choice": "required"
+        });
+        let out = conv().convert_request(&body);
+        let contents = out["contents"].as_array().unwrap();
+        assert_eq!(
+            contents[1],
+            json!({"role": "model", "parts": [{"functionCall": {"name": "getw", "args": {"city": "NYC"}}}]})
+        );
+        assert_eq!(
+            contents[2],
+            json!({"role": "user", "parts": [{"functionResponse": {"name": "getw", "response": {"temp": 20}}}]})
+        );
+        assert_eq!(
+            out["tools"],
+            json!([{"functionDeclarations": [{"name": "getw", "description": "d", "parameters": {"type": "object"}}]}])
+        );
+        assert_eq!(out["toolConfig"], json!({"functionCallingConfig": {"mode": "ANY"}}));
+    }
+
+    #[test]
+    fn tool_result_wraps_non_json_content() {
+        let body = json!({
+            "model": "g",
+            "messages": [{"role": "tool", "tool_call_id": "x", "content": "plain text"}]
+        });
+        let out = conv().convert_request(&body);
+        assert_eq!(
+            out["contents"][0]["parts"][0]["functionResponse"]["response"],
+            json!({"result": "plain text"})
+        );
+    }
+
+    #[test]
+    fn response_maps_text_thought_and_usage() {
+        let upstream = json!({
+            "responseId": "r1",
+            "modelVersion": "gemini-2.5-pro",
+            "candidates": [{
+                "content": {"role": "model", "parts": [
+                    {"text": "thinking...", "thought": true},
+                    {"text": "answer"}
+                ]},
+                "finishReason": "STOP"
+            }],
+            "usageMetadata": {"promptTokenCount": 8, "candidatesTokenCount": 4, "thoughtsTokenCount": 2, "totalTokenCount": 14}
+        });
+        let out = conv().convert_response(&upstream);
+        let choice = &out["choices"][0];
+        assert_eq!(choice["message"]["content"], json!("answer"));
+        assert_eq!(choice["message"]["reasoning_content"], json!("thinking..."));
+        assert_eq!(choice["finish_reason"], json!("stop"));
+        assert_eq!(out["id"], json!("r1"));
+        assert_eq!(out["model"], json!("gemini-2.5-pro"));
+        assert_eq!(out["usage"], json!({"prompt_tokens": 8, "completion_tokens": 6, "total_tokens": 14}));
+    }
+
+    #[test]
+    fn response_maps_function_call() {
+        let upstream = json!({
+            "candidates": [{
+                "content": {"parts": [{"functionCall": {"name": "getw", "args": {"city": "NYC"}}}]},
+                "finishReason": "STOP"
+            }]
+        });
+        let out = conv().convert_response(&upstream);
+        let choice = &out["choices"][0];
+        assert_eq!(choice["finish_reason"], json!("tool_calls"));
+        assert_eq!(choice["message"]["content"], Value::Null);
+        let tc = &choice["message"]["tool_calls"][0];
+        assert_eq!(tc["id"], json!("call_0"));
+        assert_eq!(tc["function"]["name"], json!("getw"));
+        assert_eq!(tc["function"]["arguments"], json!("{\"city\":\"NYC\"}"));
+    }
+
+    fn ev(data: Value) -> SseEvent {
+        SseEvent { event: String::new(), data: data.to_string() }
+    }
+
+    #[test]
+    fn stream_emits_role_reasoning_content_and_finish() {
+        let c = conv();
+        let mut state = StreamState::default();
+        let first = c.convert_stream_event(
+            &ev(json!({
+                "modelVersion": "gemini-2.5-pro",
+                "candidates": [{"content": {"parts": [{"text": "hmm", "thought": true}]}}]
+            })),
+            &mut state,
+        );
+        assert_eq!(first.len(), 2);
+        let role: Value = serde_json::from_str(&first[0]).unwrap();
+        assert_eq!(role["choices"][0]["delta"]["role"], json!("assistant"));
+        assert_eq!(role["model"], json!("gemini-2.5-pro"));
+        let reason: Value = serde_json::from_str(&first[1]).unwrap();
+        assert_eq!(reason["choices"][0]["delta"]["reasoning_content"], json!("hmm"));
+
+        let second = c.convert_stream_event(
+            &ev(json!({"candidates": [{"content": {"parts": [{"text": "hello"}]}}]})),
+            &mut state,
+        );
+        assert_eq!(second.len(), 1);
+        let content: Value = serde_json::from_str(&second[0]).unwrap();
+        assert_eq!(content["choices"][0]["delta"]["content"], json!("hello"));
+
+        let last = c.convert_stream_event(
+            &ev(json!({
+                "candidates": [{"finishReason": "STOP"}],
+                "usageMetadata": {"promptTokenCount": 3, "candidatesTokenCount": 2, "totalTokenCount": 5}
+            })),
+            &mut state,
+        );
+        assert_eq!(last.len(), 2);
+        let finish: Value = serde_json::from_str(&last[0]).unwrap();
+        assert_eq!(finish["choices"][0]["finish_reason"], json!("stop"));
+        assert_eq!(finish["usage"]["prompt_tokens"], json!(3));
+        assert_eq!(last[1], "[DONE]");
+        assert!(state.finished);
+    }
+
+    #[test]
+    fn stream_function_call_emits_full_tool_call() {
+        let c = conv();
+        let mut state = StreamState::default();
+        let out = c.convert_stream_event(
+            &ev(json!({
+                "candidates": [{
+                    "content": {"parts": [{"functionCall": {"name": "getw", "args": {"x": 1}}}]},
+                    "finishReason": "STOP"
+                }]
+            })),
+            &mut state,
+        );
+        // role chunk + tool_calls chunk + finish + [DONE]
+        assert_eq!(out.len(), 4);
+        let tool: Value = serde_json::from_str(&out[1]).unwrap();
+        let tc = &tool["choices"][0]["delta"]["tool_calls"][0];
+        assert_eq!(tc["index"], json!(0));
+        assert_eq!(tc["id"], json!("call_0"));
+        assert_eq!(tc["function"]["name"], json!("getw"));
+        assert_eq!(tc["function"]["arguments"], json!("{\"x\":1}"));
+        let finish: Value = serde_json::from_str(&out[2]).unwrap();
+        assert_eq!(finish["choices"][0]["finish_reason"], json!("tool_calls"));
+        assert_eq!(out[3], "[DONE]");
     }
 }

--- a/src-tauri/src/core/server/mod.rs
+++ b/src-tauri/src/core/server/mod.rs
@@ -1,4 +1,5 @@
 pub mod commands;
+pub mod converters;
 pub mod provider_secrets;
 pub mod proxy;
 pub mod remote_provider_commands;

--- a/src-tauri/src/core/server/proxy.rs
+++ b/src-tauri/src/core/server/proxy.rs
@@ -2238,8 +2238,8 @@ async fn proxy_request(
                                 if let Some(api_url) = provider_cfg.base_url.clone() {
                                     let path = converter
                                         .as_ref()
-                                        .map(|c| c.upstream_path())
-                                        .unwrap_or(destination_path.as_str());
+                                        .map(|c| c.upstream_path(&json_body))
+                                        .unwrap_or_else(|| destination_path.clone());
                                     target_base_url = Some(format!("{api_url}{path}"));
                                 } else {
                                     target_base_url = None;
@@ -2655,7 +2655,12 @@ async fn proxy_request(
         }
 
         if let Some(key) = key_opt {
-            outbound_req = outbound_req.header("Authorization", format!("Bearer {key}"));
+            // The converter decides the auth scheme (Google uses x-goog-api-key).
+            let (auth_name, auth_value) = match &upstream_converter {
+                Some(conv) => conv.auth_header(key),
+                None => ("authorization", format!("Bearer {key}")),
+            };
+            outbound_req = outbound_req.header(auth_name, auth_value);
         } else {
             log::debug!("No session API key for this attempt");
         }

--- a/src-tauri/src/core/server/proxy.rs
+++ b/src-tauri/src/core/server/proxy.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use tauri_plugin_llamacpp::state::LlamacppState;
 use tokio::sync::Mutex;
 
+use crate::core::server::converters::{converter_for, SseAccumulator, StreamState, UpstreamConverter};
 use crate::core::{
     mcp::models::McpSettings,
     state::{ProviderConfig, ServerHandle, SharedMcpServers},
@@ -1559,6 +1560,9 @@ async fn proxy_request(
     let mut buffered_body: Option<Bytes> = None;
     let mut target_base_url: Option<String> = None;
     let mut is_anthropic_messages = false;
+    // Set when the resolved remote provider fronts a non-chat/completions native
+    // API; drives request rewrite + response translation back to chat shape.
+    let mut upstream_converter: Option<Box<dyn UpstreamConverter>> = None;
     // Model id when the request resolves to an MLX session — MLX has no preset,
     // so sampling defaults are injected into the body before forwarding.
     let mut mlx_model_id: Option<String> = None;
@@ -2224,11 +2228,23 @@ async fn proxy_request(
                             drop(pc2);
 
                             if let Some(provider_cfg) = provider_config {
+                                // A converter only applies to chat/completions; other
+                                // paths keep verbatim forwarding.
+                                let converter = if destination_path == "/chat/completions" {
+                                    converter_for(provider_cfg.api_type.as_deref())
+                                } else {
+                                    None
+                                };
                                 if let Some(api_url) = provider_cfg.base_url.clone() {
-                                    target_base_url = Some(format!("{api_url}{destination_path}"));
+                                    let path = converter
+                                        .as_ref()
+                                        .map(|c| c.upstream_path())
+                                        .unwrap_or(destination_path.as_str());
+                                    target_base_url = Some(format!("{api_url}{path}"));
                                 } else {
                                     target_base_url = None;
                                 }
+                                upstream_converter = converter;
                                 session_api_keys = provider_cfg.bearer_key_chain();
                             } else {
                                 log::error!("Provider config not found for '{provider}'");
@@ -2586,6 +2602,16 @@ async fn proxy_request(
         }
     };
 
+    // Rewrite the chat/completions body into the provider's native request shape.
+    if let Some(converter) = &upstream_converter {
+        if let Ok(v) = serde_json::from_slice::<serde_json::Value>(&body_bytes_for_proxy) {
+            let native = converter.convert_request(&v);
+            if let Ok(bytes) = serde_json::to_vec(&native) {
+                body_bytes_for_proxy = Bytes::from(bytes);
+            }
+        }
+    }
+
     // MLX targets carry no router preset, so apply the model's stored sampling
     // defaults here for keys the caller omitted (llamacpp uses the preset;
     // remote providers are intentionally left untouched).
@@ -2816,6 +2842,27 @@ async fn proxy_request(
                 &origin_header,
                 &config.trusted_hosts,
             );
+
+            // When the provider fronts a non-chat/completions API, translate the
+            // response back to chat shape; otherwise forward bytes verbatim.
+            if let Some(converter) = upstream_converter.take() {
+                let is_sse = response
+                    .headers()
+                    .get(hyper::header::CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok())
+                    .map(|ct| ct.contains("event-stream"))
+                    .unwrap_or(false);
+                let (sender, body) = body_channel();
+                tokio::spawn(async move {
+                    if is_sse {
+                        forward_converted_stream(response.bytes_stream(), sender, converter).await;
+                    } else {
+                        forward_converted_non_streaming(response.bytes().await, sender, converter)
+                            .await;
+                    }
+                });
+                return Ok(builder.body(body).unwrap());
+            }
 
             let mut stream = response.bytes_stream();
             let (mut sender, body) = body_channel();
@@ -3083,6 +3130,67 @@ pub(crate) fn sse_event(data: &serde_json::Value) -> Bytes {
 
 /// Transform and forward streaming OpenAI response as Anthropic /messages chunks.
 /// Handles both text content and tool_calls streaming.
+/// Stream a native upstream response through an [`UpstreamConverter`], emitting
+/// chat/completions SSE chunks. Uses [`SseAccumulator`] so events split across
+/// network chunks are reassembled before translation.
+async fn forward_converted_stream<S>(
+    mut stream: S,
+    mut sender: BodySender,
+    converter: Box<dyn UpstreamConverter>,
+) where
+    S: futures_util::Stream<Item = Result<Bytes, reqwest::Error>> + Unpin,
+{
+    let mut acc = SseAccumulator::new();
+    let mut state = StreamState::default();
+    'outer: while let Some(chunk_result) = stream.next().await {
+        match chunk_result {
+            Ok(chunk) => {
+                let text = String::from_utf8_lossy(&chunk);
+                for event in acc.push(&text) {
+                    for payload in converter.convert_stream_event(&event, &mut state) {
+                        let framed = Bytes::from(format!("data: {payload}\n\n"));
+                        if sender.send_data(framed).await.is_err() {
+                            break 'outer;
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                log::error!("Converter stream error: {e}");
+                break;
+            }
+        }
+    }
+    if let Some(event) = acc.finish() {
+        for payload in converter.convert_stream_event(&event, &mut state) {
+            let framed = Bytes::from(format!("data: {payload}\n\n"));
+            if sender.send_data(framed).await.is_err() {
+                return;
+            }
+        }
+    }
+}
+
+/// Translate a non-streaming native upstream response into a chat.completion
+/// object and forward it as a single body frame.
+async fn forward_converted_non_streaming(
+    body: Result<Bytes, reqwest::Error>,
+    mut sender: BodySender,
+    converter: Box<dyn UpstreamConverter>,
+) {
+    match body {
+        Ok(bytes) => {
+            let out = match serde_json::from_slice::<serde_json::Value>(&bytes) {
+                Ok(v) => serde_json::to_vec(&converter.convert_response(&v))
+                    .unwrap_or_else(|_| bytes.to_vec()),
+                Err(_) => bytes.to_vec(),
+            };
+            let _ = sender.send_data(Bytes::from(out)).await;
+        }
+        Err(e) => log::error!("Converter non-streaming error: {e}"),
+    }
+}
+
 async fn transform_and_forward_stream<S>(
     mut stream: S,
     mut sender: BodySender,

--- a/src-tauri/src/core/server/proxy.rs
+++ b/src-tauri/src/core/server/proxy.rs
@@ -2665,6 +2665,13 @@ async fn proxy_request(
             log::debug!("No session API key for this attempt");
         }
 
+        // Fixed headers the native API requires (Anthropic: anthropic-version).
+        if let Some(conv) = &upstream_converter {
+            for (name, value) in conv.extra_headers() {
+                outbound_req = outbound_req.header(name, value);
+            }
+        }
+
         let outbound_req_with_body = outbound_req.body(body_bytes_for_proxy.clone());
 
         match outbound_req_with_body.send().await {

--- a/src-tauri/src/core/server/remote_provider_commands.rs
+++ b/src-tauri/src/core/server/remote_provider_commands.rs
@@ -23,6 +23,10 @@ pub struct RegisterProviderRequest {
     pub base_url: Option<String>,
     pub custom_headers: Vec<ProviderCustomHeader>,
     pub models: Vec<String>,
+    /// Upstream wire API (`"openai"` default, or `"openai-responses"` /
+    /// `"google"` / `"anthropic"` to engage a translating converter).
+    #[serde(default)]
+    pub api_type: Option<String>,
 }
 
 fn merge_register_api_keys(api_key: Option<String>, api_keys: Vec<String>) -> Vec<String> {
@@ -68,6 +72,7 @@ pub async fn register_provider_config(
             })
             .collect(),
         models: request.models, // Models will be added when they are configured
+        api_type: request.api_type,
     };
 
     // Persist the key chain to the OS keyring so it survives webview storage
@@ -201,6 +206,7 @@ mod tests {
             base_url: None,
             custom_headers: vec![],
             models: vec![],
+            api_type: None,
         }
     }
 

--- a/src-tauri/src/core/state.rs
+++ b/src-tauri/src/core/state.rs
@@ -27,6 +27,13 @@ pub struct ProviderConfig {
     pub base_url: Option<String>,
     pub custom_headers: Vec<ProviderCustomHeader>,
     pub models: Vec<String>,
+    /// Upstream wire API this provider speaks. `None`/`"openai"` = OpenAI
+    /// chat/completions (verbatim passthrough). Other values select a
+    /// translating converter (e.g. `"openai-responses"`, `"google"`,
+    /// `"anthropic"`) so the proxy can accept OpenAI-shaped requests and talk
+    /// the provider's native API.
+    #[serde(default)]
+    pub api_type: Option<String>,
 }
 
 impl ProviderConfig {

--- a/src-tauri/src/core/state.rs
+++ b/src-tauri/src/core/state.rs
@@ -1,6 +1,9 @@
 use std::{collections::HashMap, sync::Arc};
 
-use crate::core::{downloads::models::DownloadManagerState, mcp::models::McpSettings};
+use crate::core::{
+    downloads::models::DownloadManagerState,
+    mcp::models::{McpSettings, ToolWithServer},
+};
 use rmcp::{
     model::{CallToolRequestParam, CallToolResult, InitializeRequestParam, Tool},
     service::RunningService,
@@ -67,6 +70,12 @@ pub struct AppState {
     pub model_param_defaults: Arc<Mutex<HashMap<String, serde_json::Value>>>,
     /// Wakes up MCP monitors to trigger an immediate health check + reconnect
     pub mcp_reconnect_notify: Arc<Notify>,
+    /// Last successful tool listing per enabled server, served when a server
+    /// is transiently disconnected so its schema stays present and stable in
+    /// the prompt instead of disappearing/reappearing across reconnects.
+    /// Cleared only on explicit user deactivation, never on a transient
+    /// list-tools failure.
+    pub mcp_last_known_tools: Arc<Mutex<HashMap<String, Vec<ToolWithServer>>>>,
 }
 
 impl Default for AppState {
@@ -86,6 +95,7 @@ impl Default for AppState {
             provider_configs: Default::default(),
             model_param_defaults: Default::default(),
             mcp_reconnect_notify: Arc::new(Notify::new()),
+            mcp_last_known_tools: Default::default(),
         }
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -277,6 +277,7 @@ pub fn run() {
             provider_configs: Arc::new(Mutex::new(HashMap::new())),
             model_param_defaults: Arc::new(Mutex::new(HashMap::new())),
             mcp_reconnect_notify: Arc::new(tokio::sync::Notify::new()),
+            mcp_last_known_tools: Arc::new(Mutex::new(HashMap::new())),
         })
         .setup(|app| {
             app.handle().plugin(

--- a/web-app/src/components/PromptProgress.tsx
+++ b/web-app/src/components/PromptProgress.tsx
@@ -39,9 +39,18 @@ export function PromptProgress({ hideIdle = false }: { hideIdle?: boolean }) {
   const loadPercentage =
     loadingModel && loadProgress ? Math.round(loadProgress.value * 100) : undefined
 
+  // Only worth naming the stage when the load actually has more than one
+  // (vision encoder and/or speculative-decoding draft model on top of the
+  // main weights) - a plain text-only load is always a single "text_model"
+  // stage for its entire duration, so calling that out would be noise.
+  const stageLabel =
+    loadingModel && loadProgress && (loadProgress.stages?.length ?? 0) > 1
+      ? describeLoadStage(loadProgress.stage)
+      : undefined
+
   const label = loadingModel
     ? loadPercentage !== undefined
-      ? `Loading model: ${loadPercentage}%`
+      ? `Loading ${stageLabel ?? 'model'}: ${loadPercentage}%`
       : 'Loading model…'
     : showReading
       ? `Reading: ${percentage}%`
@@ -59,9 +68,6 @@ export function PromptProgress({ hideIdle = false }: { hideIdle?: boolean }) {
       {showReading && !loadingModel && (
         <Progress value={percentage} className="h-1 bg-secondary/60" />
       )}
-      {loadingModel && loadPercentage !== undefined && (
-        <Progress value={loadPercentage} className="h-1 bg-secondary/60" />
-      )}
       {detail && (
         <div className="text-xs text-muted-foreground tabular-nums">
           {detail}
@@ -69,6 +75,19 @@ export function PromptProgress({ hideIdle = false }: { hideIdle?: boolean }) {
       )}
     </div>
   )
+}
+
+function describeLoadStage(stage: string | undefined): string | undefined {
+  switch (stage) {
+    case 'text_model':
+      return 'text model'
+    case 'mmproj_model':
+      return 'vision encoder'
+    case 'spec_model':
+      return 'draft model'
+    default:
+      return undefined
+  }
 }
 
 function buildDetail(progress: {

--- a/web-app/src/components/PromptProgress.tsx
+++ b/web-app/src/components/PromptProgress.tsx
@@ -14,6 +14,10 @@ export function PromptProgress({ hideIdle = false }: { hideIdle?: boolean }) {
     (threadId ? state.loadingModels[threadId] : undefined) ??
     state.loadingModel
   )
+  const loadProgress = useAppState((state) =>
+    (threadId ? state.modelLoadProgressByThread[threadId] : undefined) ??
+    state.modelLoadProgress
+  )
 
   const percentage =
     promptProgress && promptProgress.total > 0
@@ -32,8 +36,13 @@ export function PromptProgress({ hideIdle = false }: { hideIdle?: boolean }) {
     return null
   }
 
+  const loadPercentage =
+    loadingModel && loadProgress ? Math.round(loadProgress.value * 100) : undefined
+
   const label = loadingModel
-    ? 'Loading model…'
+    ? loadPercentage !== undefined
+      ? `Loading model: ${loadPercentage}%`
+      : 'Loading model…'
     : showReading
       ? `Reading: ${percentage}%`
       : 'Working…'
@@ -49,6 +58,9 @@ export function PromptProgress({ hideIdle = false }: { hideIdle?: boolean }) {
       </div>
       {showReading && !loadingModel && (
         <Progress value={percentage} className="h-1 bg-secondary/60" />
+      )}
+      {loadingModel && loadPercentage !== undefined && (
+        <Progress value={loadPercentage} className="h-1 bg-secondary/60" />
       )}
       {detail && (
         <div className="text-xs text-muted-foreground tabular-nums">

--- a/web-app/src/components/__tests__/PromptProgress.test.tsx
+++ b/web-app/src/components/__tests__/PromptProgress.test.tsx
@@ -57,6 +57,34 @@ describe('PromptProgress', () => {
     ).toBeInTheDocument()
   })
 
+  it('should show load percentage while loading model', () => {
+    mockUseAppState.mockImplementation((selector) =>
+      selector({
+        promptProgress: undefined,
+        loadingModel: true,
+        modelLoadProgress: { modelId: 'model-1', value: 0.42 },
+      })
+    )
+
+    render(<PromptProgress />)
+
+    expect(screen.getByText('Loading model: 42%')).toBeInTheDocument()
+  })
+
+  it('should fall back to generic loading label when no progress event has arrived yet', () => {
+    mockUseAppState.mockImplementation((selector) =>
+      selector({
+        promptProgress: undefined,
+        loadingModel: true,
+        modelLoadProgress: undefined,
+      })
+    )
+
+    render(<PromptProgress />)
+
+    expect(screen.getByText('Loading model…')).toBeInTheDocument()
+  })
+
   it('should handle zero total gracefully', () => {
     const mockProgress = {
       cache: 0,

--- a/web-app/src/components/__tests__/PromptProgress.test.tsx
+++ b/web-app/src/components/__tests__/PromptProgress.test.tsx
@@ -71,6 +71,70 @@ describe('PromptProgress', () => {
     expect(screen.getByText('Loading model: 42%')).toBeInTheDocument()
   })
 
+  it('should not render a progress bar while loading a model', () => {
+    mockUseAppState.mockImplementation((selector) =>
+      selector({
+        promptProgress: undefined,
+        loadingModel: true,
+        modelLoadProgress: { modelId: 'model-1', value: 0.42 },
+      })
+    )
+
+    const { container } = render(<PromptProgress />)
+
+    expect(screen.getByText('Loading model: 42%')).toBeInTheDocument()
+    expect(container.querySelector('[data-slot="progress"]')).toBeNull()
+  })
+
+  it('should still render the progress bar while reading (unaffected by the load-bar removal)', () => {
+    const mockProgress = { cache: 0, processed: 50, time_ms: 500, total: 100 }
+    mockUseAppState.mockImplementation((selector) =>
+      selector({ promptProgress: mockProgress, loadingModel: false })
+    )
+
+    const { container } = render(<PromptProgress />)
+
+    expect(container.querySelector('[data-slot="progress"]')).not.toBeNull()
+  })
+
+  it('should name the stage when a load has more than one (vision model)', () => {
+    mockUseAppState.mockImplementation((selector) =>
+      selector({
+        promptProgress: undefined,
+        loadingModel: true,
+        modelLoadProgress: {
+          modelId: 'model-1',
+          value: 0.8,
+          stage: 'mmproj_model',
+          stages: ['text_model', 'mmproj_model'],
+        },
+      })
+    )
+
+    render(<PromptProgress />)
+
+    expect(screen.getByText('Loading vision encoder: 80%')).toBeInTheDocument()
+  })
+
+  it('should not name the stage for a plain single-stage text-only load', () => {
+    mockUseAppState.mockImplementation((selector) =>
+      selector({
+        promptProgress: undefined,
+        loadingModel: true,
+        modelLoadProgress: {
+          modelId: 'model-1',
+          value: 0.5,
+          stage: 'text_model',
+          stages: ['text_model'],
+        },
+      })
+    )
+
+    render(<PromptProgress />)
+
+    expect(screen.getByText('Loading model: 50%')).toBeInTheDocument()
+  })
+
   it('should fall back to generic loading label when no progress event has arrived yet', () => {
     mockUseAppState.mockImplementation((selector) =>
       selector({

--- a/web-app/src/components/ai-elements/chain-of-thought.tsx
+++ b/web-app/src/components/ai-elements/chain-of-thought.tsx
@@ -73,7 +73,7 @@ export const ChainOfThought = memo(
   ({
     className,
     isStreaming = false,
-    shouldCollapse = false,
+    shouldCollapse,
     forceOpen = false,
     open,
     defaultOpen = true,
@@ -87,14 +87,16 @@ export const ChainOfThought = memo(
       onChange: onOpenChange,
     })
 
-    // Auto-collapse once text content appears after this CoT group, unless
-    // something inside still needs the user's attention (forceOpen).
+    // Follow the caller's open intent. forceOpen pins it open (e.g. a tool
+    // awaiting approval). When shouldCollapse is a boolean, track it two-way so
+    // the trace opens as a step gains content and collapses when it has none or
+    // the answer begins; when undefined the caller isn't controlling collapse,
+    // so defaultOpen / manual toggle is left untouched. Re-applied only on
+    // input change, preserving a manual toggle between changes.
     useEffect(() => {
-      if (forceOpen) {
-        setIsOpen(true)
-      } else if (shouldCollapse) {
-        setIsOpen(false)
-      }
+      if (forceOpen) setIsOpen(true)
+      else if (shouldCollapse === true) setIsOpen(false)
+      else if (shouldCollapse === false) setIsOpen(true)
     }, [forceOpen, shouldCollapse, setIsOpen])
 
     const handleOpenChange = (newOpen: boolean) => {
@@ -123,7 +125,12 @@ export const ChainOfThought = memo(
     return (
       <ChainOfThoughtContext.Provider value={contextValue}>
         <Collapsible
-          className={cn('not-prose', className)}
+          className={cn(
+            'not-prose rounded-2xl transition-colors',
+            // Card frame only while expanded; collapsed shows a bare summary row.
+            'data-[state=open]:border data-[state=open]:border-border/50 data-[state=open]:bg-main-view-fg/2 data-[state=open]:p-3',
+            className
+          )}
           onOpenChange={handleOpenChange}
           open={isOpen}
           {...props}
@@ -209,9 +216,7 @@ export const ChainOfThoughtContent = memo(
       )}
       {...props}
     >
-      <div className="ml-2 pl-4 border-l-2 border-dotted space-y-3">
-        {children}
-      </div>
+      <div className="space-y-3">{children}</div>
     </CollapsibleContent>
   )
 )

--- a/web-app/src/components/ai-elements/reasoning-timeline.tsx
+++ b/web-app/src/components/ai-elements/reasoning-timeline.tsx
@@ -1,0 +1,73 @@
+import { memo } from 'react'
+import { cn } from '@/lib/utils'
+import { splitReasoningParagraphs } from '@/lib/reasoning'
+
+type StepRowProps = {
+  text: string
+  connector?: boolean
+}
+
+const StepRow = ({ text, connector = false }: StepRowProps) => (
+  <li className="relative flex gap-2.5">
+    {connector && (
+      <span className="absolute left-[3px] top-3.5 -bottom-2.5 border-l border-dotted border-border" />
+    )}
+    <span className="relative z-10 mt-1.5 size-1.5 shrink-0 rounded-full bg-muted-foreground/40" />
+    <div
+      dir="auto"
+      className="select-text whitespace-pre-wrap wrap-break-word text-sm text-main-view-fg/70"
+    >
+      {text}
+    </div>
+  </li>
+)
+
+/**
+ * Full stepped reasoning trace — one dot-railed step per paragraph, joined by a
+ * single dotted connector. Shown when reasoning has finished (or for historical
+ * messages) where the whole trace is revealed on expand.
+ */
+export const ReasoningTimeline = memo(({ text }: { text: string }) => {
+  const steps = splitReasoningParagraphs(text)
+  if (steps.length === 0) return null
+  return (
+    <ol className="relative flex flex-col gap-2.5">
+      {steps.map((step, i) => (
+        <StepRow key={i} text={step} connector={i < steps.length - 1} />
+      ))}
+    </ol>
+  )
+})
+
+/**
+ * While reasoning streams, show only the most recently *completed* paragraph as
+ * plain text — never the paragraph currently being written. As the model
+ * finishes each paragraph and starts the next, the derived last-completed
+ * paragraph swaps, so exactly one bounded block is visible at a time instead of
+ * the whole growing trace.
+ */
+export const ReasoningActiveStep = memo(({ text }: { text: string }) => {
+  const steps = splitReasoningParagraphs(text)
+  // The final element is the in-progress paragraph; the one before it is the
+  // last paragraph the model has actually finished.
+  const completed = steps.slice(0, -1)
+  const current = completed[completed.length - 1] ?? ''
+  if (!current) return null
+  // Key by paragraph index so each swap remounts the block, replaying the
+  // fade/collapse enter transition as one paragraph gives way to the next.
+  return (
+    <div
+      key={completed.length}
+      dir="auto"
+      className={cn(
+        'select-text whitespace-pre-wrap wrap-break-word text-sm text-main-view-fg/70',
+        'animate-in fade-in-0 slide-in-from-top-1 duration-300 ease-out'
+      )}
+    >
+      {current}
+    </div>
+  )
+})
+
+ReasoningTimeline.displayName = 'ReasoningTimeline'
+ReasoningActiveStep.displayName = 'ReasoningActiveStep'

--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -2234,8 +2234,16 @@ const ChatInput = memo(function ChatInput({
                 )}
 
                 {!effectiveAgentMode &&
-                  selectedProvider === 'llamacpp' &&
+                  (selectedProvider === 'llamacpp' ||
+                    selectedProvider === 'google' ||
+                    selectedProvider === 'gemini' ||
+                    selectedProvider === 'anthropic' ||
+                    selectedProvider === 'openai') &&
                   (() => {
+                    // The token-budget submenu only applies to local llama.cpp
+                    // (budget resolved against live n_ctx). Cloud providers size
+                    // their own budget dynamically, so on/off/auto is enough.
+                    const showThinkingBudget = selectedProvider === 'llamacpp'
                     const reasoningValue =
                       (selectedModel?.settings?.reasoning?.controller_props
                         ?.value as 'auto' | 'on' | 'off' | undefined) ?? 'auto'
@@ -2282,6 +2290,114 @@ const ChatInput = memo(function ChatInput({
                       // chat transport both observe the new value.
                       selectModelProvider(selectedProvider, selectedModel.id)
                     }
+                    const clearModelSetting = (settingKey: string) => {
+                      if (!selectedProvider || !selectedModel) return
+                      const providerObj = getProviderByName(selectedProvider)
+                      if (!providerObj) return
+                      const modelIndex = providerObj.models.findIndex(
+                        (m) => m.id === selectedModel.id
+                      )
+                      if (modelIndex === -1) return
+                      const nextSettings = { ...(selectedModel.settings ?? {}) }
+                      delete nextSettings[settingKey]
+                      const updatedModels = [...providerObj.models]
+                      updatedModels[modelIndex] = {
+                        ...selectedModel,
+                        settings: nextSettings,
+                      } as Model
+                      updateProvider(selectedProvider, { models: updatedModels })
+                      selectModelProvider(selectedProvider, selectedModel.id)
+                    }
+
+                    // OpenAI reasoning models expose a discrete effort (no
+                    // on/off, no token budget). Reuse the thinking_budget_tokens
+                    // level as the effort value; "Default" clears it so the
+                    // model uses its own default effort.
+                    if (selectedProvider === 'openai') {
+                      const rawEffort =
+                        selectedModel?.settings?.thinking_budget_tokens
+                          ?.controller_props?.value
+                      const currentEffort =
+                        isThinkingBudgetLevelKey(rawEffort) &&
+                        rawEffort !== 'unlimited'
+                          ? rawEffort
+                          : undefined
+                      const EFFORTS: ThinkingBudgetLevelKey[] = [
+                        'low',
+                        'medium',
+                        'high',
+                        'xhigh',
+                      ]
+                      const effortLabel = currentEffort
+                        ? THINKING_BUDGET_LEVELS.find(
+                            (l) => l.key === currentEffort
+                          )!.label
+                        : 'Default'
+                      return (
+                        <DropdownMenu>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <DropdownMenuTrigger asChild>
+                                <Button
+                                  variant="ghost"
+                                  size="icon-xs"
+                                  aria-label={`Reasoning effort: ${effortLabel}`}
+                                >
+                                  <IconBrain
+                                    size={18}
+                                    className={cn(
+                                      'text-muted-foreground',
+                                      currentEffort && 'text-primary'
+                                    )}
+                                  />
+                                </Button>
+                              </DropdownMenuTrigger>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                              <p>Reasoning effort: {effortLabel}</p>
+                            </TooltipContent>
+                          </Tooltip>
+                          <DropdownMenuContent align="start">
+                            <DropdownMenuItem
+                              onClick={() =>
+                                clearModelSetting('thinking_budget_tokens')
+                              }
+                            >
+                              Default
+                              {!currentEffort && (
+                                <span className="ml-auto text-xs text-muted-foreground">
+                                  ✓
+                                </span>
+                              )}
+                            </DropdownMenuItem>
+                            {EFFORTS.map((key) => (
+                              <DropdownMenuItem
+                                key={key}
+                                onClick={() =>
+                                  updateModelSetting(
+                                    'thinking_budget_tokens',
+                                    'Reasoning Effort',
+                                    'dropdown',
+                                    key
+                                  )
+                                }
+                              >
+                                {
+                                  THINKING_BUDGET_LEVELS.find(
+                                    (l) => l.key === key
+                                  )!.label
+                                }
+                                {currentEffort === key && (
+                                  <span className="ml-auto text-xs text-muted-foreground">
+                                    ✓
+                                  </span>
+                                )}
+                              </DropdownMenuItem>
+                            ))}
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      )
+                    }
                     const setReasoning = (value: 'auto' | 'on' | 'off') =>
                       updateModelSetting(
                         'reasoning',
@@ -2300,7 +2416,7 @@ const ChatInput = memo(function ChatInput({
                         ? 'Reasoning forced on for every request.'
                         : reasoningValue === 'off'
                           ? 'Reasoning disabled for every request.'
-                          : "Reasoning auto-detected from the model's chat template."
+                          : "Reasoning uses the model's default."
 
                     // Stored as a symbolic level, not an absolute token count:
                     // the live context size (post auto-fit) is only known once
@@ -2380,44 +2496,53 @@ const ChatInput = memo(function ChatInput({
                               </span>
                             )}
                           </DropdownMenuItem>
-                          <DropdownMenuSeparator />
-                          <DropdownMenuSub>
-                            <DropdownMenuSubTrigger>
-                              <span className="flex-1">Thinking Budget</span>
-                              <span className="text-xs text-muted-foreground">
-                                {currentBudgetLabel}
-                              </span>
-                            </DropdownMenuSubTrigger>
-                            <DropdownMenuSubContent
-                              collisionPadding={{ bottom: 16 }}
-                            >
-                              {THINKING_BUDGET_LEVELS.map((level) => {
-                                const approxTokens = tokensForThinkingBudgetLevel(
-                                  level.key,
-                                  approxContextSize
-                                )
-                                return (
-                                  <DropdownMenuItem
-                                    key={level.key}
-                                    onClick={() => setThinkingBudget(level.key)}
-                                    className="gap-2"
-                                  >
-                                    <span className="flex-1">{level.label}</span>
-                                    <span className="w-14 shrink-0 text-right text-xs text-muted-foreground tabular-nums">
-                                      {approxTokens === -1
-                                        ? ''
-                                        : `~${approxTokens}`}
-                                    </span>
-                                    <span className="w-3 shrink-0 text-xs text-muted-foreground">
-                                      {currentBudgetLevel === level.key
-                                        ? '✓'
-                                        : ''}
-                                    </span>
-                                  </DropdownMenuItem>
-                                )
-                              })}
-                            </DropdownMenuSubContent>
-                          </DropdownMenuSub>
+                          {showThinkingBudget && (
+                            <>
+                              <DropdownMenuSeparator />
+                              <DropdownMenuSub>
+                                <DropdownMenuSubTrigger>
+                                  <span className="flex-1">Thinking Budget</span>
+                                  <span className="text-xs text-muted-foreground">
+                                    {currentBudgetLabel}
+                                  </span>
+                                </DropdownMenuSubTrigger>
+                                <DropdownMenuSubContent
+                                  collisionPadding={{ bottom: 16 }}
+                                >
+                                  {THINKING_BUDGET_LEVELS.map((level) => {
+                                    const approxTokens =
+                                      tokensForThinkingBudgetLevel(
+                                        level.key,
+                                        approxContextSize
+                                      )
+                                    return (
+                                      <DropdownMenuItem
+                                        key={level.key}
+                                        onClick={() =>
+                                          setThinkingBudget(level.key)
+                                        }
+                                        className="gap-2"
+                                      >
+                                        <span className="flex-1">
+                                          {level.label}
+                                        </span>
+                                        <span className="w-14 shrink-0 text-right text-xs text-muted-foreground tabular-nums">
+                                          {approxTokens === -1
+                                            ? ''
+                                            : `~${approxTokens}`}
+                                        </span>
+                                        <span className="w-3 shrink-0 text-xs text-muted-foreground">
+                                          {currentBudgetLevel === level.key
+                                            ? '✓'
+                                            : ''}
+                                        </span>
+                                      </DropdownMenuItem>
+                                    )
+                                  })}
+                                </DropdownMenuSubContent>
+                              </DropdownMenuSub>
+                            </>
+                          )}
                         </DropdownMenuContent>
                       </DropdownMenu>
                     )

--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -15,6 +15,10 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
 } from '@/components/ui/dropdown-menu'
 import { ArrowRight, PlusIcon } from 'lucide-react'
 import {
@@ -39,6 +43,14 @@ import { BotIcon } from 'lucide-react'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { useGeneralSetting } from '@/hooks/useGeneralSetting'
 import { useModelProvider } from '@/hooks/useModelProvider'
+import { useTokensCount } from '@/hooks/useTokensCount'
+import {
+  THINKING_BUDGET_LEVELS,
+  DEFAULT_THINKING_BUDGET_LEVEL,
+  tokensForThinkingBudgetLevel,
+  isThinkingBudgetLevelKey,
+  type ThinkingBudgetLevelKey,
+} from '@/lib/thinkingBudget'
 import { useReconcileVideoCapability } from '@/hooks/useReconcileVideoCapability'
 
 import { useAppState } from '@/hooks/useAppState'
@@ -120,6 +132,7 @@ const videoMimeForExt = (ext: string | undefined): string => {
   }
 }
 
+
 const ChatInput = memo(function ChatInput({
   className,
   initialMessage,
@@ -191,6 +204,8 @@ const ChatInput = memo(function ChatInput({
     (state) => state.selectModelProvider
   )
   const updateProvider = useModelProvider((state) => state.updateProvider)
+  const { maxTokens: liveMaxTokens, configuredCtxLen } =
+    useTokensCount(threadMessages || [])
   const [message, setMessage] = useState('')
   const [dropdownToolsAvailable, setDropdownToolsAvailable] = useState(false)
   const [tooltipShown, setTooltipShown] = useState<
@@ -2224,7 +2239,12 @@ const ChatInput = memo(function ChatInput({
                     const reasoningValue =
                       (selectedModel?.settings?.reasoning?.controller_props
                         ?.value as 'auto' | 'on' | 'off' | undefined) ?? 'auto'
-                    const setReasoning = (value: 'auto' | 'on' | 'off') => {
+                    const updateModelSetting = (
+                      settingKey: string,
+                      title: string,
+                      controllerType: string,
+                      value: unknown
+                    ) => {
                       if (!selectedProvider || !selectedModel) return
                       const providerObj = getProviderByName(selectedProvider)
                       if (!providerObj) return
@@ -2232,19 +2252,18 @@ const ChatInput = memo(function ChatInput({
                         (m) => m.id === selectedModel.id
                       )
                       if (modelIndex === -1) return
-                      const existing =
-                        selectedModel.settings?.reasoning ?? {
-                          key: 'reasoning',
-                          title: 'Reasoning',
-                          description: '',
-                          controller_type: 'dropdown',
-                          controller_props: { value },
-                        }
+                      const existing = selectedModel.settings?.[settingKey] ?? {
+                        key: settingKey,
+                        title,
+                        description: '',
+                        controller_type: controllerType,
+                        controller_props: { value },
+                      }
                       const updatedModel = {
                         ...selectedModel,
                         settings: {
                           ...selectedModel.settings,
-                          reasoning: {
+                          [settingKey]: {
                             ...existing,
                             controller_props: {
                               ...(existing.controller_props ?? {}),
@@ -2263,6 +2282,13 @@ const ChatInput = memo(function ChatInput({
                       // chat transport both observe the new value.
                       selectModelProvider(selectedProvider, selectedModel.id)
                     }
+                    const setReasoning = (value: 'auto' | 'on' | 'off') =>
+                      updateModelSetting(
+                        'reasoning',
+                        'Reasoning',
+                        'dropdown',
+                        value
+                      )
                     const label =
                       reasoningValue === 'on'
                         ? 'On'
@@ -2275,6 +2301,35 @@ const ChatInput = memo(function ChatInput({
                         : reasoningValue === 'off'
                           ? 'Reasoning disabled for every request.'
                           : "Reasoning auto-detected from the model's chat template."
+
+                    // Stored as a symbolic level, not an absolute token count:
+                    // the live context size (post auto-fit) is only known once
+                    // the model is actually loaded, so resolving to tokens
+                    // happens at send time (custom-chat-transport.ts) against
+                    // whatever the context size turns out to be then.
+                    const rawBudgetLevel =
+                      selectedModel?.settings?.thinking_budget_tokens
+                        ?.controller_props?.value
+                    const currentBudgetLevel = isThinkingBudgetLevelKey(
+                      rawBudgetLevel
+                    )
+                      ? rawBudgetLevel
+                      : DEFAULT_THINKING_BUDGET_LEVEL
+                    const setThinkingBudget = (level: ThinkingBudgetLevelKey) =>
+                      updateModelSetting(
+                        'thinking_budget_tokens',
+                        'Thinking Budget',
+                        'dropdown',
+                        level
+                      )
+                    const currentBudgetLabel = THINKING_BUDGET_LEVELS.find(
+                      (l) => l.key === currentBudgetLevel
+                    )!.label
+                    // Best-effort preview only; the request-time value may
+                    // differ once the model is loaded and fit settles n_ctx.
+                    const approxContextSize =
+                      liveMaxTokens || configuredCtxLen || 8192
+
                     return (
                       <DropdownMenu>
                         <Tooltip>
@@ -2325,6 +2380,44 @@ const ChatInput = memo(function ChatInput({
                               </span>
                             )}
                           </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuSub>
+                            <DropdownMenuSubTrigger>
+                              <span className="flex-1">Thinking Budget</span>
+                              <span className="text-xs text-muted-foreground">
+                                {currentBudgetLabel}
+                              </span>
+                            </DropdownMenuSubTrigger>
+                            <DropdownMenuSubContent
+                              collisionPadding={{ bottom: 16 }}
+                            >
+                              {THINKING_BUDGET_LEVELS.map((level) => {
+                                const approxTokens = tokensForThinkingBudgetLevel(
+                                  level.key,
+                                  approxContextSize
+                                )
+                                return (
+                                  <DropdownMenuItem
+                                    key={level.key}
+                                    onClick={() => setThinkingBudget(level.key)}
+                                    className="gap-2"
+                                  >
+                                    <span className="flex-1">{level.label}</span>
+                                    <span className="w-14 shrink-0 text-right text-xs text-muted-foreground tabular-nums">
+                                      {approxTokens === -1
+                                        ? ''
+                                        : `~${approxTokens}`}
+                                    </span>
+                                    <span className="w-3 shrink-0 text-xs text-muted-foreground">
+                                      {currentBudgetLevel === level.key
+                                        ? '✓'
+                                        : ''}
+                                    </span>
+                                  </DropdownMenuItem>
+                                )
+                              })}
+                            </DropdownMenuSubContent>
+                          </DropdownMenuSub>
                         </DropdownMenuContent>
                       </DropdownMenu>
                     )

--- a/web-app/src/containers/MessageItem.tsx
+++ b/web-app/src/containers/MessageItem.tsx
@@ -43,6 +43,11 @@ import { parseCitationsFromToolOutput } from '@/lib/citation-parser'
 import type { RagCitation } from '@/components/Citations'
 import { useGroundingStore } from '@/stores/grounding-store'
 import { injectCitationMarkers } from '@/lib/grounding'
+import {
+  ReasoningTimeline,
+  ReasoningActiveStep,
+} from '@/components/ai-elements/reasoning-timeline'
+import { splitReasoningParagraphs } from '@/lib/reasoning'
 
 const CHAT_STATUS = {
   STREAMING: 'streaming',
@@ -476,10 +481,6 @@ export const MessageItem = memo(
       const groupIsStreaming =
         isStreaming && lastEntryIndex === message.parts.length - 1
 
-      // Keep the trace expanded while a tool is still running or awaiting the
-      // user's approval — collapsing it would hide the approval controls.
-      const keepOpen = hasPendingToolCall || awaitingApproval
-
       // While streaming, surface only the latest step (current reasoning
       // paragraph or tool call) so each step replaces the previous one rather
       // than the whole trace scrolling by. The full trace renders once done.
@@ -510,17 +511,36 @@ export const MessageItem = memo(
         meaningful.length > 0 &&
         meaningful[meaningful.length - 1].part.type.startsWith('tool-')
 
+      // Only reasoning text is worth expanding for — a tool-only step collapses
+      // to the header. While streaming that means the current step is a
+      // reasoning paragraph that has completed at least once (something for
+      // ReasoningActiveStep to render); once done, any reasoning text qualifies.
+      const hasDisplayableContent = groupIsStreaming
+        ? lastMeaningful?.part.type === CONTENT_TYPE.REASONING &&
+          splitReasoningParagraphs(lastMeaningful.part.text ?? '').length >= 2
+        : entries.some(
+            (e) =>
+              e.part.type === CONTENT_TYPE.REASONING &&
+              Boolean(e.part.text && e.part.text.trim())
+          )
+
+      // Force open only while a tool awaits approval — its approve/deny controls
+      // live inside the collapsible and must stay mounted. A running (already
+      // approved) tool does not force it open, so tool-only steps collapse.
+      const forceOpen = awaitingApproval
+      const shouldCollapse = hasFollowingContent || !hasDisplayableContent
+
       return (
         <ChainOfThought
           key={groupKey}
           className="w-full text-muted-foreground"
           isStreaming={groupIsStreaming}
-          shouldCollapse={hasFollowingContent && !keepOpen}
-          forceOpen={keepOpen}
-          defaultOpen={true}
+          shouldCollapse={shouldCollapse}
+          forceOpen={forceOpen}
+          defaultOpen={hasDisplayableContent && !hasFollowingContent}
         >
           <ChainOfThoughtHeader
-            streamingLabel={currentStepIsTool ? 'Using tools...' : 'Reasoning...'}
+            streamingLabel={currentStepIsTool ? 'Using tools...' : 'Thinking'}
             completedVerb={hasTools ? 'Worked' : 'Thought'}
           />
           <ChainOfThoughtContent>
@@ -530,44 +550,43 @@ export const MessageItem = memo(
                   partIndex === message.parts.length - 1
                 const partIsStreaming = isStreaming && isLastMsgPart
 
-                return (
-                  <div
-                    key={`${message.id}-r-${partIndex}`}
-                    className="relative"
-                  >
-                    {partIsStreaming && (
-                      <div className="absolute top-0 left-0 right-0 h-8 bg-linear-to-br from-neutral-50 mask-t-from-98% dark:from-background to-transparent pointer-events-none z-10" />
-                    )}
+                // Streaming: show only the current paragraph as a single
+                // active step (bounded height, swaps as each paragraph
+                // completes). Done/historical: full dot-railed step timeline.
+                if (partIsStreaming) {
+                  return (
                     <div
-                      ref={partIsStreaming ? reasoningContainerRef : null}
-                      onScroll={
-                        partIsStreaming ? onReasoningScroll : undefined
-                      }
-                      className={twMerge(
-                        'w-full overflow-auto relative',
-                        partIsStreaming
-                          ? 'max-h-64 opacity-70 mt-2 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden'
-                          : 'h-auto opacity-100'
-                      )}
+                      key={`${message.id}-r-${partIndex}`}
+                      className="relative"
                     >
                       <div
-                        dir="auto"
-                        className="select-text whitespace-pre-wrap wrap-break-word text-sm text-main-view-fg/70"
+                        ref={reasoningContainerRef}
+                        onScroll={onReasoningScroll}
+                        className={twMerge(
+                          'w-full overflow-auto relative max-h-40',
+                          '[scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden'
+                        )}
                       >
-                        {part.text}
+                        <ReasoningActiveStep text={part.text} />
                       </div>
+                      {!isReasoningAtBottom && (
+                        <Button
+                          className="absolute bottom-2 left-[50%] translate-x-[-50%] rounded-full size-7 z-10"
+                          onClick={onReasoningScrollToBottom}
+                          size="icon"
+                          type="button"
+                          variant="outline"
+                        >
+                          <IconArrowDown className="size-3" />
+                        </Button>
+                      )}
                     </div>
-                    {partIsStreaming && !isReasoningAtBottom && (
-                      <Button
-                        className="absolute bottom-2 left-[50%] translate-x-[-50%] rounded-full size-7 z-10"
-                        onClick={onReasoningScrollToBottom}
-                        size="icon"
-                        type="button"
-                        variant="outline"
-                      >
-                        <IconArrowDown className="size-3" />
-                      </Button>
-                    )}
+                  )
+                }
+
+                return (
+                  <div key={`${message.id}-r-${partIndex}`} className="relative">
+                    <ReasoningTimeline text={part.text} />
                   </div>
                 )
               }
@@ -739,7 +758,9 @@ export const MessageItem = memo(
           message.role === 'assistant' &&
           !awaitingApproval &&
           (hasPendingToolCall || status === CHAT_STATUS.SUBMITTED) && (
-            <PromptProgress hideIdle={hasPendingToolCall} />
+            <div className="mt-2">
+              <PromptProgress hideIdle={hasPendingToolCall} />
+            </div>
           )}
 
         {typeof messageError === 'string' && messageError.length > 0 && (

--- a/web-app/src/containers/SamplerDefaults.tsx
+++ b/web-app/src/containers/SamplerDefaults.tsx
@@ -44,22 +44,16 @@ export function SamplerDefaults({
               )
         return (
           <div key={key} className="space-y-2">
-            <div className="flex items-start justify-between gap-8">
-              <div className="mb-1 shrink-0 basis-28 truncate">
-                <span title={def.title} className="font-medium">
-                  {def.title}
-                </span>
-              </div>
-              <div className="flex-1 min-w-0">
-                <DynamicControllerSetting
-                  title={def.title}
-                  description={def.description}
-                  controllerType={def.controllerType}
-                  controllerProps={{ ...(def.controllerProps ?? {}), value }}
-                  onChange={(newValue) => onChange(key, newValue)}
-                />
-              </div>
+            <div className="mb-1">
+              <span className="font-medium">{def.title}</span>
             </div>
+            <DynamicControllerSetting
+              title={def.title}
+              description={def.description}
+              controllerType={def.controllerType}
+              controllerProps={{ ...(def.controllerProps ?? {}), value }}
+              onChange={(newValue) => onChange(key, newValue)}
+            />
             <p className="text-muted-foreground leading-normal text-xs">
               {def.description}
             </p>

--- a/web-app/src/containers/SamplerDefaults.tsx
+++ b/web-app/src/containers/SamplerDefaults.tsx
@@ -45,18 +45,20 @@ export function SamplerDefaults({
         return (
           <div key={key} className="space-y-2">
             <div className="flex items-start justify-between gap-8">
-              <div className="mb-1 truncate">
+              <div className="mb-1 shrink-0 basis-28 truncate">
                 <span title={def.title} className="font-medium">
                   {def.title}
                 </span>
               </div>
-              <DynamicControllerSetting
-                title={def.title}
-                description={def.description}
-                controllerType={def.controllerType}
-                controllerProps={{ ...(def.controllerProps ?? {}), value }}
-                onChange={(newValue) => onChange(key, newValue)}
-              />
+              <div className="flex-1 min-w-0">
+                <DynamicControllerSetting
+                  title={def.title}
+                  description={def.description}
+                  controllerType={def.controllerType}
+                  controllerProps={{ ...(def.controllerProps ?? {}), value }}
+                  onChange={(newValue) => onChange(key, newValue)}
+                />
+              </div>
             </div>
             <p className="text-muted-foreground leading-normal text-xs">
               {def.description}

--- a/web-app/src/containers/__tests__/ChatInput.test.tsx
+++ b/web-app/src/containers/__tests__/ChatInput.test.tsx
@@ -80,6 +80,18 @@ vi.mock('@/hooks/useModelProvider', () => ({
     }),
 }))
 
+vi.mock('@/hooks/useTokensCount', () => ({
+  useTokensCount: () => ({
+    maxTokens: undefined,
+    configuredCtxLen: undefined,
+    tokenCount: 0,
+    isNearLimit: false,
+    loading: false,
+    fitEnabled: false,
+    calculateTokens: vi.fn(),
+  }),
+}))
+
 vi.mock('@/hooks/useAssistant', () => ({
   useAssistant: () => ({
     loading: false,

--- a/web-app/src/containers/dialogs/ImportLlamacppModelDialog.tsx
+++ b/web-app/src/containers/dialogs/ImportLlamacppModelDialog.tsx
@@ -9,7 +9,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
 import { useServiceHub } from '@/hooks/useServiceHub'
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useCallback } from 'react'
 import { toast } from 'sonner'
 import {
   IconLoader2,
@@ -19,6 +19,7 @@ import {
   IconCheck,
   IconAlertTriangle,
   IconCodeCircle2,
+  IconBolt,
 } from '@tabler/icons-react'
 
 type DetectedModalities = { vision: boolean; audio: boolean }
@@ -36,6 +37,90 @@ const EMBEDDING_GGUF_ARCHS = new Set([
   'pangu-embedded',
   'llama-embed',
 ])
+
+// Mirrors llama.cpp's common_speculative_are_compatible (common/speculative.cpp):
+// draft/target compatibility is decided by tokenizer type, BOS/EOS ids, and
+// vocab size - never by comparing general.architecture strings, which are
+// legitimately different for MTP draft heads (e.g. "gemma4-assistant" vs "gemma4").
+const SPEC_VOCAB_MAX_SIZE_DIFFERENCE = 128
+
+type TokenizerInfo = {
+  tokenizerModel?: string
+  addBos?: boolean
+  addEos?: boolean
+  bosTokenId?: number
+  eosTokenId?: number
+  vocabSize?: number
+}
+
+function extractTokenizerInfo(
+  meta: Record<string, string> | undefined
+): TokenizerInfo {
+  if (!meta) return {}
+  const truthy = (v: string | undefined) =>
+    typeof v === 'string' && v.toLowerCase() === 'true'
+  const num = (v: string | undefined) => {
+    if (typeof v !== 'string' || v === '') return undefined
+    const n = Number(v)
+    return Number.isFinite(n) ? n : undefined
+  }
+  const vocabSizeKey = Object.keys(meta).find((k) =>
+    k.endsWith('.vocab_size')
+  )
+  return {
+    tokenizerModel: meta['tokenizer.ggml.model'],
+    addBos:
+      meta['tokenizer.ggml.add_bos_token'] !== undefined
+        ? truthy(meta['tokenizer.ggml.add_bos_token'])
+        : undefined,
+    addEos:
+      meta['tokenizer.ggml.add_eos_token'] !== undefined
+        ? truthy(meta['tokenizer.ggml.add_eos_token'])
+        : undefined,
+    bosTokenId: num(meta['tokenizer.ggml.bos_token_id']),
+    eosTokenId: num(meta['tokenizer.ggml.eos_token_id']),
+    vocabSize: vocabSizeKey ? num(meta[vocabSizeKey]) : undefined,
+  }
+}
+
+function findTokenizerMismatch(
+  main: TokenizerInfo,
+  draft: TokenizerInfo
+): string | null {
+  if (
+    main.tokenizerModel &&
+    draft.tokenizerModel &&
+    main.tokenizerModel !== draft.tokenizerModel
+  ) {
+    return `tokenizer type "${draft.tokenizerModel}" does not match the main model's tokenizer type "${main.tokenizerModel}"`
+  }
+  if (
+    main.addBos &&
+    draft.addBos &&
+    main.bosTokenId !== undefined &&
+    draft.bosTokenId !== undefined &&
+    main.bosTokenId !== draft.bosTokenId
+  ) {
+    return `BOS token id ${draft.bosTokenId} does not match the main model's BOS token id ${main.bosTokenId}`
+  }
+  if (
+    main.addEos &&
+    draft.addEos &&
+    main.eosTokenId !== undefined &&
+    draft.eosTokenId !== undefined &&
+    main.eosTokenId !== draft.eosTokenId
+  ) {
+    return `EOS token id ${draft.eosTokenId} does not match the main model's EOS token id ${main.eosTokenId}`
+  }
+  if (
+    main.vocabSize !== undefined &&
+    draft.vocabSize !== undefined &&
+    Math.abs(main.vocabSize - draft.vocabSize) > SPEC_VOCAB_MAX_SIZE_DIFFERENCE
+  ) {
+    return `vocab size ${draft.vocabSize} differs from the main model's vocab size ${main.vocabSize} by more than ${SPEC_VOCAB_MAX_SIZE_DIFFERENCE} tokens`
+  }
+  return null
+}
 
 function detectEmbeddingFromMetadata(
   meta: Record<string, string> | undefined
@@ -80,15 +165,26 @@ export const ImportLlamacppModelDialog = ({
   const [detectedModalities, setDetectedModalities] =
     useState<DetectedModalities | null>(null)
   const [isEmbeddingModel, setIsEmbeddingModel] = useState(false)
+  const [isDraftModel, setIsDraftModel] = useState(false)
+  const [draftFile, setDraftFile] = useState<string | null>(null)
+  const [draftValidationError, setDraftValidationError] = useState<
+    string | null
+  >(null)
+  const [isValidatingDraft, setIsValidatingDraft] = useState(false)
+  const [modelTokenizerInfo, setModelTokenizerInfo] =
+    useState<TokenizerInfo | null>(null)
 
   const validateGgufFile = useCallback(
-    async (filePath: string, fileType: 'model' | 'mmproj'): Promise<void> => {
+    async (filePath: string, fileType: 'model' | 'mmproj' | 'draft'): Promise<void> => {
       if (fileType === 'model') {
         setIsValidating(true)
         setValidationError(null)
-      } else {
+      } else if (fileType === 'mmproj') {
         setIsValidatingMmproj(true)
         setMmprojValidationError(null)
+      } else {
+        setIsValidatingDraft(true)
+        setDraftValidationError(null)
       }
 
       try {
@@ -104,6 +200,9 @@ export const ImportLlamacppModelDialog = ({
                 result.metadata.metadata?.['general.architecture']
 
               setModelName(await serviceHub.path().basename(filePath))
+              setModelTokenizerInfo(
+                extractTokenizerInfo(result.metadata.metadata)
+              )
 
               const embedding = detectEmbeddingFromMetadata(
                 result.metadata.metadata
@@ -115,6 +214,10 @@ export const ImportLlamacppModelDialog = ({
                 setMmprojValidationError(null)
                 setIsValidatingMmproj(false)
                 setDetectedModalities(null)
+                setIsDraftModel(false)
+                setDraftFile(null)
+                setDraftValidationError(null)
+                setIsValidatingDraft(false)
               }
 
               if (architecture === 'clip') {
@@ -133,7 +236,7 @@ export const ImportLlamacppModelDialog = ({
               console.error('Model validation failed:', result.error)
             }
           }
-        } else {
+        } else if (fileType === 'mmproj') {
           // For mmproj files, we need to manually validate since validateGgufFile rejects CLIP models
           try {
             // Import the readGgufMetadata function directly from Tauri
@@ -180,6 +283,35 @@ export const ImportLlamacppModelDialog = ({
             }`
             setMmprojValidationError(errorMessage)
           }
+        } else {
+          // Draft (speculative-decoding) models are ordinary causal-LM ggufs,
+          // not CLIP - reuse the standard validator and cross-check tokenizer
+          // compatibility (not architecture name; see findTokenizerMismatch).
+          if (typeof serviceHub.models().validateGgufFile === 'function') {
+            const result = await serviceHub.models().validateGgufFile(filePath)
+            const architecture =
+              result.metadata?.metadata?.['general.architecture']
+
+            if (architecture === 'clip') {
+              setDraftValidationError(
+                'This file has CLIP architecture and cannot be used as a draft model.'
+              )
+            } else if (!result.isValid) {
+              setDraftValidationError(
+                result.error || 'Draft model validation failed'
+              )
+            } else if (modelTokenizerInfo) {
+              const mismatch = findTokenizerMismatch(
+                modelTokenizerInfo,
+                extractTokenizerInfo(result.metadata?.metadata)
+              )
+              if (mismatch) {
+                setDraftValidationError(
+                  `Draft model is not compatible with the main model: ${mismatch}.`
+                )
+              }
+            }
+          }
         }
       } catch (error) {
         console.error(`Failed to validate ${fileType} file:`, error)
@@ -187,18 +319,22 @@ export const ImportLlamacppModelDialog = ({
 
         if (fileType === 'model') {
           setValidationError(errorMessage)
-        } else {
+        } else if (fileType === 'mmproj') {
           setMmprojValidationError(errorMessage)
+        } else {
+          setDraftValidationError(errorMessage)
         }
       } finally {
         if (fileType === 'model') {
           setIsValidating(false)
-        } else {
+        } else if (fileType === 'mmproj') {
           setIsValidatingMmproj(false)
+        } else {
+          setIsValidatingDraft(false)
         }
       }
     },
-    [serviceHub]
+    [serviceHub, modelTokenizerInfo]
   )
 
   const validateModelFile = useCallback(
@@ -215,7 +351,14 @@ export const ImportLlamacppModelDialog = ({
     [validateGgufFile]
   )
 
-  const handleFileSelect = async (type: 'model' | 'mmproj') => {
+  const validateDraftFile = useCallback(
+    async (filePath: string): Promise<void> => {
+      await validateGgufFile(filePath, 'draft')
+    },
+    [validateGgufFile]
+  )
+
+  const handleFileSelect = async (type: 'model' | 'mmproj' | 'draft') => {
     const selectedFile = await serviceHub.dialog().open({
       multiple: false,
       directory: false,
@@ -235,10 +378,14 @@ export const ImportLlamacppModelDialog = ({
 
         // Validate the selected model file (this will update model name with baseName from metadata)
         await validateModelFile(selectedFile)
-      } else {
+      } else if (type === 'mmproj') {
         setMmProjFile(selectedFile)
         // Validate the selected mmproj file
         await validateMmprojFile(selectedFile)
+      } else {
+        setDraftFile(selectedFile)
+        // Validate the selected draft model file
+        await validateDraftFile(selectedFile)
       }
     }
   }
@@ -251,6 +398,11 @@ export const ImportLlamacppModelDialog = ({
 
     if (isMultimodal && !mmProjFile) {
       toast.error('Please select both model and MMPROJ files for multimodal models')
+      return
+    }
+
+    if (isDraftModel && !draftFile) {
+      toast.error('Please select a draft model file')
       return
     }
 
@@ -274,20 +426,17 @@ export const ImportLlamacppModelDialog = ({
     setImporting(true)
 
     try {
-      if (isMultimodal && mmProjFile) {
-        // Import vision model with both files - let backend calculate SHA256 and sizes
-        await serviceHub.models().pullModel(
-          modelName,
-          modelFile,
-          undefined, // modelSha256 - calculated by backend
-          undefined, // modelSize - calculated by backend
-          mmProjFile // mmprojPath
-          // mmprojSha256 and mmprojSize omitted - calculated by backend
-        )
-      } else {
-        // Import regular model - let backend calculate SHA256 and size
-        await serviceHub.models().pullModel(modelName, modelFile)
-      }
+      // Let backend calculate SHA256 and sizes for all files
+      await serviceHub.models().pullModel(
+        modelName,
+        modelFile,
+        undefined, // modelSha256
+        undefined, // modelSize
+        isMultimodal && mmProjFile ? mmProjFile : undefined,
+        undefined, // mmprojSha256
+        undefined, // mmprojSize
+        isDraftModel && draftFile ? draftFile : undefined
+      )
 
       toast.success('Model imported successfully', {
         description: `${modelName} has been imported`,
@@ -319,13 +468,12 @@ export const ImportLlamacppModelDialog = ({
     setIsValidatingMmproj(false)
     setDetectedModalities(null)
     setIsEmbeddingModel(false)
+    setModelTokenizerInfo(null)
+    setIsDraftModel(false)
+    setDraftFile(null)
+    setDraftValidationError(null)
+    setIsValidatingDraft(false)
   }
-
-  useEffect(() => {
-    if (mmProjFile && modelName && isMultimodal) {
-      validateMmprojFile(mmProjFile)
-    }
-  }, [modelName, mmProjFile, isMultimodal, validateMmprojFile])
 
   const handleOpenChange = (newOpen: boolean) => {
     if (!importing) {
@@ -350,8 +498,9 @@ export const ImportLlamacppModelDialog = ({
           </DialogTitle>
           <DialogDescription>
             Import a GGUF model file to add it to your collection. Enable
-            multimodal support to attach an mmproj for image or audio input.
-            Embedding models are detected automatically.
+            multimodal support to attach an mmproj for image or audio input,
+            or draft model support for speculative decoding. Embedding models
+            are detected automatically.
           </DialogDescription>
         </DialogHeader>
 
@@ -379,6 +528,36 @@ export const ImportLlamacppModelDialog = ({
                     setMmprojValidationError(null)
                     setIsValidatingMmproj(false)
                     setDetectedModalities(null)
+                  }
+                }}
+                className="mt-1"
+              />
+            </div>
+          </div>
+
+          <div className="border  rounded-lg p-4 space-y-3">
+            <div className="flex items-start space-x-3">
+              <div className="shrink-0 mt-0.5">
+                <IconBolt size={20} className="text-muted-foreground" />
+              </div>
+              <div className="flex-1">
+                <h3 className="font-medium">Draft Model Support</h3>
+                <p className="text-sm text-muted-foreground leading-normal">
+                  Attach a smaller draft model (including MTP draft heads) for
+                  speculative decoding. The draft model must share the main
+                  model&apos;s tokenizer and vocabulary.
+                </p>
+              </div>
+              <Switch
+                id="draft-model"
+                checked={isDraftModel}
+                disabled={isEmbeddingModel}
+                onCheckedChange={(checked) => {
+                  setIsDraftModel(checked)
+                  if (!checked) {
+                    setDraftFile(null)
+                    setDraftValidationError(null)
+                    setIsValidatingDraft(false)
                   }
                 }}
                 className="mt-1"
@@ -620,6 +799,92 @@ export const ImportLlamacppModelDialog = ({
                 )}
               </div>
             )}
+
+            {isDraftModel && (
+              <div className="border rounded-lg p-4 space-y-3">
+                <div className="flex items-center gap-2">
+                  <h3 className="font-medium">Draft Model File (GGUF)</h3>
+                  <span className="text-xs bg-secondary px-2 py-1 rounded-sm">
+                    Required for Draft Model
+                  </span>
+                </div>
+
+                {draftFile ? (
+                  <div className="space-y-2">
+                    <div className="bg-accent/10 border rounded-lg p-3">
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-2">
+                          {isValidatingDraft ? (
+                            <IconLoader2 size={16} className="animate-spin" />
+                          ) : draftValidationError ? (
+                            <IconAlertTriangle
+                              size={16}
+                              className="text-destructive"
+                            />
+                          ) : (
+                            <IconCheck size={16} />
+                          )}
+                          <span className="text-sm font-medium">
+                            {draftFile.split(/[\\/]/).pop()}
+                          </span>
+                        </div>
+                        <Button
+                          variant="secondary"
+                          size="sm"
+                          onClick={() => handleFileSelect('draft')}
+                          disabled={importing || isValidatingDraft}
+                        >
+                          Change
+                        </Button>
+                      </div>
+                    </div>
+
+                    {draftValidationError && (
+                      <div className="bg-destructive/10 border border-destructive/20 rounded-lg p-3">
+                        <div className="flex items-start gap-2">
+                          <IconAlertTriangle
+                            size={16}
+                            className="text-destructive mt-0.5 shrink-0"
+                          />
+                          <div>
+                            <p className="text-sm font-medium text-destructive">
+                              Draft Model Validation Error
+                            </p>
+                            <p className="text-sm text-destructive/90 mt-1">
+                              {draftValidationError}
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+
+                    {isValidatingDraft && (
+                      <div className="bg-blue-50 border border-blue-200 rounded-lg p-3">
+                        <div className="flex items-center gap-2">
+                          <IconLoader2
+                            size={16}
+                            className="text-blue-500 animate-spin"
+                          />
+                          <p className="text-sm text-blue-700">
+                            Validating draft model file...
+                          </p>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <Button
+                    type="button"
+                    variant="link"
+                    onClick={() => handleFileSelect('draft')}
+                    disabled={importing}
+                    className="w-full h-12 border border-dashed text-muted-foreground"
+                  >
+                    Select Draft GGUF File
+                  </Button>
+                )}
+              </div>
+            )}
           </div>
         </div>
 
@@ -640,10 +905,13 @@ export const ImportLlamacppModelDialog = ({
               !modelFile ||
               !modelName ||
               (isMultimodal && !mmProjFile) ||
+              (isDraftModel && !draftFile) ||
               validationError !== null ||
               isValidating ||
               mmprojValidationError !== null ||
-              isValidatingMmproj
+              isValidatingMmproj ||
+              draftValidationError !== null ||
+              isValidatingDraft
             }
           >
             {importing && <IconLoader2 className="mr-2 size-4 animate-spin" />}

--- a/web-app/src/containers/dialogs/LlamacppOomListener.tsx
+++ b/web-app/src/containers/dialogs/LlamacppOomListener.tsx
@@ -15,6 +15,11 @@ type LoadProgressPayload = {
   value: number
 }
 
+type UnloadEventPayload = {
+  model: string
+  exit_code?: number | null
+}
+
 export default function LlamacppOomListener() {
   useEffect(() => {
     if (!isPlatformTauri()) return
@@ -56,10 +61,25 @@ export default function LlamacppOomListener() {
       console.warn('listen llamacpp-model-load-progress failed:', e)
       return () => {}
     })
+    // Fired for every model unload the router observes (explicit unload, LRU
+    // eviction under models_max, or a crash) - forwarded unconditionally.
+    // Jan already flips activeModels off for unloads it requested itself, so
+    // reconciling an already-correct state here is a harmless no-op; the
+    // real value is catching router-side evictions Jan didn't initiate.
+    const unlistenUnloaded = listen<UnloadEventPayload>(
+      'llamacpp-model-unloaded',
+      (event) => {
+        useAppState.getState().removeActiveModel(event.payload.model)
+      }
+    ).catch((e) => {
+      console.warn('listen llamacpp-model-unloaded failed:', e)
+      return () => {}
+    })
     return () => {
       void unlistenOom.then((fn) => fn?.())
       void unlistenBackend.then((fn) => fn?.())
       void unlistenLoadProgress.then((fn) => fn?.())
+      void unlistenUnloaded.then((fn) => fn?.())
     }
   }, [])
 

--- a/web-app/src/containers/dialogs/LlamacppOomListener.tsx
+++ b/web-app/src/containers/dialogs/LlamacppOomListener.tsx
@@ -9,6 +9,12 @@ import {
   stampErrorOnLastUserMessage,
 } from './llamacppRouterError'
 
+type LoadProgressPayload = {
+  model: string
+  stage?: string
+  value: number
+}
+
 export default function LlamacppOomListener() {
   useEffect(() => {
     if (!isPlatformTauri()) return
@@ -35,9 +41,25 @@ export default function LlamacppOomListener() {
       console.warn('listen llamacpp-router-backend-error failed:', e)
       return () => {}
     })
+    const unlistenLoadProgress = listen<LoadProgressPayload>(
+      'llamacpp-model-load-progress',
+      (event) => {
+        const { model, stage, value } = event.payload
+        const progress = { modelId: model, stage, value }
+        useAppState.getState().updateModelLoadProgress(progress)
+        const threadId = useAppState.getState().currentStreamThreadId
+        if (threadId) {
+          useAppState.getState().updateThreadModelLoadProgress(threadId, progress)
+        }
+      }
+    ).catch((e) => {
+      console.warn('listen llamacpp-model-load-progress failed:', e)
+      return () => {}
+    })
     return () => {
       void unlistenOom.then((fn) => fn?.())
       void unlistenBackend.then((fn) => fn?.())
+      void unlistenLoadProgress.then((fn) => fn?.())
     }
   }, [])
 

--- a/web-app/src/containers/dialogs/LlamacppOomListener.tsx
+++ b/web-app/src/containers/dialogs/LlamacppOomListener.tsx
@@ -12,6 +12,7 @@ import {
 type LoadProgressPayload = {
   model: string
   stage?: string
+  stages: string[]
   value: number
 }
 
@@ -49,8 +50,8 @@ export default function LlamacppOomListener() {
     const unlistenLoadProgress = listen<LoadProgressPayload>(
       'llamacpp-model-load-progress',
       (event) => {
-        const { model, stage, value } = event.payload
-        const progress = { modelId: model, stage, value }
+        const { model, stage, stages, value } = event.payload
+        const progress = { modelId: model, stage, stages, value }
         useAppState.getState().updateModelLoadProgress(progress)
         const threadId = useAppState.getState().currentStreamThreadId
         if (threadId) {

--- a/web-app/src/containers/dialogs/__tests__/ImportLlamacppModelDialog.test.tsx
+++ b/web-app/src/containers/dialogs/__tests__/ImportLlamacppModelDialog.test.tsx
@@ -70,6 +70,132 @@ describe('ImportLlamacppModelDialog', () => {
     expect(screen.getByText('Select GGUF File')).toBeInTheDocument()
   })
 
+  it('shows Select Draft GGUF File when the draft model switch is enabled', () => {
+    render(
+      <ImportLlamacppModelDialog
+        provider={provider}
+        trigger={<button>Open</button>}
+      />
+    )
+    openDialog()
+    fireEvent.click(document.getElementById('draft-model')!)
+    expect(screen.getByText('Select Draft GGUF File')).toBeInTheDocument()
+  })
+
+  it('passes the draft model path through to pullModel', async () => {
+    hoisted.dialogOpen
+      .mockResolvedValueOnce('/tmp/ok.gguf')
+      .mockResolvedValueOnce('/tmp/draft.gguf')
+    hoisted.pullModel.mockResolvedValueOnce(undefined)
+    render(
+      <ImportLlamacppModelDialog
+        provider={provider}
+        trigger={<button>Open</button>}
+      />
+    )
+    openDialog()
+    fireEvent.click(screen.getByText('Select GGUF File'))
+    await waitFor(() => expect(hoisted.validateGgufFile).toHaveBeenCalled())
+    fireEvent.click(document.getElementById('draft-model')!)
+    fireEvent.click(screen.getByText('Select Draft GGUF File'))
+    await waitFor(() =>
+      expect(screen.getByText('draft.gguf')).toBeInTheDocument()
+    )
+    const importBtn = await screen.findByRole('button', {
+      name: /Import Model/i,
+    })
+    await waitFor(() => expect(importBtn).not.toBeDisabled())
+    fireEvent.click(importBtn)
+    await waitFor(() =>
+      expect(hoisted.pullModel).toHaveBeenCalledWith(
+        'ok.gguf',
+        '/tmp/ok.gguf',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        '/tmp/draft.gguf'
+      )
+    )
+  })
+
+  it('rejects a draft model whose tokenizer type does not match the main model', async () => {
+    hoisted.dialogOpen
+      .mockResolvedValueOnce('/tmp/ok.gguf')
+      .mockResolvedValueOnce('/tmp/draft.gguf')
+    hoisted.validateGgufFile.mockImplementation(async (path: string) => ({
+      isValid: true,
+      metadata: {
+        metadata: {
+          'general.architecture': 'llama',
+          'tokenizer.ggml.model': path.includes('draft') ? 'bpe' : 'llama',
+        },
+      },
+    }))
+    render(
+      <ImportLlamacppModelDialog
+        provider={provider}
+        trigger={<button>Open</button>}
+      />
+    )
+    openDialog()
+    fireEvent.click(screen.getByText('Select GGUF File'))
+    await waitFor(() => expect(hoisted.validateGgufFile).toHaveBeenCalled())
+    await waitFor(() =>
+      expect(screen.getAllByText('ok.gguf').length).toBeGreaterThan(0)
+    )
+    fireEvent.click(document.getElementById('draft-model')!)
+    fireEvent.click(screen.getByText('Select Draft GGUF File'))
+    await waitFor(() =>
+      expect(screen.getAllByText('draft.gguf').length).toBeGreaterThan(0)
+    )
+    await waitFor(() =>
+      expect(
+        screen.getByText(/not compatible with the main model/i)
+      ).toBeInTheDocument()
+    )
+  })
+
+  it('accepts a draft model whose architecture name differs but tokenizer matches (MTP assistant heads)', async () => {
+    hoisted.dialogOpen
+      .mockResolvedValueOnce('/tmp/ok.gguf')
+      .mockResolvedValueOnce('/tmp/mtp.gguf')
+    hoisted.validateGgufFile.mockImplementation(async (path: string) => ({
+      isValid: true,
+      metadata: {
+        metadata: {
+          'general.architecture': path.includes('mtp')
+            ? 'gemma4-assistant'
+            : 'gemma4',
+          'tokenizer.ggml.model': 'llama',
+          'tokenizer.ggml.bos_token_id': '2',
+          'tokenizer.ggml.eos_token_id': '1',
+        },
+      },
+    }))
+    render(
+      <ImportLlamacppModelDialog
+        provider={provider}
+        trigger={<button>Open</button>}
+      />
+    )
+    openDialog()
+    fireEvent.click(screen.getByText('Select GGUF File'))
+    await waitFor(() => expect(hoisted.validateGgufFile).toHaveBeenCalled())
+    await waitFor(() =>
+      expect(screen.getAllByText('ok.gguf').length).toBeGreaterThan(0)
+    )
+    fireEvent.click(document.getElementById('draft-model')!)
+    fireEvent.click(screen.getByText('Select Draft GGUF File'))
+    await waitFor(() =>
+      expect(screen.getAllByText('mtp.gguf').length).toBeGreaterThan(0)
+    )
+    expect(
+      screen.queryByText('Draft Model Validation Error')
+    ).not.toBeInTheDocument()
+  })
+
   it('shows Select MMPROJ File when the vision switch is enabled', () => {
     render(
       <ImportLlamacppModelDialog
@@ -78,7 +204,7 @@ describe('ImportLlamacppModelDialog', () => {
       />
     )
     openDialog()
-    const sw = screen.getByRole('switch')
+    const sw = document.getElementById('multimodal')!
     fireEvent.click(sw)
     expect(screen.getByText('Select MMPROJ File')).toBeInTheDocument()
   })
@@ -188,7 +314,13 @@ describe('ImportLlamacppModelDialog', () => {
     await waitFor(() =>
       expect(hoisted.pullModel).toHaveBeenCalledWith(
         'ok.gguf',
-        '/tmp/ok.gguf'
+        '/tmp/ok.gguf',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined
       )
     )
     await waitFor(() =>
@@ -235,7 +367,7 @@ describe('ImportLlamacppModelDialog', () => {
     )
     openDialog()
     // Enable vision mode first
-    fireEvent.click(screen.getByRole('switch'))
+    fireEvent.click(document.getElementById('multimodal')!)
     fireEvent.click(screen.getByText('Select MMPROJ File'))
     await waitFor(() =>
       expect(hoisted.invoke).toHaveBeenCalledWith(
@@ -260,7 +392,7 @@ describe('ImportLlamacppModelDialog', () => {
       />
     )
     openDialog()
-    fireEvent.click(screen.getByRole('switch'))
+    fireEvent.click(document.getElementById('multimodal')!)
     fireEvent.click(screen.getByText('Select MMPROJ File'))
     await waitFor(() =>
       expect(screen.getByText('MMProj Validation Error')).toBeInTheDocument()

--- a/web-app/src/containers/dialogs/__tests__/LlamacppOomListener.test.tsx
+++ b/web-app/src/containers/dialogs/__tests__/LlamacppOomListener.test.tsx
@@ -44,13 +44,19 @@ describe('LlamacppOomListener - model load progress', () => {
     expect(loadProgressHandler).toBeDefined()
     act(() => {
       loadProgressHandler?.({
-        payload: { model: 'model-1', stage: 'text_model', value: 0.75 },
+        payload: {
+          model: 'model-1',
+          stage: 'mmproj_model',
+          stages: ['text_model', 'mmproj_model'],
+          value: 0.75,
+        },
       })
     })
 
     expect(useAppState.getState().modelLoadProgress).toEqual({
       modelId: 'model-1',
-      stage: 'text_model',
+      stage: 'mmproj_model',
+      stages: ['text_model', 'mmproj_model'],
       value: 0.75,
     })
   })

--- a/web-app/src/containers/dialogs/__tests__/LlamacppOomListener.test.tsx
+++ b/web-app/src/containers/dialogs/__tests__/LlamacppOomListener.test.tsx
@@ -5,11 +5,15 @@ import LlamacppOomListener from '../LlamacppOomListener'
 import { useAppState } from '@/hooks/useAppState'
 
 let loadProgressHandler: ((event: { payload: unknown }) => void) | undefined
+let unloadHandler: ((event: { payload: unknown }) => void) | undefined
 
 vi.mock('@tauri-apps/api/event', () => ({
   listen: vi.fn((eventName: string, handler: (event: { payload: unknown }) => void) => {
     if (eventName === 'llamacpp-model-load-progress') {
       loadProgressHandler = handler
+    }
+    if (eventName === 'llamacpp-model-unloaded') {
+      unloadHandler = handler
     }
     return Promise.resolve(() => {})
   }),
@@ -71,5 +75,44 @@ describe('LlamacppOomListener - model load progress', () => {
       stage: undefined,
       value: 0.3,
     })
+  })
+})
+
+describe('LlamacppOomListener - model unloaded', () => {
+  beforeEach(() => {
+    unloadHandler = undefined
+    act(() => {
+      useAppState.setState({ activeModels: ['model-1', 'model-2'] })
+    })
+  })
+
+  it('removes the unloaded model from activeModels', async () => {
+    render(<LlamacppOomListener />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(unloadHandler).toBeDefined()
+    act(() => {
+      unloadHandler?.({ payload: { model: 'model-1', exit_code: 0 } })
+    })
+
+    expect(useAppState.getState().activeModels).toEqual(['model-2'])
+  })
+
+  it('is a no-op when the unloaded model was already reconciled', async () => {
+    act(() => {
+      useAppState.setState({ activeModels: ['model-2'] })
+    })
+    render(<LlamacppOomListener />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    act(() => {
+      unloadHandler?.({ payload: { model: 'model-1', exit_code: 137 } })
+    })
+
+    expect(useAppState.getState().activeModels).toEqual(['model-2'])
   })
 })

--- a/web-app/src/containers/dialogs/__tests__/LlamacppOomListener.test.tsx
+++ b/web-app/src/containers/dialogs/__tests__/LlamacppOomListener.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { act } from '@testing-library/react'
+import LlamacppOomListener from '../LlamacppOomListener'
+import { useAppState } from '@/hooks/useAppState'
+
+let loadProgressHandler: ((event: { payload: unknown }) => void) | undefined
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn((eventName: string, handler: (event: { payload: unknown }) => void) => {
+    if (eventName === 'llamacpp-model-load-progress') {
+      loadProgressHandler = handler
+    }
+    return Promise.resolve(() => {})
+  }),
+}))
+
+vi.mock('@/lib/platform/utils', () => ({
+  isPlatformTauri: () => true,
+}))
+
+describe('LlamacppOomListener - model load progress', () => {
+  beforeEach(() => {
+    loadProgressHandler = undefined
+    act(() => {
+      useAppState.setState({
+        modelLoadProgress: undefined,
+        modelLoadProgressByThread: {},
+        currentStreamThreadId: undefined,
+      })
+    })
+  })
+
+  it('updates global model load progress on event', async () => {
+    render(<LlamacppOomListener />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    expect(loadProgressHandler).toBeDefined()
+    act(() => {
+      loadProgressHandler?.({
+        payload: { model: 'model-1', stage: 'text_model', value: 0.75 },
+      })
+    })
+
+    expect(useAppState.getState().modelLoadProgress).toEqual({
+      modelId: 'model-1',
+      stage: 'text_model',
+      value: 0.75,
+    })
+  })
+
+  it('also updates per-thread progress when a stream thread is active', async () => {
+    act(() => {
+      useAppState.setState({ currentStreamThreadId: 'thread-1' })
+    })
+    render(<LlamacppOomListener />)
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    act(() => {
+      loadProgressHandler?.({
+        payload: { model: 'model-1', value: 0.3 },
+      })
+    })
+
+    expect(useAppState.getState().modelLoadProgressByThread['thread-1']).toEqual({
+      modelId: 'model-1',
+      stage: undefined,
+      value: 0.3,
+    })
+  })
+})

--- a/web-app/src/hooks/__tests__/useAppState.coverage.test.ts
+++ b/web-app/src/hooks/__tests__/useAppState.coverage.test.ts
@@ -132,6 +132,45 @@ describe('useAppState - coverage', () => {
     expect(result.current.promptProgress).toBeUndefined()
   })
 
+  it('should update live token stats globally and per-thread', () => {
+    const { result } = renderHook(() => useAppState())
+    const stats = {
+      promptTokens: 12,
+      completionTokens: 34,
+      tokensPerSecond: 56.7,
+      promptPerSecond: 89.1,
+    }
+
+    act(() => {
+      result.current.updateLiveTokenStats(stats)
+      result.current.updateThreadLiveTokenStats('t1', stats)
+    })
+    expect(result.current.liveTokenStats).toEqual(stats)
+    expect(result.current.liveTokenStatsByThread['t1']).toEqual(stats)
+
+    act(() => {
+      result.current.updateLiveTokenStats(undefined)
+      result.current.updateThreadLiveTokenStats('t1', undefined)
+    })
+    expect(result.current.liveTokenStats).toBeUndefined()
+    expect(result.current.liveTokenStatsByThread['t1']).toBeUndefined()
+  })
+
+  it('should clear liveTokenStatsByThread on clearThreadState', () => {
+    const { result } = renderHook(() => useAppState())
+
+    act(() => {
+      result.current.updateThreadLiveTokenStats('t1', {
+        promptTokens: 1,
+        completionTokens: 2,
+        tokensPerSecond: 3,
+        promptPerSecond: 4,
+      })
+      result.current.clearThreadState('t1')
+    })
+    expect(result.current.liveTokenStatsByThread['t1']).toBeUndefined()
+  })
+
   it('should set active models', () => {
     const { result } = renderHook(() => useAppState())
 

--- a/web-app/src/hooks/__tests__/useAppState.coverage.test.ts
+++ b/web-app/src/hooks/__tests__/useAppState.coverage.test.ts
@@ -171,6 +171,38 @@ describe('useAppState - coverage', () => {
     expect(result.current.liveTokenStatsByThread['t1']).toBeUndefined()
   })
 
+  it('should update model load progress globally and per-thread', () => {
+    const { result } = renderHook(() => useAppState())
+    const progress = { modelId: 'model-1', value: 0.42, stage: 'text_model' }
+
+    act(() => {
+      result.current.updateModelLoadProgress(progress)
+      result.current.updateThreadModelLoadProgress('t1', progress)
+    })
+    expect(result.current.modelLoadProgress).toEqual(progress)
+    expect(result.current.modelLoadProgressByThread['t1']).toEqual(progress)
+
+    act(() => {
+      result.current.updateModelLoadProgress(undefined)
+      result.current.updateThreadModelLoadProgress('t1', undefined)
+    })
+    expect(result.current.modelLoadProgress).toBeUndefined()
+    expect(result.current.modelLoadProgressByThread['t1']).toBeUndefined()
+  })
+
+  it('should clear modelLoadProgressByThread on clearThreadState', () => {
+    const { result } = renderHook(() => useAppState())
+
+    act(() => {
+      result.current.updateThreadModelLoadProgress('t1', {
+        modelId: 'model-1',
+        value: 0.5,
+      })
+      result.current.clearThreadState('t1')
+    })
+    expect(result.current.modelLoadProgressByThread['t1']).toBeUndefined()
+  })
+
   it('should set active models', () => {
     const { result } = renderHook(() => useAppState())
 

--- a/web-app/src/hooks/__tests__/useAppState.coverage.test.ts
+++ b/web-app/src/hooks/__tests__/useAppState.coverage.test.ts
@@ -212,4 +212,24 @@ describe('useAppState - coverage', () => {
     expect(result.current.activeModels).toEqual(['model-a', 'model-b'])
   })
 
+  it('should remove a single active model', () => {
+    const { result } = renderHook(() => useAppState())
+
+    act(() => {
+      result.current.setActiveModels(['model-a', 'model-b'])
+      result.current.removeActiveModel('model-a')
+    })
+    expect(result.current.activeModels).toEqual(['model-b'])
+  })
+
+  it('should no-op removing a model that is not active', () => {
+    const { result } = renderHook(() => useAppState())
+
+    act(() => {
+      result.current.setActiveModels(['model-a'])
+      result.current.removeActiveModel('model-does-not-exist')
+    })
+    expect(result.current.activeModels).toEqual(['model-a'])
+  })
+
 })

--- a/web-app/src/hooks/__tests__/useTokensCount.test.ts
+++ b/web-app/src/hooks/__tests__/useTokensCount.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { ThreadMessage } from '@janhq/core'
+import { useTokensCount } from '../useTokensCount'
+import { useAppState } from '../useAppState'
+
+const mockGetModelProps = vi.fn()
+
+vi.mock('@/lib/extension', () => ({
+  ExtensionManager: {
+    getInstance: () => ({
+      getByName: () => ({ getModelProps: mockGetModelProps }),
+      listExtensions: () => [],
+    }),
+  },
+}))
+
+vi.mock('../useModelProvider', () => ({
+  useModelProvider: () => ({
+    selectedModel: { id: 'model-1', name: 'Model One', capabilities: [], settings: {} },
+    selectedProvider: 'llamacpp',
+    getProviderByName: () => ({ settings: [] }),
+  }),
+}))
+
+function makeMessage(
+  overrides: Partial<ThreadMessage> = {}
+): ThreadMessage {
+  return {
+    id: 'm1',
+    object: 'thread.message',
+    thread_id: 'thread-1',
+    role: 'assistant',
+    content: [],
+    status: 'ready' as ThreadMessage['status'],
+    created_at: 1,
+    completed_at: 1,
+    metadata: {},
+    ...overrides,
+  } as ThreadMessage
+}
+
+describe('useTokensCount', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockGetModelProps.mockResolvedValue({ nCtx: 1000 })
+    act(() => {
+      useAppState.setState({
+        liveTokenStats: undefined,
+        liveTokenStatsByThread: {},
+      })
+    })
+  })
+
+  it('falls back to the last message usage when no live stats are present', async () => {
+    const messages = [
+      makeMessage({ metadata: { usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } } }),
+    ]
+    const { result } = renderHook(() => useTokensCount(messages))
+    await waitFor(() => expect(result.current.modelProps).toBeDefined())
+    expect(result.current.tokenCount).toBe(15)
+  })
+
+  it('prefers live per-thread token stats over the static last-message usage while streaming', async () => {
+    const messages = [
+      makeMessage({ metadata: { usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } } }),
+    ]
+    act(() => {
+      useAppState.getState().updateThreadLiveTokenStats('thread-1', {
+        promptTokens: 900,
+        completionTokens: 40,
+        tokensPerSecond: 30,
+        promptPerSecond: 60,
+      })
+    })
+    const { result } = renderHook(() => useTokensCount(messages))
+    await waitFor(() => expect(result.current.modelProps).toBeDefined())
+    expect(result.current.tokenCount).toBe(940)
+    expect(result.current.inputTokens).toBe(900)
+    expect(result.current.outputTokens).toBe(40)
+  })
+
+  it('context overflow still takes priority over live stats', async () => {
+    const messages = [
+      makeMessage({
+        metadata: {
+          contextError: 'Context length exceeded (1200 tokens) is greater than context size (1000 tokens)',
+        },
+      }),
+    ]
+    act(() => {
+      useAppState.getState().updateThreadLiveTokenStats('thread-1', {
+        promptTokens: 50,
+        completionTokens: 5,
+        tokensPerSecond: 30,
+        promptPerSecond: 60,
+      })
+    })
+    const { result } = renderHook(() => useTokensCount(messages))
+    await waitFor(() => expect(result.current.modelProps).toBeDefined())
+    expect(result.current.isOverflow).toBe(true)
+    expect(result.current.tokenCount).toBe(1200)
+    expect(result.current.maxTokens).toBe(1000)
+  })
+
+  it('context overflow still works when there are no live stats at all', async () => {
+    const messages = [
+      makeMessage({
+        metadata: {
+          contextError: 'Context length exceeded (1200 tokens) is greater than context size (1000 tokens)',
+        },
+      }),
+    ]
+    const { result } = renderHook(() => useTokensCount(messages))
+    await waitFor(() => expect(result.current.modelProps).toBeDefined())
+    expect(result.current.isOverflow).toBe(true)
+    expect(result.current.tokenCount).toBe(1200)
+    expect(result.current.maxTokens).toBe(1000)
+  })
+})

--- a/web-app/src/hooks/__tests__/useTools.test.ts
+++ b/web-app/src/hooks/__tests__/useTools.test.ts
@@ -7,6 +7,11 @@ const mockGetTools = vi.fn()
 const mockUpdateTools = vi.fn()
 const mockListen = vi.fn()
 const mockUnsubscribe = vi.fn()
+const mockInvalidateCache = vi.fn()
+
+vi.mock('@/lib/mcp-orchestrator/mcp-orchestrator', () => ({
+  mcpOrchestrator: { invalidateCache: mockInvalidateCache },
+}))
 
 // Mock useAppState
 vi.mock('../useAppState', () => ({
@@ -106,6 +111,31 @@ describe('useTools', () => {
 
     expect(mockGetTools).toHaveBeenCalledTimes(1)
     expect(mockUpdateTools).toHaveBeenCalledWith(mockTools)
+  })
+
+  it('invalidates the MCP orchestrator tool cache on mount and on MCP_UPDATE, so a server connect/disconnect cannot serve stale tools to the next chat request', async () => {
+    const { useTools } = await import('../useTools')
+
+    let eventCallback: () => void
+    mockListen.mockImplementation((_event, callback) => {
+      eventCallback = callback
+      return Promise.resolve(mockUnsubscribe)
+    })
+
+    renderHook(() => useTools())
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(mockInvalidateCache).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      eventCallback()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    expect(mockInvalidateCache).toHaveBeenCalledTimes(2)
   })
 
   it('should return unsubscribe function for cleanup', async () => {

--- a/web-app/src/hooks/useAppState.ts
+++ b/web-app/src/hooks/useAppState.ts
@@ -9,6 +9,13 @@ export type PromptProgress = {
   total: number
 }
 
+export type LiveTokenStats = {
+  promptTokens: number
+  completionTokens: number
+  tokensPerSecond: number | null
+  promptPerSecond: number | null
+}
+
 type AppErrorMessage = {
   message?: string
   title?: string
@@ -26,12 +33,14 @@ type AppState = {
   showOutOfContextDialog?: boolean
   errorMessage?: AppErrorMessage
   promptProgress?: PromptProgress
+  liveTokenStats?: LiveTokenStats
   activeModels: string[]
   cancelToolCall?: () => void
 
   streamingContents: Record<string, ThreadMessage>
   loadingModels: Record<string, boolean>
   promptProgresses: Record<string, PromptProgress>
+  liveTokenStatsByThread: Record<string, LiveTokenStats>
   cancelToolCalls: Record<string, () => void>
   errorMessages: Record<string, AppErrorMessage>
   busyThreads: Record<string, boolean>
@@ -55,6 +64,7 @@ type AppState = {
   setCancelToolCall: (cancel: (() => void) | undefined) => void
   setErrorMessage: (error: AppErrorMessage | undefined) => void
   updatePromptProgress: (progress: PromptProgress | undefined) => void
+  updateLiveTokenStats: (stats: LiveTokenStats | undefined) => void
   setActiveModels: (models: string[]) => void
 
   updateThreadStreamingContent: (
@@ -65,6 +75,10 @@ type AppState = {
   updateThreadPromptProgress: (
     threadId: string,
     progress: PromptProgress | undefined
+  ) => void
+  updateThreadLiveTokenStats: (
+    threadId: string,
+    stats: LiveTokenStats | undefined
   ) => void
   setThreadCancelToolCall: (
     threadId: string,
@@ -94,6 +108,7 @@ export const useAppState = create<AppState>()((set) => ({
   streamingContents: {},
   loadingModels: {},
   promptProgresses: {},
+  liveTokenStatsByThread: {},
   cancelToolCalls: {},
   errorMessages: {},
   busyThreads: {},
@@ -175,6 +190,11 @@ export const useAppState = create<AppState>()((set) => ({
       promptProgress: progress,
     }))
   },
+  updateLiveTokenStats: (stats) => {
+    set(() => ({
+      liveTokenStats: stats,
+    }))
+  },
   setActiveModels: (models: string[]) => {
     set(() => ({
       activeModels: models,
@@ -208,6 +228,13 @@ export const useAppState = create<AppState>()((set) => ({
       else delete next[threadId]
       return { promptProgresses: next }
     }),
+  updateThreadLiveTokenStats: (threadId, stats) =>
+    set((state) => {
+      const next = { ...state.liveTokenStatsByThread }
+      if (stats) next[threadId] = stats
+      else delete next[threadId]
+      return { liveTokenStatsByThread: next }
+    }),
   setThreadCancelToolCall: (threadId, cancel) =>
     set((state) => {
       const next = { ...state.cancelToolCalls }
@@ -227,6 +254,7 @@ export const useAppState = create<AppState>()((set) => ({
       const streamingContents = { ...state.streamingContents }
       const loadingModels = { ...state.loadingModels }
       const promptProgresses = { ...state.promptProgresses }
+      const liveTokenStatsByThread = { ...state.liveTokenStatsByThread }
       const cancelToolCalls = { ...state.cancelToolCalls }
       const errorMessages = { ...state.errorMessages }
       const busyThreads = { ...state.busyThreads }
@@ -234,6 +262,7 @@ export const useAppState = create<AppState>()((set) => ({
       delete streamingContents[threadId]
       delete loadingModels[threadId]
       delete promptProgresses[threadId]
+      delete liveTokenStatsByThread[threadId]
       delete cancelToolCalls[threadId]
       delete errorMessages[threadId]
       delete busyThreads[threadId]
@@ -242,6 +271,7 @@ export const useAppState = create<AppState>()((set) => ({
         streamingContents,
         loadingModels,
         promptProgresses,
+        liveTokenStatsByThread,
         cancelToolCalls,
         errorMessages,
         busyThreads,

--- a/web-app/src/hooks/useAppState.ts
+++ b/web-app/src/hooks/useAppState.ts
@@ -16,6 +16,12 @@ export type LiveTokenStats = {
   promptPerSecond: number | null
 }
 
+export type ModelLoadProgress = {
+  modelId: string
+  value: number
+  stage?: string
+}
+
 type AppErrorMessage = {
   message?: string
   title?: string
@@ -34,6 +40,7 @@ type AppState = {
   errorMessage?: AppErrorMessage
   promptProgress?: PromptProgress
   liveTokenStats?: LiveTokenStats
+  modelLoadProgress?: ModelLoadProgress
   activeModels: string[]
   cancelToolCall?: () => void
 
@@ -41,6 +48,7 @@ type AppState = {
   loadingModels: Record<string, boolean>
   promptProgresses: Record<string, PromptProgress>
   liveTokenStatsByThread: Record<string, LiveTokenStats>
+  modelLoadProgressByThread: Record<string, ModelLoadProgress>
   cancelToolCalls: Record<string, () => void>
   errorMessages: Record<string, AppErrorMessage>
   busyThreads: Record<string, boolean>
@@ -65,6 +73,7 @@ type AppState = {
   setErrorMessage: (error: AppErrorMessage | undefined) => void
   updatePromptProgress: (progress: PromptProgress | undefined) => void
   updateLiveTokenStats: (stats: LiveTokenStats | undefined) => void
+  updateModelLoadProgress: (progress: ModelLoadProgress | undefined) => void
   setActiveModels: (models: string[]) => void
 
   updateThreadStreamingContent: (
@@ -79,6 +88,10 @@ type AppState = {
   updateThreadLiveTokenStats: (
     threadId: string,
     stats: LiveTokenStats | undefined
+  ) => void
+  updateThreadModelLoadProgress: (
+    threadId: string,
+    progress: ModelLoadProgress | undefined
   ) => void
   setThreadCancelToolCall: (
     threadId: string,
@@ -109,6 +122,7 @@ export const useAppState = create<AppState>()((set) => ({
   loadingModels: {},
   promptProgresses: {},
   liveTokenStatsByThread: {},
+  modelLoadProgressByThread: {},
   cancelToolCalls: {},
   errorMessages: {},
   busyThreads: {},
@@ -195,6 +209,11 @@ export const useAppState = create<AppState>()((set) => ({
       liveTokenStats: stats,
     }))
   },
+  updateModelLoadProgress: (progress) => {
+    set(() => ({
+      modelLoadProgress: progress,
+    }))
+  },
   setActiveModels: (models: string[]) => {
     set(() => ({
       activeModels: models,
@@ -235,6 +254,13 @@ export const useAppState = create<AppState>()((set) => ({
       else delete next[threadId]
       return { liveTokenStatsByThread: next }
     }),
+  updateThreadModelLoadProgress: (threadId, progress) =>
+    set((state) => {
+      const next = { ...state.modelLoadProgressByThread }
+      if (progress) next[threadId] = progress
+      else delete next[threadId]
+      return { modelLoadProgressByThread: next }
+    }),
   setThreadCancelToolCall: (threadId, cancel) =>
     set((state) => {
       const next = { ...state.cancelToolCalls }
@@ -255,6 +281,7 @@ export const useAppState = create<AppState>()((set) => ({
       const loadingModels = { ...state.loadingModels }
       const promptProgresses = { ...state.promptProgresses }
       const liveTokenStatsByThread = { ...state.liveTokenStatsByThread }
+      const modelLoadProgressByThread = { ...state.modelLoadProgressByThread }
       const cancelToolCalls = { ...state.cancelToolCalls }
       const errorMessages = { ...state.errorMessages }
       const busyThreads = { ...state.busyThreads }
@@ -263,6 +290,7 @@ export const useAppState = create<AppState>()((set) => ({
       delete loadingModels[threadId]
       delete promptProgresses[threadId]
       delete liveTokenStatsByThread[threadId]
+      delete modelLoadProgressByThread[threadId]
       delete cancelToolCalls[threadId]
       delete errorMessages[threadId]
       delete busyThreads[threadId]
@@ -272,6 +300,7 @@ export const useAppState = create<AppState>()((set) => ({
         loadingModels,
         promptProgresses,
         liveTokenStatsByThread,
+        modelLoadProgressByThread,
         cancelToolCalls,
         errorMessages,
         busyThreads,

--- a/web-app/src/hooks/useAppState.ts
+++ b/web-app/src/hooks/useAppState.ts
@@ -20,6 +20,7 @@ export type ModelLoadProgress = {
   modelId: string
   value: number
   stage?: string
+  stages?: string[]
 }
 
 type AppErrorMessage = {

--- a/web-app/src/hooks/useAppState.ts
+++ b/web-app/src/hooks/useAppState.ts
@@ -75,6 +75,7 @@ type AppState = {
   updateLiveTokenStats: (stats: LiveTokenStats | undefined) => void
   updateModelLoadProgress: (progress: ModelLoadProgress | undefined) => void
   setActiveModels: (models: string[]) => void
+  removeActiveModel: (modelId: string) => void
 
   updateThreadStreamingContent: (
     threadId: string,
@@ -217,6 +218,11 @@ export const useAppState = create<AppState>()((set) => ({
   setActiveModels: (models: string[]) => {
     set(() => ({
       activeModels: models,
+    }))
+  },
+  removeActiveModel: (modelId: string) => {
+    set((state) => ({
+      activeModels: state.activeModels.filter((id) => id !== modelId),
     }))
   },
 

--- a/web-app/src/hooks/useTokensCount.ts
+++ b/web-app/src/hooks/useTokensCount.ts
@@ -106,6 +106,13 @@ export const useTokensCount = (messages: ThreadMessage[] = []) => {
   const liveStats = useAppState((s) =>
     threadId ? s.liveTokenStatsByThread[threadId] : undefined
   )
+  // getModelProps only succeeds once the router has autoloaded the model, which
+  // normally doesn't happen until the first turn is sent. Refetch as soon as that
+  // load finishes so the counter can appear mid-turn instead of waiting for the
+  // full response (and the resulting messages.length bump) to land.
+  const loadingModel = useAppState((s) =>
+    threadId ? s.loadingModels[threadId] : s.loadingModel
+  )
 
   useEffect(() => {
     if (!modelId) {
@@ -134,7 +141,7 @@ export const useTokensCount = (messages: ThreadMessage[] = []) => {
         if (id !== reqId.current) return
         setLoading(false)
       })
-  }, [modelId, messages.length])
+  }, [modelId, messages.length, loadingModel])
 
   const tokenData: TokenCountData = useMemo(() => {
     if (selectedProvider !== 'llamacpp' || !modelId) {

--- a/web-app/src/hooks/useTokensCount.ts
+++ b/web-app/src/hooks/useTokensCount.ts
@@ -3,6 +3,7 @@ import { ThreadMessage } from '@janhq/core'
 import { ExtensionManager } from '@/lib/extension'
 import { parseContextOverflow } from '@/utils/error'
 import { useModelProvider } from './useModelProvider'
+import { useAppState } from './useAppState'
 
 export interface ModelProps {
   nCtx: number
@@ -99,6 +100,13 @@ export const useTokensCount = (messages: ThreadMessage[] = []) => {
   const modelId =
     selectedProvider === 'llamacpp' ? selectedModel?.id : undefined
 
+  const threadId = messages[0]?.thread_id
+  // Populated per-chunk while a llama.cpp turn is streaming (timings_per_token);
+  // cleared on stream start/finish/error, so its presence means "live now".
+  const liveStats = useAppState((s) =>
+    threadId ? s.liveTokenStatsByThread[threadId] : undefined
+  )
+
   useEffect(() => {
     if (!modelId) {
       setModelProps(undefined)
@@ -138,7 +146,13 @@ export const useTokensCount = (messages: ThreadMessage[] = []) => {
       }
     }
     const overflow = getActiveContextOverflow(messages)
-    const usage = getLatestServerUsage(messages)
+    const usage = liveStats
+      ? {
+          inputTokens: liveStats.promptTokens,
+          outputTokens: liveStats.completionTokens,
+          totalTokens: liveStats.promptTokens + liveStats.completionTokens,
+        }
+      : getLatestServerUsage(messages)
     const tokenCount = overflow?.requestTokens ?? usage.totalTokens ?? 0
     const maxTokens = overflow?.contextTokens ?? modelProps?.nCtx
     const percentage = maxTokens ? (tokenCount / maxTokens) * 100 : undefined
@@ -180,6 +194,7 @@ export const useTokensCount = (messages: ThreadMessage[] = []) => {
     selectedProvider,
     modelProps,
     loading,
+    liveStats,
     getProviderByName,
     selectedModel?.name,
     selectedModel?.capabilities,

--- a/web-app/src/hooks/useTokensCount.ts
+++ b/web-app/src/hooks/useTokensCount.ts
@@ -1,16 +1,14 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { ThreadMessage } from '@janhq/core'
-import { ExtensionManager } from '@/lib/extension'
 import { parseContextOverflow } from '@/utils/error'
+import {
+  getLlamacppExtension,
+  type LlamacppModelProps,
+} from '@/lib/llamacppRouterProps'
 import { useModelProvider } from './useModelProvider'
 import { useAppState } from './useAppState'
 
-export interface ModelProps {
-  nCtx: number
-  totalSlots?: number
-  modelAlias?: string
-  isSleeping?: boolean
-}
+export type ModelProps = LlamacppModelProps
 
 export interface TokenCountData {
   tokenCount: number
@@ -35,10 +33,6 @@ interface UsageMeta {
   totalTokens?: number
 }
 
-interface LlamacppExtensionLike {
-  getModelProps?: (modelId: string) => Promise<ModelProps | undefined>
-}
-
 // The token-usage popup normally reflects the last *successful* turn. When a
 // request overflows, that turn is never recorded, so the popup would keep
 // showing a comfortable percentage next to an "out of context" error. Parse
@@ -61,22 +55,6 @@ const getLatestServerUsage = (messages: ThreadMessage[]): UsageMeta => {
       return usage
   }
   return {}
-}
-
-const getLlamacppExtension = (): LlamacppExtensionLike | undefined => {
-  const mgr = ExtensionManager.getInstance()
-  const candidates = [
-    mgr.getByName('@janhq/llamacpp-extension'),
-    mgr.getByName('llamacpp-extension'),
-  ]
-  for (const c of candidates) {
-    if (c && typeof (c as LlamacppExtensionLike).getModelProps === 'function')
-      return c as LlamacppExtensionLike
-  }
-  return mgr.listExtensions().find(
-    (ext) =>
-      typeof (ext as LlamacppExtensionLike).getModelProps === 'function'
-  ) as LlamacppExtensionLike | undefined
 }
 
 const readSettingNumber = (v: unknown): number | undefined => {

--- a/web-app/src/hooks/useTools.ts
+++ b/web-app/src/hooks/useTools.ts
@@ -5,6 +5,7 @@ import { useAppState } from './useAppState'
 import { useToolAvailable } from './useToolAvailable'
 import { ExtensionManager } from '@/lib/extension'
 import { ExtensionTypeEnum, MCPExtension } from '@janhq/core'
+import { mcpOrchestrator } from '@/lib/mcp-orchestrator/mcp-orchestrator'
 
 export const useTools = () => {
   const updateTools = useAppState((state) => state.updateTools)
@@ -15,6 +16,12 @@ export const useTools = () => {
   useEffect(() => {
     async function setTools() {
       try {
+        // A server connect/disconnect/tools-refresh fired this (mcp-update);
+        // the orchestrator's per-request tool cache would otherwise only
+        // notice via its own TTL, serving stale/reordered tools in the
+        // meantime and destabilizing the KV-cache prefix Jan sends.
+        mcpOrchestrator.invalidateCache()
+
         // Get MCP extension first
         const mcpExtension = ExtensionManager.getInstance().get<MCPExtension>(
           ExtensionTypeEnum.MCP

--- a/web-app/src/lib/__tests__/custom-chat-transport-tool-freeze.test.ts
+++ b/web-app/src/lib/__tests__/custom-chat-transport-tool-freeze.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  disabledTools: [] as string[],
+  servers: ['srv'] as string[],
+  getRelevantTools: vi.fn(),
+  serviceHub: null as unknown,
+}))
+
+const mcpService = {
+  getTools: vi.fn(async () => []),
+  getToolsForServers: vi.fn(async () => []),
+  getServerSummaries: vi.fn(async () =>
+    h.servers.map((name) => ({ name, capabilities: [], description: '' }))
+  ),
+}
+
+h.serviceHub = {
+  mcp: () => mcpService,
+  rag: () => ({ getTools: async () => [] }),
+}
+
+vi.mock('@/hooks/useServiceHub', () => ({
+  useServiceStore: { getState: () => ({ serviceHub: h.serviceHub }) },
+}))
+vi.mock('@/hooks/useToolAvailable', () => ({
+  useToolAvailable: { getState: () => ({ getDisabledTools: () => h.disabledTools }) },
+}))
+vi.mock('@/hooks/useModelProvider', () => ({
+  useModelProvider: {
+    getState: () => ({
+      selectedModel: { capabilities: ['tools'] },
+      selectedProvider: '',
+      getProviderByName: () => null,
+    }),
+  },
+}))
+vi.mock('@/hooks/useAssistant', () => ({
+  useAssistant: { getState: () => ({ currentAssistant: null }) },
+}))
+vi.mock('@/hooks/useThreads', () => ({
+  useThreads: { getState: () => ({ threads: {} }) },
+}))
+vi.mock('@/hooks/useAttachments', () => ({
+  useAttachments: { getState: () => ({ enabled: false }) },
+}))
+vi.mock('@/hooks/useMCPServers', () => ({
+  useMCPServers: {
+    getState: () => ({ settings: { enableSmartToolRouting: true } }),
+  },
+}))
+vi.mock('@/lib/extension', () => ({
+  ExtensionManager: { getInstance: () => ({ get: () => null }) },
+}))
+vi.mock('@/lib/mcp-orchestrator', () => ({
+  mcpOrchestrator: { getRelevantTools: h.getRelevantTools },
+}))
+vi.mock('@/lib/mcp-router-model-filter', () => ({
+  isRouterModelSelectable: () => false,
+}))
+vi.mock('../model-factory', () => ({
+  ModelFactory: { createModel: vi.fn() },
+}))
+
+import { CustomChatTransport } from '../custom-chat-transport'
+
+describe('CustomChatTransport smart-tool-routing freeze', () => {
+  let transport: CustomChatTransport
+
+  beforeEach(() => {
+    h.disabledTools = []
+    h.servers = ['srv']
+    h.getRelevantTools.mockReset()
+    h.getRelevantTools.mockResolvedValue([
+      { name: 'tool_a', description: '', inputSchema: {}, server: 'srv' },
+    ])
+    transport = new CustomChatTransport('sys', 'thread-1')
+  })
+
+  it('routes once and freezes the set across subsequent turns', async () => {
+    transport.setLastUserMessage('first query')
+    await transport.refreshTools()
+    expect(h.getRelevantTools).toHaveBeenCalledTimes(1)
+    expect(Object.keys(transport.getTools())).toContain('tool_a')
+
+    transport.setLastUserMessage('a completely different query')
+    await transport.refreshTools()
+    expect(h.getRelevantTools).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-routes when the disabled-tool set changes', async () => {
+    transport.setLastUserMessage('q1')
+    await transport.refreshTools()
+    expect(h.getRelevantTools).toHaveBeenCalledTimes(1)
+
+    h.disabledTools = ['srv::something']
+    transport.setLastUserMessage('q2')
+    await transport.refreshTools()
+    expect(h.getRelevantTools).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-routes when the connected server set changes', async () => {
+    transport.setLastUserMessage('q1')
+    await transport.refreshTools()
+    expect(h.getRelevantTools).toHaveBeenCalledTimes(1)
+
+    h.servers = ['srv', 'srv2']
+    transport.setLastUserMessage('q2')
+    await transport.refreshTools()
+    expect(h.getRelevantTools).toHaveBeenCalledTimes(2)
+  })
+})

--- a/web-app/src/lib/__tests__/model-factory.coverage.test.ts
+++ b/web-app/src/lib/__tests__/model-factory.coverage.test.ts
@@ -43,6 +43,7 @@ vi.mock('@ai-sdk/openai', () => ({
   createOpenAI: vi.fn(() => {
     const fn: any = vi.fn(() => ({ type: 'openai' }))
     fn.chat = vi.fn(() => ({ type: 'openai' }))
+    fn.responses = vi.fn(() => ({ type: 'openai' }))
     return fn
   }),
 }))

--- a/web-app/src/lib/__tests__/model-factory.deep.test.ts
+++ b/web-app/src/lib/__tests__/model-factory.deep.test.ts
@@ -143,7 +143,15 @@ describe('model-factory deep coverage', () => {
     it('extractMetadata handles missing fields in timings', async () => {
       const ext = await getExtractor()
       const result = await ext.extractMetadata({ parsedBody: { timings: {} } })
-      expect(result.providerMetadata.promptTokens).toBeNull()
+      expect(result.providerMetadata.promptTokens).toBe(0)
+    })
+
+    it('extractMetadata sums prompt_n and cache_n (KV-cache-reused tokens) into promptTokens', async () => {
+      const ext = await getExtractor()
+      const result = await ext.extractMetadata({
+        parsedBody: { timings: { prompt_n: 21, cache_n: 200, predicted_n: 95 } },
+      })
+      expect(result.providerMetadata.promptTokens).toBe(221)
     })
 
     it('createStreamExtractor processes chunks and builds metadata', async () => {
@@ -159,6 +167,58 @@ describe('model-factory deep coverage', () => {
       const s = ext.createStreamExtractor()
       s.processChunk({})
       expect(s.buildMetadata()).toBeUndefined()
+    })
+
+    it('createStreamExtractor publishes live token stats globally and per-thread on every chunk', async () => {
+      const { useAppState } = await import('@/hooks/useAppState')
+      useAppState.getState().setCurrentStreamThreadId('thread-live')
+
+      const ext = await getExtractor()
+      const s = ext.createStreamExtractor()
+      s.processChunk({
+        timings: { prompt_n: 5, predicted_n: 15, predicted_per_second: 35, prompt_per_second: 65 },
+      })
+
+      expect(useAppState.getState().liveTokenStats).toEqual({
+        promptTokens: 5,
+        completionTokens: 15,
+        tokensPerSecond: 35,
+        promptPerSecond: 65,
+      })
+      expect(useAppState.getState().liveTokenStatsByThread['thread-live']).toEqual({
+        promptTokens: 5,
+        completionTokens: 15,
+        tokensPerSecond: 35,
+        promptPerSecond: 65,
+      })
+
+      s.processChunk({
+        timings: { prompt_n: 5, predicted_n: 20, predicted_per_second: 40, prompt_per_second: 65 },
+      })
+      expect(useAppState.getState().liveTokenStatsByThread['thread-live'].completionTokens).toBe(20)
+
+      useAppState.getState().setCurrentStreamThreadId(undefined)
+      useAppState.getState().updateThreadLiveTokenStats('thread-live', undefined)
+    })
+
+    it('live promptTokens includes cache_n so context usage does not reset on cached turns', async () => {
+      const { useAppState } = await import('@/hooks/useAppState')
+      useAppState.getState().setCurrentStreamThreadId('thread-cached')
+
+      const ext = await getExtractor()
+      const s = ext.createStreamExtractor()
+      // Deep into a conversation: only 21 tokens are freshly processed this
+      // turn, the other 20,935 are served from the KV cache.
+      s.processChunk({
+        timings: { prompt_n: 21, cache_n: 20935, predicted_n: 95, predicted_per_second: 30 },
+      })
+
+      expect(useAppState.getState().liveTokenStatsByThread['thread-cached'].promptTokens).toBe(
+        20956
+      )
+
+      useAppState.getState().setCurrentStreamThreadId(undefined)
+      useAppState.getState().updateThreadLiveTokenStats('thread-cached', undefined)
     })
   })
 

--- a/web-app/src/lib/__tests__/model-factory.deep.test.ts
+++ b/web-app/src/lib/__tests__/model-factory.deep.test.ts
@@ -45,6 +45,7 @@ vi.mock('@ai-sdk/openai', () => ({
     ;(globalThis as any).__capturedOpenAICfg = config
     const fn: any = vi.fn(() => ({ type: 'openai' }))
     fn.chat = vi.fn(() => ({ type: 'openai' }))
+    fn.responses = vi.fn(() => ({ type: 'openai' }))
     return fn
   }),
 }))

--- a/web-app/src/lib/__tests__/model-factory.gemini-regression.test.ts
+++ b/web-app/src/lib/__tests__/model-factory.gemini-regression.test.ts
@@ -32,6 +32,7 @@ vi.mock('@ai-sdk/openai', () => ({
   createOpenAI: vi.fn(() => {
     const fn: any = vi.fn(() => ({ type: 'openai' }))
     fn.chat = vi.fn(() => ({ type: 'openai' }))
+    fn.responses = vi.fn(() => ({ type: 'openai' }))
     return fn
   }),
 }))

--- a/web-app/src/lib/__tests__/model-factory.test.ts
+++ b/web-app/src/lib/__tests__/model-factory.test.ts
@@ -330,6 +330,21 @@ describe('createCustomFetch — max_tokens coercion', () => {
     expect(sent.timings_per_token).toBeUndefined()
   })
 
+  it('sets cache_prompt=true when keepLlamacppOnly is true', async () => {
+    const sent = await captureSentBody({}, true, {})
+    expect(sent.cache_prompt).toBe(true)
+  })
+
+  it('does not set cache_prompt for non-llamacpp providers', async () => {
+    const sent = await captureSentBody({}, false, {})
+    expect(sent.cache_prompt).toBeUndefined()
+  })
+
+  it('preserves an explicit id_slot passed via parameters (title-gen path)', async () => {
+    const sent = await captureSentBody({ id_slot: 3 }, true, {})
+    expect(sent.id_slot).toBe(3)
+  })
+
   it('leaves non-zero max_tokens alone', async () => {
     const sent = await captureSentBody({}, true, { max_tokens: 512 })
     expect(sent.max_tokens).toBe(512)

--- a/web-app/src/lib/__tests__/model-factory.test.ts
+++ b/web-app/src/lib/__tests__/model-factory.test.ts
@@ -314,6 +314,22 @@ describe('createCustomFetch — max_tokens coercion', () => {
     expect(sent.max_tokens).toBe(0)
   })
 
+  it('sets timings_per_token when keepLlamacppOnly and streaming', async () => {
+    const sent = await captureSentBody({}, true, { stream: true })
+    expect(sent.timings_per_token).toBe(true)
+    expect(sent.return_progress).toBe(true)
+  })
+
+  it('does not set timings_per_token when not streaming', async () => {
+    const sent = await captureSentBody({}, true, { stream: false })
+    expect(sent.timings_per_token).toBeUndefined()
+  })
+
+  it('does not set timings_per_token for non-llamacpp providers', async () => {
+    const sent = await captureSentBody({}, false, { stream: true })
+    expect(sent.timings_per_token).toBeUndefined()
+  })
+
   it('leaves non-zero max_tokens alone', async () => {
     const sent = await captureSentBody({}, true, { max_tokens: 512 })
     expect(sent.max_tokens).toBe(512)

--- a/web-app/src/lib/__tests__/model-factory.test.ts
+++ b/web-app/src/lib/__tests__/model-factory.test.ts
@@ -367,6 +367,45 @@ describe('createCustomFetch — max_tokens coercion', () => {
     })
     expect(sent.max_tokens).toBe('')
   })
+
+  it('remaps dynatemp_exp to the llama-server wire name dynatemp_exponent', async () => {
+    const sent = await captureSentBody({ dynatemp_exp: 1.5 }, true, {
+      messages: [],
+    })
+    expect(sent.dynatemp_exponent).toBe(1.5)
+    expect(sent.dynatemp_exp).toBeUndefined()
+  })
+
+  it('splits the samplers string param into an array on the wire', async () => {
+    const sent = await captureSentBody(
+      { samplers: 'top_k, typ_p ;top_p' },
+      true,
+      { messages: [] }
+    )
+    expect(sent.samplers).toEqual(['top_k', 'typ_p', 'top_p'])
+  })
+
+  it('omits samplers entirely when the string is empty', async () => {
+    const sent = await captureSentBody({ samplers: '' }, true, {
+      messages: [],
+    })
+    expect(sent.samplers).toBeUndefined()
+  })
+
+  it('forwards repeat_last_n, backend_sampling, and thinking_budget_tokens as-is', async () => {
+    const sent = await captureSentBody(
+      {
+        repeat_last_n: 128,
+        backend_sampling: true,
+        thinking_budget_tokens: 4096,
+      },
+      true,
+      { messages: [] }
+    )
+    expect(sent.repeat_last_n).toBe(128)
+    expect(sent.backend_sampling).toBe(true)
+    expect(sent.thinking_budget_tokens).toBe(4096)
+  })
 })
 
 describe('createCustomFetch — llamacpp 500 handling', () => {

--- a/web-app/src/lib/__tests__/reasoning.test.ts
+++ b/web-app/src/lib/__tests__/reasoning.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { splitReasoningParagraphs } from '../reasoning'
+
+describe('splitReasoningParagraphs', () => {
+  it('returns [] for empty/whitespace input', () => {
+    expect(splitReasoningParagraphs('')).toEqual([])
+    expect(splitReasoningParagraphs('   \n  ')).toEqual([])
+  })
+
+  it('splits on blank lines, keeping single newlines within a step', () => {
+    const text = 'First thought\nstill first\n\nSecond thought'
+    expect(splitReasoningParagraphs(text)).toEqual([
+      'First thought\nstill first',
+      'Second thought',
+    ])
+  })
+
+  it('collapses runs of 3+ newlines into one boundary', () => {
+    expect(splitReasoningParagraphs('a\n\n\n\nb')).toEqual(['a', 'b'])
+  })
+
+  it('treats a trailing in-progress paragraph as the last element', () => {
+    const streaming = 'Done paragraph\n\nHalf-written para'
+    const parts = splitReasoningParagraphs(streaming)
+    expect(parts).toHaveLength(2)
+    expect(parts[parts.length - 1]).toBe('Half-written para')
+  })
+
+  it('returns a single step when there are no blank lines', () => {
+    expect(splitReasoningParagraphs('one continuous thought')).toEqual([
+      'one continuous thought',
+    ])
+  })
+
+  it('ignores blank-line-only gaps between paragraphs with trailing spaces', () => {
+    expect(splitReasoningParagraphs('a  \n   \nb')).toEqual(['a', 'b'])
+  })
+})

--- a/web-app/src/lib/__tests__/reasoningProviderOptions.test.ts
+++ b/web-app/src/lib/__tests__/reasoningProviderOptions.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import { buildReasoningProviderOptions } from '../reasoningProviderOptions'
+
+const modelWith = (settings: Record<string, unknown>) =>
+  ({ settings }) as unknown as Model
+
+const reasoning = (value: string) => ({
+  reasoning: { controller_props: { value } },
+})
+const budget = (value: string) => ({
+  thinking_budget_tokens: { controller_props: { value } },
+})
+
+describe('buildReasoningProviderOptions', () => {
+  it('returns undefined for unknown/local providers', () => {
+    expect(
+      buildReasoningProviderOptions('llamacpp', modelWith(reasoning('on')))
+    ).toBeUndefined()
+    expect(buildReasoningProviderOptions('mlx', null)).toBeUndefined()
+  })
+
+  describe('google', () => {
+    it('maps reasoning off to a zero thinking budget', () => {
+      expect(
+        buildReasoningProviderOptions('google', modelWith(reasoning('off')))
+      ).toEqual({ google: { thinkingConfig: { thinkingBudget: 0 } } })
+    })
+
+    it('maps reasoning on to a dynamic budget with thought summaries', () => {
+      expect(
+        buildReasoningProviderOptions('google', modelWith(reasoning('on')))
+      ).toEqual({
+        google: { thinkingConfig: { thinkingBudget: -1, includeThoughts: true } },
+      })
+    })
+
+    it('enables dynamic thinking when only a budget level is set', () => {
+      expect(
+        buildReasoningProviderOptions('google', modelWith(budget('high')))
+      ).toEqual({
+        google: { thinkingConfig: { thinkingBudget: -1, includeThoughts: true } },
+      })
+    })
+
+    it('returns undefined when reasoning is auto with no level', () => {
+      expect(
+        buildReasoningProviderOptions('google', modelWith(reasoning('auto')))
+      ).toBeUndefined()
+    })
+
+    it('matches the real gemini provider id too', () => {
+      expect(
+        buildReasoningProviderOptions('gemini', modelWith(reasoning('on')))
+      ).toEqual({
+        google: { thinkingConfig: { thinkingBudget: -1, includeThoughts: true } },
+      })
+    })
+  })
+
+  describe('anthropic', () => {
+    it('maps reasoning off to disabled thinking', () => {
+      expect(
+        buildReasoningProviderOptions('anthropic', modelWith(reasoning('off')))
+      ).toEqual({ anthropic: { thinking: { type: 'disabled' } } })
+    })
+
+    it('maps reasoning on to adaptive thinking (no token guess)', () => {
+      expect(
+        buildReasoningProviderOptions('anthropic', modelWith(reasoning('on')))
+      ).toEqual({
+        anthropic: { thinking: { type: 'adaptive', display: 'summarized' } },
+      })
+    })
+
+    it('returns undefined at provider default', () => {
+      expect(
+        buildReasoningProviderOptions('anthropic', modelWith({}))
+      ).toBeUndefined()
+    })
+  })
+
+  describe('openai', () => {
+    it('maps each concrete budget level to a reasoning effort', () => {
+      const cases: Array<[string, string]> = [
+        ['low', 'low'],
+        ['medium', 'medium'],
+        ['high', 'high'],
+        ['xhigh', 'xhigh'],
+      ]
+      for (const [level, effort] of cases) {
+        expect(
+          buildReasoningProviderOptions('openai', modelWith(budget(level)))
+        ).toEqual({
+          openai: { reasoningEffort: effort, reasoningSummary: 'auto' },
+        })
+      }
+    })
+
+    it('treats unlimited as no explicit effort (model default)', () => {
+      expect(
+        buildReasoningProviderOptions('openai', modelWith(budget('unlimited')))
+      ).toBeUndefined()
+    })
+
+    it('returns undefined when no level is chosen (reasoning off has no effort)', () => {
+      expect(
+        buildReasoningProviderOptions('openai', modelWith(reasoning('off')))
+      ).toBeUndefined()
+      expect(buildReasoningProviderOptions('openai', modelWith({}))).toBeUndefined()
+    })
+  })
+})

--- a/web-app/src/lib/custom-chat-transport.ts
+++ b/web-app/src/lib/custom-chat-transport.ts
@@ -43,7 +43,6 @@ import { mcpOrchestrator } from '@/lib/mcp-orchestrator'
 import { isRouterModelSelectable } from '@/lib/mcp-router-model-filter'
 import { encodeAudioSentinel, parseAudioDataUrl } from '@/lib/audio-sentinel'
 import { encodeVideoSentinel, parseVideoDataUrl } from '@/lib/video-sentinel'
-import { extractFilesFromPrompt, type FileMetadata } from '@/lib/fileMetadata'
 import { isPredefinedRemoteProvider, getProviderApiType } from '@/lib/providerCaps'
 import { paramsSettings } from '@/lib/predefinedParams'
 
@@ -996,7 +995,7 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
     // tool_use / tool_result pairing that the Claude API requires.
     // See: https://platform.claude.com/docs/en/agents-and-tools/tool-use/implement-tool-use#parallel-tool-use
     const effectiveApiType = getProviderApiType(provider)
-    let messagesToConvert = (() => {
+    const messagesToConvert = (() => {
       if (effectiveApiType !== 'anthropic') {
         return options.messages
       }
@@ -1044,14 +1043,11 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
 
     const selectedModel = useModelProvider.getState().selectedModel
 
-    const { messages: strippedMessages, files: attachedFiles } =
-      this.extractFileMetadataForSystem(messagesToConvert)
-    messagesToConvert = strippedMessages
-    const filesAddendum = this.buildFilesSystemAddendum(attachedFiles)
-    const rawSystem = filesAddendum
+    const filesInstruction = this.buildFilesSystemInstruction(messagesToConvert)
+    const rawSystem = filesInstruction
       ? this.systemMessage
-        ? `${this.systemMessage}\n\n${filesAddendum}`
-        : filesAddendum
+        ? `${this.systemMessage}\n\n${filesInstruction}`
+        : filesInstruction
       : this.systemMessage
     // Drop whitespace-only system prompts so we don't send a useless system
     // turn that some chat templates still wrap into special tokens.
@@ -1378,69 +1374,31 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
   }
 
   /**
-   *  Map user messages to include inline attachments in the message parts
-   * @param messages
-   * @returns
+   * [ATTACHED_FILES] blocks stay on the user message that carries them (see
+   * fileMetadata.ts injectFilesIntoPrompt) so the model reads file_ids in the
+   * turn they belong to. Only a static, file-independent instruction is added
+   * to the system prompt - it never varies per attachment, so it doesn't
+   * defeat prompt caching.
    */
-  /**
-   * Strip persisted [ATTACHED_FILES] blocks from user message text and return
-   * the aggregated, deduped file metadata so it can be folded into the system
-   * prompt instead of the user turn. The stored ThreadMessages are untouched
-   * (UI still relies on the inline block for display); this only affects what
-   * is sent to the model.
-   */
-  extractFileMetadataForSystem(
-    messages: UIMessage[]
-  ): { messages: UIMessage[]; files: FileMetadata[] } {
-    const byId = new Map<string, FileMetadata>()
-    const next = messages.map((message) => {
-      if (message.role !== 'user' || !Array.isArray(message.parts)) return message
-      let touched = false
-      const parts = message.parts.map((part) => {
-        if (
-          part?.type === 'text' &&
-          typeof (part as { text?: string }).text === 'string' &&
-          (part as { text: string }).text.includes('[ATTACHED_FILES]')
-        ) {
-          const { files, cleanPrompt } = extractFilesFromPrompt(
-            (part as { text: string }).text
-          )
-          if (files.length === 0) return part
-          for (const f of files) {
-            if (!byId.has(f.id)) byId.set(f.id, f)
-          }
-          touched = true
-          return { ...part, text: cleanPrompt }
-        }
-        return part
-      })
-      if (!touched) return message
-      return { ...message, parts } as UIMessage
-    })
-    return { messages: next, files: Array.from(byId.values()) }
-  }
-
-  /**
-   * Format collected file metadata as a system-prompt addendum. The block is
-   * stable / parseable so models can reference file_ids when invoking RAG tools.
-   */
-  buildFilesSystemAddendum(files: FileMetadata[]): string {
-    if (files.length === 0) return ''
-    const lines = files.map((f) => {
-      const parts = [`file_id: ${f.id}`, `name: ${f.name}`]
-      if (f.type) parts.push(`type: ${f.type}`)
-      if (typeof f.size === 'number') parts.push(`size: ${f.size}`)
-      if (typeof f.chunkCount === 'number') parts.push(`chunks: ${f.chunkCount}`)
-      if (f.injectionMode) parts.push(`mode: ${f.injectionMode}`)
-      return `- ${parts.join(', ')}`
-    })
+  buildFilesSystemInstruction(messages: UIMessage[]): string {
+    const hasAttachedFiles = messages.some(
+      (message) =>
+        message.role === 'user' &&
+        Array.isArray(message.parts) &&
+        message.parts.some(
+          (part) =>
+            part?.type === 'text' &&
+            typeof (part as { text?: string }).text === 'string' &&
+            (part as { text: string }).text.includes('[ATTACHED_FILES]')
+        )
+    )
+    if (!hasAttachedFiles) return ''
     return [
-      'The user has attached the following files to this conversation.',
-      'Use the available retrieval tools with these file_ids when their contents are relevant.',
-      '[ATTACHED_FILES]',
-      ...lines,
-      '[/ATTACHED_FILES]',
-    ].join('\n')
+      'Some user messages contain an [ATTACHED_FILES] block listing files',
+      'attached to that turn (file_id, name, type, size, chunk count, mode).',
+      'Use the available retrieval tools with those file_ids when their',
+      'contents are relevant to the request.',
+    ].join(' ')
   }
 
   mapUserInlineAttachments(messages: UIMessage[]): UIMessage[] {

--- a/web-app/src/lib/custom-chat-transport.ts
+++ b/web-app/src/lib/custom-chat-transport.ts
@@ -1103,6 +1103,8 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
     let streamStartTime: number | undefined
     useAppState.getState().updatePromptProgress(undefined)
     useAppState.getState().updateThreadPromptProgress(threadId, undefined)
+    useAppState.getState().updateLiveTokenStats(undefined)
+    useAppState.getState().updateThreadLiveTokenStats(threadId, undefined)
 
     const result = streamText({
       model: this.model,
@@ -1197,6 +1199,8 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
           useAppState.getState().updateLoadingModel(false)
           useAppState.getState().updateThreadPromptProgress(threadId, undefined)
           useAppState.getState().updateThreadLoadingModel(threadId, false)
+          useAppState.getState().updateLiveTokenStats(undefined)
+          useAppState.getState().updateThreadLiveTokenStats(threadId, undefined)
           if (useAppState.getState().currentStreamThreadId === threadId) {
             useAppState.getState().setCurrentStreamThreadId(undefined)
           }
@@ -1223,6 +1227,8 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
           useAppState.getState().updateLoadingModel(false)
           useAppState.getState().updateThreadPromptProgress(threadId, undefined)
           useAppState.getState().updateThreadLoadingModel(threadId, false)
+          useAppState.getState().updateLiveTokenStats(undefined)
+          useAppState.getState().updateThreadLiveTokenStats(threadId, undefined)
           if (useAppState.getState().currentStreamThreadId === threadId) {
             useAppState.getState().setCurrentStreamThreadId(undefined)
           }

--- a/web-app/src/lib/custom-chat-transport.ts
+++ b/web-app/src/lib/custom-chat-transport.ts
@@ -603,6 +603,12 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
   private routerModel: LanguageModel | null = null
   private routerModelKey = ''
   private tools: Record<string, Tool> = {}
+  // Smart tool routing selects tools from the latest user message, which would
+  // change the tool set (and thus the cached prompt prefix) every turn. Freeze
+  // the routed set for the thread's lifetime so the prefix stays stable;
+  // re-route only when the connected servers or disabled-tool set changes.
+  private frozenRoutedTools: MCPTool[] | null = null
+  private frozenRoutedSig = ''
   private onTokenUsage?: TokenUsageCallback
   private hasDocuments = false
   private modelSupportsTools = false
@@ -770,26 +776,37 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
           mcpService.getToolsForServers &&
           mcpService.getServerSummaries
         ) {
-          const routerModel =
-            mcpSettings.useLightweightRouterModel &&
-            mcpSettings.routerModelProvider.trim() &&
-            mcpSettings.routerModelId.trim()
-              ? (await this.resolveRouterModel(mcpSettings)) ?? this.model
-              : this.model
-          mcpTools = await mcpOrchestrator.getRelevantTools(
-            this.lastUserMessage,
-            {
-              getTools: () => mcpService.getTools(),
-              getToolsForServers: (names) =>
-                mcpService.getToolsForServers!(names),
-              getServerSummaries: () => mcpService.getServerSummaries!(),
-            },
-            disabledToolKeys,
-            {
-              routerModel,
-              abortSignal,
-            }
-          )
+          const summaries = await mcpService.getServerSummaries!()
+          const routedSig = JSON.stringify({
+            servers: summaries.map((s) => s.name).sort(),
+            disabled: [...disabledToolKeys].sort(),
+          })
+          if (this.frozenRoutedTools && this.frozenRoutedSig === routedSig) {
+            mcpTools = this.frozenRoutedTools
+          } else {
+            const routerModel =
+              mcpSettings.useLightweightRouterModel &&
+              mcpSettings.routerModelProvider.trim() &&
+              mcpSettings.routerModelId.trim()
+                ? (await this.resolveRouterModel(mcpSettings)) ?? this.model
+                : this.model
+            mcpTools = await mcpOrchestrator.getRelevantTools(
+              this.lastUserMessage,
+              {
+                getTools: () => mcpService.getTools(),
+                getToolsForServers: (names) =>
+                  mcpService.getToolsForServers!(names),
+                getServerSummaries: () => Promise.resolve(summaries),
+              },
+              disabledToolKeys,
+              {
+                routerModel,
+                abortSignal,
+              }
+            )
+            this.frozenRoutedTools = mcpTools
+            this.frozenRoutedSig = routedSig
+          }
         } else {
           mcpTools = await mcpService.getTools()
         }
@@ -966,6 +983,12 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
       }
       if (isPredefinedRemoteProvider(effectiveProviderName)) {
         for (const key of Object.keys(paramsSettings)) delete mergedParams[key]
+      }
+      // Pin chat to slot 0 so llama-server reuses this thread's cached KV
+      // prefix across turns; title generation uses the reserved background
+      // slot (RESERVED_BACKGROUND_SLOTS) and can't evict it.
+      if (providerId === 'llamacpp') {
+        mergedParams.id_slot = 0
       }
       this.model = await ModelFactory.createModel(
         modelId,

--- a/web-app/src/lib/custom-chat-transport.ts
+++ b/web-app/src/lib/custom-chat-transport.ts
@@ -895,6 +895,8 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
           if (!loaded.includes(modelId)) {
             useAppState.getState().updateLoadingModel(true)
             useAppState.getState().updateThreadLoadingModel(threadId, true)
+            useAppState.getState().updateModelLoadProgress(undefined)
+            useAppState.getState().updateThreadModelLoadProgress(threadId, undefined)
           }
         } catch {
           // Ignore probe failures; the router will still load on demand
@@ -923,9 +925,13 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
       )
       useAppState.getState().updateLoadingModel(false)
       useAppState.getState().updateThreadLoadingModel(threadId, false)
+      useAppState.getState().updateModelLoadProgress(undefined)
+      useAppState.getState().updateThreadModelLoadProgress(threadId, undefined)
     } catch (error) {
       useAppState.getState().updateLoadingModel(false)
       useAppState.getState().updateThreadLoadingModel(threadId, false)
+      useAppState.getState().updateModelLoadProgress(undefined)
+      useAppState.getState().updateThreadModelLoadProgress(threadId, undefined)
       console.error('Failed to create model:', error)
       throw new Error(
         `Failed to create model: ${error instanceof Error ? error.message : JSON.stringify(error)}`

--- a/web-app/src/lib/custom-chat-transport.ts
+++ b/web-app/src/lib/custom-chat-transport.ts
@@ -23,6 +23,11 @@ import { useMCPServers } from '@/hooks/useMCPServers'
 import { useAppState } from '@/hooks/useAppState'
 import { invoke } from '@tauri-apps/api/core'
 import { ExtensionManager } from '@/lib/extension'
+import { getLlamacppExtension } from '@/lib/llamacppRouterProps'
+import {
+  tokensForThinkingBudgetLevel,
+  isThinkingBudgetLevelKey,
+} from '@/lib/thinkingBudget'
 import {
   ExtensionTypeEnum,
   VectorDBExtension,
@@ -118,6 +123,42 @@ function extractModelSamplingDefaults(
     }
   }
   return out
+}
+
+/**
+ * `thinking_budget_tokens` is stored as a symbolic level (low/medium/high/
+ * xhigh/unlimited), not a frozen absolute count — llama.cpp's --fit can pick
+ * a runtime n_ctx far from the configured/default size, and that's only known
+ * once the model is actually loaded. Resolve against the live n_ctx here, at
+ * send time, instead of whatever context size was in scope when the level
+ * was picked in ChatInput.
+ */
+async function resolveThinkingBudgetTokens(
+  model: Model | null | undefined,
+  modelId: string | undefined
+): Promise<number | undefined> {
+  const rawLevel = model?.settings?.thinking_budget_tokens?.controller_props?.value
+  if (!isThinkingBudgetLevelKey(rawLevel)) return undefined
+  if (rawLevel === 'unlimited') return -1
+
+  let contextSize: number | undefined
+  if (modelId) {
+    try {
+      contextSize = (await getLlamacppExtension()?.getModelProps?.(modelId))?.nCtx
+    } catch {
+      // Model not loaded yet or router unreachable; fall through to configured/default.
+    }
+  }
+  if (!contextSize) {
+    const configured = model?.settings?.ctx_len?.controller_props?.value
+    contextSize =
+      typeof configured === 'number'
+        ? configured
+        : typeof configured === 'string' && configured !== ''
+          ? Number(configured)
+          : undefined
+  }
+  return tokensForThinkingBudgetLevel(rawLevel, contextSize || 8192)
 }
 
 /**
@@ -907,6 +948,15 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
       // overrides (router mode can't bake them into CLI args). Assistant
       // params still win — they're the explicit per-conversation override.
       const modelSamplingDefaults = extractModelSamplingDefaults(selectedModel)
+      if (providerId === 'llamacpp') {
+        const thinkingBudgetTokens = await resolveThinkingBudgetTokens(
+          selectedModel,
+          modelId
+        )
+        if (thinkingBudgetTokens !== undefined) {
+          modelSamplingDefaults.thinking_budget_tokens = thinkingBudgetTokens
+        }
+      }
 
       // Create the model before refreshing tools so the MCP orchestrator can run
       // structured LLM routing when many servers are connected.

--- a/web-app/src/lib/custom-chat-transport.ts
+++ b/web-app/src/lib/custom-chat-transport.ts
@@ -28,6 +28,7 @@ import {
   tokensForThinkingBudgetLevel,
   isThinkingBudgetLevelKey,
 } from '@/lib/thinkingBudget'
+import { buildReasoningProviderOptions } from '@/lib/reasoningProviderOptions'
 import {
   ExtensionTypeEnum,
   VectorDBExtension,
@@ -1175,6 +1176,13 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
     const modelSupportsTools = selectedModel?.capabilities?.includes('tools') ?? this.modelSupportsTools
     const shouldEnableTools = hasTools && modelSupportsTools
 
+    // Cloud providers take reasoning via the AI SDK's per-request
+    // providerOptions (native thinking config), not the raw body.
+    const reasoningProviderOptions = buildReasoningProviderOptions(
+      providerId,
+      useModelProvider.getState().selectedModel
+    )
+
     let streamStartTime: number | undefined
     useAppState.getState().updatePromptProgress(undefined)
     useAppState.getState().updateThreadPromptProgress(threadId, undefined)
@@ -1189,6 +1197,9 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
       toolChoice: shouldEnableTools ? 'auto' : undefined,
       system: effectiveSystem,
       ...(maxOutputTokens !== undefined ? { maxTokens: maxOutputTokens } : {}),
+      ...(reasoningProviderOptions
+        ? { providerOptions: reasoningProviderOptions }
+        : {}),
       experimental_repairToolCall: async ({ toolCall, error }) => {
         // Windows paths (`C:\Users\...`) contain invalid JSON escapes that make
         // the SDK's argument parse fail. Re-escape lone backslashes and retry

--- a/web-app/src/lib/llamacppRouterProps.ts
+++ b/web-app/src/lib/llamacppRouterProps.ts
@@ -1,0 +1,29 @@
+import { ExtensionManager } from '@/lib/extension'
+
+export interface LlamacppModelProps {
+  nCtx: number
+  totalSlots?: number
+  modelAlias?: string
+  isSleeping?: boolean
+}
+
+interface LlamacppExtensionLike {
+  getModelProps?: (modelId: string) => Promise<LlamacppModelProps | undefined>
+}
+
+/** Post-fit `nCtx` is only available once the router has actually loaded the
+ *  model; callers must fall back to a configured/default context size until then. */
+export const getLlamacppExtension = (): LlamacppExtensionLike | undefined => {
+  const mgr = ExtensionManager.getInstance()
+  const candidates = [
+    mgr.getByName('@janhq/llamacpp-extension'),
+    mgr.getByName('llamacpp-extension'),
+  ]
+  for (const c of candidates) {
+    if (c && typeof (c as LlamacppExtensionLike).getModelProps === 'function')
+      return c as LlamacppExtensionLike
+  }
+  return mgr.listExtensions().find(
+    (ext) => typeof (ext as LlamacppExtensionLike).getModelProps === 'function'
+  ) as LlamacppExtensionLike | undefined
+}

--- a/web-app/src/lib/mcp-orchestrator/__tests__/mcp-orchestrator.test.ts
+++ b/web-app/src/lib/mcp-orchestrator/__tests__/mcp-orchestrator.test.ts
@@ -75,6 +75,26 @@ describe('MCPOrchestrator', () => {
       expect(tools).toHaveLength(1)
       expect(tools[0].name).toBe('read_file')
     })
+
+    it('returns tools sorted by (server, name) regardless of fetch order, to keep the serialized tool list stable across turns for KV-cache reuse', async () => {
+      const shuffledTools = [
+        { name: 'browse', description: '', inputSchema: {}, server: 'web' },
+        { name: 'write_file', description: '', inputSchema: {}, server: 'fs' },
+        { name: 'read_file', description: '', inputSchema: {}, server: 'fs' },
+      ]
+      const service = makeService({
+        getServerSummaries: vi.fn().mockResolvedValue(fewSummaries),
+        getTools: vi.fn().mockResolvedValue(shuffledTools),
+      })
+
+      const tools = await orchestrator.getRelevantTools('do something', service, [])
+
+      expect(tools.map((t) => `${(t as { server?: string }).server}::${t.name}`)).toEqual([
+        'fs::read_file',
+        'fs::write_file',
+        'web::browse',
+      ])
+    })
   })
 
   // ─── above threshold — uses getToolsForServers() ─────────────────────────

--- a/web-app/src/lib/mcp-orchestrator/mcp-orchestrator.ts
+++ b/web-app/src/lib/mcp-orchestrator/mcp-orchestrator.ts
@@ -275,10 +275,22 @@ export class MCPOrchestrator {
   }
 
   private filterDisabled(tools: MCPTool[], disabledKeys: string[]): MCPTool[] {
-    if (disabledKeys.length === 0) return tools
-    return tools.filter((tool) => {
-      const key = `${(tool as { server?: string }).server ?? 'unknown'}::${tool.name}`
-      return !disabledKeys.includes(key)
+    const filtered =
+      disabledKeys.length === 0
+        ? tools
+        : tools.filter((tool) => {
+            const key = `${(tool as { server?: string }).server ?? 'unknown'}::${tool.name}`
+            return !disabledKeys.includes(key)
+          })
+    // Sort by (server, name) so transient fetch-order/count fluctuations from
+    // MCP servers (reconnects, TTL-driven re-fetches) can't reorder the
+    // serialized tool list and invalidate the llama-server KV-cache prefix
+    // when the underlying tool set is otherwise unchanged.
+    return [...filtered].sort((a, b) => {
+      const serverA = (a as { server?: string }).server ?? 'unknown'
+      const serverB = (b as { server?: string }).server ?? 'unknown'
+      if (serverA !== serverB) return serverA < serverB ? -1 : 1
+      return a.name < b.name ? -1 : a.name > b.name ? 1 : 0
     })
   }
 }

--- a/web-app/src/lib/model-factory.ts
+++ b/web-app/src/lib/model-factory.ts
@@ -585,6 +585,15 @@ export function stripAssistantReasoningInBody(
   }
 }
 
+/** Reads the per-provider "Strip reasoning from context" checkbox; defaults to true. */
+function shouldStripReasoningFromContext(provider?: ProviderObject): boolean {
+  const setting = provider?.settings?.find(
+    (s) => s.key === 'strip_reasoning_from_context'
+  )
+  const value = setting?.controller_props?.value
+  return typeof value === 'boolean' ? value : true
+}
+
 /** Wraps `inner` to strip reasoning fields from assistant messages before send. */
 function withAssistantReasoningStripped(
   inner: typeof globalThis.fetch
@@ -875,12 +884,19 @@ export class ModelFactory {
           })()
         }
       : undefined
-    const customFetch = createCustomFetch(
+    // Reasoning content re-shapes assistant turns (content + sibling
+    // reasoning_content) relative to what llama-server originally streamed
+    // and cached, so stripping it (default on) preserves KV-cache prefix
+    // reuse across turns; some models recommend keeping it, hence the toggle.
+    let customFetch = createCustomFetch(
       httpFetch,
       parameters,
       true,
       onLlamacppServerError
     )
+    if (shouldStripReasoningFromContext(provider)) {
+      customFetch = withAssistantReasoningStripped(customFetch)
+    }
 
     return new OpenAICompatibleChatLanguageModel(modelId, {
       provider: 'llamacpp',
@@ -945,7 +961,10 @@ export class ModelFactory {
     // rebuilds upstream errors from buffered text rather than re-decoding the
     // raw stream) with every other provider, then layer MLX's /cancel-on-abort
     // on top.
-    const baseCustomFetch = createCustomFetch(httpFetch, parameters)
+    let baseCustomFetch = createCustomFetch(httpFetch, parameters)
+    if (shouldStripReasoningFromContext(provider)) {
+      baseCustomFetch = withAssistantReasoningStripped(baseCustomFetch)
+    }
     const customFetch: typeof globalThis.fetch = async (
       input: RequestInfo | URL,
       init?: RequestInit

--- a/web-app/src/lib/model-factory.ts
+++ b/web-app/src/lib/model-factory.ts
@@ -376,6 +376,23 @@ export function createCustomFetch(
     return Number.isNaN(n) ? value : n
   }
 
+  // Internal param keys that don't match the llama-server wire field name.
+  const WIRE_KEY_REMAP: Record<string, string> = {
+    max_output_tokens: 'max_tokens',
+    dynatemp_exp: 'dynatemp_exponent',
+  }
+
+  // Server expects an array of sampler names; the UI stores a comma/
+  // semicolon-separated string for easy editing.
+  const coerceSamplers = (value: unknown): unknown => {
+    if (typeof value !== 'string') return value
+    const names = value
+      .split(/[,;]/)
+      .map((s) => s.trim())
+      .filter(Boolean)
+    return names.length > 0 ? names : undefined
+  }
+
   const buildBody = (
     rawBody: Record<string, unknown>,
     includeOurParams: boolean
@@ -389,8 +406,13 @@ export function createCustomFetch(
     for (const [key, value] of Object.entries(parameters)) {
       if (CLIENT_SIDE_PARAM_KEYS.has(key)) continue
       if (!keepLlamacppOnly && LLAMACPP_ONLY_PARAM_KEYS.has(key)) continue
-      const targetKey = key === 'max_output_tokens' ? 'max_tokens' : key
-      normalised[targetKey] = coerceNumericParam(key, value)
+      const targetKey = WIRE_KEY_REMAP[key] ?? key
+      const coerced =
+        key === 'samplers'
+          ? coerceSamplers(value)
+          : coerceNumericParam(key, value)
+      if (coerced === undefined) continue
+      normalised[targetKey] = coerced
     }
     const merged = { ...rawBody, ...normalised }
     if (keepLlamacppOnly && merged.stream === true) {

--- a/web-app/src/lib/model-factory.ts
+++ b/web-app/src/lib/model-factory.ts
@@ -415,6 +415,11 @@ export function createCustomFetch(
       normalised[targetKey] = coerced
     }
     const merged = { ...rawBody, ...normalised }
+    if (keepLlamacppOnly) {
+      // Assert the server default explicitly so a preset/CLI override can't
+      // silently disable prompt-prefix KV reuse across turns.
+      merged.cache_prompt = true
+    }
     if (keepLlamacppOnly && merged.stream === true) {
       merged.return_progress = true
       // Requests per-chunk timings so the token counter can update live

--- a/web-app/src/lib/model-factory.ts
+++ b/web-app/src/lib/model-factory.ts
@@ -84,7 +84,14 @@ interface LlamaCppTimings {
   predicted_n?: number
   predicted_per_second?: number
   prompt_per_second?: number
+  cache_n?: number
 }
+
+// prompt_n only counts tokens freshly processed this turn; tokens served from
+// the KV cache (the rest of the conversation) are reported separately in
+// cache_n, so total prompt/context usage is the sum of both.
+const totalPromptTokens = (timings: LlamaCppTimings): number =>
+  (timings.prompt_n ?? 0) + (timings.cache_n ?? 0)
 
 interface LlamaCppPromptProgress {
   total?: number
@@ -109,7 +116,7 @@ const providerMetadataExtractor: MetadataExtractor = {
     if (body?.timings) {
       return {
         providerMetadata: {
-          promptTokens: body.timings.prompt_n ?? null,
+          promptTokens: totalPromptTokens(body.timings),
           completionTokens: body.timings.predicted_n ?? null,
           tokensPerSecond: body.timings.predicted_per_second ?? null,
           promptPerSecond: body.timings.prompt_per_second ?? null,
@@ -134,6 +141,16 @@ const providerMetadataExtractor: MetadataExtractor = {
         }
         if (chunk?.timings) {
           lastTimings = chunk.timings
+          const liveStats = {
+            promptTokens: totalPromptTokens(lastTimings),
+            completionTokens: lastTimings.predicted_n ?? 0,
+            tokensPerSecond: lastTimings.predicted_per_second ?? null,
+            promptPerSecond: lastTimings.prompt_per_second ?? null,
+          }
+          state.updateLiveTokenStats(liveStats)
+          if (streamThreadId) {
+            state.updateThreadLiveTokenStats(streamThreadId, liveStats)
+          }
         }
         const pp = chunk?.prompt_progress
         if (
@@ -157,7 +174,7 @@ const providerMetadataExtractor: MetadataExtractor = {
         if (lastTimings) {
           return {
             providerMetadata: {
-              promptTokens: lastTimings.prompt_n ?? null,
+              promptTokens: totalPromptTokens(lastTimings),
               completionTokens: lastTimings.predicted_n ?? null,
               tokensPerSecond: lastTimings.predicted_per_second ?? null,
               promptPerSecond: lastTimings.prompt_per_second ?? null,
@@ -378,6 +395,9 @@ export function createCustomFetch(
     const merged = { ...rawBody, ...normalised }
     if (keepLlamacppOnly && merged.stream === true) {
       merged.return_progress = true
+      // Requests per-chunk timings so the token counter can update live
+      // during generation instead of only once the stream finishes.
+      merged.timings_per_token = true
     }
     // llama-server convention: max_tokens = -1 means "unlimited". Users who
     // set max_output_tokens = 0 in assistant params mean "no cap", not

--- a/web-app/src/lib/model-factory.ts
+++ b/web-app/src/lib/model-factory.ts
@@ -64,6 +64,7 @@ import { hasVideoSentinel, splitVideoSentinels } from './video-sentinel'
 import { filterDefaultSseEvents } from './sseEventTypeFilter'
 import { isPlatformTauri } from '@/lib/platform/utils'
 import { providerRemoteApiKeyChain } from '@/lib/provider-api-keys'
+import { isThinkingBudgetLevelKey } from '@/lib/thinkingBudget'
 import {
   LLAMACPP_ONLY_PARAM_KEYS,
   paramsSettings,
@@ -1085,7 +1086,17 @@ export class ModelFactory {
       fetch: fetchImpl,
     })
 
-    return openai.chat(modelId)
+    // Reasoning summaries (reasoningSummary) are only returned by the Responses
+    // API, so switch to it when the user set a concrete effort level. Everyone
+    // else stays on Chat Completions to avoid breaking OpenAI-compatible
+    // proxies that only implement /chat/completions.
+    const effortLevel =
+      provider.models?.find((m) => m.id === modelId)?.settings
+        ?.thinking_budget_tokens?.controller_props?.value
+    const useResponses =
+      isThinkingBudgetLevelKey(effortLevel) && effortLevel !== 'unlimited'
+
+    return useResponses ? openai.responses(modelId) : openai.chat(modelId)
   }
 
   /**

--- a/web-app/src/lib/model-factory.ts
+++ b/web-app/src/lib/model-factory.ts
@@ -64,7 +64,6 @@ import { hasVideoSentinel, splitVideoSentinels } from './video-sentinel'
 import { filterDefaultSseEvents } from './sseEventTypeFilter'
 import { isPlatformTauri } from '@/lib/platform/utils'
 import { providerRemoteApiKeyChain } from '@/lib/provider-api-keys'
-import { isThinkingBudgetLevelKey } from '@/lib/thinkingBudget'
 import {
   LLAMACPP_ONLY_PARAM_KEYS,
   paramsSettings,
@@ -1086,17 +1085,12 @@ export class ModelFactory {
       fetch: fetchImpl,
     })
 
-    // Reasoning summaries (reasoningSummary) are only returned by the Responses
-    // API, so switch to it when the user set a concrete effort level. Everyone
-    // else stays on Chat Completions to avoid breaking OpenAI-compatible
-    // proxies that only implement /chat/completions.
-    const effortLevel =
-      provider.models?.find((m) => m.id === modelId)?.settings
-        ?.thinking_budget_tokens?.controller_props?.value
-    const useResponses =
-      isThinkingBudgetLevelKey(effortLevel) && effortLevel !== 'unlimited'
-
-    return useResponses ? openai.responses(modelId) : openai.chat(modelId)
+    // The genuine OpenAI provider always supports the Responses API, so use it
+    // unconditionally: it is a superset of Chat Completions and the only surface
+    // that returns reasoning summaries. Custom OpenAI-compatible providers route
+    // through createOpenAICompatibleModel, not here, so this cannot hit a proxy
+    // that only implements /chat/completions.
+    return openai.responses(modelId)
   }
 
   /**

--- a/web-app/src/lib/predefinedParams.ts
+++ b/web-app/src/lib/predefinedParams.ts
@@ -30,6 +30,9 @@ export type SamplerCap =
   | 'grammar'
   | 'json_schema'
   | 'ignore_eos'
+  | 'sampler_order'
+  | 'backend_sampling'
+  | 'thinking_budget'
   | 'client_only'
 
 export interface ParamControllerProps {
@@ -348,13 +351,50 @@ export const paramsSettings: Record<string, ParamDef> = {
     controllerType: 'checkbox',
     capability: 'ignore_eos',
   },
+  repeat_last_n: {
+    key: 'repeat_last_n',
+    title: 'Repeat Last N',
+    description:
+      'Number of recent tokens considered for the repeat penalty. -1 = full context, 0 = disabled.',
+    value: 64,
+    controllerType: 'input',
+    controllerProps: { min: -1, step: 1 },
+    capability: 'repetition',
+  },
+  samplers: {
+    key: 'samplers',
+    title: 'Sampler Order',
+    description:
+      'Order in which samplers are applied, comma-separated (e.g. "top_k,typ_p,top_p,min_p,xtc,temperature"). Empty = server default order.',
+    value: '',
+    controllerType: 'input',
+    controllerProps: { placeholder: 'top_k,typ_p,top_p,min_p,xtc,temperature' },
+    capability: 'sampler_order',
+  },
+  backend_sampling: {
+    key: 'backend_sampling',
+    title: 'Backend Sampling',
+    description: 'Use the model backend\'s own sampler instead of llama.cpp\'s.',
+    value: false,
+    controllerType: 'checkbox',
+    capability: 'backend_sampling',
+  },
+  thinking_budget_tokens: {
+    key: 'thinking_budget_tokens',
+    title: 'Thinking Budget',
+    description:
+      'Maximum tokens the model may spend on reasoning before being forced to answer. -1 = unlimited.',
+    value: -1,
+    controllerType: 'input',
+    controllerProps: { min: -1, step: 1 },
+    capability: 'thinking_budget',
+  },
 }
 
 /**
  * Sampler keys exposed as per-model defaults in the model edit dialog. Persist
  * to the model (model.yml → router preset for llamacpp) and act as defaults the
  * local API server uses; per-assistant and per-request values override them.
- * `repeat_last_n` is intentionally omitted — it has no paramsSettings entry.
  */
 export const SAMPLER_DEFAULT_KEYS = [
   'temperature',
@@ -362,6 +402,7 @@ export const SAMPLER_DEFAULT_KEYS = [
   'top_k',
   'min_p',
   'repeat_penalty',
+  'repeat_last_n',
   'presence_penalty',
   'frequency_penalty',
 ] as const
@@ -417,6 +458,10 @@ export const LLAMACPP_ONLY_PARAM_KEYS: ReadonlySet<string> = new Set([
   'ignore_eos',
   'min_p',
   'repeat_penalty',
+  'repeat_last_n',
+  'samplers',
+  'backend_sampling',
+  'thinking_budget_tokens',
 ])
 
 export function evaluateDisabled(
@@ -519,7 +564,12 @@ export const paramCategories: CategoryDef[] = [
   {
     id: 'penalties',
     title: 'Penalties',
-    paramKeys: ['frequency_penalty', 'presence_penalty', 'repeat_penalty'],
+    paramKeys: [
+      'frequency_penalty',
+      'presence_penalty',
+      'repeat_penalty',
+      'repeat_last_n',
+    ],
     groupIds: [],
   },
   {
@@ -532,13 +582,14 @@ export const paramCategories: CategoryDef[] = [
       'auto_compact',
       'max_context_tokens',
       'ignore_eos',
+      'thinking_budget_tokens',
     ],
     groupIds: [],
   },
   {
     id: 'advanced',
     title: 'Advanced samplers',
-    paramKeys: ['typical_p', 'top_n_sigma'],
+    paramKeys: ['typical_p', 'top_n_sigma', 'samplers', 'backend_sampling'],
     groupIds: ['mirostat', 'dry', 'xtc', 'dynatemp'],
   },
 ]

--- a/web-app/src/lib/providerCaps.ts
+++ b/web-app/src/lib/providerCaps.ts
@@ -105,7 +105,10 @@ const LLAMACPP: ProviderCaps = {
     'top_n_sigma',
     'grammar',
     'json_schema',
-    'ignore_eos'
+    'ignore_eos',
+    'sampler_order',
+    'backend_sampling',
+    'thinking_budget'
   ),
   maybe: new Set(),
 }
@@ -136,6 +139,9 @@ const CUSTOM_PERMISSIVE: ProviderCaps = {
     'grammar',
     'json_schema',
     'ignore_eos',
+    'sampler_order',
+    'backend_sampling',
+    'thinking_budget',
   ]),
 }
 

--- a/web-app/src/lib/reasoning.ts
+++ b/web-app/src/lib/reasoning.ts
@@ -1,0 +1,16 @@
+/**
+ * Split a reasoning trace into paragraph "steps". Models separate distinct
+ * thoughts with a blank line, so a run of 2+ newlines starts a new step; a
+ * single newline stays within the current step (soft wrap / list item).
+ *
+ * Because the caller passes the full accumulated text on every streaming tick,
+ * the last element is the paragraph currently being written; earlier elements
+ * are completed steps. No external accumulator state is needed.
+ */
+export function splitReasoningParagraphs(text: string): string[] {
+  if (!text) return []
+  return text
+    .split(/\n[ \t]*\n+/)
+    .map((p) => p.replace(/\s+$/, ''))
+    .filter((p) => p.trim().length > 0)
+}

--- a/web-app/src/lib/reasoningProviderOptions.ts
+++ b/web-app/src/lib/reasoningProviderOptions.ts
@@ -1,0 +1,90 @@
+import {
+  isThinkingBudgetLevelKey,
+  type ThinkingBudgetLevelKey,
+} from './thinkingBudget'
+
+type ReasoningChoice = 'auto' | 'on' | 'off' | undefined
+
+// OpenAI's reasoning_effort is a discrete level (no token budget). Our shared
+// thinking-budget levels map 1:1; 'unlimited' has no effort equivalent and is
+// treated as "no explicit effort" (model default), matching the UI's Default.
+const LEVEL_TO_OPENAI_EFFORT: Partial<Record<ThinkingBudgetLevelKey, string>> = {
+  low: 'low',
+  medium: 'medium',
+  high: 'high',
+  xhigh: 'xhigh',
+}
+
+function readReasoning(model: Model | null | undefined): ReasoningChoice {
+  const v = model?.settings?.reasoning?.controller_props?.value
+  return v === 'on' || v === 'off' || v === 'auto' ? v : undefined
+}
+
+function readBudgetLevel(
+  model: Model | null | undefined
+): ThinkingBudgetLevelKey | undefined {
+  const v = model?.settings?.thinking_budget_tokens?.controller_props?.value
+  return isThinkingBudgetLevelKey(v) ? v : undefined
+}
+
+/**
+ * Translate Jan's shared reasoning settings (reasoning on/off/auto + thinking
+ * budget level) into the per-request `providerOptions` the AI SDK expects for
+ * cloud providers, using each provider's NATIVE options rather than a
+ * context-derived token budget (which we can't know for cloud models):
+ *
+ * - Google Gemini: `thinkingConfig.thinkingBudget` -1 (dynamic, model-sized) /
+ *   0 (off), plus `includeThoughts` to surface thought summaries.
+ * - Anthropic: `thinking` adaptive (model-sized, no token guess) / disabled.
+ * - OpenAI: `reasoningEffort` discrete level (no budget).
+ *
+ * Returns undefined when the provider has no mapping or the user left reasoning
+ * at its provider default.
+ */
+export function buildReasoningProviderOptions(
+  providerId: string,
+  model: Model | null | undefined
+): Record<string, Record<string, unknown>> | undefined {
+  const reasoning = readReasoning(model)
+  const level = readBudgetLevel(model)
+
+  if (providerId === 'google' || providerId === 'gemini') {
+    if (reasoning === 'off') {
+      return { google: { thinkingConfig: { thinkingBudget: 0 } } }
+    }
+    if (reasoning === 'on' || level) {
+      return {
+        google: { thinkingConfig: { thinkingBudget: -1, includeThoughts: true } },
+      }
+    }
+    return undefined
+  }
+
+  if (providerId === 'anthropic') {
+    if (reasoning === 'off') {
+      return { anthropic: { thinking: { type: 'disabled' } } }
+    }
+    if (reasoning === 'on' || level) {
+      // Adaptive lets Claude size its own thinking budget; 'summarized' streams
+      // the thought summary we render in the reasoning trace.
+      return {
+        anthropic: { thinking: { type: 'adaptive', display: 'summarized' } },
+      }
+    }
+    return undefined
+  }
+
+  if (providerId === 'openai') {
+    // Reasoning models always reason, so 'off' has no universal equivalent;
+    // only a concrete effort level maps ('unlimited' = model default).
+    // reasoningSummary surfaces the (otherwise hidden) reasoning as summary
+    // parts — it requires the Responses API, which model-factory selects when
+    // an effort level is set.
+    const effort = level ? LEVEL_TO_OPENAI_EFFORT[level] : undefined
+    return effort
+      ? { openai: { reasoningEffort: effort, reasoningSummary: 'auto' } }
+      : undefined
+  }
+
+  return undefined
+}

--- a/web-app/src/lib/reasoningProviderOptions.ts
+++ b/web-app/src/lib/reasoningProviderOptions.ts
@@ -1,3 +1,4 @@
+import type { JSONObject } from '@ai-sdk/provider'
 import {
   isThinkingBudgetLevelKey,
   type ThinkingBudgetLevelKey,
@@ -44,7 +45,7 @@ function readBudgetLevel(
 export function buildReasoningProviderOptions(
   providerId: string,
   model: Model | null | undefined
-): Record<string, Record<string, unknown>> | undefined {
+): Record<string, JSONObject> | undefined {
   const reasoning = readReasoning(model)
   const level = readBudgetLevel(model)
 

--- a/web-app/src/lib/thinkingBudget.ts
+++ b/web-app/src/lib/thinkingBudget.ts
@@ -1,0 +1,41 @@
+export type ThinkingBudgetLevelKey =
+  | 'low'
+  | 'medium'
+  | 'high'
+  | 'xhigh'
+  | 'unlimited'
+
+// Fractions of the model's context window; null = unlimited (-1, llama.cpp's
+// sentinel for "don't cap reasoning"). Resolved against the LIVE (post-fit)
+// context size at send time, not the configured/default size at selection
+// time, since llama.cpp's --fit can pick a runtime n_ctx far from either.
+export const THINKING_BUDGET_LEVELS: Array<{
+  key: ThinkingBudgetLevelKey
+  label: string
+  ratio: number | null
+}> = [
+  { key: 'low', label: 'Low', ratio: 0.1 },
+  { key: 'medium', label: 'Medium', ratio: 0.25 },
+  { key: 'high', label: 'High', ratio: 0.5 },
+  { key: 'xhigh', label: 'XHigh', ratio: 0.75 },
+  { key: 'unlimited', label: 'Unlimited', ratio: null },
+]
+
+export const DEFAULT_THINKING_BUDGET_LEVEL: ThinkingBudgetLevelKey = 'unlimited'
+
+export function tokensForThinkingBudgetLevel(
+  level: ThinkingBudgetLevelKey,
+  contextSize: number
+): number {
+  const ratio = THINKING_BUDGET_LEVELS.find((l) => l.key === level)?.ratio
+  return ratio == null ? -1 : Math.max(1, Math.round(contextSize * ratio))
+}
+
+export function isThinkingBudgetLevelKey(
+  value: unknown
+): value is ThinkingBudgetLevelKey {
+  return (
+    typeof value === 'string' &&
+    THINKING_BUDGET_LEVELS.some((l) => l.key === value)
+  )
+}

--- a/web-app/src/lib/thread-title-summarizer.ts
+++ b/web-app/src/lib/thread-title-summarizer.ts
@@ -80,10 +80,22 @@ export async function generateThreadTitle(
     }
 
     console.log('[ThreadTitle] Creating model:', selectedModel.id, 'provider:', selectedProvider)
-    const params: Record<string, unknown> =
-      selectedProvider === 'llamacpp'
-        ? { chat_template_kwargs: { enable_thinking: false } }
-        : {}
+    // Pin to the reserved background slot (RESERVED_BACKGROUND_SLOTS in
+    // preset.ts) — one index past the user-visible "Parallel Sequences"
+    // count — so this call can never evict a chat request's KV cache.
+    // "Parallel Sequences" = 0 means auto (llama.cpp picks its own slot
+    // count); we can't safely reserve a slot in that case, so skip pinning.
+    const params: Record<string, unknown> = {}
+    if (selectedProvider === 'llamacpp') {
+      params.chat_template_kwargs = { enable_thinking: false }
+      const userParallel = Number(
+        provider.settings?.find((s) => s.key === 'parallel')?.controller_props
+          ?.value ?? 1
+      )
+      if (Number.isFinite(userParallel) && userParallel > 0) {
+        params.id_slot = userParallel
+      }
+    }
     const model = await ModelFactory.createModel(
       selectedModel.id,
       provider,

--- a/web-app/src/providers/DataProvider.tsx
+++ b/web-app/src/providers/DataProvider.tsx
@@ -278,12 +278,30 @@ export function DataProvider() {
   }, [serviceHub])
 
   useEffect(() => {
-    serviceHub
-      .threads()
-      .fetchThreads()
-      .then((threads) => {
-        setThreads(threads)
-      })
+    // fetchThreads throws while the Conversational extension is still loading
+    // (startup race, e.g. reload mid-stream). Retry with backoff instead of
+    // letting a single failed fetch leave the thread list permanently empty.
+    let cancelled = false
+    let attempt = 0
+    let timer: ReturnType<typeof setTimeout>
+    const load = () => {
+      serviceHub
+        .threads()
+        .fetchThreads()
+        .then((threads) => {
+          if (!cancelled) setThreads(threads)
+        })
+        .catch(() => {
+          if (cancelled || attempt >= 20) return
+          attempt += 1
+          timer = setTimeout(load, Math.min(1000, 150 * attempt))
+        })
+    }
+    load()
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
   }, [serviceHub, setThreads])
 
   // Sync remote providers with backend when providers change

--- a/web-app/src/providers/__tests__/DataProvider.test.tsx
+++ b/web-app/src/providers/__tests__/DataProvider.test.tsx
@@ -238,6 +238,23 @@ describe('DataProvider', () => {
     })
   })
 
+  it('retries fetchThreads when it throws (extension not ready) and never wipes the list on failure', async () => {
+    hubState.fetchThreads
+      .mockRejectedValueOnce(new Error('Conversational extension not available yet'))
+      .mockResolvedValueOnce([{ id: 't1' }])
+
+    render(<DataProvider />)
+
+    await waitFor(() => {
+      expect(hubState.fetchThreads).toHaveBeenCalledTimes(2)
+    })
+    // The failed first attempt must not push an empty array.
+    expect(h.setThreads).not.toHaveBeenCalledWith([])
+    await waitFor(() => {
+      expect(h.setThreads).toHaveBeenCalledWith([{ id: 't1' }])
+    })
+  })
+
   it('passes DEFAULT_MCP_SETTINGS when mcp config lacks values', async () => {
     hubState.getMCPConfig.mockResolvedValue({})
     render(<DataProvider />)

--- a/web-app/src/services/__tests__/threads.test.ts
+++ b/web-app/src/services/__tests__/threads.test.ts
@@ -246,14 +246,12 @@ describe('DefaultThreadsService', () => {
   })
 
   describe('edge cases and error handling', () => {
-    it('should handle fetchThreads when extension manager returns null', async () => {
+    it('should throw when the conversational extension is not ready (startup race)', async () => {
       ;(ExtensionManager.getInstance as any).mockReturnValue({
         get: vi.fn().mockReturnValue(null),
       })
 
-      const result = await threadsService.fetchThreads()
-
-      expect(result).toEqual([])
+      await expect(threadsService.fetchThreads()).rejects.toThrow()
     })
 
     it('should handle createThread when extension manager returns null', async () => {

--- a/web-app/src/services/threads/default.ts
+++ b/web-app/src/services/threads/default.ts
@@ -23,55 +23,58 @@ function fromModelResponse(
 
 export class DefaultThreadsService implements ThreadsService {
   async fetchThreads(): Promise<Thread[]> {
-    return (
-      ExtensionManager.getInstance()
-        .get<ConversationalExtension>(ExtensionTypeEnum.Conversational)
-        ?.listThreads()
-        .then((threads) => {
-          if (!Array.isArray(threads)) return []
-
-          // new String("id") !== "id"
-          threads.forEach((e) => {
-            e.id = e.id?.toString()
-            e.assistants?.forEach((a) => {
-              a.id = a.id?.toString()
-              if (a.model) a.model.id = a.model.id?.toString()
-            })
-          })
-
-          // Filter out temporary threads from the list
-          const filteredThreads = threads.filter(
-            (e) => e.id !== TEMPORARY_CHAT_ID
-          )
-
-          return filteredThreads.map((e) => {
-            const model = fromModelResponse(e.assistants?.[0]?.model)
-            const assistants = e.assistants
-
-            return {
-              ...e,
-              updated:
-                typeof e.updated === 'number' && e.updated > 1e12
-                  ? Math.floor(e.updated / 1000)
-                  : (e.updated ?? 0),
-              order: e.metadata?.order,
-              isFavorite: e.metadata?.is_favorite,
-              model,
-              assistants,
-              metadata: {
-                ...e.metadata,
-                // Override extracted fields to avoid duplication
-                order: e.metadata?.order,
-                is_favorite: e.metadata?.is_favorite,
-              },
-            } as Thread
-          })
-        })
-        ?.catch((e) => {
-          console.error('Error fetching threads:', e)
-          return []
-        }) ?? []
+    const ext = ExtensionManager.getInstance().get<ConversationalExtension>(
+      ExtensionTypeEnum.Conversational
     )
+    // The extension may not be registered yet during a startup race (e.g. a
+    // reload while the llamacpp router is busy). Throw so the caller can retry
+    // instead of treating "not ready" as "no threads" and wiping the list.
+    if (!ext) {
+      throw new Error('Conversational extension not available yet')
+    }
+
+    try {
+      const threads = await ext.listThreads()
+      if (!Array.isArray(threads)) return []
+
+      // new String("id") !== "id"
+      threads.forEach((e) => {
+        e.id = e.id?.toString()
+        e.assistants?.forEach((a) => {
+          a.id = a.id?.toString()
+          if (a.model) a.model.id = a.model.id?.toString()
+        })
+      })
+
+      // Filter out temporary threads from the list
+      const filteredThreads = threads.filter((e) => e.id !== TEMPORARY_CHAT_ID)
+
+      return filteredThreads.map((e) => {
+        const model = fromModelResponse(e.assistants?.[0]?.model)
+        const assistants = e.assistants
+
+        return {
+          ...e,
+          updated:
+            typeof e.updated === 'number' && e.updated > 1e12
+              ? Math.floor(e.updated / 1000)
+              : (e.updated ?? 0),
+          order: e.metadata?.order,
+          isFavorite: e.metadata?.is_favorite,
+          model,
+          assistants,
+          metadata: {
+            ...e.metadata,
+            // Override extracted fields to avoid duplication
+            order: e.metadata?.order,
+            is_favorite: e.metadata?.is_favorite,
+          },
+        } as Thread
+      })
+    } catch (e) {
+      console.error('Error fetching threads:', e)
+      return []
+    }
   }
 
   async createThread(thread: Thread): Promise<Thread> {


### PR DESCRIPTION
## Describe Your Changes

#### API server Translating Gateway
- **Phase 1 (P1)**: Foundation layer — `api_type` detection and SSE stream accumulation (`SseAccumulator`).
- **Phase 2 (P2)**: Translate Google `generateContent` → OpenAI `/chat/completions` shape; handle Gemini's native `reasoning_content` + `thinkingBudget`.
- **Phase 3 (P3)**: Translate Anthropic `Messages` API upstream (model selection, thinking budget, native budget tracking).
- Enables external tools, clients, and agents to target Jan via their preferred API schema without client-side knowledge of the backend provider.

#### OpenAI Provider
- **Always use Responses API**: `createOpenAIModel()` now unconditionally returns the OpenAI Responses surface instead of Chat Completions + reasoning toggle. Responses is a superset of Chat Completions and the only endpoint returning reasoning summaries; genuine OpenAI always supports it.
- Drops unused `effortLevel` lookup logic.

#### Reasoning Across Providers
- **OpenAI, Anthropic, Google**: Expose reasoning/thinking controls via native provider capabilities.
- **Anthropic**: Extended `thinking` budget parameter + native budget tracking.
- **Google (Gemini 3)**: Native `reasoning_content` field + `thinkingBudget` support; reasoning is split into a separate track from generation tokens.
- Unified thinking-budget submenu resolved at send time, supporting platform-specific defaults.

#### Chat & Inference
- **KV-cache prefix stability**: Keep KV-cache prefix stable across chat turns (llamacpp); enable KV cache reuse for efficiency.
- **KV-unified backend setting**: Add `--kv-unified` support for better KV cache management on compatible backends.
- **Context shifting**: Preserve `context_shift=true` events and emit them correctly to the frontend.
- **Model compatibility checks**: Import draft/MTP models with proper validation logic.
- **Thread list**: retry thread load so a startup race doesn't wipe the list.

#### RAG Improvements
- **Default embedding model**: Honor the configured default embedding model instead of hardcoding.
- **Chunk sizing**: Guarantee chunk sizes fit the embedding model's context window.

#### Chat Transport & UI
- **Message metadata**: Keep `[ATTACHED_FILES]` metadata on the attaching user message.
- **Sampler controls**: Expose sampler order, backend sampling, `repeat_last_n`, and thinking budget as live controls.
- **UI Polish**: Stack sampler-default title above controls, fix padding on multi-stage model loads.

#### Bug Fixes
- **Startup race condition**: Retry thread list load to prevent initial load race from wiping thread state.
- **Model load state**: Refetch model props on load-state change for live context counter updates.

## Files Changed

- `web-app/src/lib/model-factory.ts`: Unconditional Responses API for OpenAI.
- `src-tauri/src/core/proxy.rs`: New `api_type` + `SseAccumulator` foundation for translating gateway.
- `src-tauri/src/core/`: Upstream translation for Google, Anthropic, native reasoning handling.
- `extensions/llamacpp-extension/src/`: KV-cache reuse + `kv_unified` + context-shift fixes.
- `extensions/rag-extension/src/`: Default embedding model + chunk-size validation.
- `web-app/src/routes/threads/`, `web-app/src/hooks/`: Chat improvements, message branching, sampler controls.
- `web-app/src/locales/`: i18n updates for new reasoning controls.

## Testing

- **API server unit tests**: New tests for `api_type` detection, SSE accumulation, and provider translation.
- **Chat transport**: Validated against OpenAI, Anthropic, Google with and without reasoning.
- **KV-cache**: Verified prefix stability and reuse efficiency across models.

## Verification

```bash
yarn tsc && yarn lint          # TS type check + linting
cargo test --all              # Rust tests including proxy suite
yarn test                      # Vitest suite
```

## Notes

- Reasoning controls are **provider-specific**; each cloud provider exposes its native budget/parameter names. This may not work in all cases.
- KV-cache improvements are **llamacpp-only** at this time; MLX support TBD.

---

## Fixes Issues

- Closes #8404 
- Closes #8398

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
