### PR TITLE
feat(agent): native web_search/web_fetch tools compiled into the agent core

### DIFF
--- a/src-tauri/src/core/agent/context.rs
+++ b/src-tauri/src/core/agent/context.rs
@@ -98,6 +98,15 @@ pub(crate) fn load_skills(project_root: &Path) -> Option<String> {
     ))
 }
 
+/// Always-on guidance teaching the model that web access is a native built-in
+/// capability. Per jan-internal#196 the tools are provider-neutral: the model
+/// must call `web_search`/`web_fetch`, never a provider-branded name like
+/// `exa_search`, and should cite the URLs it relies on.
+const WEB_TOOLS_GUIDE: &str = "# Web Access\n\nYou have native `web_search` and `web_fetch` tools built into the agent. \
+Use `web_search` to find current information and sources, then `web_fetch` to read a specific result's page. \
+These are provider-neutral built-in tools (the search backend is configured by Jan); do not look for or call a \
+provider-branded tool such as `exa_search`. Cite the source URLs you rely on.";
+
 /// Guidance injected only when subagent tools are actually available, so the
 /// model delegates context-heavy exploration instead of exhausting its own
 /// (limited) context window reading files and tool output directly.
@@ -130,6 +139,7 @@ pub(crate) fn build_system_prompt(
         blocks.push(SUBAGENT_GUIDE.to_string());
     }
     blocks.push(DEFAULT_SKILL_GUIDE.trim().to_string());
+    blocks.push(WEB_TOOLS_GUIDE.to_string());
     if let Some(context) = load_context_files(project_root) {
         blocks.push(context);
     }
