### PR TITLE
build(cli): gate desktop-only setup/updater modules out of headless jan build

### DIFF
--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -6,6 +6,9 @@ pub mod downloads;
 pub mod filesystem;
 pub mod mcp;
 pub mod server;
+// Desktop-only app setup (tray, theme, window wiring); pulls in Tauri GUI types
+// (Wry/AppHandle) the headless `jan` CLI build does not link.
+#[cfg(not(feature = "cli"))]
 pub mod setup;
 pub mod state;
 pub mod system;

--- a/src-tauri/src/core/updater/mod.rs
+++ b/src-tauri/src/core/updater/mod.rs
@@ -1,3 +1,6 @@
+// Desktop-only Tauri commands (AppHandle<Wry>); the headless `jan` CLI build
+// still uses the sibling `hmac_client`/`session` modules via `downloads`.
+#[cfg(not(feature = "cli"))]
 pub mod commands;
 pub mod custom_updater;
 pub mod hmac_client;


### PR DESCRIPTION
## What

Fixes the headless `jan` CLI build (`cargo build --no-default-features --features cli --bin jan`), which currently fails with 5 compile errors:

```
error[E0432]: unresolved import `tauri::Wry`: no `Wry` in the root
error[E0107]: missing generics for struct `AppHandle`: expected 1 generic argument
```

`core::setup` and `core::updater::commands` were compiled unconditionally and use desktop-only Tauri GUI types (`tauri::Wry`, `AppHandle<Wry>`). Neither is used by the CLI path (`bin/jan.rs` / `core/cli/*`) — `setup` is desktop-only, and in `updater` only `commands` is desktop-bound (`hmac_client`/`session` stay available since `core::downloads` still uses them).

## How

Gate both behind `#[cfg(not(feature = "cli"))]` — the same convention `lib.rs` already uses ~15+ times (e.g. `pub fn run()`).

- `src-tauri/src/core/mod.rs`: gate `pub mod setup;`
- `src-tauri/src/core/updater/mod.rs`: gate `pub mod commands;`

2 files, +6 lines (2 are the `#[cfg]` attrs, 4 are explanatory comments). No logic changed.

## Verified locally (macOS, arm64)

- `cargo check --no-default-features --features cli --bin jan` — 0 errors (previously 5)
- `cargo check --features desktop --bin jan-desktop` — still compiles clean, no regression
- `cargo build --release --no-default-features --features cli --bin jan` — produces a 6.9 MB Mach-O binary
- Binary runs headless: `jan --version` → `jan 0.8.4`; `jan --help` renders correctly

## Known follow-up (not fixed here, out of scope for this PR)

On macOS, `objc2-web-kit`/`objc2-app-kit` are unconditional target-deps of the base `tauri` crate (no `optional = true` upstream) — so the CLI binary still dynamically links WebKit/AppKit even headless. Harmless on macOS (system frameworks, zero cost). On Linux, `webkit2gtk` is correctly `optional`/gated behind the `wry` feature (which `cli` never requests), but `gtk` itself is not marked optional in tauri's Cargo.toml — worth verifying whether a Linux `jan` binary built this way actually requires `libgtk-3` at runtime. Tracked as a follow-up on jan-internal#216; not blocking this fix.

## Context

Part of jan-internal#216 (Ship Jan Agent as its own binary distribution).
