### PR TITLE
fix(tui): always send MessagesUpdated so /goal evaluator sees tool results

### DIFF
--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -1005,10 +1005,7 @@ async fn run_turn_cycle(
     // mid-task by a fixed turn cap.
     let unlimited = max_turns == 0;
     let mut turn: usize = 0;
-    // Set on any turn where compaction ran, so the final return can emit
-    // `MessagesUpdated` even when compaction happened on a prior (tool-call)
-    // turn and the final turn itself didn't need retry.
-    let mut did_compact = false;
+
     while unlimited || turn < max_turns {
         let _ = events.send(StreamEvent::Step {
             index: (turn as u32) + 1,
@@ -1047,7 +1044,6 @@ async fn run_turn_cycle(
                             attempts + 1
                         );
                         conversation_messages = compacted;
-                        did_compact = true;
                         keep_recent = (keep_recent / 2).max(2);
                         attempts += 1;
                     }
@@ -1061,11 +1057,9 @@ async fn run_turn_cycle(
         let tool_calls = extract_tool_calls(&completion);
 
         if tool_calls.is_empty() {
-            if did_compact {
-                let _ = events.send(StreamEvent::MessagesUpdated {
-                    messages: conversation_messages.clone(),
-                });
-            }
+            let _ = events.send(StreamEvent::MessagesUpdated {
+                messages: conversation_messages.clone(),
+            });
             return Ok(completion);
         }
 


### PR DESCRIPTION
## Problem

When an agent run under `/goal` uses tools (e.g. `write`), the `run_turn_cycle` function appends tool call and tool result messages to its local `conversation_messages`. However, it only sent a `MessagesUpdated` event back to the TUI when compaction had occurred (`did_compact == true`). In the normal case (no compaction), the updated messages were silently dropped.

This meant the TUI's `self.history` never contained tool call or tool result messages. When `/goal` evaluation ran, it passed `self.history` to the evaluator model, which saw only user prompts and bare assistant answers — with no tool result evidence. The evaluator would repeatedly say "goal not met" even though the agent had successfully written files.

## Root Cause

In `src-tauri/src/core/agent/loop.rs`, `run_turn_cycle`:
- Maintains `conversation_messages` locally, appending `role:assistant` (with `tool_calls`) and `role:tool` messages during the loop
- On successful exit (no more tool calls), only sends `MessagesUpdated { messages: conversation_messages }` if `did_compact` was true
- Without compaction, the augmented `conversation_messages` is dropped when the function returns

The TUI receives `Done` but never gets the intermediate tool messages, so `self.history` stays stale.

## Fix

Remove the `if did_compact` guard: always send `MessagesUpdated` when `run_turn_cycle` completes successfully. This ensures the TUI always has the full conversation including tool calls/results.

Also removed the now-dead `did_compact` flag that was only used for this gating.

## Testing

- cargo check --features cli --lib passes
- The /goal evaluator will now receive the full conversation including tool role messages with write/edit/bash results