### PR TITLE
fix(mcp): guard against duplicate serve() on streamable-http MCP servers

### DIFF
--- a/src-tauri/src/core/mcp/helpers.rs
+++ b/src-tauri/src/core/mcp/helpers.rs
@@ -336,11 +336,11 @@ pub async fn start_mcp_server<R: Runtime>(
     // 400, tearing down the connection (issue #8411). This can happen when boot
     // startup and a frontend activation fire for the same server.
     if servers_state.lock().await.contains_key(&name) {
-        log::info!("MCP server {name} already running; skipping duplicate start");
+        log::debug!("MCP server {name} already running; skipping duplicate start");
         return Ok(());
     }
     if !app_state.mcp_starting.lock().await.insert(name.clone()) {
-        log::info!("MCP server {name} start already in progress; skipping duplicate start");
+        log::debug!("MCP server {name} start already in progress; skipping duplicate start");
         return Ok(());
     }
 

--- a/src-tauri/src/core/mcp/helpers.rs
+++ b/src-tauri/src/core/mcp/helpers.rs
@@ -330,6 +330,20 @@ pub async fn start_mcp_server<R: Runtime>(
     let app_state = app.state::<AppState>();
     let active_servers_state = app_state.mcp_active_servers.clone();
 
+    // Idempotency guard: never serve() the same server twice. Two serve() calls
+    // spin up two independent clients that each send an `initialize` (both with
+    // request id 0); the second is rejected by streamable-http servers with a
+    // 400, tearing down the connection (issue #8411). This can happen when boot
+    // startup and a frontend activation fire for the same server.
+    if servers_state.lock().await.contains_key(&name) {
+        log::info!("MCP server {name} already running; skipping duplicate start");
+        return Ok(());
+    }
+    if !app_state.mcp_starting.lock().await.insert(name.clone()) {
+        log::info!("MCP server {name} start already in progress; skipping duplicate start");
+        return Ok(());
+    }
+
     // Store active server config for restart purposes
     store_active_server_config(&active_servers_state, &name, &config).await;
 
@@ -342,6 +356,10 @@ pub async fn start_mcp_server<R: Runtime>(
         config.clone(),
     )
     .await;
+
+    // Start attempt finished (success or failure) — clear the in-flight marker so
+    // future (re)activations aren't blocked.
+    app_state.mcp_starting.lock().await.remove(&name);
 
     match first_start_result {
         Ok(_) => {

--- a/src-tauri/src/core/state.rs
+++ b/src-tauri/src/core/state.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 
 use crate::core::{downloads::models::DownloadManagerState, mcp::models::McpSettings};
 use rmcp::{
@@ -57,6 +60,10 @@ pub struct AppState {
     pub mcp_settings: Arc<Mutex<McpSettings>>,
     pub mcp_shutdown_in_progress: Arc<Mutex<bool>>,
     pub mcp_monitoring_tasks: Arc<Mutex<HashMap<String, tauri::async_runtime::JoinHandle<()>>>>,
+    /// Names of MCP servers whose initial start is currently in flight. Guards
+    /// against a server being `serve()`'d twice (e.g. boot startup racing a
+    /// frontend activation), which sends duplicate `initialize` requests.
+    pub mcp_starting: Arc<Mutex<HashSet<String>>>,
     pub background_cleanup_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
     pub mcp_server_pids: Arc<Mutex<HashMap<String, u32>>>,
     /// Remote provider configurations (e.g., Anthropic, OpenAI, etc.)
@@ -81,6 +88,7 @@ impl Default for AppState {
             mcp_settings: Default::default(),
             mcp_shutdown_in_progress: Default::default(),
             mcp_monitoring_tasks: Default::default(),
+            mcp_starting: Default::default(),
             background_cleanup_handle: Default::default(),
             mcp_server_pids: Default::default(),
             provider_configs: Default::default(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,7 +12,10 @@ use core::{
 #[cfg(not(feature = "cli"))]
 use jan_utils::generate_app_token;
 #[cfg(not(feature = "cli"))]
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+};
 #[cfg(not(feature = "cli"))]
 use tauri::{Emitter, Manager, RunEvent};
 #[cfg(not(feature = "cli"))]
@@ -264,6 +267,7 @@ pub fn run() {
             mcp_settings: Arc::new(Mutex::new(McpSettings::default())),
             mcp_shutdown_in_progress: Arc::new(Mutex::new(false)),
             mcp_monitoring_tasks: Arc::new(Mutex::new(HashMap::new())),
+            mcp_starting: Arc::new(Mutex::new(HashSet::new())),
             background_cleanup_handle: Arc::new(Mutex::new(None)),
             mcp_server_pids: Arc::new(Mutex::new(HashMap::new())),
             provider_configs: Arc::new(Mutex::new(HashMap::new())),


### PR DESCRIPTION
## Problem

Fixes #8411

Remote streamable-HTTP MCP servers (`type: "http"`) intermittently fail to connect with:

```
Failed to connect to server: ... 400 Bad Request ... when send initialize request
```

or connect (UI turns green) then drop a few seconds later. Server-side logs show Jan sending the `initialize` JSON-RPC request **twice** with the same request id `0`; the first succeeds, the second is rejected as a duplicate on an already-initialized session.

## Root cause

`start_mcp_server` had no idempotency guard, so a server could be `serve()`'d twice. rmcp's `serve()` creates a fresh client that sends `initialize` exactly once (request id starts at 0 per client) — so **two `initialize` with id 0 means two `serve()` calls**, not an rmcp retry.

Two starts happen in practice because `restart_active_mcp_servers` (helpers.rs) restarts every active server **without clearing it from the running map first**, and several frontend flows fire `activate` **and** a restart-all for one action (e.g. renaming a server: `activate` + `syncServersAndRestart`). The two `serve()` calls each POST `initialize`; the second gets `400`.

## Fix

Make `start_mcp_server` idempotent (3 files, +32/-2):

- Skip if the server is **already running** (present in the live map).
- Skip if a start is **already in flight** — tracked via a new `mcp_starting: HashSet<String>` on `AppState`; cleared when the attempt finishes (success or failure).

The reconnect path (`schedule_mcp_start_task`) is intentionally left **unguarded** so health-check auto-reconnect can still re-serve.

## Verification

Tested locally against a mock streamable-HTTP server that mimics the remote (first `initialize` → 200 + session id, duplicate → 400), with injected latency to widen the race window:

- **Bug reproduced**: two concurrent `initialize` → `200` + `400 DUPLICATE`.
- **Fix confirmed**: renaming a connected server (the deterministic double-start trigger) now logs `MCP server <name> start already in progress; skipping duplicate start`; the mock receives **exactly one** `initialize`, no `400`, connection stays up.
- **No regression**: fresh connect, auto-reconnect, JSON re-add, and edit+save re-activation all produce a single `initialize` and remain connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)