### PR TITLE
fix(hub): prioritize exact model id matches in search results

### DIFF
--- a/web-app/src/routes/hub/__tests__/searchRanking.test.ts
+++ b/web-app/src/routes/hub/__tests__/searchRanking.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import {
+  cleanHubSearchQuery,
+  prioritizeExactModelMatches,
+  type RankableCatalogModel,
+} from '../searchRanking'
+
+const model = (
+  model_name: string,
+  developer?: string,
+  quantIds: string[] = []
+): RankableCatalogModel => ({
+  model_name,
+  developer,
+  quants: quantIds.map((model_id) => ({ model_id })),
+})
+
+describe('cleanHubSearchQuery', () => {
+  it('strips huggingface host prefixes', () => {
+    expect(
+      cleanHubSearchQuery(
+        'https://huggingface.co/unsloth/gemma-4-26B-A4B-it-qat-GGUF'
+      )
+    ).toBe('unsloth/gemma-4-26B-A4B-it-qat-GGUF')
+  })
+
+  it('leaves bare repo ids unchanged', () => {
+    expect(cleanHubSearchQuery('unsloth/gemma-4-26B-A4B-it-qat-GGUF')).toBe(
+      'unsloth/gemma-4-26B-A4B-it-qat-GGUF'
+    )
+  })
+})
+
+describe('prioritizeExactModelMatches', () => {
+  it('moves an exact model_name match to the front', () => {
+    const models = [
+      model('gemma-related-other', 'someone'),
+      model('gemma-4-26B-A4B-it-qat-GGUF', 'unsloth'),
+      model('another-gemma', 'org'),
+    ]
+
+    const ranked = prioritizeExactModelMatches(
+      models,
+      'unsloth/gemma-4-26B-A4B-it-qat-GGUF'
+    )
+
+    expect(ranked[0].developer).toBe('unsloth')
+    expect(ranked[0].model_name).toBe('gemma-4-26B-A4B-it-qat-GGUF')
+  })
+
+  it('matches when model_name already includes the author prefix', () => {
+    const models = [
+      model('unsloth/gemma-nearby', 'unsloth'),
+      model('unsloth/gemma-4-26B-A4B-it-qat-GGUF'),
+      model('google/gemma-2b', 'google'),
+    ]
+
+    const ranked = prioritizeExactModelMatches(
+      models,
+      'unsloth/gemma-4-26B-A4B-it-qat-GGUF'
+    )
+
+    expect(ranked[0].model_name).toBe(
+      'unsloth/gemma-4-26B-A4B-it-qat-GGUF'
+    )
+  })
+
+  it('prefers exact quant ids over fuzzy neighbors', () => {
+    const models = [
+      model('neighbor-model', 'org', ['neighbor-Q4']),
+      model('target-model', 'org', ['exact-quant-id']),
+    ]
+
+    const ranked = prioritizeExactModelMatches(models, 'exact-quant-id')
+    expect(ranked[0].model_name).toBe('target-model')
+  })
+
+  it('is case-insensitive and stable for non-exact rows', () => {
+    const models = [
+      model('Alpha', 'a'),
+      model('Beta', 'b'),
+      model('Target', 'Org'),
+    ]
+
+    const ranked = prioritizeExactModelMatches(models, 'org/target')
+    expect(ranked.map((m) => m.model_name)).toEqual([
+      'Target',
+      'Alpha',
+      'Beta',
+    ])
+  })
+
+  it('returns the input when the query is empty', () => {
+    const models = [model('a'), model('b')]
+    expect(prioritizeExactModelMatches(models, '   ')).toBe(models)
+  })
+})

--- a/web-app/src/routes/hub/index.tsx
+++ b/web-app/src/routes/hub/index.tsx
@@ -50,6 +50,10 @@ import HeaderPage from '@/containers/HeaderPage'
 import { ChevronsUpDown, Loader } from 'lucide-react'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import Fuse from 'fuse.js'
+import {
+  cleanHubSearchQuery,
+  prioritizeExactModelMatches,
+} from './searchRanking'
 import { useGeneralSetting } from '@/hooks/useGeneralSetting'
 import { DownloadButtonPlaceholder } from '@/containers/DownloadButton'
 import { useShallow } from 'zustand/shallow'
