### PR TITLE
fix(chat): stop hiding the llama.cpp token counter during chat

### DIFF
--- a/extensions/assistant-extension/package.json
+++ b/extensions/assistant-extension/package.json
@@ -22,8 +22,7 @@
     "vitest": "3.2.4"
   },
   "dependencies": {
-    "@janhq/core": "workspace:*",
-    "ts-loader": "^9.5.0"
+    "@janhq/core": "workspace:*"
   },
   "files": [
     "dist/*",

--- a/extensions/conversational-extension/package.json
+++ b/extensions/conversational-extension/package.json
@@ -20,7 +20,6 @@
     "jsdom": "^26.1.0",
     "rimraf": "6.0.1",
     "rolldown": "1.0.0-beta.1",
-    "ts-loader": "^9.5.0",
     "typescript": "5.9.2",
     "vitest": "3.2.4"
   },

--- a/extensions/llamacpp-extension/package.json
+++ b/extensions/llamacpp-extension/package.json
@@ -17,12 +17,11 @@
     "test:coverage": "vitest run --coverage"
   },
   "devDependencies": {
-    "@vitest/ui": "2.1.9",
+    "@vitest/ui": "3.2.4",
     "cpx": "1.5.0",
     "jsdom": "26.1.0",
     "rimraf": "3.0.2",
     "rolldown": "1.0.0-beta.1",
-    "ts-loader": "^9.5.0",
     "typescript": "5.9.2",
     "vitest": "3.2.4"
   },

--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -83,6 +83,7 @@ import { ExtensionManager } from '@/lib/extension'
 import { useAttachments } from '@/hooks/useAttachments'
 import { toast } from 'sonner'
 import { isPlatformTauri } from '@/lib/platform/utils'
