### PR TITLE
feat: add MiniMax M3 model support

### DIFF
--- a/docs/src/pages/docs/desktop/remote-models/_meta.json
+++ b/docs/src/pages/docs/desktop/remote-models/_meta.json
@@ -23,6 +23,9 @@
   "huggingface": {
     "title": "Hugging Face"
   },
+  "minimax": {
+    "title": "MiniMax"
+  },
   "custom-endpoint": {
     "title": "Custom Endpoints"
   }

--- a/docs/src/pages/docs/desktop/remote-models/minimax.mdx
+++ b/docs/src/pages/docs/desktop/remote-models/minimax.mdx
@@ -1,0 +1,75 @@
+---
+title: MiniMax API
+description: Connect Jan to MiniMax-M3 and MiniMax-M2.7 through OpenAI-compatible or Anthropic-compatible endpoints.
+keywords:
+  [
+    Jan,
+    MiniMax,
+    MiniMax-M3,
+    MiniMax-M2.7,
+    OpenAI-compatible,
+    Anthropic-compatible,
+    API key,
+    base URL,
+    cloud models,
+  ]
+---
+
+import { Callout, Steps } from 'nextra/components'
+import { Settings, Plus } from 'lucide-react'
+
+# MiniMax
+
+Jan includes MiniMax as a built-in cloud provider. The model list includes **MiniMax-M3**, with
+tool use and vision support, and **MiniMax-M2.7**, with text and tool use support.
+
+## Use the built-in provider
+
+<Steps>
+
+### Get an API key
+
+Create an API key in the MiniMax platform for your region.
+
+### Configure Jan
+
+1. Navigate to **Settings** (<Settings width={16} height={16} style={{display:"inline"}}/>) >
+   **Model Providers**.
+2. Select **MiniMax**.
+3. Enter your API key.
+
+The built-in provider uses the global OpenAI-compatible endpoint.
+
+### Select a model
+
+Start or open a chat, then select **MiniMax-M3** or **MiniMax-M2.7** from the model selector.
+
+</Steps>
+
+## Endpoint options
+
+Jan has one base URL per provider. Use the built-in provider for the default endpoint, or add a custom
+provider for another region or API format.
+
+| Region | API format | Base URL | Jan setup |
+| --- | --- | --- | --- |
+| Global | OpenAI-compatible | `https://api.minimax.io/v1` | Built-in MiniMax provider |
+| CN | OpenAI-compatible | `https://api.minimaxi.com/v1` | Custom provider with OpenAI-compatible selected |
+| Global | Anthropic-compatible | `https://api.minimax.io/anthropic` | Custom provider with Anthropic-compatible selected |
+| CN | Anthropic-compatible | `https://api.minimaxi.com/anthropic` | Custom provider with Anthropic-compatible selected |
+
+To use a custom endpoint:
+
+1. In **Settings** > **Model Providers**, click **Add Provider**
+   (<Plus width={16} height={16} style={{display:"inline"}}/>).
+2. Select the API format shown in the table and enter the matching base URL and API key.
+3. Add `MiniMax-M3` or `MiniMax-M2.7` to the provider's model list. Enable tools and vision for
+   MiniMax-M3, or tools for MiniMax-M2.7.
+
+<Callout type="warning">
+For Anthropic-compatible endpoints, enter the base URL exactly as shown, ending in `/anthropic`.
+Do not append `/v1`; Jan adds the `/v1/messages` request path internally.
+</Callout>
+
+See the official [global documentation](https://platform.minimax.io/docs/guides/text-generation)
+or [CN documentation](https://platform.minimaxi.com/docs/guides/text-generation) for API details.

--- a/web-app/src/constants/models.ts
+++ b/web-app/src/constants/models.ts
@@ -109,12 +109,12 @@ export const providerModels = {
     supportsN: true,
   },
   minimax: {
-    models: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
+    models: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
     supportsCompletion: true,
-    supportsStreaming: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
+    supportsStreaming: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
     supportsJSON: [],
-    supportsImages: [],
-    supportsToolCalls: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
+    supportsImages: ['MiniMax-M3'],
+    supportsToolCalls: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
     supportsN: true,
   },
   openrouter: {

--- a/web-app/src/constants/providers.ts
+++ b/web-app/src/constants/providers.ts
@@ -287,10 +287,17 @@ export const predefinedProviders = [
     ],
     models: [
       {
+        id: 'MiniMax-M3',
+        name: 'MiniMax-M3',
+        version: '1.0',
+        description: 'Frontier multimodal coding model with a 1M token context window.',
+        capabilities: ['completion', 'tools', 'vision'],
+      },
+      {
         id: 'MiniMax-M2.7',
         name: 'MiniMax-M2.7',
         version: '1.0',
-        description: 'Latest flagship model with enhanced reasoning and coding.',
+        description: 'Reasoning and coding model with a 204.8K token context window.',
         capabilities: ['completion', 'tools'],
       },
       {

--- a/web-app/src/lib/__tests__/model-factory.test.ts
+++ b/web-app/src/lib/__tests__/model-factory.test.ts
@@ -118,6 +118,38 @@ describe('ModelFactory', () => {
       )
     })
 
+    it.each([
+      [
+        'https://api.minimax.io/anthropic',
+        'https://api.minimax.io/anthropic/v1',
+      ],
+      [
+        'https://api.minimaxi.com/anthropic',
+        'https://api.minimaxi.com/anthropic/v1',
+      ],
+    ])(
+      'derives the internal Anthropic version path for %s',
+      async (baseUrl, expectedSdkBaseUrl) => {
+        const { createAnthropic } = await import('@ai-sdk/anthropic')
+        vi.mocked(createAnthropic).mockClear()
+        const provider: ProviderObject = {
+          provider: 'minimax-anthropic',
+          api_type: 'anthropic',
+          api_key: 'test-api-key',
+          base_url: baseUrl,
+          models: [],
+          settings: [],
+          active: true,
+        }
+
+        await ModelFactory.createModel('MiniMax-M3', provider)
+
+        expect(createAnthropic).toHaveBeenCalledWith(
+          expect.objectContaining({ baseURL: expectedSdkBaseUrl })
+        )
+      }
+    )
+
     it('routes google and gemini through the native @ai-sdk/google client and strips the /openai suffix', async () => {
       const { createGoogleGenerativeAI } = await import('@ai-sdk/google')
       for (const name of ['google', 'gemini'] as const) {

--- a/web-app/src/lib/__tests__/models.test.ts
+++ b/web-app/src/lib/__tests__/models.test.ts
@@ -348,6 +348,22 @@ describe('getModelCapabilities', () => {
     expect(capabilities).toContain(ModelCapabilities.VISION)
   })
 
+  it('reports the distinct MiniMax M3 and M2.7 capabilities', () => {
+    const m3Capabilities = getModelCapabilities('minimax', 'MiniMax-M3')
+    const m27Capabilities = getModelCapabilities('minimax', 'MiniMax-M2.7')
+
+    expect(defaultModel('minimax')).toBe('MiniMax-M3')
+    expect(m3Capabilities).toEqual([
+      ModelCapabilities.COMPLETION,
+      ModelCapabilities.TOOLS,
+      ModelCapabilities.VISION,
+    ])
+    expect(m27Capabilities).toEqual([
+      ModelCapabilities.COMPLETION,
+      ModelCapabilities.TOOLS,
+    ])
+  })
+
   it('handles provider with no capability arrays gracefully', () => {
     const capabilities = getModelCapabilities('ai21', 'jamba-instruct')
     expect(capabilities).toEqual([ModelCapabilities.COMPLETION])

--- a/web-app/src/lib/model-factory.ts
+++ b/web-app/src/lib/model-factory.ts
@@ -711,6 +711,20 @@ const REASONING_TAG_MAP: Record<string, string> = {
  */
 const DEFAULT_REASONING_TAG = 'think'
 
+const MINIMAX_ANTHROPIC_BASE_URLS = new Set([
+  'https://api.minimax.io/anthropic',
+  'https://api.minimaxi.com/anthropic',
+])
+
+function getAnthropicSdkBaseUrl(baseUrl: string | undefined) {
+  const normalized = baseUrl?.replace(/\/+$/, '')
+  if (normalized && MINIMAX_ANTHROPIC_BASE_URLS.has(normalized)) {
+    // The SDK appends /messages, while MiniMax exposes /anthropic/v1/messages.
+    return `${normalized}/v1`
+  }
+  return baseUrl
+}
+
 /**
  * Determines the reasoning tag name based on the model ID.
  * Defaults to 'think' if no specific override is found in the map.
@@ -975,7 +989,7 @@ export class ModelFactory {
 
     const anthropic = createAnthropic({
       apiKey: keyChain[0] ?? provider.api_key ?? '',
-      baseURL: provider.base_url,
+      baseURL: getAnthropicSdkBaseUrl(provider.base_url),
       headers: Object.keys(headers).length > 0 ? headers : undefined,
       fetch: fetchImpl,
     })


### PR DESCRIPTION
This cleanly replaces #8401.

## Describe Your Changes

- Add MiniMax-M3 to the built-in MiniMax model and capability registries with streaming, tools, and vision support.
- Keep MiniMax-M2.7 available with its documented 204.8K context window.
- Derive the Anthropic API version path inside the adapter so users configure the documented `/anthropic` base URL while requests reach `/v1/messages`.
- Document global and CN OpenAI-compatible and Anthropic-compatible endpoint setup.

## Test Plan

- `corepack yarn vitest run --project @janhq/web-app web-app/src/lib/__tests__/models.test.ts web-app/src/lib/__tests__/model-factory.test.ts` (81 passed)
- `NODE_OPTIONS='--max-old-space-size=4096 --no-experimental-webstorage' corepack yarn vitest run --project @janhq/web-app` (2,715 passed)
- `corepack yarn lint`
- `corepack yarn build:web`
- `cd docs && yarn build`
- Captured request URLs for both regions and both API formats.

## Screenshots

Not applicable. This changes provider metadata, request routing, tests, and documentation without changing the existing UI layout.

## Self Checklist

- [x] Added focused tests.
- [x] Updated documentation.
- [x] Kept the change scoped to MiniMax support.
