### PR TITLE
fix: persist chain-of-thought duration in thread metadata

### DIFF
--- a/web-app/src/components/ai-elements/chain-of-thought.tsx
+++ b/web-app/src/components/ai-elements/chain-of-thought.tsx
@@ -67,6 +67,8 @@ export type ChainOfThoughtProps = ComponentProps<typeof Collapsible> & {
   open?: boolean
   defaultOpen?: boolean
   onOpenChange?: (open: boolean) => void
+  /** Pre-computed duration in seconds. When provided, overrides the internal timer. */
+  duration?: number
 }
 
 export const ChainOfThought = memo(
@@ -78,6 +80,7 @@ export const ChainOfThought = memo(
     open,
     defaultOpen = true,
     onOpenChange,
+    duration: durationProp,
     children,
     ...props
   }: ChainOfThoughtProps) => {
@@ -104,18 +107,28 @@ export const ChainOfThought = memo(
     }
 
     const [startTime, setStartTime] = useState<number | null>(null)
-    const [duration, setDuration] = useState<number | undefined>(undefined)
+    const [internalDuration, setInternalDuration] = useState<number | undefined>(
+      undefined
+    )
+
+    // Use the prop when provided, otherwise fall back to the internal timer.
+    // This allows a persisted duration (e.g. from message timestamps) to survive
+    // remount when navigating between threads.
+    const duration = durationProp ?? internalDuration
 
     useEffect(() => {
+      // When durationProp is provided externally, don't run the internal timer.
+      if (durationProp !== undefined) return
+
       if (isStreaming) {
         if (startTime === null) {
           setStartTime(Date.now())
         }
       } else if (startTime !== null) {
-        setDuration(Math.ceil((Date.now() - startTime) / MS_IN_S))
+        setInternalDuration(Math.ceil((Date.now() - startTime) / MS_IN_S))
         setStartTime(null)
       }
-    }, [isStreaming, startTime])
+    }, [isStreaming, startTime, durationProp])
 
     const contextValue = useMemo(
       () => ({ isStreaming, isOpen, setIsOpen, duration }),

--- a/web-app/src/containers/MessageItem.tsx
+++ b/web-app/src/containers/MessageItem.tsx
@@ -190,6 +190,12 @@ export const MessageItem = memo(
           status === CHAT_STATUS.SUBMITTED)) ||
       hasPendingToolCall
 
+    // Pre-computed duration (seconds) written to JSONL metadata at stream
+    // completion, surviving remount when navigating between threads.
+    const persistedDuration = !isStreaming
+      ? (metadata?.duration as number | undefined)
+      : undefined
+
     // Aggregate RAG citations in part order and record each rag tool part's
     // base offset, so its card numbers/anchors continue the same global
     // sequence the inline superscript markers use.
@@ -633,6 +639,7 @@ export const MessageItem = memo(
           key={groupKey}
           className="w-full text-muted-foreground"
           isStreaming={groupIsStreaming}
+          duration={persistedDuration}
           shouldCollapse={shouldCollapse}
           forceOpen={forceOpen}
           defaultOpen={hasDisplayableContent && !hasFollowingContent}

--- a/web-app/src/lib/custom-chat-transport.ts
+++ b/web-app/src/lib/custom-chat-transport.ts
@@ -1437,6 +1437,7 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
               totalTokens:
                 usage?.totalTokens ?? (inputTokens ?? 0) + outputTokens,
             },
+            duration: Math.max(1, Math.ceil(durationSec)),
             tokenSpeed: {
               tokenSpeed: Math.round(tokenSpeed * 100) / 100,
               promptSpeed: promptPerSecond

--- a/web-app/src/lib/messages.ts
+++ b/web-app/src/lib/messages.ts
@@ -368,6 +368,9 @@ export function convertThreadMessageToUIMessage(
     metadata: {
       ...(threadMessage.metadata || {}),
       createdAt: new Date(threadMessage.created_at || Date.now()),
+      completedAt: threadMessage.completed_at
+        ? new Date(threadMessage.completed_at)
+        : undefined,
     },
   } as UIMessage
 }


### PR DESCRIPTION
## Describe Your Changes

- The ChainOfThought header showed 'Worked for a few seconds' after navigating away and back to a thread, because duration was tracked in a transient component timer that was lost on unmount.

Now the duration (in seconds) is computed at stream completion in custom-chat-transport.ts and stored in the AI SDK message metadata, which flows into the persisted JSONL thread metadata. MessageItem reads metadata.duration directly on remount, so the correct elapsed time survives thread navigation.

## Fixes Issues

- Closes #8473
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
