### PR TITLE
feat: move project path display from header to below input box

### DIFF
--- a/AGENT-TUI.md
+++ b/AGENT-TUI.md
@@ -157,9 +157,10 @@ The `apply` method processes `StreamEvent`s from the agent:
 ### Render Pipeline (`render` method)
 
 ```
-header    — project name, git branch, tokens, elapsed time, goal status
+header    — jan agent badge, model name, git branch, tokens, elapsed time, goal status
 transcript — scrollable chat area with user/assistant/tool rows
 input_box  — text input area
+path_line — project root path + git branch (dimmed, between input and footer)
 footer     — keybinding hints
 ```
 

--- a/build-tui.sh
+++ b/build-tui.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CRATE_DIR="$SCRIPT_DIR/src-tauri"
 INSTALL_DIR="${HOME}/.local/bin"
-BIN_NAME="jan-agent"
+BIN_NAME="jan"
 
 # Ensure install dir exists
 mkdir -p "$INSTALL_DIR"

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -4412,16 +4412,17 @@ fn hint_spans(key_style: Style, pairs: &[(&str, &str)]) -> Vec<Span<'static>> {
 /// One-line path display shown below the input box.
 fn path_line(app: &App) -> Paragraph<'static> {
     let path = app.project_root.to_string_lossy();
-    let git = app
-        .git_branch
-        .as_ref()
-        .map(|b| format!(" ⎇ {}", b))
-        .unwrap_or_default();
-    Paragraph::new(Line::from(vec![
+    let mut spans = vec![
         Span::styled("📂 ", Style::new().dark_gray()),
         Span::styled(path.to_string(), Style::new().dark_gray()),
-        Span::styled(git, Style::new().dark_gray()),
-    ]))
+    ];
+    if let Some(branch) = app.git_branch.as_ref() {
+        spans.push(Span::styled(
+            format!(" ⎇ {}", branch),
+            Style::new().dark_gray(),
+        ));
+    }
+    Paragraph::new(Line::from(spans))
 }
 
 fn footer(app: &App) -> Paragraph<'static> {

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -4241,7 +4241,11 @@ fn header(app: &App) -> Paragraph<'static> {
         (n, 0) => format!("turn {n}  "),
         (n, m) => format!("turn {n}/{m}  "),
     };
-    let project_str = app.project_root.to_string_lossy();
+    let dir_name = app
+        .project_root
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(".");
     let elapsed = app
         .run_started
         .map(|t| format!("  {}", format_elapsed(t.elapsed().as_secs())))
@@ -4249,7 +4253,7 @@ fn header(app: &App) -> Paragraph<'static> {
     let mut spans = vec![
         Span::styled(" jan agent ", Style::new().on_blue().white().bold()),
         Span::raw(format!("  {}  ", app.model)),
-        Span::styled(format!("📂 {}", &project_str as &str), Style::new().dark_gray()),
+        Span::styled(format!("📂 {}", dir_name), Style::new().dark_gray()),
     ];
     if let Some(branch) = app.git_branch.as_ref() {
         spans.push(Span::styled(

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -4252,12 +4252,6 @@ fn header(app: &App) -> Paragraph<'static> {
         Span::styled(" jan agent ", Style::new().on_blue().white().bold()),
         Span::raw(format!("  {}  ", app.model)),
     ];
-    if let Some(branch) = app.git_branch.as_ref() {
-        spans.push(Span::styled(
-            format!(" ⎇ {}", branch),
-            Style::new().dark_gray(),
-        ));
-    }
     spans.push(Span::raw(format!("  {turn}tokens {}", app.tokens)));
     spans.push(Span::styled(elapsed, Style::new().dim()));
     // Active-goal indicator: `◎ /goal active <duration>` (cyan while running,

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -3795,7 +3795,8 @@ fn draw(f: &mut Frame, app: &mut App) {
         Constraint::Length(1),
         Constraint::Min(1),
         Constraint::Length(input_h),
-        Constraint::Length(1),
+        Constraint::Length(1),  // path line
+        Constraint::Length(1),  // footer
     ])
     .split(f.area());
 
@@ -3810,7 +3811,8 @@ fn draw(f: &mut Frame, app: &mut App) {
         app.row_index.clear();
         draw_picker(f, chunks[1], picker);
         f.render_widget(input_box(app), chunks[2]);
-        f.render_widget(footer(app), chunks[3]);
+        f.render_widget(path_line(app), chunks[3]);
+        f.render_widget(footer(app), chunks[4]);
         return;
     }
 
@@ -3986,7 +3988,8 @@ fn draw(f: &mut Frame, app: &mut App) {
         0
     };
     f.render_widget(input_box(app).scroll((input_scroll, 0)), chunks[2]);
-    f.render_widget(footer(app), chunks[3]);
+    f.render_widget(path_line(app), chunks[3]);
+    f.render_widget(footer(app), chunks[4]);
 
     // Dock the permission prompt directly above the input box, growing upward
     // and clamped to the body area so it never overruns the transcript.
@@ -4241,11 +4244,6 @@ fn header(app: &App) -> Paragraph<'static> {
         (n, 0) => format!("turn {n}  "),
         (n, m) => format!("turn {n}/{m}  "),
     };
