### PR TITLE
fix(agent): web_search/web_fetch provider errors not flagged as errors

### DIFF
--- a/src-tauri/src/core/agent/tools/web.rs
+++ b/src-tauri/src/core/agent/tools/web.rs
@@ -57,7 +57,7 @@ pub async fn web_search(args: &Value) -> String {
             format!("No web search results found for query: {query}")
         }
         Ok(results) => render_search_results(&results),
-        Err(e) => e,
+        Err(e) => format!("ERROR: {e}"),
     }
 }
 
@@ -79,7 +79,7 @@ pub async fn web_fetch(args: &Value) -> String {
     };
     match provider.fetch(url).await {
         Ok(page) => render_fetched_page(&page),
-        Err(e) => e,
+        Err(e) => format!("ERROR: {e}"),
     }
 }
 


### PR DESCRIPTION
## Problem

When `web_search` or `web_fetch` encounters a provider-level failure (e.g. HTTP error from the hosted Exa endpoint, network timeout, keyless endpoint down), the error string was returned as-is **without an `ERROR:` prefix**:

```rust
Err(e) => e,
```

The tool-result pipeline in `run_turn_cycle` flags errors via `is_error: content.starts_with("ERROR")`, so these failures were silently treated as **successful results**. The model would see text like `Hosted call failed with HTTP 502: ...` and interpret it as an actual search result rather than a failure.

This could cause the model to:
- Report fabricated search results based on error text
- Keep calling `web_fetch` on URLs that were never properly resolved
- Fail silently without the user knowing the search backend is unavailable

## Fix

Prefix provider errors with `ERROR:` so they are correctly flagged:

```rust
Err(e) => format!("ERROR: {e}"),
```

Applied to both `web_search` and `web_fetch`.

Validation errors (e.g. missing `query`) already had the `ERROR:` prefix — only the `Err(e)` arm from the actual provider call was missing it.

## Testing

- `cargo test --features cli --lib -- web` — all 8 web tool tests pass (1 ignored is the live network test)