### PR TITLE
ci: add CLI-only nightly build workflow for Jan Agent nightlies

### DIFF
--- a/.github/workflows/jan-tauri-build-agent-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-agent-nightly.yaml
@@ -1,0 +1,96 @@
+name: Jan Agent CLI - Nightly Build
+
+on:
+  schedule:
+    - cron: '0 10 * * *' # 10 AM UTC daily
+  workflow_dispatch:
+
+concurrency:
+  group: agent-nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  AGENT_BRANCH: refs/heads/goal/general-agent
+
+jobs:
+  resolve-ref:
+    runs-on: ubuntu-latest
+    outputs:
+      ref: ${{ steps.resolve.outputs.ref }}
+    steps:
+      - name: Resolve target ref
+        id: resolve
+        run: |
+          echo "ref=${{ env.AGENT_BRANCH }}" >> "$GITHUB_OUTPUT"
+
+  get-update-version:
+    uses: ./.github/workflows/template-get-update-version.yml
+
+  build-linux-x64:
+    uses: ./.github/workflows/template-cli-build-linux-x64.yml
+    needs: [get-update-version, resolve-ref]
+    secrets: inherit
+    with:
+      ref: ${{ needs.resolve-ref.outputs.ref }}
+      new_version: ${{ needs.get-update-version.outputs.new_version }}
+      channel: agent-nightly
+
+  build-macos:
+    uses: ./.github/workflows/template-cli-build-macos.yml
+    needs: [get-update-version, resolve-ref]
+    secrets: inherit
+    with:
+      ref: ${{ needs.resolve-ref.outputs.ref }}
+      new_version: ${{ needs.get-update-version.outputs.new_version }}
+      channel: agent-nightly
+
+  build-windows-x64:
+    uses: ./.github/workflows/template-cli-build-windows-x64.yml
+    needs: [get-update-version, resolve-ref]
+    secrets: inherit
+    with:
+      ref: ${{ needs.resolve-ref.outputs.ref }}
+      new_version: ${{ needs.get-update-version.outputs.new_version }}
+      channel: agent-nightly
+
+  sync-manifest:
+    needs: [get-update-version, build-linux-x64, build-macos, build-windows-x64]
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install jq
+        uses: dcarbone/install-jq-action@v3
+
+      - name: Generate version manifest
+        run: |
+          VERSION="${{ needs.get-update-version.outputs.new_version }}"
+          PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")
+
+          cat <<MANIFEST > manifest.json
+          {
+            "version": "$VERSION",
+            "pub_date": "$PUB_DATE",
+            "platforms": {
+              "linux-x86_64": {
+                "url": "https://delta.jan.ai/agent-nightly/${{ needs.build-linux-x64.outputs.FILE_NAME }}"
+              },
+              "darwin-universal": {
+                "url": "https://delta.jan.ai/agent-nightly/${{ needs.build-macos.outputs.FILE_NAME }}"
+              },
+              "windows-x86_64": {
+                "url": "https://delta.jan.ai/agent-nightly/${{ needs.build-windows-x64.outputs.FILE_NAME }}"
+              }
+            }
+          }
+          MANIFEST
+          cat manifest.json
+
+      - name: Upload manifest to S3
+        run: |
+          aws s3 cp ./manifest.json "s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/agent-nightly/manifest.json"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.DELTA_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DELTA_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.DELTA_AWS_REGION }}
+          AWS_EC2_METADATA_DISABLED: 'true'

--- a/.github/workflows/template-cli-build-linux-x64.yml
+++ b/.github/workflows/template-cli-build-linux-x64.yml
@@ -1,0 +1,75 @@
+# Builds the Jan Agent CLI binary for Linux x86_64.
+# Produces a single stripped tarball; no Tauri bundler, no frontend.
+name: cli-build-linux-x64
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+        default: refs/heads/goal/general-agent
+      new_version:
+        required: true
+        type: string
+        default: ''
+      channel:
+        required: true
+        type: string
+        default: agent-nightly
+    secrets:
+      DELTA_AWS_S3_BUCKET_NAME:
+        required: false
+      DELTA_AWS_ACCESS_KEY_ID:
+        required: false
+      DELTA_AWS_SECRET_ACCESS_KEY:
+        required: false
+      DELTA_AWS_REGION:
+        required: false
+    outputs:
+      FILE_NAME:
+        value: ${{ jobs.build-linux-x64.outputs.FILE_NAME }}
+
+jobs:
+  build-linux-x64:
+    runs-on: ubuntu-22.04
+    outputs:
+      FILE_NAME: ${{ steps.package.outputs.FILE_NAME }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build CLI binary
+        run: |
+          cd src-tauri
+          cargo build --features cli --bin jan --release
+
+      - name: Strip binary
+        run: strip src-tauri/target/release/jan
+
+      - name: Package tarball
+        id: package
+        run: |
+          VERSION="${{ inputs.new_version }}"
+          FILE_NAME="jan-agent-linux-x86_64-$VERSION.tar.gz"
+          tar czf "$FILE_NAME" -C src-tauri/target/release jan
+          echo "FILE_NAME=$FILE_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to S3
+        run: |
+          aws s3 cp "./${{ steps.package.outputs.FILE_NAME }}" \
+            "s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/${{ inputs.channel }}/${{ steps.package.outputs.FILE_NAME }}"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.DELTA_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DELTA_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.DELTA_AWS_REGION }}
+          AWS_EC2_METADATA_DISABLED: 'true'

