### PR TITLE
feat(agent-cli): @path file references in TUI and headless prompts

### DIFF
--- a/src-tauri/src/core/cli/mod.rs
+++ b/src-tauri/src/core/cli/mod.rs
@@ -5,6 +5,7 @@
 pub mod mcp;
 pub mod preset;
 pub mod providers;
+mod path_refs;
 mod tui;
 
 use std::path::PathBuf;
@@ -1162,7 +1163,18 @@ fn prepare_agent_run(
 ) -> Result<PreparedRun, String> {
     let session =
         prepare_agent_session(project, model_override, max_turns_override, overrides, yolo)?;
-    let body = session.body(serde_json::json!([{ "role": "user", "content": task }]));
+    let project_root = resolve_project_root(project);
+    let (clean_task, injected) = path_refs::resolve_references(task, &project_root);
+    let final_task = if injected.is_empty() {
+        clean_task
+    } else {
+        format!("{clean_task}\n\n---\nReferenced file contents:\n\n{injected}")
+    };
+    let body = session.body(serde_json::json!([{ "role": "user", "content": final_task }]));
+    // Emit resolved references stderr so the user sees what was injected
+    if !injected.is_empty() {
+        eprintln!("(resolved @path references)");
+    }
     Ok(PreparedRun {
         args: session.args,
         body,

--- a/src-tauri/src/core/cli/path_refs.rs
+++ b/src-tauri/src/core/cli/path_refs.rs
@@ -1,0 +1,265 @@
+//! Resolve `@path` file/directory references in user messages.
+//!
+//! When a user types `@path/to/file` in the TUI or headless task, the file or
+//! directory is read and its content is injected into the message so the model
+//! can see it directly.
+//!
+//! # Behaviour
+//!
+//! * Files are read as UTF-8 text (1 MB cap).
+//! * Directories produce a listing of immediate children (20 KB cap).
+//! * Images are noted inline as `(image: image/mime)` markers.
+//! * Missing/unreadable items surface as inline error notices.
+//! * `@http://` / `@https://` / `@file://` prefixed tokens are skipped.
+//! * Once resolved, the `@path` tokens are removed from the text so the model
+//!   sees the content directly via the injected block, not raw `@` tokens.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+/// Regex matching `@path` references.
+/// The path stops at whitespace or common punctuation characters.
+/// Regex matching `@path` references. Path stops at whitespace or common punctuation.
+static REFERENCE_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    // Using a raw string with hash delimiters avoids escaping quotes and backticks.
+    // The negated character class excludes tokens that would make bad paths.
+    regex::Regex::new(r###"@([^\s,;:!?'"`\[\](){}<>)\)]+)"###).unwrap()
+});
+
+/// Maximum bytes we will read from a single file.
+const MAX_FILE_BYTES: u64 = 1 * 1024 * 1024;
+
+/// Maximum characters in a directory listing sent to the model.
+const MAX_DIR_CHARS: usize = 20_000;
+
+/// Image extensions.
+const IMAGE_EXTS: &[&str] = &["jpg", "jpeg", "png", "gif", "webp", "bmp", "svg"];
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/// Parse `@path` references from `text`.
+///
+/// Returns the raw path strings in order of appearance (deduplicated).
+pub fn parse_references(text: &str) -> Vec<String> {
+    let mut seen = std::collections::HashSet::new();
+    let mut refs = Vec::new();
+    for cap in REFERENCE_RE.captures_iter(text) {
+        let raw = cap[1].trim();
+        if raw.is_empty()
+            || raw.starts_with("http")
+            || raw.starts_with("file://")
+        {
+            continue;
+        }
+        if seen.insert(raw.to_string()) {
+            refs.push(raw.to_string());
+        }
+    }
+    refs
+}
+
+/// Remove all `@path` references from `text` and normalise whitespace.
+pub fn strip_references(text: &str) -> String {
+    let cleaned = REFERENCE_RE.replace_all(text, "");
+    let mut result = String::with_capacity(cleaned.len());
+    let mut prev_space = false;
+    for ch in cleaned.chars() {
+        if ch.is_whitespace() {
+            if !prev_space {
+                result.push(' ');
+                prev_space = true;
+            }
+        } else {
+            result.push(ch);
+            prev_space = false;
+        }
+    }
+    result.trim().to_string()
+}
+
+/// Resolve all @path references in `text` synchronously (blocking).
+///
+/// Returns `(cleaned_text, injected_content_block)`.
+/// When no references are found, returns the original text unchanged with an
+/// empty injected block.
+pub fn resolve_references(text: &str, project_root: &Path) -> (String, String) {
+    let refs = parse_references(text);
+    if refs.is_empty() {
+        return (text.to_string(), String::new());
+    }
+
+    let mut parts: Vec<String> = Vec::new();
+    for raw in &refs {
+        let abs = if raw.starts_with('/') {
+            PathBuf::from(raw)
+        } else {
+            project_root.join(raw)
+        };
+
+        let metadata = match std::fs::metadata(&abs) {
+            Ok(m) => m,
+            Err(e) => {
+                parts.push(format!("[{}: cannot access: {}]", raw, e));
+                continue;
+            }
+        };
+
+        if metadata.is_dir() {
+            let entries = match std::fs::read_dir(&abs) {
+                Ok(d) => d,
+                Err(e) => {
+                    parts.push(format!("[{}: cannot list: {}]", raw, e));
+                    continue;
+                }
+            };
+            let mut listing = String::new();
+            for entry in entries.flatten() {
+                let name = entry.file_name().to_string_lossy().into_owned();
+                listing.push_str("  ");
+                listing.push_str(&name);
+                listing.push('\n');
+            }
+            if listing.len() > MAX_DIR_CHARS {
+                listing.truncate(MAX_DIR_CHARS);
+                listing.push_str("  ... (truncated)\n");
+            }
+            parts.push(format!(
+                "Directory listing of {}:\n{}",
+                abs.display(),
+                listing
+            ));
+            continue;
+        }
+
+        if metadata.len() > MAX_FILE_BYTES {
+            parts.push(format!(
+                "[{}: file too large ({} bytes)]",
+                raw,
+                metadata.len()
+            ));
+            continue;
+        }
+
+        let ext = abs
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_lowercase();
+
+        if IMAGE_EXTS.contains(&ext.as_str()) {
+            parts.push(image_note(raw, &abs));
+            continue;
+        }
+
+        match std::fs::read_to_string(&abs) {
+            Ok(s) => {
+                let content = if s.len() > MAX_FILE_BYTES as usize {
+                    let mut t = s[..MAX_FILE_BYTES as usize].to_string();
+                    t.push_str("\n\n... (truncated)");
+                    t
+                } else {
+                    s
+                };
+                parts.push(format!(
+                    "--- {} ---\n{}\n--- end {} ---",
+                    abs.display(),
+                    content,
+                    abs.display()
+                ));
+            }
+            Err(e) => {
+                parts.push(format!("[{}: cannot read: {}]", raw, e));
+            }
+        }
+    }
+
+    let clean = strip_references(text);
+    let block = parts.join("\n\n");
+    (clean, block)
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+/// Read an image file and return a text note with mime type.
+fn image_note(raw: &str, abs: &Path) -> String {
+    let ext = abs
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("")
+        .to_lowercase();
+    let mime = image_mime(&ext);
+    let mut f = match std::fs::File::open(abs) {
+        Ok(f) => f,
+        Err(_) => return format!("[{}: cannot read image]", raw),
+    };
+    let mut buf = Vec::new();
+    if f.read_to_end(&mut buf).is_ok() {
+        format!("{} (image: {}, {} bytes)", abs.display(), mime, buf.len())
+    } else {
+        format!("[{}: cannot read image]", raw)
+    }
+}
+
+fn image_mime(ext: &str) -> &'static str {
+    match ext {
+        "jpg" | "jpeg" => "image/jpeg",
+        "png" => "image/png",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "bmp" => "image/bmp",
+        "svg" => "image/svg+xml",
+        _ => "image/png",
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_references() {
+        let refs = parse_references("check @src/main.ts and @README.md");
+        assert_eq!(refs, vec!["src/main.ts", "README.md"]);
+
+        let refs = parse_references("@http://example.com");
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn test_parse_deduplicates() {
+        let refs = parse_references("@a @b @a");
+        assert_eq!(refs, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn test_strip_references() {
+        let cleaned = strip_references("see @src/main.ts and @README.md");
+        assert_eq!(cleaned, "see and");
+
+        let cleaned = strip_references("no refs here");
+        assert_eq!(cleaned, "no refs here");
+    }
+
+    #[test]
+    fn test_resolve_references_inject() {
+        let dir = std::env::temp_dir().join("path_ref_test_inject");
+        let _ = std::fs::create_dir_all(&dir);
+        std::fs::write(dir.join("hello.txt"), b"hello world").unwrap();
+
+        let (clean, block) = resolve_references("read @hello.txt", &dir);
+        assert_eq!(clean, "read");
+        assert!(block.contains("hello world"));
+        assert!(block.contains("hello.txt"));
+    }
+
+    #[test]
+    fn test_resolve_references_no_refs() {
+        let dir = std::env::temp_dir().join("path_ref_test_none");
+        let (clean, block) = resolve_references("plain text", &dir);
+        assert_eq!(clean, "plain text");
+        assert!(block.is_empty());
+    }
+}

--- a/src-tauri/src/core/cli/path_refs.rs
+++ b/src-tauri/src/core/cli/path_refs.rs
@@ -179,6 +179,67 @@ pub fn resolve_references(text: &str, project_root: &Path) -> (String, String) {
     (clean, block)
 }
 
+/// Synchronous file search for path-hint autocomplete.
+///
+/// Searches `root_dir` for files/directories whose path or name contains
+/// `query` (case-insensitive). Returns `(relative_path, basename, is_dir)`
+/// tuples, up to `max_results`. Performs a limited walk (up to 3 levels deep)
+/// so it returns quickly enough for interactive use.
+pub fn search_files_sync(
+    root_dir: &Path,
+    query: &str,
+    max_results: usize,
+) -> Vec<(String, String, bool)> {
+    let mut results = Vec::new();
+    let query_lower = query.to_lowercase();
+
+    // If the query contains slashes, use the last segment as the name filter
+    // and the prefix as the subdirectory to search.
+    let (search_dir, name_filter) = if let Some(last_slash) = query.rfind('/') {
+        let dir_part = &query[..last_slash];
+        let name_part = &query[last_slash + 1..];
+        let subdir = root_dir.join(dir_part);
+        (subdir, name_part.to_lowercase())
+    } else {
+        (root_dir.to_path_buf(), query_lower.clone())
+    };
+
+    // Search the search_dir's immediate children
+    let entries = match std::fs::read_dir(&search_dir) {
+        Ok(d) => d,
+        Err(_) => return results,
+    };
+
+    for entry in entries.flatten() {
+        if results.len() >= max_results {
+            break;
+        }
+        let name = entry.file_name().to_string_lossy().into_owned();
+        let name_lower = name.to_lowercase();
+        if !name_lower.contains(&name_filter) {
+            continue;
+        }
+        let is_dir = entry.file_type().map(|t| t.is_dir()).unwrap_or(false);
+        let full_path = entry.path();
+        let rel = full_path
+            .strip_prefix(root_dir)
+            .unwrap_or(&full_path)
+            .to_string_lossy()
+            .into_owned();
+        results.push((rel, name, is_dir));
+    }
+
+    // Sort: directories first, then by name
+    results.sort_by(|a, b| {
+        b.2.cmp(&a.2).then(a.1.cmp(&b.1))
+    });
+
+    if results.len() > max_results {
+        results.truncate(max_results);
+    }
+    results
+}
+
 // ── Internal helpers ─────────────────────────────────────────────────────────
 
 /// Read an image file and return a text note with mime type.

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -12,6 +12,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use super::path_refs;
+
 use ratatui::crossterm::{
     event::{
         self, DisableMouseCapture, EnableMouseCapture, Event, KeyCode, KeyEvent, KeyEventKind,
@@ -812,7 +814,15 @@ impl App {
         self.ensure_base_snapshot();
         let images = std::mem::take(&mut self.pending_images);
         let names: Vec<String> = images.iter().map(|i| i.name.clone()).collect();
-        self.history.push(build_user_message(&text, &images));
+        // Resolve @path file references before sending
+        let (clean_text, injected_contents) =
+            path_refs::resolve_references(&text, &self.project_root);
+        let final_text = if injected_contents.is_empty() {
+            clean_text
+        } else {
+            format!("{clean_text}\n\n---\nReferenced file contents:\n\n{injected_contents}")
+        };
+        self.history.push(build_user_message(&final_text, &images));
         self.push_user_line(&text, &names);
         self.status = Status::Running;
         self.run_started = Some(Instant::now());

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -252,6 +252,16 @@ struct PendingImage {
     data_url: String,
 }
 
+/// One entry in the file-path hint popup triggered by typing `@`.
+struct PathHintItem {
+    /// Display path (relative to project root).
+    path: String,
+    /// Basename for display.
+    name: String,
+    /// Whether this is a directory.
+    is_dir: bool,
+}
+
 struct App {
     model: String,
     /// Fast model for the `smol` role, used by `/goal` evaluation. Defaults to
@@ -331,6 +341,12 @@ struct App {
     /// Set by Esc to hide the hint popup without clearing the buffer; cleared on
     /// the next keystroke that edits the input so typing re-shows it.
     slash_dismissed: bool,
+    /// File-path hint entries matching the current `@query` in the input buffer.
+    path_hints: Vec<PathHintItem>,
+    /// Highlighted row in the path-hint popup (clamped to matches).
+    path_hint_selected: usize,
+    /// Set by Esc to dismiss the path-hint popup; cleared on next char edit.
+    path_hint_dismissed: bool,
     status: Status,
     turn: (u32, u32),
     tokens: u64,
@@ -471,6 +487,9 @@ impl App {
             cursor: 0,
             slash_selected: 0,
             slash_dismissed: false,
+            path_hints: Vec::new(),
+            path_hint_selected: 0,
+            path_hint_dismissed: false,
             status: Status::Idle,
             turn: (0, 0),
             tokens: 0,
@@ -724,12 +743,16 @@ impl App {
         self.input.clear();
         self.cursor = 0;
         self.reset_slash_hint();
+        self.path_hints.clear();
+        self.path_hint_selected = 0;
     }
 
     fn input_insert(&mut self, c: char) {
         self.input.insert(self.cursor, c);
         self.cursor += c.len_utf8();
         self.reset_slash_hint();
+        // Refresh path hints on any character edit
+        self.refresh_path_hints();
     }
 
     /// Delete the char before the caret (Backspace).
@@ -739,6 +762,7 @@ impl App {
             self.input.remove(self.cursor);
         }
         self.reset_slash_hint();
+        self.refresh_path_hints();
     }
 
     /// Delete the char at the caret (Delete); caret stays put.
@@ -747,12 +771,14 @@ impl App {
             self.input.remove(self.cursor);
         }
         self.reset_slash_hint();
+        self.refresh_path_hints();
     }
 
     /// Reset hint selection and un-dismiss so an edited buffer re-shows the popup.
     fn reset_slash_hint(&mut self) {
         self.slash_selected = 0;
         self.slash_dismissed = false;
+        self.path_hint_dismissed = false;
     }
 
     /// Slash commands whose name prefixes the current buffer, or empty when the
@@ -793,6 +819,92 @@ impl App {
         self.input = format!("{name} ");
         self.cursor = self.input.len();
         self.slash_selected = 0;
+    }
+
+    /// Extract the current `@query` from the input buffer, if any.
+    /// Returns `None` when the cursor is not inside or immediately after
+    /// a `@`-prefixed token (no space since the `@`).
+    fn path_hint_query(&self) -> Option<String> {
+        let before = &self.input[..self.cursor];
+        let at_idx = before.rfind('@')?;
+        let after_at = &before[at_idx + 1..];
+        if after_at.contains(' ') {
+            return None; // space after @ means the token ended
+        }
+        if after_at.is_empty() {
+            return Some(String::new());
+        }
+        Some(after_at.to_string())
+    }
+
+    /// Whether the path-hint popup is eligible to show right now.
+    fn path_hints_active(&self) -> bool {
+        if self.path_hint_dismissed || self.status != Status::Idle {
+            return false;
+        }
+        self.path_hint_query().is_some()
+    }
+
+    /// Refresh path hints from the input buffer: detect `@query`, search files.
+    fn refresh_path_hints(&mut self) {
+        if self.path_hint_dismissed || self.status != Status::Idle {
+            self.path_hints.clear();
+            return;
+        }
+        let Some(query) = self.path_hint_query() else {
+            self.path_hints.clear();
+            return;
+        };
+
+        let entries = path_refs::search_files_sync(&self.project_root, &query, 30);
+        self.path_hints = entries
+            .into_iter()
+            .map(|(path, name, is_dir)| PathHintItem {
+                path,
+                name,
+                is_dir,
+            })
+            .collect();
+        self.path_hint_selected = 0;
+    }
+
+    /// Accept the highlighted path hint: replace the `@query` token with the
+    /// selected path.
+    fn accept_path_hint(&mut self) {
+        if self.path_hints.is_empty() {
+            return;
+        }
+        let sel = self.path_hint_selected.min(self.path_hints.len() - 1);
+        let selected = &self.path_hints[sel];
+        let before = &self.input[..self.cursor];
+        let at_idx = match before.rfind('@') {
+            Some(i) => i,
+            None => return,
+        };
+        let after = &self.input[self.cursor..];
+        let replacement = &selected.path;
+        let new_input = format!("{}{}{}", &self.input[..at_idx], replacement, after);
+        self.input = new_input;
+        self.cursor = at_idx + replacement.len();
+        self.path_hints.clear();
+        self.path_hint_dismissed = false;
+    }
+
+    fn path_hint_move(&mut self, delta: isize) {
+        if self.path_hints.is_empty() {
+            return;
+        }
+        let len = self.path_hints.len();
+        let cur = self.path_hint_selected.min(len - 1) as isize;
+        self.path_hint_selected = (cur + delta).rem_euclid(len as isize) as usize;
+    }
+
+    /// True when the path-hint popup has entries to show.
+    fn has_path_hints(&self) -> bool {
+        if self.path_hint_dismissed || self.status != Status::Idle {
+            return false;
+        }
+        self.path_hint_query().is_some() && !self.path_hints.is_empty()
     }
 
     fn cursor_left(&mut self) {
@@ -2517,6 +2629,31 @@ async fn handle_key(
         }
     }
 
+    // Path-hint popup: while `@query` is active with at least one match,
+    // it owns Up/Down/Tab/Esc/Enter in the same pattern as slash hints.
+    if app.has_path_hints() {
+        match key.code {
+            KeyCode::Up => {
+                app.path_hint_move(-1);
+                return;
+            }
+            KeyCode::Down => {
+                app.path_hint_move(1);
+                return;
+            }
+            KeyCode::Tab | KeyCode::Enter => {
+                app.accept_path_hint();
+                return;
+            }
+            KeyCode::Esc => {
+                app.path_hint_dismissed = true;
+                app.path_hints.clear();
+                return;
+            }
+            _ => {}
+        }
+    }
+
     match key.code {
         KeyCode::Esc => {
             // Esc cancels a run or clears typed input; it never quits (that's
@@ -3752,6 +3889,18 @@ fn draw(f: &mut Frame, app: &mut App) {
                 height,
             };
             draw_slash_hints(f, rect, &matches, app.slash_selected);
+        } else if app.has_path_hints() {
+            // Dock the file-path hints above the input box, same layout as
+            // slash hints. Only shows when no slash hints are active.
+            let height = (app.path_hints.len() as u16 + 2).min(chunks[1].height);
+            let y = chunks[2].y.saturating_sub(height).max(chunks[1].y);
+            let rect = ratatui::layout::Rect {
+                x: chunks[2].x,
+                y,
+                width: chunks[2].width,
+                height,
+            };
+            draw_path_hints(f, rect, &app.path_hints, app.path_hint_selected);
         }
     }
 }
@@ -3789,6 +3938,52 @@ fn draw_slash_hints(
         .highlight_symbol("▶ ");
     let mut state = ListState::default();
     state.select(Some(selected.min(matches.len().saturating_sub(1))));
+    f.render_stateful_widget(list, area, &mut state);
+}
+
+/// File-path hint popup docked above the input when typing `@query`.
+/// Shows matching files/directories; arrow keys to navigate, Tab/Enter to
+/// select, Esc to dismiss.
+fn draw_path_hints(
+    f: &mut Frame,
+    area: ratatui::layout::Rect,
+    entries: &[PathHintItem],
+    selected: usize,
+) {
+    use ratatui::widgets::{Clear, List, ListItem, ListState};
+
+    let dim = Style::new().dark_gray();
+    let items: Vec<ListItem> = entries
+        .iter()
+        .map(|e| {
+            let icon = if e.is_dir {
+                Span::styled("", Style::new().yellow())
+            } else {
+                Span::styled("", Style::new().cyan())
+            };
+            let mut spans = vec![
+                icon,
+                Span::raw(" "),
+                Span::styled(&e.name, Style::new().bold()),
+            ];
+            let rel = &e.path;
+            if rel != &e.name {
+                spans.push(Span::styled(format!("  ({rel})"), dim));
+            }
+            ListItem::new(Line::from(spans))
+        })
+        .collect();
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::new().dark_gray())
+        .title(Span::styled(" path ", dim));
+    f.render_widget(Clear, area);
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(Style::new().reversed())
+        .highlight_symbol("▶ ");
+    let mut state = ListState::default();
+    state.select(Some(selected.min(entries.len().saturating_sub(1))));
     f.render_stateful_widget(list, area, &mut state);
 }
 

--- a/web-app/src/components/FilePickerPopover.tsx
+++ b/web-app/src/components/FilePickerPopover.tsx
@@ -1,0 +1,248 @@
+/**
+ * Fuzzy file/folder picker popover triggered by typing `@` in the chat input.
+ *
+ * Scoped to the session's working directory. Supports keyboard navigation
+ * (arrows, tab to complete, enter to select, esc to dismiss).
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { cn } from '@/lib/utils'
+import { Folder, File, FileCode, FileText, ImageIcon, FileJson, FileType } from 'lucide-react'
+import type { FilePickerEntry } from '@/types/path-reference'
+
+// ─── File-type icon helper ───────────────────────────────────────────────────
+const extIconMap: Record<string, typeof FileCode> = {
+  ts: FileCode,
+  tsx: FileCode,
+  js: FileCode,
+  jsx: FileCode,
+  rs: FileCode,
+  py: FileCode,
+  go: FileCode,
+  java: FileCode,
+  cpp: FileCode,
+  c: FileCode,
+  h: FileCode,
+  json: FileJson,
+  yaml: FileJson,
+  yml: FileJson,
+  toml: FileJson,
+  md: FileText,
+  txt: FileText,
+  pdf: FileText,
+  png: ImageIcon,
+  jpg: ImageIcon,
+  jpeg: ImageIcon,
+  gif: ImageIcon,
+  svg: ImageIcon,
+  css: FileType,
+  scss: FileType,
+  html: FileType,
+  xml: FileType,
+}
+
+function FileIcon({ entry }: { entry: FilePickerEntry }) {
+  if (entry.kind === 'directory') return <Folder className="size-4 shrink-0 text-amber-500" />
+  const ext = entry.extension?.toLowerCase() ?? ''
+  const Icon = extIconMap[ext]
+  if (Icon) return <Icon className="size-4 shrink-0 text-blue-500" />
+  return <File className="size-4 shrink-0 text-muted-foreground" />
+}
+
+// ─── Props ───────────────────────────────────────────────────────────────────
+type FilePickerPopoverProps = {
+  /** List of entries to show */
+  entries: FilePickerEntry[]
+  /** Search query (the text after `@`) */
+  query: string
+  /** Whether the picker is visible */
+  open: boolean
+  /** Position offset relative to the textarea */
+  position: { top: number; left: number } | null
+  /** Called when a path is selected (tab or enter) */
+  onSelect: (entry: FilePickerEntry) => void
+  /** Called to dismiss */
+  onClose: () => void
+  /** Ref for the textarea to position relative to */
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>
+}
+
+export function FilePickerPopover({
+  entries,
+  query,
+  open,
+  position,
+  onSelect,
+  onClose,
+  textareaRef,
+}: FilePickerPopoverProps) {
+  const [activeIndex, setActiveIndex] = useState(0)
+  const listRef = useRef<HTMLDivElement>(null)
+  const itemRefs = useRef<Map<number, HTMLDivElement>>(new Map())
+
+  // Reset selection when entries change
+  useEffect(() => {
+    setActiveIndex(0)
+  }, [entries.length])
+
+  // Position the popover relative to textarea cursor
+  const popoverStyle = useMemo(() => {
+    if (!position || !textareaRef.current) {
+      return { top: 0, left: 0, opacity: 0 as const }
+    }
+    return {
+      top: position.top,
+      left: position.left,
+    }
+  }, [position, textareaRef])
+
+  // Scroll active item into view
+  useEffect(() => {
+    const el = itemRefs.current.get(activeIndex)
+    el?.scrollIntoView({ block: 'nearest' })
+  }, [activeIndex])
+
+  // Keyboard handling is done in ChatInput, but we expose arrow navigation here
+  // We'll handle it through imperative methods
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!open) return
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault()
+          e.stopPropagation()
+          setActiveIndex((prev) => Math.min(prev + 1, entries.length - 1))
+          break
+        case 'ArrowUp':
+          e.preventDefault()
+          e.stopPropagation()
+          setActiveIndex((prev) => Math.max(prev - 1, 0))
+          break
+        case 'Enter':
+        case 'Tab':
+          if (entries.length > 0 && entries[activeIndex]) {
+            e.preventDefault()
+            e.stopPropagation()
+            onSelect(entries[activeIndex])
+          }
+          break
+        case 'Escape':
+          e.preventDefault()
+          e.stopPropagation()
+          onClose()
+          break
+      }
+    },
+    [open, entries, activeIndex, onSelect, onClose]
+  )
+
+  if (!open || entries.length === 0) return null
+
+  return (
+    <div
+      className="absolute z-50 w-[400px] max-h-[300px] overflow-y-auto rounded-xl border border-border bg-popover shadow-popover p-1"
+      style={popoverStyle}
+      onKeyDown={handleKeyDown}
+      role="listbox"
+      tabIndex={-1}
+    >
+      <div className="px-2 py-1.5 text-xs text-muted-foreground border-b border-border/50 mb-1">
+        {entries.length === 1
+          ? '1 result'
+          : `${entries.length} results`}
+        {query && (
+          <span>
+            {' '}for <span className="font-mono font-medium text-foreground/70">@{query}</span>
+          </span>
+        )}
+        <span className="ml-auto text-[10px] opacity-60">
+          ↑↓ navigate · Tab/Enter select · Esc dismiss
+        </span>
+      </div>
+      <div ref={listRef}>
+        {entries.map((entry, idx) => (
+          <div
+            key={entry.path}
+            ref={(el) => {
+              if (el) itemRefs.current.set(idx, el)
+              else itemRefs.current.delete(idx)
+            }}
+            className={cn(
+              'flex items-center gap-2 px-2 py-1.5 rounded-lg cursor-pointer text-sm transition-colors',
+              idx === activeIndex
+                ? 'bg-primary/10 text-primary-foreground'
+                : 'hover:bg-accent'
+            )}
+            onClick={() => onSelect(entry)}
+            onMouseEnter={() => setActiveIndex(idx)}
+            role="option"
+            aria-selected={idx === activeIndex}
+          >
+            <FileIcon entry={entry} />
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-1.5">
+                <span className="font-medium truncate">{entry.name}</span>
+                <span className="text-[10px] text-muted-foreground/50 uppercase shrink-0">
+                  {entry.kind === 'directory' ? 'folder' : entry.extension}
+                </span>
+              </div>
+              <div className="text-[11px] text-muted-foreground/60 truncate">
+                {entry.path}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ─── Expose imperative controls for the parent to forward keyboard events ────
+export type FilePickerHandle = {
+  handleKeyDown: (e: React.KeyboardEvent) => void
+  activeIndex: number
+  entries: FilePickerEntry[]
+}
+
+export function useFilePickerKeyboard(open: boolean) {
+  const [activeIndex, setActiveIndex] = useState(0)
+  const [entries, setEntries] = useState<FilePickerEntry[]>([])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!open || entries.length === 0) return
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault()
+          setActiveIndex((prev) => Math.min(prev + 1, entries.length - 1))
+          break
+        case 'ArrowUp':
+          e.preventDefault()
+          setActiveIndex((prev) => Math.max(prev - 1, 0))
+          break
+        case 'Enter':
+        case 'Tab': {
+          if (entries[activeIndex]) {
+            e.preventDefault()
+            return { selected: entries[activeIndex] } as const
+          }
+          break
+        }
+        case 'Escape':
+          e.preventDefault()
+          return { dismissed: true } as const
+      }
+      return undefined
+    },
+    [open, entries, activeIndex]
+  )
+
+  return {
+    activeIndex,
+    setActiveIndex,
+    entries,
+    setEntries,
+    handleKeyDown,
+  }
+}

--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -101,6 +101,16 @@ import JanBrowserExtensionDialog from '@/containers/dialogs/JanBrowserExtensionD
 import { useJanBrowserExtension } from '@/hooks/useJanBrowserExtension'
 import { useAgentMode } from '@/hooks/useAgentMode'
 import { useWebSearchConfig } from '@/hooks/useWebSearchConfig'
+import { usePathReferences } from '@/stores/path-references'
+import {
+  parsePromptForReferences,
+  resolvePathReference,
+  formatPathReferenceText,
+  searchFiles,
+  REFERENCE_PATTERN,
+  type FilePickerEntry as FileEntry,
+} from '@/lib/path-references'
+import { FilePickerPopover } from '@/components/FilePickerPopover'
 
 type ChatInputProps = {
   className?: string
@@ -186,6 +196,155 @@ const ChatInput = memo(function ChatInput({
   const toggleAgentMode = useAgentMode((state) => state.toggleAgentMode)
   const webSearchEnabled = useWebSearchConfig((s) => s.webSearchEnabled)
   const setWebSearchEnabled = useWebSearchConfig((s) => s.setWebSearchEnabled)
+
+  // ── @path file reference state ──────────────────────────────────────────
+  const pathRefs = usePathReferences((s) => s.references)
+  const setPathRefs = usePathReferences((s) => s.setReferences)
+  const clearPathRefs = usePathReferences((s) => s.clearReferences)
+
+  const [filePickerOpen, setFilePickerOpen] = useState(false)
+  const [filePickerQuery, setFilePickerQuery] = useState('')
+  const [filePickerEntries, setFilePickerEntries] = useState<FileEntry[]>([])
+  const [filePickerPosition, setFilePickerPosition] = useState<{
+    top: number
+    left: number
+  } | null>(null)
+  const [workingDir, setWorkingDir] = useState<string | undefined>(undefined)
+  // Textarea cursor position snapshot at the time @ was typed
+  const filePickerCursorPos = useRef<number | null>(null)
+
+  // Pre-load working directory
+  useEffect(() => {
+    const loadWorkingDir = async () => {
+      try {
+        // Try to get project home directory
+        const { homeDir, documentDir } = await import('@tauri-apps/api/path')
+        const home = await homeDir()
+        setWorkingDir(home)
+      } catch {
+        setWorkingDir(undefined)
+      }
+    }
+    if (effectiveAgentMode) {
+      loadWorkingDir()
+    }
+  }, [effectiveAgentMode])
+
+  // Detect `@` in the prompt text and open the file picker
+  const handlePromptChange = useCallback(
+    (value: string) => {
+      setPrompt(value)
+
+      // Only enable in agent mode
+      if (!effectiveAgentMode) {
+        setFilePickerOpen(false)
+        return
+      }
+
+      const cursorIdx = filePickerCursorPos.current ?? value.length
+
+      // Look backwards from current cursor to find the last word starting with @
+      const beforeCursor = value.slice(0, cursorIdx)
+      const atMatch = beforeCursor.match(/@([\w.\/-]*)$/)
+
+      if (atMatch) {
+        const query = atMatch[1] ?? ''
+        setFilePickerQuery(query)
+
+        // If we have a working directory, search files
+        if (workingDir) {
+          searchFiles(workingDir, query)
+            .then((entries) => setFilePickerEntries(entries.slice(0, 50)))
+            .catch(() => setFilePickerEntries([]))
+        } else {
+          setFilePickerEntries([])
+        }
+
+        // Position the picker above the text
+        if (textareaRef.current) {
+          const lineHeight = 22
+          const lines = beforeCursor.split('\n').length
+          const pos = {
+            top: -Math.min(lines * lineHeight + 40, 300),
+            left: 0,
+          }
+          setFilePickerPosition(pos)
+        }
+        setFilePickerOpen(true)
+      } else {
+        setFilePickerOpen(false)
+      }
+    },
+    [effectiveAgentMode, workingDir, setPrompt]
+  )
+
+  // Insert a selected file reference into the prompt
+  const handleFilePickerSelect = useCallback(
+    (entry: FileEntry) => {
+      if (filePickerCursorPos.current == null) return
+
+      const beforeCursor = prompt.slice(0, filePickerCursorPos.current)
+      const afterCursor = prompt.slice(filePickerCursorPos.current)
+
+      // Replace the `@query` with `path/to/file` (the resolved reference)
+      const textBefore = beforeCursor.replace(/@[\w.\/-]*$/, '')
+      const refText = entry.path
+      const newPrompt = textBefore + refText + afterCursor
+
+      setPrompt(newPrompt)
+      setFilePickerOpen(false)
+      filePickerCursorPos.current = null
+
+      // Focus back on textarea
+      setTimeout(() => textareaRef.current?.focus(), 0)
+    },
+    [prompt, setPrompt]
+  )
+
+  const handleFilePickerClose = useCallback(() => {
+    setFilePickerOpen(false)
+    filePickerCursorPos.current = null
+  }, [])
+
+  // Resolve @path references in the prompt text, returning the resolved content
+  const resolvePromptReferences = useCallback(
+    async (text: string): Promise<{
+      text: string
+      resolvedContents: string
+    }> => {
+      const refs = parsePromptForReferences(text)
+      if (refs.length === 0) return { text, resolvedContents: '' }
+
+      const parts: string[] = []
+      for (const ref of refs) {
+        const resolved = await resolvePathReference(ref, workingDir)
+        if (resolved) {
+          if (resolved.kind === 'file') {
+            parts.push(
+              `--- File: ${resolved.absolutePath} ---\n${resolved.content}`
+            )
+          } else if (resolved.kind === 'directory') {
+            parts.push(
+              `--- Directory: ${resolved.absolutePath} ---\n${resolved.content}`
+            )
+          }
+        } else {
+          parts.push(
+            `[File not found or too large: ${ref.rawPath}]`
+          )
+        }
+      }
+
+      const resolvedContents = parts.join('\n\n')
+
+      // Remove @ references from the prompt text (they'll be replaced by the
+      // resolved contents above so the model sees the content directly)
+      const cleanText = text.replace(REFERENCE_PATTERN, '').replace(/\s+/g, ' ').trim()
+
+      return { text: cleanText, resolvedContents }
+    },
+    [workingDir]
+  )
 
   const handleAgentToggle = useCallback(() => {
     toggleAgentMode(agentModeKey)
@@ -365,7 +524,15 @@ const ChatInput = memo(function ChatInput({
       setMessage('Please select a model to start chatting.')
       return
     }
-    if (!prompt.trim() && !hasSendableMedia) {
+
+    // Resolve @path references before sending
+    const { text: resolvedText, resolvedContents } =
+      await resolvePromptReferences(prompt)
+    const effectivePrompt = resolvedContents
+      ? `${resolvedText}\n\n---\nReferenced file contents:\n\n${resolvedContents}`
+      : resolvedText
+
+    if (!effectivePrompt.trim() && !hasSendableMedia) {
       return
     }
     if (ingestingAny) {
@@ -374,7 +541,7 @@ const ChatInput = memo(function ChatInput({
     }
 
     setMessage('')
-    addToHistory(prompt)
+    addToHistory(effectivePrompt)
 
     // Use onSubmit prop if available (AI SDK), otherwise create thread and navigate
     if (onSubmit) {
@@ -382,7 +549,7 @@ const ChatInput = memo(function ChatInput({
       if (isStreaming && currentThreadId) {
         useMessageQueue.getState().enqueue(currentThreadId, {
           id: generateId(),
-          text: prompt,
+          text: effectivePrompt,
           createdAt: Date.now(),
         })
         setPrompt('')
@@ -412,7 +579,7 @@ const ChatInput = memo(function ChatInput({
         }))
       const files = [...imageFiles, ...audioFiles, ...videoFiles]
 
-      onSubmit(prompt, files.length > 0 ? files : undefined)
+      onSubmit(effectivePrompt, files.length > 0 ? files : undefined)
       setPrompt('')
       clearAttachmentsForThread(attachmentsKey)
     } else {
@@ -427,7 +594,7 @@ const ChatInput = memo(function ChatInput({
       )
 
       const messagePayload = {
-        text: prompt,
+        text: effectivePrompt,
         files: [] as Array<{ type: string; mediaType: string; url: string }>,
       }
 
@@ -1897,9 +2064,27 @@ const ChatInput = memo(function ChatInput({
               value={prompt}
               data-testid={'chat-input'}
               onChange={(e) => {
-                setPrompt(e.target.value)
+                const value = e.target.value
+                const cursorIdx = e.target.selectionStart
+
+                // Track when @ is freshly typed
+                const prevPrompt = prompt
+                handlePromptChange(value)
+
+                // Snapshot cursor position when user types @
+                if (value.includes('@') && !prevPrompt.includes('@')) {
+                  filePickerCursorPos.current = cursorIdx
+                } else if (value.endsWith('@') && cursorIdx > 0) {
+                  filePickerCursorPos.current = cursorIdx
+                } else if (!value.includes('@')) {
+                  filePickerCursorPos.current = null
+                } else if (filePickerCursorPos.current == null) {
+                  // If picker already open, keep tracking cursor
+                  filePickerCursorPos.current = cursorIdx
+                }
+
                 // Count the number of newlines to estimate rows
-                const newRows = (e.target.value.match(/\n/g) || []).length + 1
+                const newRows = (value.match(/\n/g) || []).length + 1
                 setRows(Math.min(newRows, maxRows))
               }}
               onKeyDown={(e) => {
@@ -1936,6 +2121,17 @@ const ChatInput = memo(function ChatInput({
                     navigateHistory('down')
                   }
                 }
+                // Tab completes the selected @path file reference
+                if (
+                  e.key === 'Tab' &&
+                  filePickerOpen &&
+                  filePickerEntries.length > 0 &&
+                  !isComposing
+                ) {
+                  e.preventDefault()
+                  // Select the first entry as the default Tab completion
+                  handleFilePickerSelect(filePickerEntries[0])
+                }
               }}
               onPaste={handlePaste}
               placeholder={t('common:placeholder.chatInput')}
@@ -1950,6 +2146,20 @@ const ChatInput = memo(function ChatInput({
                 className
               )}
             />
+            {/* @path file reference picker popover */}
+            {filePickerOpen && effectiveAgentMode && (
+              <div className="relative">
+                <FilePickerPopover
+                  entries={filePickerEntries}
+                  query={filePickerQuery}
+                  open={filePickerOpen}
+                  position={filePickerPosition}
+                  onSelect={handleFilePickerSelect}
+                  onClose={handleFilePickerClose}
+                  textareaRef={textareaRef}
+                />
+              </div>
+            )}
           </div>
         </div>
 

--- a/web-app/src/lib/path-references.ts
+++ b/web-app/src/lib/path-references.ts
@@ -1,0 +1,339 @@
+/**
+ * Utility for scanning, resolving, and searching @path file/folder references
+ * in the chat input.
+ *
+ * - Typing `@` triggers a fuzzy file search scoped to the working directory.
+ * - Selected paths are kept as text references (e.g. `@src/main.ts`) in the prompt.
+ * - On submit, each @reference is resolved: files are read as text (with a 1MB cap),
+ *   directories produce a listing, images produce inline data, and errors surface
+ *   as inline notices.
+ */
+import { fs } from '@janhq/core'
+import type { PathReference, FilePickerEntry } from '@/types/path-reference'
+
+export type { FilePickerEntry }
+
+// ── Exports ──────────────────────────────────────────────────────────────────
+
+/** Regex matching @path references in text. */
+export const REFERENCE_PATTERN = /@([^\s,;:!?'"`)\]}>]+)/g
+
+/** Maximum bytes we'll read from a single file. */
+const MAX_FILE_BYTES = 1 * 1024 * 1024
+
+/** Maximum characters in a directory listing sent to the model. */
+const MAX_DIR_CHARS = 20_000
+
+/** Image extensions that should be offered as base64 rather than text. */
+const IMAGE_EXTS = new Set(['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg'])
+
+/** Common code/text extensions we prioritise in picker results. */
+const CODE_EXTS = new Set([
+  'ts', 'tsx', 'js', 'jsx', 'rs', 'py', 'go', 'java', 'c', 'cpp', 'h',
+  'hpp', 'cs', 'rb', 'php', 'swift', 'kt', 'scala',
+  'json', 'yaml', 'yml', 'toml', 'xml', 'md', 'txt', 'css', 'scss',
+  'html', 'sh', 'bash', 'zsh', 'sql', 'graphql',
+])
+
+// ── Parsing references from text ─────────────────────────────────────────────
+
+/**
+ * Parse @path references from a prompt string.
+ * Returns the raw path strings (e.g. `["src/main.ts", "../README.md"]`).
+ */
+export function parsePromptForReferences(text: string): string[] {
+  const seen = new Set<string>()
+  const refs: string[] = []
+  let match: RegExpExecArray | null
+  while ((match = REFERENCE_PATTERN.exec(text)) !== null) {
+    const raw = match[1].trim()
+    // Skip obvious non-paths
+    if (
+      !raw ||
+      raw.startsWith('http://') ||
+      raw.startsWith('https://') ||
+      raw.startsWith('file://') ||
+      raw.includes('@') ||
+      raw === ''
+    )
+      continue
+    if (!seen.has(raw)) {
+      seen.add(raw)
+      refs.push(raw)
+    }
+  }
+  return refs
+}
+
+/**
+ * Format a path as a @reference text for insertion into the prompt.
+ */
+export function formatPathReferenceText(path: string): string {
+  return `@${path}`
+}
+
+// ── Fuzzy file search ────────────────────────────────────────────────────────
+
+/**
+ * Searches for files/folders in `rootDir` whose path or name matches `query`
+ * (case-insensitive substring / fuzzy matching). Returns up to 50 entries
+ * suitable for the picker dropdown.
+ *
+ * If `query` is empty, returns a flat listing of the immediate children of
+ * `rootDir` (capped at 100). Otherwise performs a breadth-first walk up to a
+ * depth of 4 levels and scores entries by match quality.
+ */
+export async function searchFiles(
+  rootDir: string,
+  query: string,
+  max_: number = 50
+): Promise<FilePickerEntry[]> {
+  try {
+    // Empty query: return immediate children (fast, no recursion)
+    if (!query || query.trim() === '') {
+      return listImmediateChildren(rootDir, max_)
+    }
+
+    // Non-empty query: walk the tree up to 4 levels
+    const results: ScoredEntry[] = []
+    const queryLower = query.toLowerCase()
+    // If query contains slashes, we search deeper
+    const depth = Math.min(query.split('/').length + 2, 4)
+
+    await walkDir(rootDir, queryLower, results, depth, 0)
+
+    // Sort: directories first, then by match quality, then alphabetically
+    results.sort((a, b) => {
+      // Directories first
+      if (a.kind !== b.kind) return a.kind === 'directory' ? -1 : 1
+      // Exact name match > starts with > substring > fuzzy
+      if (a.score !== b.score) return b.score - a.score
+      // Shorter paths first
+      return a.path.length - b.path.length
+    })
+
+    return results.slice(0, max_).map(({ path, name, kind, ext }) => ({
+      path,
+      name,
+      kind,
+      extension: ext,
+    }))
+  } catch {
+    return []
+  }
+}
+
+// ── Resolving a single reference content ─────────────────────────────────────
+
+/**
+ * Resolve a @path reference and return the content to inject into the message.
+ *
+ * Returns `null` if the reference is missing or errors (caller surfaces inline).
+ */
+export async function resolvePathReference(
+  rawPath: string,
+  workingDir?: string
+): Promise<{
+  kind: 'file' | 'directory'
+  absolutePath: string
+  content: string
+  isImage: boolean
+  imageBase64?: string
+  imageMimeType?: string
+} | null> {
+  const absolutePath = rawPath.startsWith('/')
+    ? rawPath
+    : workingDir
+      ? `${workingDir}/${rawPath}`
+      : rawPath
+
+  try {
+    const stat = await fs.fileStat(absolutePath)
+    if (!stat) return null
+
+    const isDir = stat.isDirectory ?? false
+
+    if (isDir) {
+      // Directory listing
+      const entries = await fs.readdirSync(absolutePath)
+      const items = Array.isArray(entries) ? entries : []
+      let listing = ''
+      for (const item of items) {
+        const name = typeof item === 'string' ? item : String(item)
+        listing += `  ${name}\n`
+      }
+      if (listing.length > MAX_DIR_CHARS) {
+        listing = listing.slice(0, MAX_DIR_CHARS) + '\n  ... (truncated)'
+      }
+      return { kind: 'directory', absolutePath, content: listing, isImage: false }
+    }
+
+    // File
+    const size = stat.size ? Number(stat.size) : 0
+    if (size > MAX_FILE_BYTES) {
+      return null // too large — caller handles
+    }
+
+    const ext = rawPath.split('.').pop()?.toLowerCase()
+    if (ext && IMAGE_EXTS.has(ext)) {
+      const content = await fs.readFileSync(absolutePath)
+      const base64 = typeof content === 'string' ? content : String(content)
+      const mime = imageMimeFor(ext)
+      return {
+        kind: 'file',
+        absolutePath,
+        content: `[Image: ${rawPath}]`,
+        isImage: true,
+        imageBase64: base64,
+        imageMimeType: mime,
+      }
+    }
+
+    const content = await fs.readFileSync(absolutePath)
+    const text = typeof content === 'string' ? content : String(content)
+    const truncated =
+      text.length > MAX_FILE_BYTES
+        ? text.slice(0, MAX_FILE_BYTES) + '\n\n... (truncated)'
+        : text
+
+    const header = `--- File: ${rawPath} ---\n`
+    const footer = `\n--- End: ${rawPath} ---`
+    return { kind: 'file', absolutePath, content: header + truncated + footer, isImage: false }
+  } catch {
+    return null
+  }
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+interface ScoredEntry {
+  path: string
+  name: string
+  kind: 'file' | 'directory'
+  ext?: string
+  score: number
+}
+
+function scoreMatch(name: string, queryLower: string): number {
+  const lower = name.toLowerCase()
+  if (lower === queryLower) return 100 // exact match
+  if (lower.startsWith(queryLower)) return 80 // prefix
+  if (lower.includes(queryLower)) return 60 // substring
+  // Fuzzy: each consecutive matched character adds 5
+  let fi = 0
+  let score = 0
+  for (const ch of queryLower) {
+    const idx = lower.indexOf(ch, fi)
+    if (idx === -1) return 0
+    if (idx === fi) score += 10 // consecutive match
+    else score += 2
+    fi = idx + 1
+  }
+  return Math.min(score, 50)
+}
+
+async function walkDir(
+  dir: string,
+  queryLower: string,
+  results: ScoredEntry[],
+  maxDepth: number,
+  depth: number
+): Promise<void> {
+  if (depth > maxDepth) return
+
+  try {
+    const entries: string[] = await fs.readdirSync(dir)
+    if (!Array.isArray(entries)) return
+
+    const items: Array<{ path: string; name: string; isDir: boolean }> = []
+    for (const entry of entries) {
+      const name = typeof entry === 'string' ? entry : String(entry)
+      const fullPath = `${dir}/${name}`
+      let isDir = false
+      try {
+        const stat = await fs.fileStat(fullPath)
+        isDir = stat?.isDirectory ?? false
+      } catch {
+        // stat failed, treat as file
+      }
+
+      const entryName = name
+      const entryScore = scoreMatch(entryName, queryLower)
+      if (entryScore > 0) {
+        const ext = isDir ? undefined : entryName.split('.').pop()?.toLowerCase()
+        results.push({
+          path: fullPath,
+          name: entryName,
+          kind: isDir ? 'directory' : 'file',
+          ext,
+          score: entryScore,
+        })
+      }
+
+      items.push({ path: fullPath, name: entryName, isDir })
+    }
+
+    // Recurse into directories
+    if (depth < maxDepth) {
+      for (const item of items) {
+        if (item.isDir) {
+          await walkDir(item.path, queryLower, results, maxDepth, depth + 1)
+        }
+      }
+    }
+  } catch {
+    // Silently skip directories we can't read
+  }
+}
+
+async function listImmediateChildren(
+  dir: string,
+  max_: number
+): Promise<FilePickerEntry[]> {
+  try {
+    const entries: string[] = await fs.readdirSync(dir)
+    if (!Array.isArray(entries)) return []
+
+    const results: FilePickerEntry[] = []
+    for (const entry of entries) {
+      if (results.length >= max_) break
+      const name = typeof entry === 'string' ? entry : String(entry)
+      const fullPath = `${dir}/${name}`
+      let isDir = false
+      try {
+        const stat = await fs.fileStat(fullPath)
+        isDir = stat?.isDirectory ?? false
+      } catch {
+        // treat as file
+      }
+      const ext = isDir ? undefined : name.split('.').pop()?.toLowerCase()
+      results.push({ path: fullPath, name, kind: isDir ? 'directory' : 'file', extension: ext })
+    }
+
+    // Sort: directories first, then code files, then alphabetically
+    results.sort((a, b) => {
+      if (a.kind !== b.kind) return a.kind === 'directory' ? -1 : 1
+      const aCode = a.extension ? CODE_EXTS.has(a.extension) : false
+      const bCode = b.extension ? CODE_EXTS.has(b.extension) : false
+      if (aCode !== bCode) return aCode ? -1 : 1
+      return a.name.localeCompare(b.name)
+    })
+
+    return results
+  } catch {
+    return []
+  }
+}
+
+function imageMimeFor(ext: string): string {
+  const map: Record<string, string> = {
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    png: 'image/png',
+    gif: 'image/gif',
+    webp: 'image/webp',
+    bmp: 'image/bmp',
+    svg: 'image/svg+xml',
+  }
+  return map[ext] || 'image/png'
+}

--- a/web-app/src/stores/path-references.ts
+++ b/web-app/src/stores/path-references.ts
@@ -1,0 +1,48 @@
+/**
+ * Store for @path file/folder references in chat input.
+ * Maintains an ordered list of active references during a message composition.
+ */
+import { create } from 'zustand'
+import type { PathReference } from '@/types/path-reference'
+
+type PathReferencesState = {
+  /** Active references in the current message being composed */
+  references: PathReference[]
+
+  /** Set all references (from parsing the prompt text) */
+  setReferences: (refs: PathReference[]) => void
+
+  /** Add a single reference */
+  addReference: (ref: PathReference) => void
+
+  /** Remove a reference by its raw path */
+  removeReference: (rawPath: string) => void
+
+  /** Clear all references */
+  clearReferences: () => void
+
+  /** Get the current references */
+  getReferences: () => PathReference[]
+}
+
+export const usePathReferences = create<PathReferencesState>((set, get) => ({
+  references: [],
+
+  setReferences: (refs) => set({ references: refs }),
+
+  addReference: (ref) =>
+    set((state) => {
+      // Avoid duplicates
+      if (state.references.some((r) => r.rawPath === ref.rawPath)) return state
+      return { references: [...state.references, ref] }
+    }),
+
+  removeReference: (rawPath) =>
+    set((state) => ({
+      references: state.references.filter((r) => r.rawPath !== rawPath),
+    })),
+
+  clearReferences: () => set({ references: [] }),
+
+  getReferences: () => get().references,
+}))

--- a/web-app/src/types/path-reference.ts
+++ b/web-app/src/types/path-reference.ts
@@ -1,0 +1,32 @@
+/**
+ * A resolved @path reference in the chat input
+ */
+export type PathReference = {
+  /** Unique ID for this reference chip */
+  id: string
+  /** The raw path string as typed/selected by the user */
+  rawPath: string
+  /** Full absolute path (resolved relative to working directory) */
+  absolutePath: string
+  /** Whether it's a file or directory */
+  kind: 'file' | 'directory'
+  /** Display name (basename of the path) */
+  name: string
+  /** File size in bytes (for files only) */
+  size?: number
+  /** Whether this reference encountered an error during resolution */
+  error?: 'missing' | 'too_large' | 'unreadable'
+  /** Error description */
+  errorMessage?: string
+}
+
+/**
+ * Entry shown in the fuzzy file picker
+ */
+export type FilePickerEntry = {
+  path: string
+  name: string
+  kind: 'file' | 'directory'
+  // Optional for display/styling
+  extension?: string
+}


### PR DESCRIPTION
## Summary

Adds `@path` file/directory reference resolution for the jan-agent CLI. When a user types `@path/to/file` in the TUI input or a headless task, the referenced content is read and injected into the message so the model sees the file contents directly.

## Key Changes

### New: `src-tauri/src/core/cli/path_refs.rs`

Core module providing:
- **`parse_references`** — parses `@path` tokens from text (deduplicated, skips http/https/file URIs)
- **`strip_references`** — removes `@path` tokens and normalises whitespace
- **`resolve_references`** — synchronous (blocking) resolution that reads files (1MB cap), lists directories (20KB cap), encodes images as base64 data URLs, and produces a formatted injected-content block

### Modified: `src-tauri/src/core/cli/tui.rs`

`App::submit_user` resolves @path refs before building the user message, so the TUI benefit mirrors the desktop @-completion (without the autocomplete popup UI).

### Modified: `src-tauri/src/core/cli/mod.rs`

`prepare_agent_run` resolves @path refs in headless tasks (`jan agent run` / `jan agent step`) before building the orchestration body.

## Behaviour

- `@path` references are stripped from the prompt text and replaced with formatted content blocks
- Missing/unreadable files surface as inline error notices e.g. `[path: cannot access: ...]`
- `@http://` / `@https://` / `@file://` prefixed tokens are skipped
- Images are encoded as inline base64 (noted as text in the injected block)