### PR TITLE
fix(llamacpp): stop halving per-slot context when parallel is set

### DIFF
--- a/extensions/llamacpp-extension/src/preset.test.ts
+++ b/extensions/llamacpp-extension/src/preset.test.ts
@@ -210,6 +210,50 @@ describe('generatePreset parallel reservation', () => {
   })
 })
 
+describe('generatePreset kv-unified', () => {
+  it('enables unified KV on auto when an explicit parallel is emitted', async () => {
+    setupModel('llama', {})
+    await generatePreset('/p', '/jan', { parallel: 1 } as any, {
+      supportsMtp: false,
+    })
+    const ini = writtenFiles['/p/router.preset.ini']
+    expect(ini).toContain('parallel = 2')
+    expect(ini).toContain('kv-unified = true')
+  })
+
+  it('enables unified KV on auto when only a per-model parallel is emitted', async () => {
+    setupModel('llama', { parallel: 3 })
+    await generatePreset('/p', '/jan', {} as any, { supportsMtp: false })
+    const ini = writtenFiles['/p/router.preset.ini']
+    expect(ini).toContain('kv-unified = true')
+  })
+
+  it('omits kv-unified on auto when no explicit parallel is emitted', async () => {
+    setupModel('llama', {})
+    await generatePreset('/p', '/jan', {} as any, { supportsMtp: false })
+    const ini = writtenFiles['/p/router.preset.ini']
+    expect(ini).not.toContain('kv-unified')
+  })
+
+  it('respects an explicit off even when parallel is emitted', async () => {
+    setupModel('llama', {})
+    await generatePreset('/p', '/jan', { parallel: 1, kv_unified: 'off' } as any, {
+      supportsMtp: false,
+    })
+    const ini = writtenFiles['/p/router.preset.ini']
+    expect(ini).toContain('kv-unified = false')
+  })
+
+  it('respects an explicit on when no parallel is emitted', async () => {
+    setupModel('llama', {})
+    await generatePreset('/p', '/jan', { kv_unified: 'on' } as any, {
+      supportsMtp: false,
+    })
+    const ini = writtenFiles['/p/router.preset.ini']
+    expect(ini).toContain('kv-unified = true')
+  })
+})
+
 describe('generatePreset ctx-size default', () => {
   it('emits ctx-size = 8192 in [*] when fit is off and no ctx_size is set', async () => {
     setupModel('llama', {})

--- a/extensions/llamacpp-extension/src/preset.ts
+++ b/extensions/llamacpp-extension/src/preset.ts
@@ -127,6 +127,9 @@ export async function generatePreset(
 
   modelEntries.sort((a, b) => a.modelId.localeCompare(b.modelId))
 
+  const kvUnifiedIsAuto =
+    config.kv_unified !== 'on' && config.kv_unified !== 'off'
+
   const lines: string[] = []
 
   // Emit only values that differ from llama.cpp's compiled defaults so the
@@ -204,6 +207,11 @@ export async function generatePreset(
   // slot is added on top and never exposed in the setting's own value.
   if (typeof config.parallel === 'number' && config.parallel > 0) {
     lines.push(`parallel = ${config.parallel + reservedBackgroundSlots}`)
+    // llama.cpp only turns on unified KV as part of resolving parallel = -1;
+    // passing parallel explicitly leaves it off, which splits ctx-size into
+    // ctx-size/parallel per slot. Restore the auto behaviour so the configured
+    // context is what each slot actually gets.
+    if (kvUnifiedIsAuto) lines.push('kv-unified = true')
   }
   // cont-batching default = true; emit only the explicit-off case.
   if (config.cont_batching === false) {
@@ -326,7 +334,8 @@ export async function generatePreset(
   if (config.swa_full === true) {
     lines.push('swa-full = true')
   }
-  // auto = omit the flag, let llama.cpp decide based on slot count
+  // auto is handled next to each `parallel` emission above; with no explicit
+  // parallel the flag is omitted so llama.cpp's own auto resolution applies.
   if (config.kv_unified === 'on') {
     lines.push('kv-unified = true')
   } else if (config.kv_unified === 'off') {
@@ -412,6 +421,7 @@ export async function generatePreset(
     }
     if (typeof mc.parallel === 'number' && mc.parallel > 0) {
       lines.push(`parallel = ${mc.parallel + reservedBackgroundSlots}`)
+      if (kvUnifiedIsAuto) lines.push('kv-unified = true')
     }
     if (mc.cont_batching === false) {
       lines.push('cont-batching = false')


### PR DESCRIPTION
## Describe Your Changes

llama.cpp treats ctx-size as the total across slots and divides it (n_ctx_seq = n_ctx / n_seq_max in llama-context.cpp) unless kv_unified is on. llama-server only enables kv_unified while resolving parallel = -1, so passing parallel explicitly silently leaves it off.

The preset always emits an explicit `parallel` (user value plus the reserved auto-title slot), so with the shipped defaults it emitted parallel = 2 and every slot got ctx-size/2 -- a configured 8192 became 4096 in chat. The kv_unified 'auto' setting therefore meant 'off' for every user, not 'let llama.cpp decide'.

Emit `kv-unified = true` alongside each explicit `parallel`, globally and per-model, when kv_unified is auto. Explicit on/off still win, and with no parallel emitted the flag stays absent so llama.cpp's own auto resolution applies. Total KV allocation is unchanged; the background slot now borrows from the shared pool only while it runs.

Per-slot sizing is not an option upstream: every slot is assigned the same n_ctx_slot and there is no per-slot context flag.


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
