### PR TITLE
fix(favorites): scope favorite models by provider + id

### DIFF
--- a/web-app/src/containers/DropdownModelProvider.tsx
+++ b/web-app/src/containers/DropdownModelProvider.tsx
@@ -309,10 +309,14 @@ const DropdownModelProvider = memo(function DropdownModelProvider({
     })
   }, [searchableItems])
 
-  // Get favorite models that are currently available
+  // Get favorite models that are currently available (provider-scoped)
   const favoriteItems = useMemo(() => {
     return searchableItems.filter((item) =>
-      favoriteModels.some((fav) => fav.id === item.model.id)
+      favoriteModels.some(
+        (fav) =>
+          fav.id === item.model.id &&
+          (!fav.provider || fav.provider === item.provider.provider)
+      )
     )
   }, [searchableItems, favoriteModels])
 
@@ -386,7 +390,11 @@ const DropdownModelProvider = memo(function DropdownModelProvider({
       }
 
       // When not searching, exclude favorite models from regular provider sections
-      const isFavorite = favoriteModels.some((fav) => fav.id === item.model.id)
+      const isFavorite = favoriteModels.some(
+        (fav) =>
+          fav.id === item.model.id &&
+          (!fav.provider || fav.provider === item.provider.provider)
+      )
       if (!searchValue && isFavorite) return // Skip adding this item to regular provider section
 
       groups[providerKey].push(item)

--- a/web-app/src/containers/FavoriteModelAction.tsx
+++ b/web-app/src/containers/FavoriteModelAction.tsx
@@ -4,18 +4,22 @@ import { Button } from '@/components/ui/button'
 
 interface FavoriteModelActionProps {
   model: Model
+  provider: string
 }
 
-export function FavoriteModelAction({ model }: FavoriteModelActionProps) {
+export function FavoriteModelAction({
+  model,
+  provider,
+}: FavoriteModelActionProps) {
   const { isFavorite, toggleFavorite } = useFavoriteModel()
-  const isModelFavorite = isFavorite(model.id)
+  const isModelFavorite = isFavorite(model.id, provider)
 
   return (
     <Button
-      aria-label="Toggle favorite" 
+      aria-label="Toggle favorite"
       variant="ghost"
       size="icon-xs"
-      onClick={() => toggleFavorite(model)}
+      onClick={() => toggleFavorite(model, provider)}
     >
       {isModelFavorite ? (
         <IconStarFilled size={18} className="text-muted-foreground" />

--- a/web-app/src/containers/dialogs/DeleteAllModels.tsx
+++ b/web-app/src/containers/dialogs/DeleteAllModels.tsx
@@ -88,7 +88,7 @@ export const DialogDeleteAllModels = ({
             // best-effort stop; continue with delete
           }
         }
-        removeFavorite(id)
+        removeFavorite(id, provider.provider)
         deleteModelCache(id)
         await serviceHub.models().deleteModel(id, provider.provider)
       } catch (err) {

--- a/web-app/src/containers/dialogs/DeleteModel.tsx
+++ b/web-app/src/containers/dialogs/DeleteModel.tsx
@@ -40,8 +40,8 @@ export const DialogDeleteModel = ({
   const serviceHub = useServiceHub()
 
   const removeModel = async () => {
-    // Remove model from favorites if it exists
-    removeFavorite(selectedModelId)
+    // Remove model from favorites if it exists (scoped to this provider)
+    removeFavorite(selectedModelId, provider.provider)
 
     deleteModelCache(selectedModelId)
     serviceHub

--- a/web-app/src/containers/dialogs/DeleteProvider.tsx
+++ b/web-app/src/containers/dialogs/DeleteProvider.tsx
@@ -39,10 +39,14 @@ const DeleteProvider = ({ provider }: Props) => {
 
   const removeProvider = async () => {
     // Remove favorite models that belong to this provider
-    const providerModelIds = provider.models.map((model) => model.id)
+    const providerModelIds = new Set(provider.models.map((model) => model.id))
     favoriteModels.forEach((favoriteModel) => {
-      if (providerModelIds.includes(favoriteModel.id)) {
-        removeFavorite(favoriteModel.id)
+      const belongsToProvider =
+        favoriteModel.provider === provider.provider ||
+        // legacy favorites without provider: fall back to model-id membership
+        (!favoriteModel.provider && providerModelIds.has(favoriteModel.id))
+      if (belongsToProvider) {
+        removeFavorite(favoriteModel.id, provider.provider)
       }
     })
 

--- a/web-app/src/hooks/__tests__/useFavoriteModel.test.ts
+++ b/web-app/src/hooks/__tests__/useFavoriteModel.test.ts
@@ -41,91 +41,129 @@ describe('useFavoriteModel', () => {
     expect(state.favoriteModels).toEqual([])
   })
 
-  it('should add a favorite', () => {
+  it('should add a favorite with provider scope', () => {
     const model = makeModel('model-1')
 
     act(() => {
-      useFavoriteModel.getState().addFavorite(model)
+      useFavoriteModel.getState().addFavorite(model, 'openrouter')
     })
 
     expect(useFavoriteModel.getState().favoriteModels).toHaveLength(1)
     expect(useFavoriteModel.getState().favoriteModels[0].id).toBe('model-1')
+    expect(useFavoriteModel.getState().favoriteModels[0].provider).toBe(
+      'openrouter'
+    )
   })
 
-  it('should not add duplicate favorites', () => {
+  it('should not add duplicate favorites for the same provider', () => {
     const model = makeModel('model-1')
 
     act(() => {
-      useFavoriteModel.getState().addFavorite(model)
-      useFavoriteModel.getState().addFavorite(model)
+      useFavoriteModel.getState().addFavorite(model, 'openrouter')
+      useFavoriteModel.getState().addFavorite(model, 'openrouter')
     })
 
     expect(useFavoriteModel.getState().favoriteModels).toHaveLength(1)
   })
 
-  it('should remove a favorite', () => {
-    const model = makeModel('model-1')
+  it('should allow the same model id under different providers', () => {
+    const model = makeModel('gpt-4o')
 
     act(() => {
-      useFavoriteModel.getState().addFavorite(model)
+      useFavoriteModel.getState().addFavorite(model, 'openrouter')
+      useFavoriteModel.getState().addFavorite(model, 'huggingface')
+    })
+
+    expect(useFavoriteModel.getState().favoriteModels).toHaveLength(2)
+    expect(
+      useFavoriteModel.getState().isFavorite('gpt-4o', 'openrouter')
+    ).toBe(true)
+    expect(
+      useFavoriteModel.getState().isFavorite('gpt-4o', 'huggingface')
+    ).toBe(true)
+  })
+
+  it('should remove a favorite for one provider only', () => {
+    const model = makeModel('gpt-4o')
+
+    act(() => {
+      useFavoriteModel.getState().addFavorite(model, 'openrouter')
+      useFavoriteModel.getState().addFavorite(model, 'huggingface')
     })
 
     act(() => {
-      useFavoriteModel.getState().removeFavorite('model-1')
+      useFavoriteModel.getState().removeFavorite('gpt-4o', 'openrouter')
     })
 
-    expect(useFavoriteModel.getState().favoriteModels).toHaveLength(0)
+    expect(useFavoriteModel.getState().favoriteModels).toHaveLength(1)
+    expect(
+      useFavoriteModel.getState().isFavorite('gpt-4o', 'openrouter')
+    ).toBe(false)
+    expect(
+      useFavoriteModel.getState().isFavorite('gpt-4o', 'huggingface')
+    ).toBe(true)
   })
 
   it('should check isFavorite correctly', () => {
     const model = makeModel('model-1')
 
     act(() => {
-      useFavoriteModel.getState().addFavorite(model)
+      useFavoriteModel.getState().addFavorite(model, 'openrouter')
     })
 
-    expect(useFavoriteModel.getState().isFavorite('model-1')).toBe(true)
-    expect(useFavoriteModel.getState().isFavorite('model-2')).toBe(false)
+    expect(useFavoriteModel.getState().isFavorite('model-1', 'openrouter')).toBe(
+      true
+    )
+    expect(
+      useFavoriteModel.getState().isFavorite('model-1', 'huggingface')
+    ).toBe(false)
+    expect(useFavoriteModel.getState().isFavorite('model-2', 'openrouter')).toBe(
+      false
+    )
   })
 
   it('should toggle favorite on', () => {
     const model = makeModel('model-1')
 
     act(() => {
-      useFavoriteModel.getState().toggleFavorite(model)
+      useFavoriteModel.getState().toggleFavorite(model, 'openrouter')
     })
 
-    expect(useFavoriteModel.getState().isFavorite('model-1')).toBe(true)
+    expect(useFavoriteModel.getState().isFavorite('model-1', 'openrouter')).toBe(
+      true
+    )
   })
 
   it('should toggle favorite off', () => {
     const model = makeModel('model-1')
 
     act(() => {
-      useFavoriteModel.getState().addFavorite(model)
+      useFavoriteModel.getState().addFavorite(model, 'openrouter')
     })
 
     act(() => {
-      useFavoriteModel.getState().toggleFavorite(model)
+      useFavoriteModel.getState().toggleFavorite(model, 'openrouter')
     })
 
-    expect(useFavoriteModel.getState().isFavorite('model-1')).toBe(false)
+    expect(useFavoriteModel.getState().isFavorite('model-1', 'openrouter')).toBe(
+      false
+    )
   })
 
   it('should handle multiple favorites', () => {
     act(() => {
-      useFavoriteModel.getState().addFavorite(makeModel('a'))
-      useFavoriteModel.getState().addFavorite(makeModel('b'))
-      useFavoriteModel.getState().addFavorite(makeModel('c'))
+      useFavoriteModel.getState().addFavorite(makeModel('a'), 'p1')
+      useFavoriteModel.getState().addFavorite(makeModel('b'), 'p1')
+      useFavoriteModel.getState().addFavorite(makeModel('c'), 'p2')
     })
 
     expect(useFavoriteModel.getState().favoriteModels).toHaveLength(3)
 
     act(() => {
-      useFavoriteModel.getState().removeFavorite('b')
+      useFavoriteModel.getState().removeFavorite('b', 'p1')
     })
 
     expect(useFavoriteModel.getState().favoriteModels).toHaveLength(2)
-    expect(useFavoriteModel.getState().isFavorite('b')).toBe(false)
+    expect(useFavoriteModel.getState().isFavorite('b', 'p1')).toBe(false)
   })
 })

--- a/web-app/src/hooks/useFavoriteModel.ts
+++ b/web-app/src/hooks/useFavoriteModel.ts
@@ -3,46 +3,76 @@ import { persist, createJSONStorage } from 'zustand/middleware'
 import { localStorageKey } from '@/constants/localStorage'
 import { backendStorage } from '@/lib/backendStorage'
 
+/** A favorited model is keyed by provider + id so identically-named models
+ * from different providers do not collapse into one entry (#8442). */
+export type FavoriteModel = Model & {
+  provider: string
+}
+
 interface FavoriteModelState {
-  favoriteModels: Model[]
-  addFavorite: (model: Model) => void
-  removeFavorite: (modelId: string) => void
-  isFavorite: (modelId: string) => boolean
-  toggleFavorite: (model: Model) => void
+  favoriteModels: FavoriteModel[]
+  addFavorite: (model: Model, provider: string) => void
+  removeFavorite: (modelId: string, provider?: string) => void
+  isFavorite: (modelId: string, provider?: string) => boolean
+  toggleFavorite: (model: Model, provider: string) => void
+}
+
+const sameFavorite = (
+  fav: FavoriteModel,
+  modelId: string,
+  provider?: string
+) => {
+  if (fav.id !== modelId) return false
+  // Legacy favorites (pre-#8442) have no provider — match by id only so they
+  // can still be removed / de-starred. New favorites always store provider.
+  if (!fav.provider) return true
+  if (!provider) return true
+  return fav.provider === provider
 }
 
 export const useFavoriteModel = create<FavoriteModelState>()(
   persist(
     (set, get) => ({
       favoriteModels: [],
-      
-      addFavorite: (model: Model) => {
+
+      addFavorite: (model: Model, provider: string) => {
         set((state) => {
-          if (!state.favoriteModels.some((fav) => fav.id === model.id)) {
-            return {
-              favoriteModels: [...state.favoriteModels, model],
-            }
+          if (
+            state.favoriteModels.some((fav) =>
+              sameFavorite(fav, model.id, provider)
+            )
+          ) {
+            return state
           }
-          return state
+          return {
+            favoriteModels: [
+              ...state.favoriteModels,
+              { ...model, provider },
+            ],
+          }
         })
       },
-      
-      removeFavorite: (modelId: string) => {
+
+      removeFavorite: (modelId: string, provider?: string) => {
         set((state) => ({
-          favoriteModels: state.favoriteModels.filter((model) => model.id !== modelId),
+          favoriteModels: state.favoriteModels.filter(
+            (model) => !sameFavorite(model, modelId, provider)
+          ),
         }))
       },
-      
-      isFavorite: (modelId: string) => {
-        return get().favoriteModels.some((model) => model.id === modelId)
+
+      isFavorite: (modelId: string, provider?: string) => {
+        return get().favoriteModels.some((model) =>
+          sameFavorite(model, modelId, provider)
+        )
       },
-      
-      toggleFavorite: (model: Model) => {
+
+      toggleFavorite: (model: Model, provider: string) => {
         const { isFavorite, addFavorite, removeFavorite } = get()
-        if (isFavorite(model.id)) {
-          removeFavorite(model.id)
+        if (isFavorite(model.id, provider)) {
+          removeFavorite(model.id, provider)
         } else {
-          addFavorite(model)
+          addFavorite(model, provider)
         }
       },
     }),

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -1387,7 +1387,7 @@ function ProviderDetail() {
                                   (p) => p.provider === provider.provider
                                 ) &&
                                 providerHasRemoteApiKeys(provider))) && (
-                              <FavoriteModelAction model={model} />
+                              <FavoriteModelAction model={model} provider={provider.provider} />
                             )}
                             <DialogDeleteModel
                               provider={provider}

--- a/web-app/src/routes/settings/providers/__tests__/$providerName.test.tsx
+++ b/web-app/src/routes/settings/providers/__tests__/$providerName.test.tsx
@@ -243,7 +243,7 @@ vi.mock('@/containers/dialogs/DeleteModel', () => ({
 }))
 
 vi.mock('@/containers/FavoriteModelAction', () => ({
-  FavoriteModelAction: ({ model }: any) => <div data-testid={`fav-${model.id}`} />,
+  FavoriteModelAction: ({ model, provider }: any) => <div data-testid={`fav-${provider}:${model.id}`} />,
 }))
 
 vi.mock('@/containers/dialogs/DeleteProvider', () => ({


### PR DESCRIPTION
## Summary
Fixes #8442: favoriting a model that exists under multiple providers (same model id) previously collapsed them into one entry, so both appeared under Favorites.

## Change
- Store `provider` on each favorite (`FavoriteModel = Model & { provider }`)
- Key favorites by `(provider, id)` in `addFavorite` / `removeFavorite` / `isFavorite` / `toggleFavorite`
- Dropdown favorites section and "exclude from regular provider list" logic match provider-scoped
- Star action + delete flows pass the provider
- Legacy favorites without `provider` still match by id so existing storage keeps working

## Test plan
- [x] Unit tests updated for same-id / different-provider cases
- [ ] Favorite model A on OpenRouter → only that provider's entry is starred
- [ ] Favorite the same id on Hugging Face → two favorites, one per provider
- [ ] Unstar one → the other remains
- [ ] Delete model / delete provider removes only that provider's favorites

Fixes #8442.