-    let dir_name = app
-        .project_root
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or(".");
     let elapsed = app
         .run_started
         .map(|t| format!("  {}", format_elapsed(t.elapsed().as_secs())))
@@ -4253,7 +4251,6 @@ fn header(app: &App) -> Paragraph<'static> {
     let mut spans = vec![
         Span::styled(" jan agent ", Style::new().on_blue().white().bold()),
         Span::raw(format!("  {}  ", app.model)),
-        Span::styled(format!("📂 {}", dir_name), Style::new().dark_gray()),
     ];
     if let Some(branch) = app.git_branch.as_ref() {
         spans.push(Span::styled(
@@ -4410,6 +4407,21 @@ fn hint_spans(key_style: Style, pairs: &[(&str, &str)]) -> Vec<Span<'static>> {
         }
     }
     spans
+}
+
+/// One-line path display shown below the input box.
+fn path_line(app: &App) -> Paragraph<'static> {
+    let path = app.project_root.to_string_lossy();
+    let git = app
+        .git_branch
+        .as_ref()
+        .map(|b| format!(" ⎇ {}", b))
+        .unwrap_or_default();
+    Paragraph::new(Line::from(vec![
+        Span::styled("📂 ", Style::new().dark_gray()),
+        Span::styled(path.to_string(), Style::new().dark_gray()),
+        Span::styled(git, Style::new().dark_gray()),
+    ]))
 }
 
 fn footer(app: &App) -> Paragraph<'static> {


### PR DESCRIPTION
## Description

Moves the project root path and git branch out of the already-crowded header bar into a dedicated dimmed line between the input box and footer.

### Before

Header showed: ` jan agent  model-xyz  📂 /full/path  ⎇ branch  turn 1 tokens 42  [working] `

### After

Header is slim — path and git branch moved to their own line below the chat input:

```
 jan agent  model-xyz  turn 1 tokens 42  [working]
┌──────────────────────────────────┐
│ chat transcript                  │
│ ...                              │
└──────────────────────────────────┘
› Type here to chat with agent
📂 /Users/user/projects/jan-agent  ⎇ branch
Esc/Ctrl-C cancel   ↑/↓ scroll   Ctrl-O expand all
```

### Changes

- **Removed** `📂 path` and `⎇ branch` from `header()` — the header is now just badge, model, tokens, goal, status
- **Added** `path_line()` — a one-line widget rendered between the input box and footer showing `📂 full/path  ⎇ branch`
- Added a new `Constraint::Length(1)` row in the layout for the path line
- Updated `build-tui.sh` to install binary as `jan` (matching the upstream binary name)

### Testing

- `./build-tui.sh test` — all 114 TUI tests pass
- `./build-tui.sh check` — compiles cleanly

Closes #8491