### PR TITLE
fix: enforce Trusted Hosts allowlist when binding 0.0.0.0 (GHSA-x6p8-7cp8-c3p6)

### DIFF
--- a/src-tauri/src/core/server/proxy.rs
+++ b/src-tauri/src/core/server/proxy.rs
@@ -3030,19 +3030,15 @@ async fn start_server_internal(
         .parse()
         .map_err(|e| format!("Invalid address: {e}"))?;
 
-    // When binding to all interfaces (0.0.0.0), the user explicitly wants the server
-    // reachable from any network interface. Allow any host header so LAN clients
-    // (e.g. 192.168.x.x) are not rejected with "Invalid host header".
-    let effective_trusted_hosts = if host == "0.0.0.0" {
-        vec![vec!["*".to_string()]]
-    } else {
-        trusted_hosts
-    };
-
+    // Binding to 0.0.0.0 exposes the server on the LAN, but that must NOT discard
+    // the user's Trusted Hosts allowlist. LAN clients connect via http://192.168.x.x:port
+    // and send that literal IP as the Host header; is_valid_host now accepts loopback
+    // and private-range IP literals, which is safe against DNS rebinding (that sends an
+    // attacker *hostname*, not an IP). Hostnames still require an explicit allowlist entry.
     let config = ProxyConfig {
         prefix,
         proxy_api_key,
-        trusted_hosts: effective_trusted_hosts,
+        trusted_hosts,
         host: host.clone(),
         port,
         enable_server_tool_execution,

--- a/src-tauri/utils/src/http.rs
+++ b/src-tauri/utils/src/http.rs
@@ -42,6 +42,22 @@ pub fn is_valid_host(host: &str, trusted_hosts: &[Vec<String>]) -> bool {
         return true;
     }
 
+    // Accept a Host that is a literal loopback or private-range IP. This covers LAN
+    // clients hitting a 0.0.0.0-bound server via http://192.168.x.x:port without
+    // wildcarding the allowlist. DNS rebinding sends an attacker *hostname* in Host,
+    // not an IP, so this does not reopen that hole.
+    // ponytail: IPv4 private/link-local + any loopback; add IPv6 ULA (fc00::/7) if a
+    // user reports it, since Ipv6Addr::is_unique_local is still unstable in std.
+    if let Ok(ip) = host_without_port.parse::<std::net::IpAddr>() {
+        let private = match ip {
+            std::net::IpAddr::V4(v4) => v4.is_private() || v4.is_link_local(),
+            std::net::IpAddr::V6(_) => false,
+        };
+        if ip.is_loopback() || private {
+            return true;
+        }
+    }
+
     trusted_hosts.iter().flatten().any(|valid| {
         let host_lower = host.to_lowercase();
         let valid_lower = valid.to_lowercase();
@@ -62,4 +78,54 @@ pub fn is_valid_host(host: &str, trusted_hosts: &[Vec<String>]) -> bool {
 
         host_without_port.to_lowercase() == valid_without_port.to_lowercase()
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Scenario A from GHSA-x6p8-7cp8-c3p6: default bind, empty allowlist stays safe.
+    #[test]
+    fn default_empty_allowlist_is_safe() {
+        let trusted: Vec<Vec<String>> = vec![vec![]];
+        assert!(is_valid_host("127.0.0.1:1337", &trusted));
+        assert!(!is_valid_host("evil-rebind.attacker.com", &trusted));
+        // CORS path: origin host of https://evil.com must not be trusted.
+        assert!(!is_valid_host(
+            &extract_host_from_origin("https://evil.com"),
+            &trusted
+        ));
+    }
+
+    // Scenario B: 0.0.0.0 bind must NOT wildcard. The user's allowlist is enforced;
+    // attacker hostnames/origins are rejected, LAN IP literals are accepted.
+    #[test]
+    fn zero_bind_enforces_allowlist_no_wildcard() {
+        let trusted = vec![vec!["myserver.local".to_string()]];
+        assert!(is_valid_host("myserver.local", &trusted));
+        assert!(!is_valid_host("attacker-controlled-rebind.com", &trusted));
+        assert!(!is_valid_host("anything.evil", &trusted));
+        assert!(!is_valid_host(
+            &extract_host_from_origin("https://evil.com"),
+            &trusted
+        ));
+        assert!(!is_valid_host(
+            &extract_host_from_origin("http://malicious.example.org:8080"),
+            &trusted
+        ));
+    }
+
+    // LAN reachability preserved: private/loopback IP literals are accepted even
+    // with an empty allowlist, so a 0.0.0.0 bind still serves LAN clients.
+    #[test]
+    fn private_and_loopback_ip_literals_accepted() {
+        let trusted: Vec<Vec<String>> = vec![vec![]];
+        assert!(is_valid_host("192.168.1.20:1337", &trusted));
+        assert!(is_valid_host("10.0.0.5", &trusted));
+        assert!(is_valid_host("172.16.4.4:8080", &trusted));
+        assert!(is_valid_host("169.254.1.1", &trusted)); // link-local
+        assert!(is_valid_host("[::1]:1337", &trusted)); // IPv6 loopback
+        // A public IP literal is NOT auto-trusted.
+        assert!(!is_valid_host("8.8.8.8:1337", &trusted));
+    }
 }


### PR DESCRIPTION
## Describe Your Changes

Binding Jan's local API server to `0.0.0.0` replaced the user-configured
`trusted_hosts` with a `"*"` wildcard (`proxy.rs`, `start_server_internal`).
Because `is_valid_host` returns `true` immediately on a `"*"` entry, this
disabled **both** security controls that gate the server:

- the Host-header check (anti-DNS-rebinding), and
- the CORS Origin allowlist.

A user who set Trusted Hosts to restrict network access actually got **no**
restriction: any `Host` was accepted, and any `Origin` was reflected with
`Access-Control-Allow-Credentials: true`. On a `0.0.0.0` bind with the default
empty API key, a LAN host — or a remote web page via DNS rebinding — reaches the
unauthenticated OpenAI-compatible API. Reported in advisory
`GHSA-x6p8-7cp8-c3p6`.

**Fix:**
- Remove the `0.0.0.0 => ["*"]` override so the user's `trusted_hosts` is always
  enforced.
- Teach `is_valid_host` to accept literal **loopback / private-range** IP `Host`
  values, so LAN clients hitting a `0.0.0.0`-bound server via
  `http://192.168.x.x:port` still work — without wildcarding. This is safe
  against DNS rebinding, which sends an attacker *hostname* (not an IP) in the
  Host header; hostnames still require an explicit allowlist entry.
- CORS reflection is fixed for free: it routes through the same predicate, so a
  hostname Origin is no longer reflected.

Out of scope (separate follow-ups): wiring the inert UI "CORS enabled" toggle
into the backend, and refusing to start on `0.0.0.0` with an empty API key.

## Fixes Issues

- Closes #8453

## Verification

Backend-only change (no UI), so verification is by tests rather than a
screen recording — consistent with other pure-Rust PRs.

Unit tests added to `src-tauri/utils/src/http.rs`, all passing:

```
$ cargo test http:: -p jan-utils
running 3 tests
test http::tests::private_and_loopback_ip_literals_accepted ... ok
test http::tests::default_empty_allowlist_is_safe ... ok
test http::tests::zero_bind_enforces_allowlist_no_wildcard ... ok
test result: ok. 3 passed; 0 failed
```

They assert the advisory's Scenario A/B tables: a set allowlist rejects
attacker hostnames and the `evil.com` Origin, while private/loopback IP
literals remain accepted.

End-to-end behavior at the HTTP layer (the two `proxy.rs` gate call-sites
driving the real `is_valid_host`):

| Request | Before (`["*"]`) | After |
|---|---|---|
| `Host: myserver.local` (trusted) | 200 | 200 |
| `Host: attacker-rebind.com` | 200 | **403** |
| `Host: anything.evil` | 200 | **403** |
| `Host: 192.168.1.20:1337` (LAN) | 200 | 200 |
| `Origin: https://evil.com` | reflected + `Allow-Credentials: true` | **not reflected** |

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [x] Created issues for follow-up changes or refactoring needed
