### PR TITLE
refactor: centralize llamacpp extension lookup with scoped-name fallback

### DIFF
--- a/web-app/src/hooks/__tests__/useBackendUpdater.test.ts
+++ b/web-app/src/hooks/__tests__/useBackendUpdater.test.ts
@@ -127,6 +127,219 @@ describe('useBackendUpdater', () => {
     expect(result.current.updateState.isUpdateAvailable).toBe(true)
   })
 
+  // --- getLlamacppExtension scoped-name fallback ---
+
+  it('installBackend works with scoped extension name', async () => {
+    const mockInstall = vi.fn().mockResolvedValue(undefined)
+    const mockRefresh = vi.fn().mockResolvedValue(undefined)
+
+    mockGetByName.mockImplementation((name: string) => {
+      if (name === '@janhq/llamacpp-extension') {
+        return {
+          installBackend: mockInstall,
+          refreshBackendOptions: mockRefresh,
+        }
+      }
+      return null
+    })
+
+    const { useBackendUpdater } = await import('../useBackendUpdater')
+    const { result } = renderHook(() => useBackendUpdater())
+
+    await act(async () => {
+      await result.current.installBackend('/path/to/backend.zip')
+    })
+
+    expect(mockInstall).toHaveBeenCalledWith('/path/to/backend.zip')
+    expect(mockRefresh).toHaveBeenCalled()
+  })
+
+  it('installBackend falls back to unscoped extension name', async () => {
+    const mockInstall = vi.fn().mockResolvedValue(undefined)
+    const mockConfigure = vi.fn().mockResolvedValue(undefined)
+
+    mockGetByName.mockImplementation((name: string) => {
+      if (name === 'llamacpp-extension') {
+        return {
+          installBackend: mockInstall,
+          configureBackends: mockConfigure,
+        }
+      }
+      return null
+    })
+
+    const { useBackendUpdater } = await import('../useBackendUpdater')
+    const { result } = renderHook(() => useBackendUpdater())
+
+    await act(async () => {
+      await result.current.installBackend('/path/to/backend.zip')
+    })
+
+    expect(mockInstall).toHaveBeenCalledWith('/path/to/backend.zip')
+    expect(mockConfigure).toHaveBeenCalled()
+  })
+
+  it('installBackend throws when extension not found', async () => {
+    const { useBackendUpdater } = await import('../useBackendUpdater')
+    const { result } = renderHook(() => useBackendUpdater())
+
+    await expect(
+      act(async () => {
+        await result.current.installBackend('/path/to/backend.zip')
+      })
+    ).rejects.toThrow('Extension does not support backend installation')
+  })
+
+  it('installBackend prefers refreshBackendOptions over configureBackends', async () => {
+    const mockInstall = vi.fn().mockResolvedValue(undefined)
+    const mockRefresh = vi.fn().mockResolvedValue(undefined)
+    const mockConfigure = vi.fn().mockResolvedValue(undefined)
+
+    mockGetByName.mockImplementation((name: string) => {
+      if (name === '@janhq/llamacpp-extension') {
+        return {
+          installBackend: mockInstall,
+          refreshBackendOptions: mockRefresh,
+          configureBackends: mockConfigure,
+        }
+      }
+      return null
+    })
+
+    const { useBackendUpdater } = await import('../useBackendUpdater')
+    const { result } = renderHook(() => useBackendUpdater())
+
+    await act(async () => {
+      await result.current.installBackend('/path/to/backend.zip')
+    })
+
+    expect(mockRefresh).toHaveBeenCalled()
+    expect(mockConfigure).not.toHaveBeenCalled()
+  })
+
+  it('installCudaRuntime works with scoped extension name', async () => {
+    const mockInstall = vi.fn().mockResolvedValue(undefined)
+
+    mockGetByName.mockImplementation((name: string) => {
+      if (name === '@janhq/llamacpp-extension') {
+        return { installCudaRuntime: mockInstall }
+      }
+      return null
+    })
+
+    const { useBackendUpdater } = await import('../useBackendUpdater')
+    const { result } = renderHook(() => useBackendUpdater())
+
+    await act(async () => {
+      await result.current.installCudaRuntime('/path/to/cuda.zip')
+    })
+
+    expect(mockInstall).toHaveBeenCalledWith('/path/to/cuda.zip')
+  })
+
+  it('installCudaRuntime falls back to unscoped extension name', async () => {
+    const mockInstall = vi.fn().mockResolvedValue(undefined)
+
+    mockGetByName.mockImplementation((name: string) => {
+      if (name === 'llamacpp-extension') {
+        return { installCudaRuntime: mockInstall }
+      }
+      return null
+    })
+
+    const { useBackendUpdater } = await import('../useBackendUpdater')
+    const { result } = renderHook(() => useBackendUpdater())
+
+    await act(async () => {
+      await result.current.installCudaRuntime('/path/to/cuda.zip')
+    })
+
+    expect(mockInstall).toHaveBeenCalledWith('/path/to/cuda.zip')
+  })
+
+  it('installCudaRuntime throws when extension not found', async () => {
+    const { useBackendUpdater } = await import('../useBackendUpdater')
+    const { result } = renderHook(() => useBackendUpdater())
+
+    await expect(
+      act(async () => {
+        await result.current.installCudaRuntime('/path/to/cuda.zip')
+      })
+    ).rejects.toThrow('Extension does not support CUDA runtime installation')
+  })
+
+  it('installCudaRuntime throws when extension lacks installCudaRuntime method', async () => {
+    mockGetByName.mockImplementation((name: string) => {
+      if (name === '@janhq/llamacpp-extension') {
+        return {} // no installCudaRuntime method
+      }
+      return null
+    })
+
+    const { useBackendUpdater } = await import('../useBackendUpdater')
+    const { result } = renderHook(() => useBackendUpdater())
+
+    await expect(
+      act(async () => {
+        await result.current.installCudaRuntime('/path/to/cuda.zip')
+      })
+    ).rejects.toThrow('Extension does not support CUDA runtime installation')
+  })
+
+  it('searches scoped extension name before fallback', async () => {
+    // Only unscoped name yields an extension; scoped returns null.
+    // This tests that the scoped lookup happens first.
+    mockGetByName.mockImplementation((name: string) => {
+      if (name === '@janhq/llamacpp-extension') return null
+      if (name === 'llamacpp-extension')
+        return {
+          installBackend: vi.fn().mockResolvedValue(undefined),
+          refreshBackendOptions: vi.fn().mockResolvedValue(undefined),
+        }
+      return null
+    })
+
+    const { useBackendUpdater } = await import('../useBackendUpdater')
+    const { result } = renderHook(() => useBackendUpdater())
+
+    await act(async () => {
+      await result.current.installBackend('/path/to/backend.zip')
+    })
+
+    // Both names were consulted during the lookup.
+    const llamacppCalls = mockGetByName.mock.calls.filter(
+      (c) =>
+        c[0] === '@janhq/llamacpp-extension' || c[0] === 'llamacpp-extension'
+    )
+    // At minimum one scoped + one unscoped call (there may be more from
+    // the auto-update-setting check which also calls getLlamacppExtension).
+    expect(llamacppCalls.length).toBeGreaterThanOrEqual(2)
+    // The very first call for any llamacpp name is the scoped one.
+    expect(llamacppCalls[0][0]).toBe('@janhq/llamacpp-extension')
+    expect(llamacppCalls[1][0]).toBe('llamacpp-extension')
+  })
+
+  it('does not fall back when scoped name resolves', async () => {
+    mockGetByName.mockImplementation((name: string) => {
+      if (name === '@janhq/llamacpp-extension')
+        return {
+          installBackend: vi.fn().mockResolvedValue(undefined),
+          refreshBackendOptions: vi.fn().mockResolvedValue(undefined),
+        }
+      return null
+    })
+
+    const { useBackendUpdater } = await import('../useBackendUpdater')
+    const { result } = renderHook(() => useBackendUpdater())
+
+    await act(async () => {
+      await result.current.installBackend('/path/to/backend.zip')
+    })
+
+    // Scoped name was found; unscoped should not be consulted.
+    expect(mockGetByName).not.toHaveBeenCalledWith('llamacpp-extension')
+  })
+
   it('checkForUpdate returns null when no update needed', async () => {
     mockGetByName.mockReturnValue({
       checkBackendForUpdates: vi.fn().mockResolvedValue({ updateNeeded: false, newVersion: '' }),

--- a/web-app/src/hooks/useBackendUpdater.ts
+++ b/web-app/src/hooks/useBackendUpdater.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect } from 'react'
-import { events } from '@janhq/core'
+import { BaseExtension, events } from '@janhq/core'
 import { ExtensionManager } from '@/lib/extension'
 import { useModelProvider } from '@/hooks/useModelProvider'
 
@@ -68,6 +68,16 @@ export interface BackendUpdateState {
   autoUpdateEnabled: boolean
 }
 
+/** Try scoped name first, then unscoped fallback for backward compat. */
+function getLlamacppExtension(): BaseExtension | undefined {
+  const mgr = ExtensionManager.getInstance()
+  return (
+    mgr.getByName('@janhq/llamacpp-extension') ??
+    mgr.getByName('llamacpp-extension') ??
+    undefined
+  )
+}
+
 export const useBackendUpdater = () => {
   const [updateState, setUpdateState] = useState<BackendUpdateState>({
     isUpdateAvailable: false,
@@ -97,21 +107,7 @@ export const useBackendUpdater = () => {
   useEffect(() => {
     const checkAutoUpdateSetting = async () => {
       try {
-        // Get llamacpp extension instance
-        const allExtensions = ExtensionManager.getInstance().listExtensions()
-        let llamacppExtension =
-          ExtensionManager.getInstance().getByName('llamacpp-extension')
-
-        if (!llamacppExtension) {
-          // Try to find by type or other properties
-          llamacppExtension =
-            allExtensions.find(
-              (ext) =>
-                ext.constructor.name.toLowerCase().includes('llamacpp') ||
-                (ext.type &&
-                  ext.type()?.toString().toLowerCase().includes('inference'))
-            ) || undefined
-        }
+        const llamacppExtension = getLlamacppExtension()
 
         if (llamacppExtension && 'getSettings' in llamacppExtension) {
           const extension = llamacppExtension as LlamacppExtension
@@ -170,30 +166,7 @@ export const useBackendUpdater = () => {
           return null
         }
 
-        // Get llamacpp extension instance
-        const allExtensions = ExtensionManager.getInstance().listExtensions()
-
-        const llamacppExtension =
-          ExtensionManager.getInstance().getByName('llamacpp-extension')
-
-        let extensionToUse = llamacppExtension
-
-        if (!llamacppExtension) {
-          // Try to find by type or other properties
-          const possibleExtension = allExtensions.find(
-            (ext) =>
-              ext.constructor.name.toLowerCase().includes('llamacpp') ||
-              (ext.type &&
-                ext.type()?.toString().toLowerCase().includes('inference'))
-          )
-
-          if (!possibleExtension) {
-            console.error('LlamaCpp extension not found')
-            return null
-          }
-
-          extensionToUse = possibleExtension
-        }
+        const extensionToUse = getLlamacppExtension()
 
         if (!extensionToUse || !('checkBackendForUpdates' in extensionToUse)) {
           console.error(
@@ -292,28 +265,7 @@ export const useBackendUpdater = () => {
         isUpdating: true,
       }))
 
-      // Get llamacpp extension instance
-      const allExtensions = ExtensionManager.getInstance().listExtensions()
-      const llamacppExtension =
-        ExtensionManager.getInstance().getByName('llamacpp-extension')
-
-      let extensionToUse = llamacppExtension
-
-      if (!llamacppExtension) {
-        // Try to find by type or other properties
-        const possibleExtension = allExtensions.find(
-          (ext) =>
-            ext.constructor.name.toLowerCase().includes('llamacpp') ||
-            (ext.type &&
-              ext.type()?.toString().toLowerCase().includes('inference'))
-        )
-
-        if (!possibleExtension) {
-          throw new Error('LlamaCpp extension not found')
-        }
-
-        extensionToUse = possibleExtension
-      }
+      const extensionToUse = getLlamacppExtension()
 
       if (
         !extensionToUse ||
@@ -402,28 +354,7 @@ export const useBackendUpdater = () => {
 
   const installBackend = useCallback(async (filePath: string) => {
     try {
-      // Get llamacpp extension instance
-      const allExtensions = ExtensionManager.getInstance().listExtensions()
-      const llamacppExtension =
-        ExtensionManager.getInstance().getByName('llamacpp-extension')
-
-      let extensionToUse = llamacppExtension
-
-      if (!llamacppExtension) {
-        // Try to find by type or other properties
-        const possibleExtension = allExtensions.find(
-          (ext) =>
-            ext.constructor.name.toLowerCase().includes('llamacpp') ||
-            (ext.type &&
-              ext.type()?.toString().toLowerCase().includes('inference'))
-        )
-
-        if (!possibleExtension) {
-          throw new Error('LlamaCpp extension not found')
-        }
-
-        extensionToUse = possibleExtension
-      }
+      const extensionToUse = getLlamacppExtension()
 
       if (!extensionToUse || !('installBackend' in extensionToUse)) {
         throw new Error('Extension does not support backend installation')
@@ -448,9 +379,7 @@ export const useBackendUpdater = () => {
   }, [])
 
   const installCudaRuntime = useCallback(async (filePath: string) => {
-    const extension = ExtensionManager.getInstance().getByName(
-      'llamacpp-extension'
-    ) as LlamacppExtension | undefined
+    const extension = getLlamacppExtension() as LlamacppExtension | undefined
     if (!extension || !('installCudaRuntime' in extension)) {
       throw new Error('Extension does not support CUDA runtime installation')
     }


### PR DESCRIPTION
## Describe Your Changes

Extract the duplicated 'find llamacpp extension by name/constructor/type' pattern into a single  helper that tries the
scoped name `@janhq/llamacpp-extension` first, then the unscoped
name `llamacpp-extension` for backward compatibility.

Add test coverage for all lookup paths:
- scoped name discovery
- unscoped name fallback
- extension-not-found error
- refreshBackendOptions preference over configureBackends
- installCudaRuntime with both name forms

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