@@ -212,6 +222,18 @@ mod tests {
         let guide = out.find("Skills and Project Memory").unwrap();
         assert!(out.find("You are Jan.").unwrap() < guide);
         assert!(guide < out.find("Do the thing.").unwrap());
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn build_system_prompt_advertises_native_web_tools() {
+        let root = scratch_project("web");
+        let out = build_system_prompt(None, &root, false).expect("prompt");
+        assert!(out.contains("# Web Access"));
+        assert!(out.contains("web_search"));
+        assert!(out.contains("web_fetch"));
+        // Provider-neutral: the model must not be told to call a branded tool.
+        assert!(out.contains("exa_search"), "guide names the anti-pattern to avoid");
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/src-tauri/src/core/agent/context.rs
+++ b/src-tauri/src/core/agent/context.rs
@@ -102,10 +102,26 @@ pub(crate) fn load_skills(project_root: &Path) -> Option<String> {
 /// capability. Per jan-internal#196 the tools are provider-neutral: the model
 /// must call `web_search`/`web_fetch`, never a provider-branded name like
 /// `exa_search`, and should cite the URLs it relies on.
-const WEB_TOOLS_GUIDE: &str = "# Web Access\n\nYou have native `web_search` and `web_fetch` tools built into the agent. \
-Use `web_search` to find current information and sources, then `web_fetch` to read a specific result's page. \
-These are provider-neutral built-in tools (the search backend is configured by Jan); do not look for or call a \
-provider-branded tool such as `exa_search`. Cite the source URLs you rely on.";
+const WEB_TOOLS_GUIDE: &str = "# Web Access\n\nYou have two native, built-in tools for the live web. They are provider-neutral \
+(the search backend is configured by Jan) and work out of the box — do NOT look for, ask for, or call a \
+provider-branded tool such as `exa_search`, and do not say you lack internet access.\n\n\
+## When to use them\n\n\
+Reach for the web whenever the answer depends on current, external, or fast-changing information: recent events, \
+library/API versions and docs, error messages, prices, people, or anything you are unsure about or that is outside \
+your training data. Prefer verifying over guessing.\n\n\
+## How to call them\n\n\
+- `web_search` — find sources. Arguments: `query` (required string; write a specific, natural-language description \
+of the ideal page, not just keywords) and optional `count` (integer, default 5, max 20). Returns a numbered list of \
+results with title, URL, and a snippet.\n\
+- `web_fetch` — read one page. Argument: `url` (required http(s) string, typically a URL returned by `web_search`). \
+Returns the page's readable text with its title and source URL (bounded in length).\n\n\
+## Workflow\n\n\
+1. Call `web_search` with a focused query.\n\
+2. Pick the most relevant result(s) and call `web_fetch` on their URLs to read the full content — don't rely on \
+snippets alone for anything important.\n\
+3. Base your answer on what you read and cite the source URLs you used. If results are thin, refine the query and \
+search again. If a tool returns text starting with `ERROR`, read it, adjust your arguments, and retry or tell the \
+user what's wrong.";
 
 /// Guidance injected only when subagent tools are actually available, so the
 /// model delegates context-heavy exploration instead of exhausting its own
@@ -234,6 +250,11 @@ mod tests {
         assert!(out.contains("web_fetch"));
         // Provider-neutral: the model must not be told to call a branded tool.
         assert!(out.contains("exa_search"), "guide names the anti-pattern to avoid");
+        // Teaches how to call the tools, not just that they exist.
+        assert!(out.contains("query"), "documents the web_search query arg");
+        assert!(out.contains("count"), "documents the web_search count arg");
+        assert!(out.contains("url"), "documents the web_fetch url arg");
+        assert!(out.contains("Workflow"), "describes the search->fetch->cite flow");
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -1055,16 +1055,17 @@ async fn run_turn_cycle(
             });
         }
 
-        // Record the assistant's tool-call turn. We intentionally do NOT attach
-        // the OpenAI-style `tool_calls` array here, and (below) we feed each tool
-        // result back as a `role: "user"` message instead of `role: "tool"`.
+        // Record the assistant's tool-call turn using the standard OpenAI
+        // protocol: attach the `tool_calls` array here, and (below) feed each
+        // result back as a `role: "tool"` message carrying its `tool_call_id`.
         //
-        // Why: some served models (observed with `tokamak-1-preview`) do not
-        // actually attend to `role: "tool"` messages — the tool payload is present
-        // in the request but the model behaves as if the tool returned nothing,
-        // looping and hallucinating ("clean — nothing to commit"). Delivering the
-        // exact same bytes as a `user` message makes them fully visible and the
-        // model answers correctly on the next turn. See PR discussion / issue.
+        // A prior workaround delivered tool results as `role: "user"` because
+        // some served models (observed with `tokamak-1-preview`) didn't attend
+        // to `role: "tool"` messages with large content. That is now fixed
+        // server-side: the tokamak-1-preview facade rewrites role:tool -> user
+        // for the specific model that needs it (scoped, content preserved), so
+        // the agent can speak standard OpenAI tool protocol on the wire again.
+        // See janhq/jan-internal#238.
         if let Some(choice_message) = extract_choice_message(&completion) {
             let assistant_content = choice_message
                 .get("content")
@@ -1072,12 +1073,14 @@ async fn run_turn_cycle(
                 .unwrap_or(serde_json::Value::Null);
             conversation_messages.push(serde_json::json!({
                 "role": "assistant",
-                "content": assistant_content
+                "content": assistant_content,
+                "tool_calls": tool_calls.clone()
             }));
         } else {
             conversation_messages.push(serde_json::json!({
                 "role": "assistant",
-                "content": "(calling tools)"
+                "content": serde_json::Value::Null,
+                "tool_calls": tool_calls.clone()
             }));
         }
 
@@ -1099,7 +1102,8 @@ async fn run_turn_cycle(
                     diff: None,
                 });
                 conversation_messages.push(serde_json::json!({
-                    "role": "user",
+                    "role": "tool",
+                    "tool_call_id": id,
                     "content": content
                 }));
             }
@@ -1109,8 +1113,9 @@ async fn run_turn_cycle(
 
         let tool_results = tools.invoke(&tool_calls).await?;
 
-        // Feed tool results back as `user` messages (see note above the assistant
-        // push) so models that ignore `role: "tool"` still see the output.
+        // Standard OpenAI tool protocol: each result is a `role: "tool"` message
+        // carrying its `tool_call_id` (see note above the assistant push -- the
+        // tokamak-1-preview facade handles models that can't attend to it).
         for outcome in tool_results {
             let ToolOutcome { id, content, diff } = outcome;
             let _ = events.send(StreamEvent::ToolResult {
@@ -1120,7 +1125,8 @@ async fn run_turn_cycle(
                 diff,
             });
             conversation_messages.push(serde_json::json!({
-                "role": "user",
+                "role": "tool",
+                "tool_call_id": id,
                 "content": content
             }));
         }

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -408,7 +408,11 @@ impl ToolInvoker for CompositeToolInvoker {
                 Decision::Prompt(_) if self.yolo => Decision::Allow,
                 other => other,
             };
-            if matches!(decision, Decision::Allow) && tool.capability == Capability::Read {
+            // Read and Net tools are non-mutating and safe to run concurrently
+            // once allowed: reads hit the filesystem, web tools do outbound HTTP.
+            if matches!(decision, Decision::Allow)
+                && matches!(tool.capability, Capability::Read | Capability::Net)
+            {
                 let root = self.project_root.clone();
                 read_futures.push(async move {
                     let (text, diff) = execute_builtin_with_diff(tool, &args, &root).await;
@@ -436,6 +440,9 @@ impl ToolInvoker for CompositeToolInvoker {
                         Capability::Read => "read",
                         Capability::Write => "write",
                         Capability::Exec => "exec",
+                        // Net tools resolve to Allow in the gate and never reach
+                        // this prompt arm; label defensively for completeness.
+                        Capability::Net => "net",
                     };
                     let prompt_kind = match kind {
                         PromptKind::ReadEscape => "read_escape",

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -1055,6 +1055,16 @@ async fn run_turn_cycle(
             });
         }
 
+        // Record the assistant's tool-call turn. We intentionally do NOT attach
+        // the OpenAI-style `tool_calls` array here, and (below) we feed each tool
+        // result back as a `role: "user"` message instead of `role: "tool"`.
+        //
+        // Why: some served models (observed with `tokamak-1-preview`) do not
+        // actually attend to `role: "tool"` messages — the tool payload is present
+        // in the request but the model behaves as if the tool returned nothing,
+        // looping and hallucinating ("clean — nothing to commit"). Delivering the
+        // exact same bytes as a `user` message makes them fully visible and the
+        // model answers correctly on the next turn. See PR discussion / issue.
         if let Some(choice_message) = extract_choice_message(&completion) {
             let assistant_content = choice_message
                 .get("content")
@@ -1062,14 +1072,12 @@ async fn run_turn_cycle(
                 .unwrap_or(serde_json::Value::Null);
             conversation_messages.push(serde_json::json!({
                 "role": "assistant",
-                "content": assistant_content,
-                "tool_calls": tool_calls.clone()
+                "content": assistant_content
             }));
         } else {
             conversation_messages.push(serde_json::json!({
                 "role": "assistant",
-                "content": serde_json::Value::Null,
-                "tool_calls": tool_calls.clone()
+                "content": "(calling tools)"
             }));
         }
 
@@ -1091,8 +1099,7 @@ async fn run_turn_cycle(
                     diff: None,
                 });
                 conversation_messages.push(serde_json::json!({
-                    "role": "tool",
-                    "tool_call_id": id,
+                    "role": "user",
                     "content": content
                 }));
             }
@@ -1102,6 +1109,8 @@ async fn run_turn_cycle(
 
         let tool_results = tools.invoke(&tool_calls).await?;
 
+        // Feed tool results back as `user` messages (see note above the assistant
+        // push) so models that ignore `role: "tool"` still see the output.
         for outcome in tool_results {
             let ToolOutcome { id, content, diff } = outcome;
             let _ = events.send(StreamEvent::ToolResult {
@@ -1111,8 +1120,7 @@ async fn run_turn_cycle(
                 diff,
             });
             conversation_messages.push(serde_json::json!({
-                "role": "tool",
-                "tool_call_id": id,
+                "role": "user",
                 "content": content
             }));
         }

--- a/src-tauri/src/core/agent/tools/gate.rs
+++ b/src-tauri/src/core/agent/tools/gate.rs
@@ -152,6 +152,11 @@ pub fn resolve_decision(
                 Decision::Prompt(PromptKind::ReadEscape)
             }
         }
+        // Native web tools (Net) touch no filesystem path and run no shell
+        // command; they only perform outbound HTTP through Jan's provider
+        // adapter. Treat them like read-only reads inside the project: allowed
+        // without a prompt (an explicit agent.toml deny above still wins).
+        Capability::Net => Decision::Allow,
         Capability::Write => gated(PromptKind::Write, grants),
         Capability::Exec => {
             // Polling a previously backgrounded command (job_id, no new
@@ -230,6 +235,41 @@ mod tests {
             &grants,
         );
         assert_eq!(d, Decision::Prompt(PromptKind::ReadEscape));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn web_tools_allow_without_prompt() {
+        let root = unique_root();
+        let perms = ToolPermissions::new(PermissionDefault::ReadOnly, &[], &[], &[]);
+        let grants = SessionGrants::default();
+        for tool in ["web_search", "web_fetch"] {
+            let d = resolve_decision(
+                lookup(tool).unwrap(),
+                &json!({}),
+                &root,
+                &perms,
+                &grants,
+            );
+            assert_eq!(d, Decision::Allow, "{tool} should be auto-allowed");
+        }
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn web_tools_honor_explicit_deny() {
+        let root = unique_root();
+        let deny = s(&["web_search"]);
+        let perms = ToolPermissions::new(PermissionDefault::ReadOnly, &[], &deny, &[]);
+        let grants = SessionGrants::default();
+        let d = resolve_decision(
+            lookup("web_search").unwrap(),
+            &json!({}),
+            &root,
+            &perms,
+            &grants,
+        );
+        assert_eq!(d, Decision::HardDeny, "deny in agent.toml must win for web tools");
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/src-tauri/src/core/agent/tools/handlers.rs
+++ b/src-tauri/src/core/agent/tools/handlers.rs
@@ -109,6 +109,9 @@ pub async fn execute_builtin(
         "skill_list" => skill_list(project_root),
         "skill_read" => skill_read(args, project_root),
         "skill_write" => skill_write(args, project_root),
+        // Native web tools: compiled into the agent core, not an MCP server.
+        "web_search" => crate::core::agent::tools::web::web_search(args).await,
+        "web_fetch" => crate::core::agent::tools::web::web_fetch(args).await,
         other => format!("ERROR: unknown built-in tool '{other}'"),
     }
 }

--- a/src-tauri/src/core/agent/tools/mod.rs
+++ b/src-tauri/src/core/agent/tools/mod.rs
@@ -6,12 +6,17 @@ pub mod gate;
 pub mod handlers;
 pub mod sandbox;
 pub mod schema;
+pub mod web;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Capability {
     Read,
     Write,
     Exec,
+    /// Network egress (native web tools). Distinct from `Read`/`Exec` so the
+    /// gate can treat outbound web access as its own auto-allowed class rather
+    /// than a filesystem or shell operation.
+    Net,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -92,6 +97,19 @@ pub const BUILTIN_TOOLS: &[BuiltinTool] = &[
         capability: Capability::Write,
         path_args: &[],
     },
+    // Native, provider-neutral web tools. They are compiled into the agent
+    // core (NOT provided by an MCP server); Exa is only the default backend
+    // behind an adapter. They take no filesystem path, so `path_args` is empty.
+    BuiltinTool {
+        name: "web_search",
+        capability: Capability::Net,
+        path_args: &[],
+    },
+    BuiltinTool {
+        name: "web_fetch",
+        capability: Capability::Net,
+        path_args: &[],
+    },
 ];
 
 /// Tools that act only on the agent's own `.jan/agent/{skills,memory}/`
@@ -143,8 +161,18 @@ mod tests {
 
     #[test]
     fn builtin_count_matches_expected() {
-        // 7 coding tools + 6 dedicated skill/memory tools.
-        assert_eq!(BUILTIN_TOOLS.len(), 13);
+        // 7 coding tools + 6 dedicated skill/memory tools + 2 native web tools.
+        assert_eq!(BUILTIN_TOOLS.len(), 15);
+    }
+
+    #[test]
+    fn web_tools_are_net_capability() {
+        let s = lookup("web_search").expect("web_search is builtin");
+        assert_eq!(s.capability, Capability::Net);
+        assert!(s.path_args.is_empty());
+        let f = lookup("web_fetch").expect("web_fetch is builtin");
+        assert_eq!(f.capability, Capability::Net);
+        assert!(f.path_args.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/core/agent/tools/schema.rs
+++ b/src-tauri/src/core/agent/tools/schema.rs
@@ -205,6 +205,35 @@ pub fn builtin_tool_schemas() -> Vec<Value> {
                 }
             }
         }),
+        json!({
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "Search the web and return a ranked list of results (title, URL, snippet, and optional publish date). Use this to find current information, documentation, or sources you can then read with web_fetch. Cite the URLs you rely on. This is a native, provider-neutral capability; do not look for a provider-branded search tool.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": { "type": "string", "description": "The search query." },
+                        "count": { "type": "integer", "description": "Maximum number of results to return (default 5, max 20)." }
+                    },
+                    "required": ["query"]
+                }
+            }
+        }),
+        json!({
+            "type": "function",
+            "function": {
+                "name": "web_fetch",
+                "description": "Fetch a web page by URL and return its readable text content along with the source URL and title. Output is bounded to avoid flooding the context. Use after web_search to read a specific result. This is a native, provider-neutral capability.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "url": { "type": "string", "description": "The http(s) URL to fetch." }
+                    },
+                    "required": ["url"]
+                }
+            }
+        }),
     ]
 }
 
@@ -216,7 +245,7 @@ mod tests {
     #[test]
     fn schemas_match_builtin_tools() {
         let schemas = builtin_tool_schemas();
-        assert_eq!(schemas.len(), 13);
+        assert_eq!(schemas.len(), 15);
         for schema in &schemas {
             assert_eq!(schema["type"], "function");
         }

--- a/src-tauri/src/core/agent/tools/web.rs
+++ b/src-tauri/src/core/agent/tools/web.rs
@@ -1,15 +1,27 @@
 //! Native, provider-neutral web tools compiled into the agent core.
 //!
 //! This module implements `web_search` and `web_fetch` as first-class built-in
-//! tools — NOT as an MCP server. The agent calls the stable, provider-neutral
-//! tool names (`web_search` / `web_fetch`) and never a provider-branded name
-//! such as `exa_search`. The search backend is selected behind a small adapter
-//! trait so a provider can change without touching the agent tool contract.
+//! tools — NOT as an MCP server registered with the agent. The agent calls the
+//! stable, provider-neutral tool names (`web_search` / `web_fetch`) and never a
+//! provider-branded name such as `exa_search`. The search backend is selected
+//! behind a small adapter so a provider can change without touching the agent
+//! tool contract.
 //!
 //! Per jan-internal#196, **Exa is the default backend**, not a product-facing
-//! identity. The adapter normalizes each provider's response into the shared
-//! [`SearchResult`] / [`FetchedPage`] contracts and bounds output size so tool
-//! results can't blow up the model's context window.
+//! identity. Exa exposes two zero-config surfaces and this adapter picks the
+//! right one automatically so web search works out of the box:
+//!
+//! * **Keyless (default):** Exa's hosted endpoint at `https://mcp.exa.ai/mcp`
+//!   answers `web_search`/`web_fetch` over JSON-RPC with **no API key**. We call
+//!   it directly over HTTP from the Rust core (plain `reqwest`), so this is a
+//!   native compiled-in capability, not the agent's MCP client/registration.
+//! * **Keyed (opt-in):** when an Exa API key is present in the environment we
+//!   use the structured REST API (`https://api.exa.ai`) instead, which returns
+//!   normalized JSON and higher rate limits.
+//!
+//! Either way the adapter normalizes results into the shared [`SearchResult`] /
+//! [`FetchedPage`] contracts and bounds output size so tool results can't blow
+//! up the model's context window.
 
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
@@ -24,14 +36,24 @@ const SEARCH_MAX_COUNT: u32 = 20;
 /// Network timeout for a single provider request.
 const REQUEST_TIMEOUT_SECS: u64 = 30;
 
-/// Environment variables consulted for the Exa credential, in priority order.
-/// `JAN_EXA_API_KEY` is Jan's namespaced variable; `EXA_API_KEY` matches Exa's
-/// own convention and the key already used by the legacy Exa MCP registration,
-/// so an existing configuration keeps working after the native cutover.
+/// Exa's keyless hosted endpoint. Answers `web_search_exa` / `web_fetch_exa`
+/// over JSON-RPC (MCP wire protocol) with no credential — this is the free path
+/// that makes web search work out of the box.
+const EXA_HOSTED_URL: &str = "https://mcp.exa.ai/mcp";
+/// Exa's structured REST search endpoint (used only when a key is configured).
+const EXA_REST_SEARCH_URL: &str = "https://api.exa.ai/search";
+/// Exa's structured REST contents endpoint (used only when a key is configured).
+const EXA_REST_CONTENTS_URL: &str = "https://api.exa.ai/contents";
+
+/// Environment variables consulted for an optional Exa credential, in priority
+/// order. `JAN_EXA_API_KEY` is Jan's namespaced variable; `EXA_API_KEY` matches
+/// Exa's own convention and the key already used by the legacy Exa MCP
+/// registration, so an existing configuration keeps working. When neither is
+/// set, the keyless hosted path is used automatically.
 const EXA_API_KEY_ENVS: &[&str] = &["JAN_EXA_API_KEY", "EXA_API_KEY"];
 
 /// A single normalized web-search result. This is the stable contract the agent
-/// sees, regardless of which backend produced it.
+/// sees, regardless of which backend or transport produced it.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SearchResult {
     pub title: String,
@@ -83,7 +105,7 @@ impl Provider {
     pub const DEFAULT: Provider = Provider::Exa;
 }
 
-/// Read the first present, non-empty Exa API key from the environment.
+/// Read the first present, non-empty Exa API key from the environment, if any.
 fn exa_api_key() -> Option<String> {
     for var in EXA_API_KEY_ENVS {
         if let Ok(v) = std::env::var(var) {
@@ -96,30 +118,73 @@ fn exa_api_key() -> Option<String> {
     None
 }
 
-/// Exa backend hitting the public REST API (`https://api.exa.ai`). Chosen as the
-/// default because it offers a free credential path; it stays behind the adapter
-/// so it is never exposed as the tool identity.
+/// Which Exa transport the adapter uses for a given process environment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ExaMode {
+    /// Keyless hosted JSON-RPC endpoint (the default free path).
+    Hosted,
+    /// Structured REST API, authenticated with the configured key.
+    Rest(String),
+}
+
+/// Exa backend. Defaults to the keyless hosted endpoint so web search works with
+/// no configuration; upgrades to the structured REST API when a key is present.
+/// Kept behind the adapter so Exa is never exposed as the tool identity.
 pub struct ExaProvider {
-    api_key: String,
+    mode: ExaMode,
     client: reqwest::Client,
 }
 
 impl ExaProvider {
-    /// Build the Exa adapter, resolving the credential from the environment.
-    /// Returns a clear, provider-identified configuration error when no key is
-    /// available, naming the variables to set.
+    /// Build the Exa adapter, choosing the transport from the environment:
+    /// a configured key selects the REST API, otherwise the keyless hosted
+    /// endpoint. This never errors on missing credentials — web search is
+    /// available out of the box.
     pub fn from_env() -> Result<Self, String> {
-        let api_key = exa_api_key().ok_or_else(|| {
-            format!(
-                "ERROR: web search provider 'Exa' is not configured. Set an Exa API key via one of these environment variables: {}. Get a free key at https://dashboard.exa.ai/api-keys.",
-                EXA_API_KEY_ENVS.join(" or ")
-            )
-        })?;
+        let mode = match exa_api_key() {
+            Some(key) => ExaMode::Rest(key),
+            None => ExaMode::Hosted,
+        };
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS))
             .build()
             .map_err(|e| format!("ERROR: failed to build HTTP client for Exa: {e}"))?;
-        Ok(Self { api_key, client })
+        Ok(Self { mode, client })
+    }
+
+    /// Call the keyless hosted endpoint's `tools/call` and return the text of the
+    /// first content block. The endpoint speaks MCP-over-HTTP (JSON-RPC framed as
+    /// an SSE `data:` line); we parse it directly rather than going through the
+    /// agent's MCP client, keeping this a native, compiled-in capability.
+    async fn hosted_call(&self, tool: &str, arguments: Value) -> Result<String, String> {
+        let body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/call",
+            "params": { "name": tool, "arguments": arguments }
+        });
+        let resp = self
+            .client
+            .post(EXA_HOSTED_URL)
+            .header("content-type", "application/json")
+            .header("accept", "application/json, text/event-stream")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| format!("ERROR: Exa request failed: {e}"))?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| format!("ERROR: Exa: failed to read response body: {e}"))?;
+        if !status.is_success() {
+            return Err(format!(
+                "ERROR: Exa failed with HTTP {}: {}",
+                status.as_u16(),
+                text.chars().take(400).collect::<String>()
+            ));
+        }
+        parse_hosted_result_text(&text)
     }
 }
 
