### PR TITLE
Add Eden AI as a predefined model provider

### DIFF
--- a/web-app/src/constants/providers.ts
+++ b/web-app/src/constants/providers.ts
@@ -388,4 +388,45 @@ export const predefinedProviders = [
     ],
     models: [],
   },
+  {
+    active: true,
+    api_key: '',
+    base_url: 'https://api.edenai.run/v3',
+    explore_models_url:
+      'https://app.edenai.run/admin/api-settings/features-preferences',
+    provider: 'edenai',
+    settings: [
+      {
+        key: 'api-key',
+        title: 'API Key',
+        description:
+          'Eden AI uses API keys for authentication. Visit your [API keys page](https://app.edenai.run/admin/api-settings/features-preferences) to retrieve the key you will use in your requests.',
+        controller_type: 'input',
+        controller_props: {
+          placeholder: 'Insert API Key',
+          value: '',
+          type: 'password',
+          input_actions: ['unobscure', 'copy'],
+        },
+      },
+    ],
+    models: [
+      {
+        id: 'openai/gpt-5.5',
+        name: 'GPT-5.5 (OpenAI)',
+        version: '1.0',
+        description:
+          'OpenAI GPT-5.5 routed through Eden AI. Models are addressed as "<provider>/<model>".',
+        capabilities: ['completion', 'tools'],
+      },
+      {
+        id: 'mistral/mistral-large-latest',
+        name: 'Mistral Large',
+        version: '1.0',
+        description:
+          'Mistral Large routed through Eden AI, showing cross-provider access from a single key.',
+        capabilities: ['completion', 'tools'],
+      },
+    ],
+  },
 ]

--- a/web-app/src/lib/providerCaps.ts
+++ b/web-app/src/lib/providerCaps.ts
@@ -91,6 +91,15 @@ const MINIMAX: ProviderCaps = {
   maybe: new Set(),
 }
 
+// Eden AI is an aggregator: a single base_url routes to many underlying
+// providers (openai/*, mistral/*, ...), so the accepted sampler surface
+// depends on the selected model. Mark the common OpenAI-compatible samplers
+// as "maybe" rather than guaranteeing them.
+const EDENAI: ProviderCaps = {
+  supported: set(),
+  maybe: new Set(['penalties', 'json_schema']),
+}
+
 const LLAMACPP: ProviderCaps = {
   supported: set(
     'penalties',
@@ -159,6 +168,7 @@ const BUILTIN_CAPS: Record<string, ProviderCaps> = {
   huggingface: HUGGINGFACE,
   nvidia: NVIDIA,
   minimax: MINIMAX,
+  edenai: EDENAI,
   llamacpp: LLAMACPP,
   mlx: MLX,
 }

--- a/web-app/src/lib/utils.ts
+++ b/web-app/src/lib/utils.ts
@@ -186,6 +186,8 @@ export const getProviderTitle = (provider: string) => {
       return 'MiniMax'
     case 'nvidia':
       return 'NVIDIA NIM'
+    case 'edenai':
+      return 'Eden AI'
     default:
       return provider.charAt(0).toUpperCase() + provider.slice(1)
   }


### PR DESCRIPTION
## My changes

Adds [Eden AI](https://www.edenai.co/) as a predefined model provider.

Eden AI exposes an OpenAI-compatible Chat Completions endpoint (`https://api.edenai.run/v3`) that routes to many underlying providers behind a single API key, so it fits the existing predefined remote-provider pattern (same shape as OpenRouter / Groq / NVIDIA). Models are addressed as `<provider>/<model>`, e.g. `openai/gpt-5.5` or `mistral/mistral-large-latest`.

Changes (all in `web-app/`):
- `src/constants/providers.ts`: a `predefinedProviders` entry with locked `base_url`, the API-key setting, `explore_models_url`, and two sample models (an OpenAI and a Mistral one, to show the cross-provider naming).
- `src/lib/utils.ts`: a `getProviderTitle` case so it displays as **Eden AI**.
- `src/lib/providerCaps.ts`: a `providerCaps` entry. Eden AI is an aggregator (accepted sampler surface depends on the routed model), so common OpenAI-compatible samplers are marked `maybe`, keeping it consistent with the other predefined remote providers.

## Fixes Issues

Only a simple and small provider addition.

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

### Notes
- No new dependencies; the existing `RemoteOAIEngine` handles requests.
- `tsc -b` reports no errors in the changed files and `eslint` is clean on them (remaining workspace typecheck errors are pre-existing/unrelated, unbuilt `@janhq/*` sub-packages).
- Verified live against `https://api.edenai.run/v3`: chat completions return 200 and tool/function calling passes through for `openai/gpt-5.5` and `mistral/mistral-large-latest`.
- Happy to add an Eden AI logo under `web-app/public/images/model-provider/`, it currently uses the initial-letter fallback.