--- a/.github/workflows/template-cli-build-macos.yml
+++ b/.github/workflows/template-cli-build-macos.yml
@@ -1,0 +1,111 @@
+# Builds the Jan Agent CLI binary for macOS (universal binary via lipo).
+# Produces a single stripped tarball; no Tauri bundler, no frontend.
+name: cli-build-macos
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+        default: refs/heads/goal/general-agent
+      new_version:
+        required: true
+        type: string
+        default: ''
+      channel:
+        required: true
+        type: string
+        default: agent-nightly
+    secrets:
+      DELTA_AWS_S3_BUCKET_NAME:
+        required: false
+      DELTA_AWS_ACCESS_KEY_ID:
+        required: false
+      DELTA_AWS_SECRET_ACCESS_KEY:
+        required: false
+      DELTA_AWS_REGION:
+        required: false
+      # Optional code signing
+      CODE_SIGN_P12_BASE64:
+        required: false
+      CODE_SIGN_P12_PASSWORD:
+        required: false
+      NOTARIZE_P8_BASE64:
+        required: false
+      NOTARY_ISSUER:
+        required: false
+      NOTARY_KEY_ID:
+        required: false
+    outputs:
+      FILE_NAME:
+        value: ${{ jobs.build-macos.outputs.FILE_NAME }}
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+    outputs:
+      FILE_NAME: ${{ steps.package.outputs.FILE_NAME }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: aarch64-apple-darwin x86_64-apple-darwin
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build CLI binary (x86_64)
+        run: |
+          cd src-tauri
+          cargo build --features cli --bin jan --release --target x86_64-apple-darwin
+
+      - name: Build CLI binary (aarch64)
+        run: |
+          cd src-tauri
+          cargo build --features cli --bin jan --release --target aarch64-apple-darwin
+
+      - name: Create universal binary
+        run: |
+          mkdir -p universal
+          lipo -create \
+            src-tauri/target/x86_64-apple-darwin/release/jan \
+            src-tauri/target/aarch64-apple-darwin/release/jan \
+            -output universal/jan
+
+      - name: Strip universal binary
+        run: strip universal/jan
+
+      - name: Code sign (if certs configured)
+        continue-on-error: true
+        run: |
+          if [ -n "${{ secrets.CODE_SIGN_P12_BASE64 }}" ]; then
+            echo "${{ secrets.CODE_SIGN_P12_BASE64 }}" | base64 -d > /tmp/cert.p12
+            security import /tmp/cert.p12 -P "${{ secrets.CODE_SIGN_P12_PASSWORD }}" -A
+            codesign --force --sign "Developer ID Application" universal/jan --timestamp
+          else
+            echo "No signing cert configured; skipping code sign."
+          fi
+
+      - name: Package tarball
+        id: package
+        run: |
+          VERSION="${{ inputs.new_version }}"
+          FILE_NAME="jan-agent-darwin-universal-$VERSION.tar.gz"
+          tar czf "$FILE_NAME" -C universal jan
+          echo "FILE_NAME=$FILE_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to S3
+        run: |
+          aws s3 cp "./${{ steps.package.outputs.FILE_NAME }}" \
+            "s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/${{ inputs.channel }}/${{ steps.package.outputs.FILE_NAME }}"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.DELTA_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DELTA_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.DELTA_AWS_REGION }}
+          AWS_EC2_METADATA_DISABLED: 'true'

--- a/.github/workflows/template-cli-build-windows-x64.yml
+++ b/.github/workflows/template-cli-build-windows-x64.yml
@@ -1,0 +1,74 @@
+# Builds the Jan Agent CLI binary for Windows x86_64.
+# Produces a single stripped zip archive; no Tauri bundler, no frontend.
+name: cli-build-windows-x64
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+        default: refs/heads/goal/general-agent
+      new_version:
+        required: true
+        type: string
+        default: ''
+      channel:
+        required: true
+        type: string
+        default: agent-nightly
+    secrets:
+      DELTA_AWS_S3_BUCKET_NAME:
+        required: false
+      DELTA_AWS_ACCESS_KEY_ID:
+        required: false
+      DELTA_AWS_SECRET_ACCESS_KEY:
+        required: false
+      DELTA_AWS_REGION:
+        required: false
+    outputs:
+      FILE_NAME:
+        value: ${{ jobs.build-windows-x64.outputs.FILE_NAME }}
+
+jobs:
+  build-windows-x64:
+    runs-on: windows-latest
+    outputs:
+      FILE_NAME: ${{ steps.package.outputs.FILE_NAME }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build CLI binary
+        run: |
+          cd src-tauri
+          cargo build --features cli --bin jan --release
+
+      - name: Package zip
+        id: package
+        shell: bash
+        run: |
+          VERSION="${{ inputs.new_version }}"
+          FILE_NAME="jan-agent-windows-x86_64-$VERSION.zip"
+          7z a "$FILE_NAME" ./src-tauri/target/release/jan.exe
+          echo "FILE_NAME=$FILE_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to S3
+        shell: bash
+        run: |
+          aws s3 cp "./${{ steps.package.outputs.FILE_NAME }}" \
+            "s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/${{ inputs.channel }}/${{ steps.package.outputs.FILE_NAME }}"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.DELTA_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DELTA_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.DELTA_AWS_REGION }}
+          AWS_EC2_METADATA_DISABLED: 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ OpenCode.md
 Claude.md
 archive/
 .cache/
+.jan/
 
 # auto qa
 autoqa/trajectories


### PR DESCRIPTION
## Describe Your Changes
Adds a nightly build pipeline that builds the Jan Agent CLI binary from the goal/general-agent branch at 10 AM UTC daily:

  - cargo build --features cli --bin jan --release
  - strip the binary
  - tar.gz (linux/macos) or zip (windows)
  - upload to S3
  - publish a manifest.json for version discovery

Three new reusable templates support each platform:
  - template-cli-build-linux-x64.yml
  - template-cli-build-macos.yml
  - template-cli-build-windows-x64.yml


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