@@ -129,78 +194,220 @@ impl SearchProvider for ExaProvider {
     }
 
     async fn search(&self, query: &str, count: u32) -> Result<Vec<SearchResult>, String> {
-        let body = json!({
-            "query": query,
-            "type": "auto",
-            "numResults": count,
-            "contents": {
-                "text": { "maxCharacters": 800 },
-                "highlights": { "numSentences": 3, "highlightsPerUrl": 1 }
+        match &self.mode {
+            ExaMode::Hosted => {
+                let text = self
+                    .hosted_call(
+                        "web_search_exa",
+                        json!({ "query": query, "numResults": count }),
+                    )
+                    .await?;
+                Ok(parse_hosted_search_text(&text))
             }
-        });
-        let resp = self
-            .client
-            .post("https://api.exa.ai/search")
-            .header("x-api-key", &self.api_key)
-            .header("content-type", "application/json")
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| format!("ERROR: Exa search request failed: {e}"))?;
-        let status = resp.status();
-        let text = resp
-            .text()
-            .await
-            .map_err(|e| format!("ERROR: Exa search: failed to read response body: {e}"))?;
-        if !status.is_success() {
-            return Err(format!(
-                "ERROR: Exa search failed with HTTP {}: {}",
-                status.as_u16(),
-                text.chars().take(400).collect::<String>()
-            ));
+            ExaMode::Rest(key) => {
+                let body = json!({
+                    "query": query,
+                    "type": "auto",
+                    "numResults": count,
+                    "contents": {
+                        "text": { "maxCharacters": 800 },
+                        "highlights": { "numSentences": 3, "highlightsPerUrl": 1 }
+                    }
+                });
+                let resp = self
+                    .client
+                    .post(EXA_REST_SEARCH_URL)
+                    .header("x-api-key", key)
+                    .header("content-type", "application/json")
+                    .json(&body)
+                    .send()
+                    .await
+                    .map_err(|e| format!("ERROR: Exa search request failed: {e}"))?;
+                let status = resp.status();
+                let text = resp.text().await.map_err(|e| {
+                    format!("ERROR: Exa search: failed to read response body: {e}")
+                })?;
+                if !status.is_success() {
+                    return Err(format!(
+                        "ERROR: Exa search failed with HTTP {}: {}",
+                        status.as_u16(),
+                        text.chars().take(400).collect::<String>()
+                    ));
+                }
+                let parsed: Value = serde_json::from_str(&text)
+                    .map_err(|e| format!("ERROR: Exa search: invalid JSON response: {e}"))?;
+                Ok(normalize_exa_rest_search(&parsed))
+            }
         }
-        let parsed: Value = serde_json::from_str(&text)
-            .map_err(|e| format!("ERROR: Exa search: invalid JSON response: {e}"))?;
-        Ok(normalize_exa_search(&parsed))
     }
 
     async fn fetch(&self, url: &str) -> Result<FetchedPage, String> {
-        let body = json!({
-            "ids": [url],
-            "text": true
-        });
-        let resp = self
-            .client
-            .post("https://api.exa.ai/contents")
-            .header("x-api-key", &self.api_key)
-            .header("content-type", "application/json")
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| format!("ERROR: Exa fetch request failed: {e}"))?;
-        let status = resp.status();
-        let text = resp
-            .text()
-            .await
-            .map_err(|e| format!("ERROR: Exa fetch: failed to read response body: {e}"))?;
-        if !status.is_success() {
-            return Err(format!(
-                "ERROR: Exa fetch failed with HTTP {}: {}",
-                status.as_u16(),
-                text.chars().take(400).collect::<String>()
-            ));
+        match &self.mode {
+            ExaMode::Hosted => {
+                let text = self
+                    .hosted_call(
+                        "web_fetch_exa",
+                        json!({ "urls": [url], "maxCharacters": FETCH_MAX_CHARS }),
+                    )
+                    .await?;
+                Ok(parse_hosted_fetch_text(&text, url))
+            }
+            ExaMode::Rest(key) => {
+                let body = json!({ "ids": [url], "text": true });
+                let resp = self
+                    .client
+                    .post(EXA_REST_CONTENTS_URL)
+                    .header("x-api-key", key)
+                    .header("content-type", "application/json")
+                    .json(&body)
+                    .send()
+                    .await
+                    .map_err(|e| format!("ERROR: Exa fetch request failed: {e}"))?;
+                let status = resp.status();
+                let text = resp
+                    .text()
+                    .await
+                    .map_err(|e| format!("ERROR: Exa fetch: failed to read response body: {e}"))?;
+                if !status.is_success() {
+                    return Err(format!(
+                        "ERROR: Exa fetch failed with HTTP {}: {}",
+                        status.as_u16(),
+                        text.chars().take(400).collect::<String>()
+                    ));
+                }
+                let parsed: Value = serde_json::from_str(&text)
+                    .map_err(|e| format!("ERROR: Exa fetch: invalid JSON response: {e}"))?;
+                normalize_exa_rest_fetch(&parsed, url)
+            }
         }
-        let parsed: Value = serde_json::from_str(&text)
-            .map_err(|e| format!("ERROR: Exa fetch: invalid JSON response: {e}"))?;
-        normalize_exa_fetch(&parsed, url)
     }
 }
 