@@ -207,11 +211,13 @@ function HubContent() {
     if (debouncedSearchValue.length) {
       const fuse = new Fuse(filtered, searchOptions)
       // Remove domain from search value (e.g., "huggingface.co/author/model" -> "author/model")
-      const cleanedSearchValue = debouncedSearchValue.replace(
-        /^https?:\/\/[^/]+\//,
-        ''
+      const cleanedSearchValue = cleanHubSearchQuery(debouncedSearchValue)
+      // Fuse scores fuzzy relevance; re-rank so an exact HF id/name is first
+      // (see #8447 — precise queries were not always top of list).
+      filtered = prioritizeExactModelMatches(
+        fuse.search(cleanedSearchValue).map((result) => result.item),
+        cleanedSearchValue
       )
-      filtered = fuse.search(cleanedSearchValue).map((result) => result.item)
     }
     // Apply downloaded filter
     if (showOnlyDownloaded) {

--- a/web-app/src/routes/hub/searchRanking.ts
+++ b/web-app/src/routes/hub/searchRanking.ts
@@ -1,0 +1,76 @@
+/**
+ * Hub search ranking helpers.
+ *
+ * Fuse.js scores fuzzy relevance but does not guarantee that an exact model id
+ * (e.g. `unsloth/gemma-4-26B-A4B-it-qat-GGUF`) lands first. Re-rank after Fuse
+ * so exact / near-exact ids bubble to the top while preserving relative order.
+ */
+
+export type RankableCatalogModel = {
+  model_name: string
+  developer?: string
+  quants?: Array<{ model_id: string }>
+}
+
+/** Strip a leading Hugging Face (or other) host prefix from a pasted URL. */
+export function cleanHubSearchQuery(raw: string): string {
+  return raw.replace(/^https?:\/\/[^/]+\//, '').trim()
+}
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase()
+}
+
+/**
+ * Lower rank = higher priority.
+ * 0: exact model id / developer+name
+ * 1: exact quant / variant id
+ * 2: prefix / suffix near-exact
+ * 3: everything else (keep Fuse order)
+ */
+function exactnessRank(model: RankableCatalogModel, query: string): number {
+  const name = normalize(model.model_name || '')
+  const developer = normalize(model.developer || '')
+  // model_name may already be `author/repo`
+  const full =
+    name.includes('/')
+      ? name
+      : developer
+        ? `${developer}/${name}`
+        : name
+
+  if (name === query || full === query) return 0
+
+  if (model.quants?.some((q) => normalize(q.model_id) === query)) return 1
+
+  if (
+    full.startsWith(query) ||
+    name.startsWith(query) ||
+    query.startsWith(full) ||
+    query.startsWith(name)
+  ) {
+    return 2
+  }
+
+  return 3
+}
+
+/**
+ * Stable re-rank: exact matches first, original relative order otherwise.
+ */
+export function prioritizeExactModelMatches<T extends RankableCatalogModel>(
+  models: T[],
+  rawQuery: string
+): T[] {
+  const query = normalize(cleanHubSearchQuery(rawQuery))
+  if (!query || models.length <= 1) return models
+
+  return models
+    .map((model, index) => ({
+      model,
+      index,
+      rank: exactnessRank(model, query),
+    }))
+    .sort((a, b) => a.rank - b.rank || a.index - b.index)
+    .map(({ model }) => model)
+}


### PR DESCRIPTION
## Describe Your Changes

- Hub search used Fuse fuzzy ranking alone, so a precise Hugging Face id (e.g. `unsloth/gemma-4-26B-A4B-it-qat-GGUF`) was not always first.
- After Fuse, re-rank results so exact `model_name` / `developer/model` / quant id matches surface first (stable for non-exact rows).
- Extract ranking helpers + unit tests under `web-app/src/routes/hub/`.

## Fixes Issues

- Closes #8447

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

## Test plan

- [x] Pure ranking helper checks (exact id, URL-stripped query, quant id, case-insensitive stability)
- [ ] Hub UI: search exact HF id and confirm it is the top catalog row when present
- [ ] Hub UI: fuzzy-only queries still return sensible Fuse order for non-exact rows