+import { shouldShowTokenCounter } from '@/lib/tokenCounterVisibility'
 import { useAttachmentIngestionPrompt } from '@/hooks/useAttachmentIngestionPrompt'
 import {
   NEW_THREAD_ATTACHMENT_KEY,
@@ -218,6 +219,14 @@ const ChatInput = memo(function ChatInput({
 
   // Reconcile video capability from /props once the model is loaded.
   useReconcileVideoCapability(selectedModel?.id, selectedProvider, isModelActive)
+
+  const tokenCounterVisible = shouldShowTokenCounter({
+    hasSelectedModel: !!selectedModel,
+    isAgentMode: effectiveAgentMode,
+    isInitialMessage: !!initialMessage,
+    hasMessages: (threadMessages?.length ?? 0) > 0,
+    hasPromptText: prompt.trim().length > 0,
+  })
   const [selectedAssistantId, setSelectedAssistantId] = useState<
     string | undefined
   >(loading ? undefined : currentAssistant?.id || '')
@@ -2540,18 +2549,11 @@ const ChatInput = memo(function ChatInput({
             </div>
 
             <div className="flex items-center gap-2">
-              {(selectedProvider === 'llamacpp' ? isModelActive : !!selectedModel) &&
-                tokenCounterCompact &&
-                !effectiveAgentMode &&
-                !initialMessage &&
-                (threadMessages?.length > 0 || prompt.trim().length > 0) && (
-                  <div className="flex-1 flex justify-center">
-                    <TokenCounter
-                      messages={threadMessages || []}
-                      compact={true}
-                    />
-                  </div>
-                )}
+              {tokenCounterVisible && tokenCounterCompact && (
+                <div className="flex-1 flex justify-center">
+                  <TokenCounter messages={threadMessages || []} compact={true} />
+                </div>
+              )}
 
               {isStreaming ? (
                 <Tooltip>
@@ -2612,15 +2614,11 @@ const ChatInput = memo(function ChatInput({
         </div>
       )}
 
-      {(selectedProvider === 'llamacpp' ? isModelActive : !!selectedModel) &&
-        !effectiveAgentMode &&
-        !tokenCounterCompact &&
-        !initialMessage &&
-        (threadMessages?.length > 0 || prompt.trim().length > 0) && (
-          <div className="flex-1 w-full flex justify-start px-2">
-            <TokenCounter messages={threadMessages || []} />
-          </div>
-        )}
+      {tokenCounterVisible && !tokenCounterCompact && (
+        <div className="flex-1 w-full flex justify-start px-2">
+          <TokenCounter messages={threadMessages || []} />
+        </div>
+      )}
 
       <JanBrowserExtensionDialog
         open={extensionDialogOpen}

--- a/web-app/src/containers/__tests__/ChatInput.test.tsx
+++ b/web-app/src/containers/__tests__/ChatInput.test.tsx
@@ -67,12 +67,13 @@ let selectedModelOverride: any = {
   capabilities: ['tools'],
   provider: 'llamacpp',
 }
+let selectedProviderOverride: any = 'llamacpp'
 const getProviderByNameMock = vi.fn()
 vi.mock('@/hooks/useModelProvider', () => ({
   useModelProvider: (selector: any) =>
     selector({
       selectedModel: selectedModelOverride,
-      selectedProvider: { provider: 'llamacpp' },
+      selectedProvider: selectedProviderOverride,
       providers: [],
       selectModelProvider: vi.fn(),
       updateProvider: vi.fn(),
@@ -197,6 +198,8 @@ vi.mock('@/lib/extension', () => ({
   ExtensionManager: {
     getInstance: () => ({
       get: () => undefined,
+      getByName: () => undefined,
+      listExtensions: () => [],
     }),
   },
 }))
@@ -269,6 +272,7 @@ vi.mock('@/components/ui/dropdown-menu', () => {
       </button>
     ),
     DropdownMenuTrigger: Pass,
+    DropdownMenuSeparator: () => null,
     DropdownMenuSub: Pass,
     DropdownMenuSubContent: Pass,
     DropdownMenuSubTrigger: Pass,
@@ -303,6 +307,7 @@ const resetAll = () => {
     capabilities: ['tools'],
     provider: 'llamacpp',
   }
+  selectedProviderOverride = { provider: 'llamacpp' }
   setPromptMock.mockClear()
   addToHistoryMock.mockClear()
   navigateHistoryMock.mockClear()
@@ -528,5 +533,39 @@ describe('ChatInput', () => {
     // dismiss icon (svg) sits alongside
     const svg = container.querySelector('.text-destructive svg')
     expect(svg).toBeTruthy()
+  })
+
+  describe('token counter visibility', () => {
+    // Regression: llama.cpp is a string provider ('llamacpp') and loads lazily,
+    // so it is never present in `activeModels` during a chat turn. The counter
+    // must still render off model selection + prompt/messages alone.
+    it('renders for llama.cpp even when activeModels is empty', () => {
+      selectedProviderOverride = { provider: 'llamacpp' }
+      appStateOverrides = { activeModels: [] }
+      promptState = 'hello'
+      renderInput()
+      expect(screen.getByTestId('stub-token-counter')).toBeInTheDocument()
+    })
+
+    it('renders for a remote provider (openai) with a selected model', () => {
+      selectedProviderOverride = 'openai'
+      appStateOverrides = { activeModels: [] }
+      promptState = 'hello'
+      renderInput()
+      expect(screen.getByTestId('stub-token-counter')).toBeInTheDocument()
+    })
+
+    it('does not render when no model is selected', () => {
+      selectedModelOverride = null
+      promptState = 'hello'
+      renderInput()
+      expect(screen.queryByTestId('stub-token-counter')).not.toBeInTheDocument()
+    })
+
+    it('does not render with no messages and an empty prompt', () => {
+      promptState = ''
+      renderInput()
+      expect(screen.queryByTestId('stub-token-counter')).not.toBeInTheDocument()
+    })
   })
 })

--- a/web-app/src/lib/__tests__/tokenCounterVisibility.test.ts
+++ b/web-app/src/lib/__tests__/tokenCounterVisibility.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest'
+import { shouldShowTokenCounter } from '@/lib/tokenCounterVisibility'
+
+const base = {
+  hasSelectedModel: true,
+  isAgentMode: false,
+  isInitialMessage: false,
+  hasMessages: true,
+  hasPromptText: false,
+}
+
+describe('shouldShowTokenCounter', () => {
+  it('shows when a model is selected and the thread has messages', () => {
+    expect(shouldShowTokenCounter(base)).toBe(true)
+  })
+
+  it('shows when a model is selected and the prompt has text but no messages yet', () => {
+    expect(
+      shouldShowTokenCounter({
+        ...base,
+        hasMessages: false,
+        hasPromptText: true,
+      })
+    ).toBe(true)
+  })
+
+  it('hides when no model is selected', () => {
+    expect(shouldShowTokenCounter({ ...base, hasSelectedModel: false })).toBe(
+      false
+    )
+  })
+
+  it('hides in agent mode', () => {
+    expect(shouldShowTokenCounter({ ...base, isAgentMode: true })).toBe(false)
+  })
+
+  it('hides for the initial-message (new-thread) input', () => {
+    expect(shouldShowTokenCounter({ ...base, isInitialMessage: true })).toBe(
+      false
+    )
+  })
+
+  it('hides when there are neither messages nor prompt text', () => {
+    expect(
+      shouldShowTokenCounter({
+        ...base,
+        hasMessages: false,
+        hasPromptText: false,
+      })
+    ).toBe(false)
+  })
+
+  // Regression: the token counter must NOT depend on whether the model is
+  // currently in `activeModels`. Router-mode llama.cpp loads lazily and never
+  // writes the model back into `activeModels` during a chat turn, so a gate on
+  // "is the model active" hid the counter for llama.cpp entirely while remote
+  // providers (which were gated only on model selection) kept showing it.
+  // Visibility is decided by model selection + conversation state only; the
+  // TokenCounter component itself decides whether it has data worth rendering.
+  it('shows for a local (llama.cpp) model regardless of active-model state', () => {
+    // There is no `isModelActive` input at all: the predicate is provider- and
+    // load-state-agnostic by construction.
+    expect(shouldShowTokenCounter(base)).toBe(true)
+    expect(
+      shouldShowTokenCounter({ ...base, hasMessages: false, hasPromptText: true })
+    ).toBe(true)
+  })
+
+  it('shows identically for local and remote providers given the same inputs', () => {
+    const inputs = { ...base, hasMessages: true, hasPromptText: false }
+    // Predicate takes no provider argument; same inputs => same result.
+    expect(shouldShowTokenCounter(inputs)).toBe(true)
+  })
+
+  it('agent mode wins even with a selected model and messages', () => {
+    expect(
+      shouldShowTokenCounter({
+        ...base,
+        isAgentMode: true,
+        hasSelectedModel: true,
+        hasMessages: true,
+        hasPromptText: true,
+      })
+    ).toBe(false)
+  })
+
+  it('initial-message wins even with a selected model and prompt text', () => {
+    expect(
+      shouldShowTokenCounter({
+        ...base,
+        isInitialMessage: true,
+        hasPromptText: true,
+      })
+    ).toBe(false)
+  })
+
+  it('requires a selected model even when messages exist', () => {
+    expect(
+      shouldShowTokenCounter({
+        ...base,
+        hasSelectedModel: false,
+        hasMessages: true,
+        hasPromptText: true,
+      })
+    ).toBe(false)
+  })
+})

--- a/web-app/src/lib/tokenCounterVisibility.ts
+++ b/web-app/src/lib/tokenCounterVisibility.ts
@@ -1,0 +1,25 @@
+export interface TokenCounterVisibilityInput {
+  hasSelectedModel: boolean
+  isAgentMode: boolean
+  isInitialMessage: boolean
+  hasMessages: boolean
+  hasPromptText: boolean
+}
+
+/**
+ * Whether the chat-input token counter should mount. Deliberately provider- and
+ * load-state-agnostic: `TokenCounter` decides on its own whether it has data
+ * worth rendering, so gating here on model load state (`activeModels`) only ever
+ * hid the counter for lazily-loaded local engines. See tokenCounterVisibility.test.ts.
+ */
+export const shouldShowTokenCounter = ({
+  hasSelectedModel,
+  isAgentMode,
+  isInitialMessage,
+  hasMessages,
+  hasPromptText,
+}: TokenCounterVisibilityInput): boolean =>
+  hasSelectedModel &&
+  !isAgentMode &&
+  !isInitialMessage &&
+  (hasMessages || hasPromptText)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2727,7 +2727,6 @@ __metadata:
     rimraf: "npm:6.0.1"
     rolldown: "npm:1.0.0-beta.1"
     run-script-os: "npm:1.1.6"
-    ts-loader: "npm:^9.5.0"
     typescript: "npm:5.9.2"
     vitest: "npm:3.2.4"
   languageName: unknown
@@ -2742,7 +2741,6 @@ __metadata:
     jsdom: "npm:^26.1.0"
     rimraf: "npm:6.0.1"
     rolldown: "npm:1.0.0-beta.1"
-    ts-loader: "npm:^9.5.0"
     typescript: "npm:5.9.2"
     vitest: "npm:3.2.4"
   languageName: unknown
@@ -2838,13 +2836,12 @@ __metadata:
     "@janhq/tauri-plugin-llamacpp-api": "link:../../src-tauri/plugins/tauri-plugin-llamacpp"
     "@tauri-apps/api": "npm:2.8.0"
     "@tauri-apps/plugin-http": "npm:2.5.9"
-    "@vitest/ui": "npm:2.1.9"
+    "@vitest/ui": "npm:3.2.4"
     cpx: "npm:1.5.0"
     fetch-retry: "npm:^5.0.6"
     jsdom: "npm:26.1.0"
     rimraf: "npm:3.0.2"
     rolldown: "npm:1.0.0-beta.1"
-    ts-loader: "npm:^9.5.0"
     typescript: "npm:5.9.2"
     ulidx: "npm:2.4.1"
     vitest: "npm:3.2.4"
@@ -2892,12 +2889,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@janhq/tauri-plugin-llamacpp-api@link:../src-tauri/plugins/tauri-plugin-llamacpp::locator=%40janhq%2Fweb-app%40workspace%3Aweb-app":
-  version: 0.0.0-use.local
-  resolution: "@janhq/tauri-plugin-llamacpp-api@link:../src-tauri/plugins/tauri-plugin-llamacpp::locator=%40janhq%2Fweb-app%40workspace%3Aweb-app"
-  languageName: node
-  linkType: soft
-
 "@janhq/tauri-plugin-hardware-api@link:../../src-tauri/plugins/tauri-plugin-hardware::locator=%40janhq%2Fllamacpp-extension%40workspace%3Aextensions%2Fllamacpp-extension":
   version: 0.0.0-use.local
   resolution: "@janhq/tauri-plugin-hardware-api@link:../../src-tauri/plugins/tauri-plugin-hardware::locator=%40janhq%2Fllamacpp-extension%40workspace%3Aextensions%2Fllamacpp-extension"
@@ -2913,6 +2904,12 @@ __metadata:
 "@janhq/tauri-plugin-llamacpp-api@link:../../src-tauri/plugins/tauri-plugin-llamacpp::locator=%40janhq%2Fmlx-extension%40workspace%3Aextensions%2Fmlx-extension":
   version: 0.0.0-use.local
   resolution: "@janhq/tauri-plugin-llamacpp-api@link:../../src-tauri/plugins/tauri-plugin-llamacpp::locator=%40janhq%2Fmlx-extension%40workspace%3Aextensions%2Fmlx-extension"
+  languageName: node
+  linkType: soft
+
+"@janhq/tauri-plugin-llamacpp-api@link:../src-tauri/plugins/tauri-plugin-llamacpp::locator=%40janhq%2Fweb-app%40workspace%3Aweb-app":
+  version: 0.0.0-use.local
+  resolution: "@janhq/tauri-plugin-llamacpp-api@link:../src-tauri/plugins/tauri-plugin-llamacpp::locator=%40janhq%2Fweb-app%40workspace%3Aweb-app"
   languageName: node
   linkType: soft
 
@@ -2961,6 +2958,7 @@ __metadata:
     vitest: "npm:3.2.4"
   languageName: unknown
   linkType: soft
+
 "@janhq/web-app@workspace:web-app":
   version: 0.0.0-use.local
   resolution: "@janhq/web-app@workspace:web-app"
@@ -7630,7 +7628,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/ui@npm:2.1.9, @vitest/ui@npm:^2.1.8":
+"@vitest/ui@npm:3.2.4":
+  version: 3.2.4
+  resolution: "@vitest/ui@npm:3.2.4"
+  dependencies:
+    "@vitest/utils": "npm:3.2.4"
+    fflate: "npm:^0.8.2"
+    flatted: "npm:^3.3.3"
+    pathe: "npm:^2.0.3"
+    sirv: "npm:^3.0.1"
+    tinyglobby: "npm:^0.2.14"
+    tinyrainbow: "npm:^2.0.0"
+  peerDependencies:
+    vitest: 3.2.4
+  checksum: 10c0/c3de1b757905d050706c7ab0199185dd8c7e115f2f348b8d5a7468528c6bf90c2c46096e8901602349ac04f5ba83ac23cd98c38827b104d5151cf8ba21739a0c
+  languageName: node
+  linkType: hard
+
+"@vitest/ui@npm:^2.1.8":
   version: 2.1.9
   resolution: "@vitest/ui@npm:2.1.9"
   dependencies:
@@ -8773,7 +8788,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^4.0.0, chalk@npm:^4.1.0, chalk@npm:^4.1.2":
+"chalk@npm:^4.0.0, chalk@npm:^4.1.2":
   version: 4.1.2
   resolution: "chalk@npm:4.1.2"
   dependencies:
@@ -11286,6 +11301,13 @@ __metadata:
   version: 3.3.3
   resolution: "flatted@npm:3.3.3"
   checksum: 10c0/e957a1c6b0254aa15b8cce8533e24165abd98fadc98575db082b786b5da1b7d72062b81bfdcd1da2f4d46b6ed93bec2434e62333e9b4261d79ef2e75a10dd538
+  languageName: node
+  linkType: hard
+
+"flatted@npm:^3.3.3":
+  version: 3.4.2
+  resolution: "flatted@npm:3.4.2"
+  checksum: 10c0/a65b67aae7172d6cdf63691be7de6c5cd5adbdfdfe2e9da1a09b617c9512ed794037741ee53d93114276bff3f93cd3b0d97d54f9b316e1e4885dde6e9ffdf7ed
   languageName: node
   linkType: hard
 
@@ -16269,13 +16291,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.0":
-  version: 4.0.5
-  resolution: "picomatch@npm:4.0.5"
-  checksum: 10c0/947bc6b6e1ff1e6c5aaf95b107a0839d12802f4f7b867663f67d47accba939ca1cb582cf99dfc30438efa1c4648ac5990967e783e8929c36b03e8440704ef1bd
-  languageName: node
-  linkType: hard
-
 "picomatch@npm:^4.0.2, picomatch@npm:^4.0.3":
   version: 4.0.3
   resolution: "picomatch@npm:4.0.3"
@@ -18331,7 +18346,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"sirv@npm:^3.0.0":
+"sirv@npm:^3.0.0, sirv@npm:^3.0.1":
   version: 3.0.2
   resolution: "sirv@npm:3.0.2"
   dependencies:
@@ -19412,24 +19427,6 @@ __metadata:
   version: 2.2.0
   resolution: "ts-dedent@npm:2.2.0"
   checksum: 10c0/175adea838468cc2ff7d5e97f970dcb798bbcb623f29c6088cb21aa2880d207c5784be81ab1741f56b9ac37840cbaba0c0d79f7f8b67ffe61c02634cafa5c303
-  languageName: node
-  linkType: hard
-
-"ts-loader@npm:^9.5.0":
-  version: 9.6.2
-  resolution: "ts-loader@npm:9.6.2"
-  dependencies:
-    chalk: "npm:^4.1.0"
-    picomatch: "npm:^4.0.0"
-    source-map: "npm:^0.7.4"
-  peerDependencies:
-    loader-utils: "*"
-    typescript: "*"
-    webpack: ^4.0.0 || ^5.0.0
-  peerDependenciesMeta:
-    loader-utils:
-      optional: true
-  checksum: 10c0/6102336ee598124249e07cce6bb3d4ee0586f962697b7388d1957296a2c7d5164b95757797db237bdb7b8f0c5a52d2f22ca5013d3337823d8e9e0e731ce03c67
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe Your Changes

The token-counter gates in ChatInput coupled the llama.cpp path to `isModelActive` (activeModels.includes(model.id)). But activeModels is only populated when the Model Settings panel mounts; router-mode llama.cpp loads lazily and never writes back into it during a chat turn, so isModelActive stays false and the counter never renders. Remote providers used `!!selectedModel` and kept showing.

Extract a provider-agnostic shouldShowTokenCounter() helper (model selected + not agent mode + not initial-message + has messages/prompt) and use it for both the compact and full gates. TokenCounter already self-guards when it has no data, so gating on load state was wrong and redundant.

Tests: tokenCounterVisibility.test.ts (matrix incl. active-state independence) + ChatInput "token counter visibility" block (renders for llama.cpp with empty activeModels).

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