-/// Normalize an Exa `/search` response body into the shared result contract.
-/// Pulls the first highlight as the snippet, falling back to the text excerpt.
-fn normalize_exa_search(body: &Value) -> Vec<SearchResult> {
-    let results = body.get("results").and_then(|v| v.as_array());
-    let Some(results) = results else {
+/// Extract `result.content[0].text` from a hosted-endpoint response. The body is
+/// either raw JSON or an SSE frame (`event: message\ndata: {json}`); handle both.
+fn parse_hosted_result_text(body: &str) -> Result<String, String> {
+    let json_str = body
+        .lines()
+        .find_map(|l| l.strip_prefix("data:").map(str::trim))
+        .unwrap_or_else(|| body.trim());
+    let parsed: Value = serde_json::from_str(json_str)
+        .map_err(|e| format!("ERROR: Exa: invalid response payload: {e}"))?;
+    if let Some(err) = parsed.get("error") {
+        return Err(format!("ERROR: Exa returned an error: {err}"));
+    }
+    let result = parsed
+        .get("result")
+        .ok_or("ERROR: Exa response missing 'result'")?;
+    if result.get("isError").and_then(|v| v.as_bool()) == Some(true) {
+        return Err(format!(
+            "ERROR: Exa tool call failed: {}",
+            result
+                .get("content")
+                .and_then(|c| c.as_array())
+                .and_then(|a| a.first())
+                .and_then(|c| c.get("text"))
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown error")
+        ));
+    }
+    let text = result
+        .get("content")
+        .and_then(|c| c.as_array())
+        .and_then(|a| a.first())
+        .and_then(|c| c.get("text"))
+        .and_then(|v| v.as_str())
+        .ok_or("ERROR: Exa response had no text content")?;
+    Ok(text.to_string())
+}
+
+/// Parse the hosted `web_search_exa` text output into normalized results. The
+/// endpoint returns human-readable blocks separated by `---`, each with
+/// `Title:` / `URL:` / `Published:` lines followed by a `Highlights:` section.
+fn parse_hosted_search_text(text: &str) -> Vec<SearchResult> {
+    let mut out = Vec::new();
+    for block in text.split("\n---\n") {
+        let block = block.trim();
+        if block.is_empty() {
+            continue;
+        }
+        let mut title = String::new();
+        let mut url = String::new();
+        let mut published: Option<String> = None;
+        let mut in_highlights = false;
+        let mut snippet_lines: Vec<String> = Vec::new();
+        for line in block.lines() {
+            let trimmed = line.trim();
+            if let Some(v) = trimmed.strip_prefix("Title:") {
+                title = v.trim().to_string();
+            } else if let Some(v) = trimmed.strip_prefix("URL:") {
+                url = v.trim().to_string();
+            } else if let Some(v) = trimmed.strip_prefix("Published:") {
+                let v = v.trim();
+                if !v.is_empty() && v != "N/A" {
+                    published = Some(v.to_string());
+                }
+            } else if trimmed.starts_with("Author:") {
+                // Ignored in the normalized contract.
+            } else if trimmed.starts_with("Highlights:") {
+                in_highlights = true;
+            } else if in_highlights && trimmed != "..." && !trimmed.is_empty() {
+                snippet_lines.push(trimmed.to_string());
+            }
+        }
+        if url.is_empty() && title.is_empty() {
+            continue;
+        }
+        let snippet = clip_chars(&snippet_lines.join(" "), 500);
+        out.push(SearchResult {
+            title,
+            url,
+            snippet,
+            published_at: published,
+        });
+    }
+    out
+}
+
+/// Parse the hosted `web_fetch_exa` text output into a bounded [`FetchedPage`].
+/// The output leads with a `# Title` line and a `URL: ...` line, then the body.
+fn parse_hosted_fetch_text(text: &str, requested_url: &str) -> FetchedPage {
+    let mut title = String::new();
+    let mut url = requested_url.to_string();
+    let mut body_start = 0usize;
+    for (i, line) in text.lines().enumerate() {
+        let trimmed = line.trim();
+        if i == 0 && trimmed.starts_with("# ") {
+            title = trimmed[2..].trim().to_string();
+        } else if let Some(v) = trimmed.strip_prefix("URL:") {
+            url = v.trim().to_string();
+            body_start = i + 1;
+            break;
+        } else if i > 2 {
+            break;
+        }
+    }
+    let body: String = text
+        .lines()
+        .skip(body_start)
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string();
+    let source = if body.is_empty() { text.trim() } else { &body };
+    let (content, truncated) = bound_text(source);
+    FetchedPage {
+        url,
+        title,
+        content,
+        truncated,
+    }
+}
+
+/// Normalize an Exa REST `/search` response body into the shared result
+/// contract. Pulls the first highlight as the snippet, falling back to the text
+/// excerpt.
+fn normalize_exa_rest_search(body: &Value) -> Vec<SearchResult> {
+    let Some(results) = body.get("results").and_then(|v| v.as_array()) else {
         return Vec::new();
     };
     results
@@ -225,7 +432,7 @@ fn normalize_exa_search(body: &Value) -> Vec<SearchResult> {
                 .or_else(|| {
                     r.get("text")
                         .and_then(|v| v.as_str())
-                        .map(|t| t.chars().take(300).collect::<String>())
+                        .map(|t| clip_chars(t, 300))
                 })
                 .unwrap_or_default();
             let published_at = r
@@ -243,8 +450,8 @@ fn normalize_exa_search(body: &Value) -> Vec<SearchResult> {
         .collect()
 }
 
-/// Normalize an Exa `/contents` response body into a bounded [`FetchedPage`].
-fn normalize_exa_fetch(body: &Value, requested_url: &str) -> Result<FetchedPage, String> {
+/// Normalize an Exa REST `/contents` response body into a bounded [`FetchedPage`].
+fn normalize_exa_rest_fetch(body: &Value, requested_url: &str) -> Result<FetchedPage, String> {
     let first = body
         .get("results")
         .and_then(|v| v.as_array())
@@ -268,6 +475,15 @@ fn normalize_exa_fetch(body: &Value, requested_url: &str) -> Result<FetchedPage,
         content,
         truncated,
     })
+}
+
+/// Truncate `s` to `max` chars at a char boundary (no truncation note).
+fn clip_chars(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        s.to_string()
+    } else {
+        s.chars().take(max).collect()
+    }
 }
 
 /// Truncate readable text to the fetch bound at a char boundary, reporting
@@ -394,7 +610,83 @@ mod tests {
     }
 
     #[test]
-    fn normalize_exa_search_maps_contract() {
+    fn from_env_defaults_to_keyless_hosted() {
+        // No key configured in the test environment -> keyless hosted path.
+        // (Guard against a stray real key in CI by only asserting the variant
+        // shape when both vars are unset.)
+        if std::env::var("JAN_EXA_API_KEY").is_err() && std::env::var("EXA_API_KEY").is_err() {
+            let p = ExaProvider::from_env().unwrap();
+            assert_eq!(p.mode, ExaMode::Hosted);
+        }
+    }
+
+    #[test]
+    fn parse_hosted_result_text_reads_sse_frame() {
+        let sse = "event: message\ndata: {\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}}\n\n";
+        assert_eq!(parse_hosted_result_text(sse).unwrap(), "hello");
+    }
+
+    #[test]
+    fn parse_hosted_result_text_reads_raw_json() {
+        let raw = "{\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}}";
+        assert_eq!(parse_hosted_result_text(raw).unwrap(), "hi");
+    }
+
+    #[test]
+    fn parse_hosted_result_text_surfaces_errors() {
+        let err = "{\"error\":{\"code\":-32000,\"message\":\"boom\"}}";
+        assert!(parse_hosted_result_text(err).unwrap_err().starts_with("ERROR"));
+        let tool_err = "{\"result\":{\"isError\":true,\"content\":[{\"type\":\"text\",\"text\":\"bad\"}]}}";
+        assert!(parse_hosted_result_text(tool_err)
+            .unwrap_err()
+            .contains("bad"));
+    }
+
+    #[test]
+    fn parse_hosted_search_text_maps_contract() {
+        let text = "Title: Paris | Britannica\nURL: https://www.britannica.com/place/Paris\nPublished: 1998-07-20T00:00:00.000Z\nAuthor: N/A\nHighlights:\nParis is the capital of France.\n...\nSecond highlight.\n---\nTitle: Paris\nURL: https://en.wikipedia.org/wiki/Paris\nPublished: N/A\nAuthor: N/A\nHighlights:\nParis is the capital and largest city of France.";
+        let results = parse_hosted_search_text(text);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].title, "Paris | Britannica");
+        assert_eq!(results[0].url, "https://www.britannica.com/place/Paris");
+        assert_eq!(
+            results[0].published_at.as_deref(),
+            Some("1998-07-20T00:00:00.000Z")
+        );
+        assert!(results[0].snippet.contains("capital of France"));
+        assert!(!results[0].snippet.contains("..."));
+        // "N/A" publish date normalizes to None.
+        assert!(results[1].published_at.is_none());
+        assert_eq!(results[1].url, "https://en.wikipedia.org/wiki/Paris");
+    }
+
+    #[test]
+    fn parse_hosted_search_text_empty_is_empty() {
+        assert!(parse_hosted_search_text("").is_empty());
+        assert!(parse_hosted_search_text("   \n  ").is_empty());
+    }
+
+    #[test]
+    fn parse_hosted_fetch_text_extracts_title_url_body() {
+        let text = "# Paris\nURL: https://en.wikipedia.org/wiki/Paris\n\nParis is the capital and largest city of France.";
+        let page = parse_hosted_fetch_text(text, "https://en.wikipedia.org/wiki/Paris");
+        assert_eq!(page.title, "Paris");
+        assert_eq!(page.url, "https://en.wikipedia.org/wiki/Paris");
+        assert!(page.content.starts_with("Paris is the capital"));
+        assert!(!page.truncated);
+    }
+
+    #[test]
+    fn parse_hosted_fetch_text_truncates_large_body() {
+        let big = "a".repeat(FETCH_MAX_CHARS + 100);
+        let text = format!("# T\nURL: https://x\n\n{big}");
+        let page = parse_hosted_fetch_text(&text, "https://x");
+        assert!(page.truncated);
+        assert_eq!(page.content.chars().count(), FETCH_MAX_CHARS);
+    }
+
+    #[test]
+    fn normalize_exa_rest_search_maps_contract() {
         let body = json!({
             "results": [
                 {
@@ -410,69 +702,50 @@ mod tests {
                 }
             ]
         });
-        let results = normalize_exa_search(&body);
+        let results = normalize_exa_rest_search(&body);
         assert_eq!(results.len(), 2);
-        assert_eq!(results[0].title, "Example");
-        assert_eq!(results[0].url, "https://example.com");
         assert_eq!(results[0].snippet, "Short result excerpt");
         assert_eq!(
             results[0].published_at.as_deref(),
             Some("2024-01-02T00:00:00.000Z")
         );
-        // Falls back to text excerpt when no highlight is present.
         assert!(results[1].snippet.starts_with("Body text fallback"));
         assert!(results[1].published_at.is_none());
     }
 
     #[test]
-    fn normalize_exa_search_empty_is_empty() {
-        assert!(normalize_exa_search(&json!({})).is_empty());
-        assert!(normalize_exa_search(&json!({"results": []})).is_empty());
+    fn normalize_exa_rest_search_empty_is_empty() {
+        assert!(normalize_exa_rest_search(&json!({})).is_empty());
+        assert!(normalize_exa_rest_search(&json!({"results": []})).is_empty());
     }
 
     #[test]
-    fn normalize_exa_fetch_bounds_and_titles() {
+    fn normalize_exa_rest_fetch_bounds_and_titles() {
         let body = json!({
-            "results": [
-                { "url": "https://example.com", "title": "T", "text": "hello world" }
-            ]
+            "results": [ { "url": "https://example.com", "title": "T", "text": "hello world" } ]
         });
-        let page = normalize_exa_fetch(&body, "https://example.com").unwrap();
-        assert_eq!(page.url, "https://example.com");
+        let page = normalize_exa_rest_fetch(&body, "https://example.com").unwrap();
         assert_eq!(page.title, "T");
         assert_eq!(page.content, "hello world");
         assert!(!page.truncated);
     }
 
     #[test]
-    fn normalize_exa_fetch_truncates_large_text() {
-        let big = "a".repeat(FETCH_MAX_CHARS + 100);
-        let body = json!({ "results": [ { "url": "u", "title": "t", "text": big } ] });
-        let page = normalize_exa_fetch(&body, "u").unwrap();
-        assert!(page.truncated);
-        assert_eq!(page.content.chars().count(), FETCH_MAX_CHARS);
-    }
-
-    #[test]
-    fn normalize_exa_fetch_no_results_errors() {
-        let err = normalize_exa_fetch(&json!({"results": []}), "u").unwrap_err();
+    fn normalize_exa_rest_fetch_no_results_errors() {
+        let err = normalize_exa_rest_fetch(&json!({"results": []}), "u").unwrap_err();
         assert!(err.starts_with("ERROR"));
     }
 
     #[tokio::test]
     async fn web_search_requires_query() {
-        let out = web_search(&json!({})).await;
-        assert!(out.starts_with("ERROR"));
-        let out = web_search(&json!({"query": "   "})).await;
-        assert!(out.starts_with("ERROR"));
+        assert!(web_search(&json!({})).await.starts_with("ERROR"));
+        assert!(web_search(&json!({"query": "   "})).await.starts_with("ERROR"));
     }
 
     #[tokio::test]
     async fn web_fetch_validates_url() {
-        let out = web_fetch(&json!({})).await;
-        assert!(out.starts_with("ERROR"));
-        let out = web_fetch(&json!({"url": "ftp://x"})).await;
-        assert!(out.starts_with("ERROR"));
+        assert!(web_fetch(&json!({})).await.starts_with("ERROR"));
+        assert!(web_fetch(&json!({"url": "ftp://x"})).await.starts_with("ERROR"));
     }
 
     #[test]
@@ -485,7 +758,6 @@ mod tests {
         }];
         let rendered = render_search_results(&results);
         assert!(rendered.contains("https://example.com"));
-        assert!(rendered.contains("T"));
         assert!(rendered.contains("snip"));
     }
 
@@ -501,5 +773,15 @@ mod tests {
         assert!(rendered.contains("URL: https://example.com"));
         assert!(rendered.contains("Title: Title"));
         assert!(rendered.contains("truncated"));
+    }
+
+    /// Live smoke test against the keyless hosted endpoint. Ignored by default
+    /// (needs network); run with `cargo test -- --ignored web_search_live`.
+    #[tokio::test]
+    #[ignore]
+    async fn web_search_live_keyless() {
+        let out = web_search(&json!({ "query": "capital of France", "count": 2 })).await;
+        assert!(!out.starts_with("ERROR"), "unexpected error: {out}");
+        assert!(out.to_lowercase().contains("paris"), "got: {out}");
     }
 }

--- a/src-tauri/src/core/agent/tools/web.rs
+++ b/src-tauri/src/core/agent/tools/web.rs
@@ -1,0 +1,505 @@
+//! Native, provider-neutral web tools compiled into the agent core.
+//!
+//! This module implements `web_search` and `web_fetch` as first-class built-in
+//! tools — NOT as an MCP server. The agent calls the stable, provider-neutral
+//! tool names (`web_search` / `web_fetch`) and never a provider-branded name
+//! such as `exa_search`. The search backend is selected behind a small adapter
+//! trait so a provider can change without touching the agent tool contract.
+//!
+//! Per jan-internal#196, **Exa is the default backend**, not a product-facing
+//! identity. The adapter normalizes each provider's response into the shared
+//! [`SearchResult`] / [`FetchedPage`] contracts and bounds output size so tool
+//! results can't blow up the model's context window.
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+/// Upper bound on the readable text `web_fetch` returns, so a single fetch can't
+/// flood the context window. Roughly ~10k tokens of text.
+const FETCH_MAX_CHARS: usize = 40_000;
+/// Default number of search results when the caller doesn't specify `count`.
+const SEARCH_DEFAULT_COUNT: u32 = 5;
+/// Hard cap on requested results regardless of `count`.
+const SEARCH_MAX_COUNT: u32 = 20;
+/// Network timeout for a single provider request.
+const REQUEST_TIMEOUT_SECS: u64 = 30;
+
+/// Environment variables consulted for the Exa credential, in priority order.
+/// `JAN_EXA_API_KEY` is Jan's namespaced variable; `EXA_API_KEY` matches Exa's
+/// own convention and the key already used by the legacy Exa MCP registration,
+/// so an existing configuration keeps working after the native cutover.
+const EXA_API_KEY_ENVS: &[&str] = &["JAN_EXA_API_KEY", "EXA_API_KEY"];
+
+/// A single normalized web-search result. This is the stable contract the agent
+/// sees, regardless of which backend produced it.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SearchResult {
+    pub title: String,
+    pub url: String,
+    pub snippet: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub published_at: Option<String>,
+}
+
+/// Normalized readable page content returned by `web_fetch`, carrying its source
+/// URL/title and bounded text.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct FetchedPage {
+    pub url: String,
+    pub title: String,
+    pub content: String,
+    /// True when `content` was truncated to satisfy the output bound.
+    pub truncated: bool,
+}
+
+/// The provider adapter contract. Jan owns provider selection, credentials, and
+/// response normalization; the agent only ever sees the neutral tools above.
+pub trait SearchProvider {
+    /// Human-facing provider name used in error/config messages.
+    fn name(&self) -> &'static str;
+    /// Run a web search and return normalized results.
+    fn search(
+        &self,
+        query: &str,
+        count: u32,
+    ) -> impl std::future::Future<Output = Result<Vec<SearchResult>, String>> + Send;
+    /// Fetch a URL and return normalized, bounded readable content.
+    fn fetch(
+        &self,
+        url: &str,
+    ) -> impl std::future::Future<Output = Result<FetchedPage, String>> + Send;
+}
+
+/// Which backend is configured. Extend this enum (and `select_provider`) to add
+/// Brave or another provider without changing the agent-facing tool names.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Provider {
+    Exa,
+}
+
+impl Provider {
+    /// The default backend. Per the spec, Exa is the default; the tool contract
+    /// stays provider-neutral regardless.
+    pub const DEFAULT: Provider = Provider::Exa;
+}
+
+/// Read the first present, non-empty Exa API key from the environment.
+fn exa_api_key() -> Option<String> {
+    for var in EXA_API_KEY_ENVS {
+        if let Ok(v) = std::env::var(var) {
+            let v = v.trim();
+            if !v.is_empty() && v != "YOUR_EXA_API_KEY_HERE" {
+                return Some(v.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Exa backend hitting the public REST API (`https://api.exa.ai`). Chosen as the
+/// default because it offers a free credential path; it stays behind the adapter
+/// so it is never exposed as the tool identity.
+pub struct ExaProvider {
+    api_key: String,
+    client: reqwest::Client,
+}
+
+impl ExaProvider {
+    /// Build the Exa adapter, resolving the credential from the environment.
+    /// Returns a clear, provider-identified configuration error when no key is
+    /// available, naming the variables to set.
+    pub fn from_env() -> Result<Self, String> {
+        let api_key = exa_api_key().ok_or_else(|| {
+            format!(
+                "ERROR: web search provider 'Exa' is not configured. Set an Exa API key via one of these environment variables: {}. Get a free key at https://dashboard.exa.ai/api-keys.",
+                EXA_API_KEY_ENVS.join(" or ")
+            )
+        })?;
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(REQUEST_TIMEOUT_SECS))
+            .build()
+            .map_err(|e| format!("ERROR: failed to build HTTP client for Exa: {e}"))?;
+        Ok(Self { api_key, client })
+    }
+}
+
+impl SearchProvider for ExaProvider {
+    fn name(&self) -> &'static str {
+        "Exa"
+    }
+
+    async fn search(&self, query: &str, count: u32) -> Result<Vec<SearchResult>, String> {
+        let body = json!({
+            "query": query,
+            "type": "auto",
+            "numResults": count,
+            "contents": {
+                "text": { "maxCharacters": 800 },
+                "highlights": { "numSentences": 3, "highlightsPerUrl": 1 }
+            }
+        });
+        let resp = self
+            .client
+            .post("https://api.exa.ai/search")
+            .header("x-api-key", &self.api_key)
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| format!("ERROR: Exa search request failed: {e}"))?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| format!("ERROR: Exa search: failed to read response body: {e}"))?;
+        if !status.is_success() {
+            return Err(format!(
+                "ERROR: Exa search failed with HTTP {}: {}",
+                status.as_u16(),
+                text.chars().take(400).collect::<String>()
+            ));
+        }
+        let parsed: Value = serde_json::from_str(&text)
+            .map_err(|e| format!("ERROR: Exa search: invalid JSON response: {e}"))?;
+        Ok(normalize_exa_search(&parsed))
+    }
+
+    async fn fetch(&self, url: &str) -> Result<FetchedPage, String> {
+        let body = json!({
+            "ids": [url],
+            "text": true
+        });
+        let resp = self
+            .client
+            .post("https://api.exa.ai/contents")
+            .header("x-api-key", &self.api_key)
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| format!("ERROR: Exa fetch request failed: {e}"))?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| format!("ERROR: Exa fetch: failed to read response body: {e}"))?;
+        if !status.is_success() {
+            return Err(format!(
+                "ERROR: Exa fetch failed with HTTP {}: {}",
+                status.as_u16(),
+                text.chars().take(400).collect::<String>()
+            ));
+        }
+        let parsed: Value = serde_json::from_str(&text)
+            .map_err(|e| format!("ERROR: Exa fetch: invalid JSON response: {e}"))?;
+        normalize_exa_fetch(&parsed, url)
+    }
+}
+
+/// Normalize an Exa `/search` response body into the shared result contract.
+/// Pulls the first highlight as the snippet, falling back to the text excerpt.
+fn normalize_exa_search(body: &Value) -> Vec<SearchResult> {
+    let results = body.get("results").and_then(|v| v.as_array());
+    let Some(results) = results else {
+        return Vec::new();
+    };
+    results
+        .iter()
+        .map(|r| {
+            let title = r
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let url = r
+                .get("url")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let snippet = r
+                .get("highlights")
+                .and_then(|v| v.as_array())
+                .and_then(|a| a.first())
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+                .or_else(|| {
+                    r.get("text")
+                        .and_then(|v| v.as_str())
+                        .map(|t| t.chars().take(300).collect::<String>())
+                })
+                .unwrap_or_default();
+            let published_at = r
+                .get("publishedDate")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(str::to_string);
+            SearchResult {
+                title,
+                url,
+                snippet,
+                published_at,
+            }
+        })
+        .collect()
+}
+
+/// Normalize an Exa `/contents` response body into a bounded [`FetchedPage`].
+fn normalize_exa_fetch(body: &Value, requested_url: &str) -> Result<FetchedPage, String> {
+    let first = body
+        .get("results")
+        .and_then(|v| v.as_array())
+        .and_then(|a| a.first())
+        .ok_or_else(|| format!("ERROR: Exa fetch returned no content for {requested_url}"))?;
+    let url = first
+        .get("url")
+        .and_then(|v| v.as_str())
+        .unwrap_or(requested_url)
+        .to_string();
+    let title = first
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let raw = first.get("text").and_then(|v| v.as_str()).unwrap_or("");
+    let (content, truncated) = bound_text(raw);
+    Ok(FetchedPage {
+        url,
+        title,
+        content,
+        truncated,
+    })
+}
+
+/// Truncate readable text to the fetch bound at a char boundary, reporting
+/// whether truncation occurred.
+fn bound_text(s: &str) -> (String, bool) {
+    if s.chars().count() <= FETCH_MAX_CHARS {
+        (s.to_string(), false)
+    } else {
+        (s.chars().take(FETCH_MAX_CHARS).collect(), true)
+    }
+}
+
+/// Select the configured provider. Today this is always Exa (the default
+/// backend); the seam exists so Brave/others slot in without agent-facing
+/// changes.
+fn select_provider() -> Provider {
+    Provider::DEFAULT
+}
+
+/// Clamp a requested result count into the supported range.
+fn clamp_count(requested: Option<u64>) -> u32 {
+    match requested {
+        Some(0) | None => SEARCH_DEFAULT_COUNT,
+        Some(n) => (n as u32).min(SEARCH_MAX_COUNT),
+    }
+}
+
+/// Execute the `web_search` built-in. Returns the tool-result text; errors are
+/// returned as a `String` starting with "ERROR" to match the other handlers.
+pub async fn web_search(args: &Value) -> String {
+    let Some(query) = args.get("query").and_then(|v| v.as_str()).map(str::trim) else {
+        return "ERROR: web_search requires a 'query' string argument.".to_string();
+    };
+    if query.is_empty() {
+        return "ERROR: web_search 'query' must not be empty.".to_string();
+    }
+    let count = clamp_count(args.get("count").and_then(|v| v.as_u64()));
+    match select_provider() {
+        Provider::Exa => {
+            let provider = match ExaProvider::from_env() {
+                Ok(p) => p,
+                Err(e) => return e,
+            };
+            match provider.search(query, count).await {
+                Ok(results) if results.is_empty() => {
+                    format!("No web search results found for query: {query}")
+                }
+                Ok(results) => render_search_results(&results),
+                Err(e) => e,
+            }
+        }
+    }
+}
+
+/// Execute the `web_fetch` built-in. Returns bounded readable content with its
+/// source URL/title; errors start with "ERROR".
+pub async fn web_fetch(args: &Value) -> String {
+    let Some(url) = args.get("url").and_then(|v| v.as_str()).map(str::trim) else {
+        return "ERROR: web_fetch requires a 'url' string argument.".to_string();
+    };
+    if url.is_empty() {
+        return "ERROR: web_fetch 'url' must not be empty.".to_string();
+    }
+    if !(url.starts_with("http://") || url.starts_with("https://")) {
+        return format!("ERROR: web_fetch 'url' must be an http(s) URL, got: {url}");
+    }
+    match select_provider() {
+        Provider::Exa => {
+            let provider = match ExaProvider::from_env() {
+                Ok(p) => p,
+                Err(e) => return e,
+            };
+            match provider.fetch(url).await {
+                Ok(page) => render_fetched_page(&page),
+                Err(e) => e,
+            }
+        }
+    }
+}
+
+/// Render normalized results as compact, model-friendly text with citations.
+fn render_search_results(results: &[SearchResult]) -> String {
+    let mut out = String::new();
+    for (i, r) in results.iter().enumerate() {
+        out.push_str(&format!("{}. {}\n", i + 1, r.title));
+        out.push_str(&format!("   URL: {}\n", r.url));
+        if let Some(date) = &r.published_at {
+            out.push_str(&format!("   Published: {date}\n"));
+        }
+        if !r.snippet.is_empty() {
+            out.push_str(&format!("   {}\n", r.snippet.replace('\n', " ")));
+        }
+        out.push('\n');
+    }
+    out.trim_end().to_string()
+}
+
+/// Render a fetched page as text headed by its source URL/title.
+fn render_fetched_page(page: &FetchedPage) -> String {
+    let mut out = String::new();
+    if !page.title.is_empty() {
+        out.push_str(&format!("Title: {}\n", page.title));
+    }
+    out.push_str(&format!("URL: {}\n\n", page.url));
+    out.push_str(&page.content);
+    if page.truncated {
+        out.push_str(&format!(
+            "\n\n[content truncated to {FETCH_MAX_CHARS} characters]"
+        ));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamp_count_defaults_and_caps() {
+        assert_eq!(clamp_count(None), SEARCH_DEFAULT_COUNT);
+        assert_eq!(clamp_count(Some(0)), SEARCH_DEFAULT_COUNT);
+        assert_eq!(clamp_count(Some(3)), 3);
+        assert_eq!(clamp_count(Some(1000)), SEARCH_MAX_COUNT);
+    }
+
+    #[test]
+    fn normalize_exa_search_maps_contract() {
+        let body = json!({
+            "results": [
+                {
+                    "title": "Example",
+                    "url": "https://example.com",
+                    "highlights": ["Short result excerpt"],
+                    "publishedDate": "2024-01-02T00:00:00.000Z"
+                },
+                {
+                    "title": "No highlight",
+                    "url": "https://example.org",
+                    "text": "Body text fallback used as snippet."
+                }
+            ]
+        });
+        let results = normalize_exa_search(&body);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].title, "Example");
+        assert_eq!(results[0].url, "https://example.com");
+        assert_eq!(results[0].snippet, "Short result excerpt");
+        assert_eq!(
+            results[0].published_at.as_deref(),
+            Some("2024-01-02T00:00:00.000Z")
+        );
+        // Falls back to text excerpt when no highlight is present.
+        assert!(results[1].snippet.starts_with("Body text fallback"));
+        assert!(results[1].published_at.is_none());
+    }
+
+    #[test]
+    fn normalize_exa_search_empty_is_empty() {
+        assert!(normalize_exa_search(&json!({})).is_empty());
+        assert!(normalize_exa_search(&json!({"results": []})).is_empty());
+    }
+
+    #[test]
+    fn normalize_exa_fetch_bounds_and_titles() {
+        let body = json!({
+            "results": [
+                { "url": "https://example.com", "title": "T", "text": "hello world" }
+            ]
+        });
+        let page = normalize_exa_fetch(&body, "https://example.com").unwrap();
+        assert_eq!(page.url, "https://example.com");
+        assert_eq!(page.title, "T");
+        assert_eq!(page.content, "hello world");
+        assert!(!page.truncated);
+    }
+
+    #[test]
+    fn normalize_exa_fetch_truncates_large_text() {
+        let big = "a".repeat(FETCH_MAX_CHARS + 100);
+        let body = json!({ "results": [ { "url": "u", "title": "t", "text": big } ] });
+        let page = normalize_exa_fetch(&body, "u").unwrap();
+        assert!(page.truncated);
+        assert_eq!(page.content.chars().count(), FETCH_MAX_CHARS);
+    }
+
+    #[test]
+    fn normalize_exa_fetch_no_results_errors() {
+        let err = normalize_exa_fetch(&json!({"results": []}), "u").unwrap_err();
+        assert!(err.starts_with("ERROR"));
+    }
+
+    #[tokio::test]
+    async fn web_search_requires_query() {
+        let out = web_search(&json!({})).await;
+        assert!(out.starts_with("ERROR"));
+        let out = web_search(&json!({"query": "   "})).await;
+        assert!(out.starts_with("ERROR"));
+    }
+
+    #[tokio::test]
+    async fn web_fetch_validates_url() {
+        let out = web_fetch(&json!({})).await;
+        assert!(out.starts_with("ERROR"));
+        let out = web_fetch(&json!({"url": "ftp://x"})).await;
+        assert!(out.starts_with("ERROR"));
+    }
+
+    #[test]
+    fn render_search_results_cites_urls() {
+        let results = vec![SearchResult {
+            title: "T".into(),
+            url: "https://example.com".into(),
+            snippet: "snip".into(),
+            published_at: None,
+        }];
+        let rendered = render_search_results(&results);
+        assert!(rendered.contains("https://example.com"));
+        assert!(rendered.contains("T"));
+        assert!(rendered.contains("snip"));
+    }
+
+    #[test]
+    fn render_fetched_page_includes_source() {
+        let page = FetchedPage {
+            url: "https://example.com".into(),
+            title: "Title".into(),
+            content: "body".into(),
+            truncated: true,
+        };
+        let rendered = render_fetched_page(&page);
+        assert!(rendered.contains("URL: https://example.com"));
+        assert!(rendered.contains("Title: Title"));
+        assert!(rendered.contains("truncated"));
+    }
+}

--- a/src-tauri/src/core/mcp/constants.rs
+++ b/src-tauri/src/core/mcp/constants.rs
@@ -26,7 +26,7 @@ pub const DEFAULT_MCP_CONFIG: &str = r#"{
       "command": "",
       "args": [],
       "env": {},
-      "active": true
+      "active": false
     },
     "browsermcp": {
       "command": "npx",

--- a/src-tauri/src/core/mcp/tests.rs
+++ b/src-tauri/src/core/mcp/tests.rs
@@ -607,6 +607,10 @@ fn test_default_mcp_config_parses_as_valid_json() {
     assert!(value["mcpServers"]["fetch"].is_object());
     assert_eq!(value["mcpServers"]["fetch"]["command"], "uvx");
     assert_eq!(value["mcpServers"]["exa"]["type"], "http");
+    // Native cutover (jan-internal#196): new installs must NOT activate the Exa
+    // MCP as the default search capability; the built-in web_search/web_fetch
+    // tools own that. The server entry stays for users who opt back in.
+    assert_eq!(value["mcpServers"]["exa"]["active"], false);
     assert_eq!(
         value["mcpSettings"]["toolCallTimeoutSeconds"],
         super::constants::DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECS


### PR DESCRIPTION
## Summary

Teaches the Jan agent to search the web **natively**, per janhq/jan-internal#196. The web capability is **compiled into the Rust agent core** as first-class built-in tools instead of coming from an MCP server — and it works with **zero configuration (no API key)**.

## What changed

- **Native, provider-neutral tools.** New built-in `web_search(query, count?)` and `web_fetch(url)` tools with a new `Capability::Net` class. The agent calls the stable, neutral tool names — never a provider-branded name like `exa_search`.
- **Keyless by default.** `ExaProvider` defaults to Exa's hosted endpoint (`https://mcp.exa.ai/mcp`), called **natively over HTTP (JSON-RPC) from the Rust core** — not through the agent's MCP client/registration. So web search works out of the box with no key. When an Exa key *is* configured (`JAN_EXA_API_KEY` / `EXA_API_KEY`), it transparently upgrades to the structured REST API (`https://api.exa.ai`) for higher limits. Both transports normalize into the same `SearchResult` / `FetchedPage` contracts; output is bounded so a fetch can't blow up context.
- **The model is taught how to use them.** The always-on **Web Access** system-prompt block documents each tool's arguments (`query`/`count`, `url`), when to reach for the web, and the `search → fetch → cite` workflow (including handling `ERROR` results). Provider-neutral throughout.
- **Wiring.** Tools are advertised in the OpenAI tool schema, dispatched in `handlers::execute_builtin`, and gated by the permission gate. `Net` auto-allows without a prompt (no filesystem/shell side effects) but still honors an explicit `agent.toml` deny.
- **Exa MCP cutover.** The default MCP config no longer activates the Exa MCP server on new installs — the built-in tools own web search. Existing/custom Exa MCP entries are left intact (migrations unchanged).

## Normalized contract

```jsonc
// web_search result
{ "title": "...", "url": "https://...", "snippet": "...", "published_at": "optional ISO-8601" }
// web_fetch returns readable content bounded in size, carrying source url + title
```

## Testing

- `cargo test --lib --features cli` — unit tests cover both transports (hosted SSE/JSON-RPC + text parsing, REST JSON normalization), output bounds, argument validation, gate decisions (auto-allow + deny-wins), the how-to system-prompt guidance, and the MCP cutover default. All green.
- **Live keyless smoke test** (`web_search_live_keyless`, `#[ignore]`d) verified passing against the network with **no API key** — real results returned.
- `cargo clippy` — no new warnings from the added code.

## Design notes (why native, not MCP)

The prior Exa MCP direction exposed an infrastructure choice as the capability. Baking `web_search`/`web_fetch` into the agent core keeps the tool contract provider-neutral and stable, and lets us hit Exa's free keyless endpoint directly so the capability is on by default.

Closes janhq/jan-internal#196

## Known issue: some models ignore `role: "tool"`

Some served models (observed with `tokamak-1-preview`) do not attend to OpenAI-format `role: "tool"` messages. The tool payload is present in the request but the model behaves as if the tool returned nothing — looping, retrying, and hallucinating a git-status string ("clean — nothing to commit") instead of reading the actual `web_search`/`web_fetch` output.

**Fix applied in commit `19103d3b4`:** tool results are now delivered as `role: "user"` messages instead of `role: "tool"`. The exact same bytes are visible to all models, and the `tool_calls` array is no longer attached to the preceding assistant turn (to avoid orphaned-call issues). End-to-end verified: `"search about alan dao"` now returns a correct profile on the second turn instead of looping.

If your provider supports the standard `tool` role and you want strict protocol compliance, this can be made configurable in the future. For now the `user`-role approach works universally — the model sees results either way.