### PR TITLE
feat(agent): add guided work states

### DIFF
--- a/src-tauri/src/bin/jan.rs
+++ b/src-tauri/src/bin/jan.rs
@@ -65,6 +65,10 @@ struct Cli {
     yolo: bool,
     #[command(flatten)]
     resume: ResumeArgs,
+    /// Start the default agent TUI in read-only plan mode (same as /plan).
+    /// Ignored when a subcommand is given.
+    #[arg(long)]
+    plan: bool,
 }
 
 /// Session-resume selection, shared by the bare TUI and `jan cli agent run`.
@@ -364,6 +368,7 @@ async fn main() {
             cli.images,
             overrides,
             cli.yolo,
+            cli.plan,
             cli.resume.into_target(),
         )
         .await
@@ -557,3 +562,20 @@ async fn handle_models(cmd: ModelsCommands) {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `--plan` is a per-invocation startup toggle mirroring `--yolo`; it must
+    // parse on the top-level `jan` command and default off.
+    #[test]
+    fn top_level_plan_flag_parses() {
+        let cli = Cli::parse_from(["jan", "--plan"]);
+        assert!(cli.plan);
+        assert!(!cli.yolo);
+        assert!(cli.command.is_none());
+
+        let cli = Cli::parse_from(["jan"]);
+        assert!(!cli.plan);
+    }
+}

--- a/src-tauri/src/core/agent/commands.rs
+++ b/src-tauri/src/core/agent/commands.rs
@@ -66,6 +66,7 @@ fn build_orchestration_args<R: Runtime>(
         permissions: ToolPermissions::allow_all(),
         project_root: None,
         permission_requests: Arc::new(Mutex::new(HashMap::new())),
+        ask_requests: None,
         system_prompt_override: None,
         subagents_enabled: true,
         yolo: false,

--- a/src-tauri/src/core/agent/commands.rs
+++ b/src-tauri/src/core/agent/commands.rs
@@ -71,6 +71,7 @@ fn build_orchestration_args<R: Runtime>(
         system_prompt_override: None,
         subagents_enabled: true,
         yolo: false,
+        run_mode: crate::core::agent::plan::RunMode::Normal,
     }
 }
 

--- a/src-tauri/src/core/agent/commands.rs
+++ b/src-tauri/src/core/agent/commands.rs
@@ -67,6 +67,7 @@ fn build_orchestration_args<R: Runtime>(
         project_root: None,
         permission_requests: Arc::new(Mutex::new(HashMap::new())),
         ask_requests: None,
+        todo_registry: None,
         system_prompt_override: None,
         subagents_enabled: true,
         yolo: false,

--- a/src-tauri/src/core/agent/context.rs
+++ b/src-tauri/src/core/agent/context.rs
@@ -18,6 +18,8 @@ running commands, editing code, and writing new files.";
 /// Always-on behavioral guidelines. Kept short and model-facing.
 const GUIDELINES: &str =
     "# Guidelines\n\n- Be concise in your responses.\n- Show file paths clearly when working with files.\n\
+- For substantive work with multiple steps or repository changes, call `todo` to initialize a concise plan before beginning, then keep it current as tasks start, finish, or are abandoned. Do not create todos for greetings, simple questions, or one-step requests.\n\
+- Call `ask` when the user's answer would materially change scope, behavior, or an irreversible action and it cannot be safely inferred from the request or project context. Ask concise, decision-ready questions; otherwise make the reasonable choice and proceed.\n\
 - Tool output is complete and verbatim. Trust it. Do not re-run a command to check for hidden or \
 missing output: when output is cut it always carries an explicit `[output truncated ...]` notice, so \
 its absence means you have everything. A command's `[exit N]` line is the authoritative result -- \
@@ -330,6 +332,9 @@ mod tests {
         assert!(out.starts_with("You are Jan, an AI coding agent."));
         assert!(out.contains("# Guidelines"));
         assert!(out.contains("Be concise"));
+        assert!(out.contains("call `todo` to initialize a concise plan"));
+        assert!(out.contains("Do not create todos for greetings"));
+        assert!(out.contains("Call `ask` when the user's answer would materially change"));
         assert!(out.contains("Tool output is complete and verbatim"));
         assert!(out.contains("Do not re-run a command to check"));
         let _ = std::fs::remove_dir_all(&root);

--- a/src-tauri/src/core/agent/events.rs
+++ b/src-tauri/src/core/agent/events.rs
@@ -62,6 +62,11 @@ pub enum StreamEvent {
         request_id: String,
         request: crate::core::agent::interaction::AskRequest,
     },
+    /// The canonical todo list changed (tool mutation or user edit in the
+    /// TUI). Carries the full resulting snapshot for reconstruction.
+    TodoUpdate {
+        list: crate::core::agent::todo::TodoList,
+    },
     /// Terminal success: the model returned a final (tool-free) completion.
     Done {
         stop_reason: String,

--- a/src-tauri/src/core/agent/events.rs
+++ b/src-tauri/src/core/agent/events.rs
@@ -57,6 +57,11 @@ pub enum StreamEvent {
     MessagesUpdated {
         messages: Vec<serde_json::Value>,
     },
+    /// The `ask` tool is waiting for structured interactive input.
+    AskRequest {
+        request_id: String,
+        request: crate::core::agent::interaction::AskRequest,
+    },
     /// Terminal success: the model returned a final (tool-free) completion.
     Done {
         stop_reason: String,

--- a/src-tauri/src/core/agent/interaction.rs
+++ b/src-tauri/src/core/agent/interaction.rs
@@ -1,0 +1,304 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tokio::sync::{oneshot, Mutex};
+
+const OTHER_LABEL: &str = "Other (type your own)";
+static NEXT_ASK_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct AskRequest {
+    pub(crate) questions: Vec<Question>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct Question {
+    pub id: String,
+    pub question: String,
+    pub options: Vec<OptionItem>,
+    #[serde(default)]
+    pub multi: bool,
+    #[serde(default)]
+    pub recommended: Option<usize>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(crate) struct OptionItem {
+    pub label: String,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub(crate) struct QuestionResult {
+    pub id: String,
+    #[serde(default)]
+    pub selected: Vec<String>,
+    #[serde(default)]
+    pub custom_input: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) enum AskError {
+    Cancelled,
+}
+
+pub(crate) type AskOutcome = Result<Vec<QuestionResult>, AskError>;
+pub(crate) type AskRegistry = Arc<Mutex<HashMap<String, oneshot::Sender<AskOutcome>>>>;
+
+impl AskRequest {
+    pub(crate) fn parse(value: &Value) -> Result<Self, String> {
+        let request: Self = serde_json::from_value(value.clone())
+            .map_err(|e| format!("invalid ask request: {e}"))?;
+        if request.questions.is_empty() {
+            return Err("ask requires at least one question".into());
+        }
+        let mut ids = HashSet::new();
+        for question in &request.questions {
+            if question.id.trim().is_empty() || !ids.insert(question.id.as_str()) {
+                return Err("question ids must be non-empty and unique".into());
+            }
+            if question.question.trim().is_empty() {
+                return Err(format!("question '{}' has no prompt", question.id));
+            }
+            if !(2..=5).contains(&question.options.len()) {
+                return Err(format!(
+                    "question '{}' requires 2 to 5 options",
+                    question.id
+                ));
+            }
+            let mut labels = HashSet::new();
+            for option in &question.options {
+                if option.label.trim().is_empty()
+                    || option.label == OTHER_LABEL
+                    || !labels.insert(option.label.as_str())
+                {
+                    return Err(format!(
+                        "question '{}' option labels must be non-empty, unique, and omit '{OTHER_LABEL}'",
+                        question.id
+                    ));
+                }
+            }
+            if question
+                .recommended
+                .is_some_and(|index| index >= question.options.len())
+            {
+                return Err(format!(
+                    "question '{}' recommended index is out of range",
+                    question.id
+                ));
+            }
+        }
+        Ok(request)
+    }
+
+    pub(crate) fn validate_results(&self, results: &[QuestionResult]) -> Result<(), String> {
+        if results.len() != self.questions.len() {
+            return Err("ask response must answer every question exactly once".into());
+        }
+        let mut ids = HashSet::new();
+        for result in results {
+            if !ids.insert(result.id.as_str()) {
+                return Err(format!("duplicate answer for '{}'", result.id));
+            }
+            let question = self
+                .questions
+                .iter()
+                .find(|question| question.id == result.id)
+                .ok_or_else(|| format!("unknown question id '{}'", result.id))?;
+            let has_custom = result
+                .custom_input
+                .as_deref()
+                .is_some_and(|text| !text.trim().is_empty());
+            if result.custom_input.is_some() && !has_custom {
+                return Err(format!("custom answer for '{}' cannot be empty", result.id));
+            }
+            if has_custom && !result.selected.is_empty() {
+                return Err(format!(
+                    "answer '{}' cannot select options and custom text",
+                    result.id
+                ));
+            }
+            if !has_custom && result.selected.is_empty() {
+                return Err(format!("question '{}' requires an answer", result.id));
+            }
+            if !question.multi && result.selected.len() > 1 {
+                return Err(format!("question '{}' accepts one option", result.id));
+            }
+            let mut selected = HashSet::new();
+            for label in &result.selected {
+                if !selected.insert(label.as_str())
+                    || !question.options.iter().any(|option| option.label == *label)
+                {
+                    return Err(format!("invalid option '{label}' for '{}'", result.id));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn ask_tool_schema() -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": "ask",
+            "description": "Ask the user one or more structured questions. Use only when the answer materially changes the work.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "questions": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "id": { "type": "string" },
+                                "question": { "type": "string" },
+                                "options": {
+                                    "type": "array",
+                                    "minItems": 2,
+                                    "maxItems": 5,
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "label": { "type": "string" },
+                                            "description": { "type": "string" }
+                                        },
+                                        "required": ["label"],
+                                        "additionalProperties": false
+                                    }
+                                },
+                                "multi": { "type": "boolean" },
+                                "recommended": { "type": "integer", "minimum": 0 }
+                            },
+                            "required": ["id", "question", "options"],
+                            "additionalProperties": false
+                        }
+                    }
+                },
+                "required": ["questions"],
+                "additionalProperties": false
+            }
+        }
+    })
+}
+
+pub(crate) fn new_registry() -> AskRegistry {
+    Arc::new(Mutex::new(HashMap::new()))
+}
+
+pub(crate) async fn register(registry: &AskRegistry) -> (String, oneshot::Receiver<AskOutcome>) {
+    let id = format!("ask-{}", NEXT_ASK_ID.fetch_add(1, Ordering::Relaxed));
+    let (sender, receiver) = oneshot::channel();
+    registry.lock().await.insert(id.clone(), sender);
+    (id, receiver)
+}
+
+pub(crate) async fn respond(
+    registry: &AskRegistry,
+    request_id: &str,
+    outcome: AskOutcome,
+) -> Result<(), String> {
+    let sender = registry
+        .lock()
+        .await
+        .remove(request_id)
+        .ok_or_else(|| format!("ask request '{request_id}' is no longer pending"))?;
+    sender
+        .send(outcome)
+        .map_err(|_| format!("ask request '{request_id}' is no longer pending"))
+}
+
+pub(crate) async fn cancel_all(registry: &AskRegistry) {
+    let pending = std::mem::take(&mut *registry.lock().await);
+    for (_, sender) in pending {
+        let _ = sender.send(Err(AskError::Cancelled));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn request() -> AskRequest {
+        AskRequest::parse(&json!({
+            "questions": [{
+                "id": "scope",
+                "question": "Which scope?",
+                "options": [
+                    {"label": "Small", "description": "Only this module"},
+                    {"label": "Large"}
+                ],
+                "multi": false,
+                "recommended": 0
+            }]
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn parses_valid_request_and_rejects_invalid_shapes() {
+        let parsed = request();
+        assert_eq!(parsed.questions[0].id, "scope");
+        assert_eq!(parsed.questions[0].options.len(), 2);
+        assert_eq!(parsed.questions[0].recommended, Some(0));
+
+        for invalid in [
+            json!({"questions": []}),
+            json!({"questions": [{"id":"x","question":"?","options":[{"label":"one"}]}]}),
+            json!({"questions": [
+                {"id":"x","question":"?","options":[{"label":"one"},{"label":"two"}]},
+                {"id":"x","question":"again?","options":[{"label":"one"},{"label":"two"}]}
+            ]}),
+            json!({"questions": [{"id":"x","question":"?","options":[{"label":"one"},{"label":"Other (type your own)"}]}]}),
+            json!({"questions": [{"id":"x","question":"?","options":[{"label":"one"},{"label":"two"}],"recommended":2}]}),
+        ] {
+            assert!(AskRequest::parse(&invalid).is_err(), "accepted {invalid}");
+        }
+    }
+
+    #[test]
+    fn validates_structured_results_against_stable_ids_and_labels() {
+        let req = request();
+        let result = vec![QuestionResult {
+            id: "scope".into(),
+            selected: vec!["Small".into()],
+            custom_input: None,
+        }];
+        assert!(req.validate_results(&result).is_ok());
+
+        let unknown = vec![QuestionResult {
+            id: "scope".into(),
+            selected: vec!["Missing".into()],
+            custom_input: None,
+        }];
+        assert!(req.validate_results(&unknown).is_err());
+
+        let both = vec![QuestionResult {
+            id: "scope".into(),
+            selected: vec!["Small".into()],
+            custom_input: Some("custom".into()),
+        }];
+        assert!(req.validate_results(&both).is_err());
+    }
+
+    #[tokio::test]
+    async fn registry_rejects_stale_response_and_cancel_drains_waiters() {
+        let registry = new_registry();
+        let (first_id, first_rx) = register(&registry).await;
+        let (second_id, second_rx) = register(&registry).await;
+        assert_ne!(first_id, second_id);
+        assert_eq!(registry.lock().await.len(), 2);
+
+        assert!(respond(&registry, "missing", Ok(vec![])).await.is_err());
+        cancel_all(&registry).await;
+        assert!(matches!(first_rx.await.unwrap(), Err(AskError::Cancelled)));
+        assert!(matches!(second_rx.await.unwrap(), Err(AskError::Cancelled)));
+        assert!(registry.lock().await.is_empty());
+    }
+}

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -63,6 +63,8 @@ pub(crate) struct OrchestrationArgs {
     pub permissions: crate::core::agent::permissions::ToolPermissions,
     pub project_root: Option<std::path::PathBuf>,
     pub permission_requests: PermissionRegistry,
+    /// Present only when a client can render and answer structured questions.
+    pub ask_requests: Option<crate::core::agent::interaction::AskRegistry>,
     /// When set, used verbatim as the system prompt, bypassing project-context
     /// assembly and memory recall/indexing. Set for subagent child runs so a
     /// dispatched subagent gets exactly its definition prompt with no parent
@@ -179,6 +181,7 @@ struct CompositeToolInvoker {
     permissions: crate::core::agent::permissions::ToolPermissions,
     events: mpsc::UnboundedSender<StreamEvent>,
     permission_requests: PermissionRegistry,
+    ask_requests: Option<crate::core::agent::interaction::AskRegistry>,
     grants: std::sync::Mutex<crate::core::agent::tools::gate::SessionGrants>,
     subagents: Option<SubagentContext>,
     yolo: bool,
@@ -320,6 +323,47 @@ impl CompositeToolInvoker {
             _ => "ERROR: unknown subagent tool".to_string(),
         }
     }
+
+    async fn handle_ask_tool(&self, args: &serde_json::Value) -> String {
+        use crate::core::agent::interaction::{register, AskError, AskRequest};
+
+        let Some(registry) = &self.ask_requests else {
+            return "ERROR [interactive_ui_required]: ask requires an attached interactive UI"
+                .to_string();
+        };
+        let request = match AskRequest::parse(args) {
+            Ok(request) => request,
+            Err(error) => return format!("ERROR: {error}"),
+        };
+        let (request_id, receiver) = register(registry).await;
+        if self
+            .events
+            .send(StreamEvent::AskRequest {
+                request_id: request_id.clone(),
+                request: request.clone(),
+            })
+            .is_err()
+        {
+            let _ = crate::core::agent::interaction::respond(
+                registry,
+                &request_id,
+                Err(AskError::Cancelled),
+            )
+            .await;
+            return "ERROR [ask_cancelled]: interactive UI disconnected".to_string();
+        }
+        match receiver.await {
+            Ok(Ok(results)) => match request.validate_results(&results) {
+                Ok(()) => serde_json::to_string(&results).unwrap_or_else(|error| {
+                    format!("ERROR: could not encode ask response: {error}")
+                }),
+                Err(error) => format!("ERROR: invalid ask response: {error}"),
+            },
+            Ok(Err(AskError::Cancelled)) | Err(_) => {
+                "ERROR [ask_cancelled]: user cancelled the question".to_string()
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -346,6 +390,22 @@ impl ToolInvoker for CompositeToolInvoker {
                 .and_then(|f| f.get("name"))
                 .and_then(|v| v.as_str())
                 .unwrap_or("");
+            if name == "ask" {
+                let id = tc
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let args: serde_json::Value = tc
+                    .get("function")
+                    .and_then(|f| f.get("arguments"))
+                    .and_then(|v| v.as_str())
+                    .and_then(|value| serde_json::from_str(value).ok())
+                    .unwrap_or(serde_json::Value::Object(Default::default()));
+                let content = self.handle_ask_tool(&args).await;
+                out.push(ToolOutcome::plain(id, content));
+                continue;
+            }
             // Subagent tools are handled ahead of the fs/exec gate and the MCP
             // fallback: they orchestrate nested runs, not filesystem access.
             if crate::core::agent::subagent::is_subagent_tool(name) {
@@ -554,6 +614,7 @@ pub(crate) async fn run_server_side_openai_orchestration(
         permissions: crate::core::agent::permissions::ToolPermissions::allow_all(),
         project_root: None,
         permission_requests: Arc::new(Mutex::new(HashMap::new())),
+        ask_requests: None,
         system_prompt_override: None,
         subagents_enabled: false,
         yolo: false,
@@ -675,6 +736,7 @@ async fn orchestrate_inner(
         permissions,
         project_root,
         permission_requests,
+        ask_requests,
         system_prompt_override,
         subagents_enabled,
         yolo,
@@ -765,19 +827,20 @@ async fn orchestrate_inner(
     // path uses `allow_all()`, so behavior there is unchanged.
     retain_advertisable_mcp_tools(&mut openai_tools, &mut tool_to_server, permissions);
 
+    // Per-run allowlist shared by builtin/subagent/ask advertisement below.
+    let allowed_names: Option<std::collections::HashSet<String>> = json_body
+        .get("allowed_tools")
+        .and_then(|v| v.as_array())
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        });
     if project_root.is_some() {
         // Built-ins are governed by the capability gate at execution time, so here
         // we only drop tools explicitly denied in agent.toml (and honor allowed_tools
         // if the request set one). Advertisement is independent of the read-only
         // default that applies to opaque MCP tools.
-        let allowed_names: Option<std::collections::HashSet<String>> = json_body
-            .get("allowed_tools")
-            .and_then(|v| v.as_array())
-            .map(|a| {
-                a.iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect()
-            });
         for schema in crate::core::agent::tools::schema::builtin_tool_schemas() {
             let name = schema["function"]["name"].as_str().unwrap_or_default();
             if permissions.is_denied(name) {
@@ -810,6 +873,16 @@ async fn orchestrate_inner(
                 }
             }
         }
+    }
+    // The `ask` tool needs no project (it's an interactive question, not
+    // filesystem access), so it's advertised independent of the project_root
+    // gate above.
+    if ask_requests.is_some()
+        && allowed_names
+            .as_ref()
+            .is_none_or(|allowed| allowed.contains("ask"))
+    {
+        openai_tools.push(crate::core::agent::interaction::ask_tool_schema());
     }
 
     let (upstream_url, session_api_keys) = resolve_upstream_for_model(
@@ -869,6 +942,7 @@ async fn orchestrate_inner(
             permissions: permissions.clone(),
             events: events.clone(),
             permission_requests: permission_requests.clone(),
+            ask_requests: ask_requests.clone(),
             grants: std::sync::Mutex::new(crate::core::agent::tools::gate::SessionGrants::default()),
             subagents,
             yolo: *yolo,
@@ -1611,6 +1685,7 @@ mod tests {
             permissions: ToolPermissions::new(PermissionDefault::ReadOnly, &[], &[], &[]),
             events,
             permission_requests: registry,
+            ask_requests: None,
             grants: std::sync::Mutex::new(SessionGrants::default()),
             subagents: None,
             yolo: false,
@@ -1635,6 +1710,77 @@ mod tests {
                 None => return,
             }
         }
+    }
+
+    fn ask_call() -> serde_json::Value {
+        json!({
+            "id": "ask-call",
+            "type": "function",
+            "function": {
+                "name": "ask",
+                "arguments": serde_json::to_string(&json!({
+                    "questions": [{
+                        "id": "scope",
+                        "question": "Which scope?",
+                        "options": [{"label": "Small"}, {"label": "Large"}]
+                    }]
+                }))
+                .unwrap()
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn ask_requires_an_attached_interactive_ui() {
+        let root = unique_project_root();
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let permissions: PermissionRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let invoker = build_prompting_invoker(root.clone(), tx, permissions);
+
+        let out = invoker.invoke(&[ask_call()]).await.unwrap();
+
+        assert_eq!(out.len(), 1);
+        assert!(out[0].content.contains("interactive_ui_required"));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn ask_waits_for_and_returns_a_structured_response() {
+        let root = unique_project_root();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let permissions: PermissionRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let asks = crate::core::agent::interaction::new_registry();
+        let mut invoker = build_prompting_invoker(root.clone(), tx, permissions);
+        invoker.ask_requests = Some(asks.clone());
+
+        let task = tokio::spawn(async move { invoker.invoke(&[ask_call()]).await.unwrap() });
+        let request_id = match rx.recv().await.unwrap() {
+            StreamEvent::AskRequest {
+                request_id,
+                request,
+            } => {
+                assert_eq!(request.questions[0].id, "scope");
+                request_id
+            }
+            event => panic!("expected ask_request, got {event:?}"),
+        };
+        crate::core::agent::interaction::respond(
+            &asks,
+            &request_id,
+            Ok(vec![crate::core::agent::interaction::QuestionResult {
+                id: "scope".into(),
+                selected: vec!["Small".into()],
+                custom_input: None,
+            }]),
+        )
+        .await
+        .unwrap();
+
+        let out = task.await.unwrap();
+        let result: serde_json::Value = serde_json::from_str(&out[0].content).unwrap();
+        assert_eq!(result[0]["id"], "scope");
+        assert_eq!(result[0]["selected"][0], "Small");
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[tokio::test]

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -893,7 +893,8 @@ task state materially changes.";
 
 /// True on a session's first substantive user message: exactly one user-role
 /// message in the conversation so far (this one), no todos staged yet, and
-/// the prompt isn't a bare question/exclamation a phased plan would be
+/// the prompt looks like actual multi-step work rather than a greeting,
+/// acknowledgement, or a bare question/exclamation a phased plan would be
 /// overkill for.
 async fn should_suggest_eager_todo_plan(
     conversation_messages: &[serde_json::Value],
@@ -911,6 +912,15 @@ async fn should_suggest_eager_todo_plan(
     };
     let trimmed = prompt_text.trim_end();
     if ['?', '！', '？', '!'].iter().any(|c| trimmed.ends_with(*c)) {
+        return false;
+    }
+    // A greeting, thanks, or one-line aside ("hi", "ok thanks") is not work a
+    // phased plan helps with. Require enough words to look like an actual
+    // request; the shortest real task prompts ("fix the login bug") clear this,
+    // while chit-chat does not. A word-count floor, not a keyword blocklist, so
+    // it never has to enumerate every possible pleasantry.
+    const MIN_SUBSTANTIVE_WORDS: usize = 4;
+    if trimmed.split_whitespace().count() < MIN_SUBSTANTIVE_WORDS {
         return false;
     }
     match todo_registry {
@@ -1741,6 +1751,19 @@ mod tests {
         assert!(!should_suggest_eager_todo_plan(&convo, &None).await);
         let convo = vec![user_message("nice work!")];
         assert!(!should_suggest_eager_todo_plan(&convo, &None).await);
+    }
+
+    #[tokio::test]
+    async fn eager_todo_plan_not_suggested_for_a_short_greeting() {
+        // Punctuation-free chit-chat must not force a todo plan: the word-count
+        // floor catches greetings and acks that the `?`/`!` check misses.
+        for msg in ["hi", "hello", "hey there", "ok thanks"] {
+            let convo = vec![user_message(msg)];
+            assert!(
+                !should_suggest_eager_todo_plan(&convo, &None).await,
+                "short greeting should not trigger eager todo: {msg:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -879,18 +879,19 @@ fn latest_user_text(messages: &[serde_json::Value]) -> Option<String> {
     }
 }
 
-/// Soft nudge appended to the system prompt on a session's first substantive
-/// message: without it, the model only ever reaches for `todo` once told
-/// explicitly that it has the tool, instead of proactively planning a
-/// multi-step request the way a plan laid out up front would help with.
-/// Advisory only -- unlike plan mode's read-only gate, nothing enforces this;
-/// the model may ignore it for a request that doesn't warrant a plan.
-const EAGER_TODO_PROMPT_ADDENDUM: &str = "Before substantial work on this request, consider \
-calling `todo` first with a single `init` op to lay out a phased plan covering investigation \
-through implementation and verification, not just the next step. Keep each task to a concise, \
-specific 5-10 word label; `init` only accepts phase names and task-label strings. If you create \
-the list, continue the request in the same turn and avoid re-calling `todo` unless task state \
-materially changes.";
+/// System-prompt addendum on a session's first substantive message: without
+/// it, the model only ever reaches for `todo` once told explicitly that it
+/// has the tool, instead of proactively planning a multi-step request the
+/// way a plan laid out up front would help with. Paired with a forced
+/// `tool_choice` on that same first turn (see `should_suggest_eager_todo_plan`
+/// and its caller), so this is a real requirement, not a suggestion the model
+/// can silently skip -- the imperative wording matches that guarantee.
+const EAGER_TODO_PROMPT_ADDENDUM: &str = "Before substantial work on this request, create a \
+phased todo. You MUST call `todo` first in this turn with a single `init` op covering \
+investigation through implementation and verification, not just the next step. Keep each task \
+to a concise, specific 5-10 word label; `init` only accepts phase names and task-label strings. \
+After `todo` succeeds, continue the request in the same turn; do not call `todo` again unless \
+task state materially changes.";
 
 /// True on a session's first substantive user message: exactly one user-role
 /// message in the conversation so far (this one), no todos staged yet, and
@@ -1004,17 +1005,21 @@ async fn orchestrate_inner(
     } else {
         assistant_instructions
     };
+    // Child (subagent) runs are excluded via `system_prompt_override`, the
+    // same gate the memory-recall block above uses to distinguish a
+    // top-level run from a subagent's isolated context.
+    let eager_todo_plan = run_mode != crate::core::agent::plan::RunMode::Plan
+        && system_prompt_override.is_none()
+        && should_suggest_eager_todo_plan(&conversation_messages, todo_registry).await;
     let system_prompt = if run_mode == crate::core::agent::plan::RunMode::Plan {
         let addendum = crate::core::agent::plan::plan_mode_prompt_addendum();
         Some(match system_prompt {
             Some(sys) => format!("{sys}\n\n{addendum}"),
             None => addendum.to_string(),
         })
-    } else if system_prompt_override.is_none()
-        && should_suggest_eager_todo_plan(&conversation_messages, todo_registry).await
-    {
-        // Child (subagent) runs are excluded above via `system_prompt_override`,
-        // the same gate the memory-recall block already uses to distinguish a
+    } else if eager_todo_plan {
+        // Child (subagent) runs are excluded via `system_prompt_override`, the
+        // same gate the memory-recall block above uses to distinguish a
         // top-level run from a subagent's isolated context.
         Some(match system_prompt {
             Some(sys) => format!("{sys}\n\n{EAGER_TODO_PROMPT_ADDENDUM}"),
@@ -1026,6 +1031,10 @@ async fn orchestrate_inner(
     if let Some(sys) = system_prompt {
         set_system_prompt(&mut conversation_messages, &sys);
     }
+    // Paired with the addendum above: force the model's very first tool call
+    // to actually be `todo` rather than leaving compliance up to a prompt it
+    // could silently ignore.
+    let force_first_tool = eager_todo_plan.then_some("todo");
 
     let model_override = json_body.get("model").and_then(|v| v.as_str());
     let mut model_id: Option<String> = model_override.map(|v| v.to_string());
@@ -1231,6 +1240,7 @@ async fn orchestrate_inner(
             &tools,
             run_mode,
             todo_registry.as_ref(),
+            force_first_tool,
         )
         .await;
         // On a clean exit, wait for any subagents the model dispatched but never
@@ -1262,6 +1272,7 @@ async fn orchestrate_inner(
             &mcp_tools,
             run_mode,
             todo_registry.as_ref(),
+            force_first_tool,
         )
         .await
     }
@@ -1277,6 +1288,7 @@ fn build_completion_request(
     conversation_messages: &[serde_json::Value],
     openai_tools: &[serde_json::Value],
     json_body: &serde_json::Value,
+    forced_tool_choice: Option<&str>,
 ) -> serde_json::Value {
     let mut completion_map = serde_json::Map::new();
     completion_map.insert("model".to_string(), serde_json::json!(model_id));
@@ -1284,7 +1296,11 @@ fn build_completion_request(
         "messages".to_string(),
         serde_json::Value::Array(conversation_messages.to_vec()),
     );
-    completion_map.insert("tool_choice".to_string(), serde_json::json!("auto"));
+    let tool_choice = match forced_tool_choice {
+        Some(name) => serde_json::json!({ "type": "function", "function": { "name": name } }),
+        None => serde_json::json!("auto"),
+    };
+    completion_map.insert("tool_choice".to_string(), tool_choice);
     if !openai_tools.is_empty() {
         completion_map.insert(
             "tools".to_string(),
@@ -1370,6 +1386,10 @@ async fn run_turn_cycle(
     tools: &dyn ToolInvoker,
     run_mode: crate::core::agent::plan::RunMode,
     todo_registry: Option<&crate::core::agent::todo::TodoRegistry>,
+    // Forces the model's very first tool call (`turn == 0` only) to be this
+    // named tool -- used to make the eager-todo nudge actually reliable
+    // instead of an easily-ignored suggestion. `None` for every later turn.
+    force_first_tool: Option<&str>,
 ) -> Result<serde_json::Value, String> {
     // `max_turns == 0` means unbounded: the session token budget and user
     // cancellation are the real guards, so an interactive run isn't cut off
@@ -1400,8 +1420,13 @@ async fn run_turn_cycle(
             let mut keep_recent = crate::core::agent::compaction::DEFAULT_KEEP_RECENT;
             let mut attempts = 0usize;
             loop {
-                let request_value =
-                    build_completion_request(model_id, &conversation_messages, openai_tools, json_body);
+                let request_value = build_completion_request(
+                    model_id,
+                    &conversation_messages,
+                    openai_tools,
+                    json_body,
+                    (turn == 0).then_some(force_first_tool).flatten(),
+                );
                 match model.invoke(&request_value, events).await {
                     Ok(c) => break c,
                     Err(e)
@@ -1775,6 +1800,7 @@ mod tests {
             &tool,
             crate::core::agent::plan::RunMode::Normal,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -1802,6 +1828,47 @@ mod tests {
             }
         }
         assert!(saw_tool_call && saw_tool_result);
+    }
+
+    #[tokio::test]
+    async fn force_first_tool_only_applies_to_the_first_turn() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let model = MockModel::new(vec![
+            tool_call_completion(),
+            json!({ "choices": [{ "message": { "content": "final answer" }, "finish_reason": "stop" }] }),
+        ]);
+        let tool = MockTool::default();
+        let mut budget = SessionBudget::new(None);
+        let convo = vec![json!({ "role": "user", "content": "hi" })];
+
+        run_turn_cycle(
+            &tx,
+            &json!({}),
+            "m",
+            &[],
+            convo,
+            8,
+            &mut budget,
+            &model,
+            &tool,
+            crate::core::agent::plan::RunMode::Normal,
+            None,
+            Some("todo"),
+        )
+        .await
+        .unwrap();
+
+        let requests = model.requests.lock().unwrap();
+        assert_eq!(requests.len(), 2, "one request per turn");
+        assert_eq!(
+            requests[0]["tool_choice"],
+            json!({ "type": "function", "function": { "name": "todo" } }),
+            "the first turn's request must force the named tool"
+        );
+        assert_eq!(
+            requests[1]["tool_choice"], "auto",
+            "later turns must not keep forcing the same tool"
+        );
     }
 
     fn mutating_tool_call_completion(id: &str, name: &str) -> serde_json::Value {
@@ -1869,6 +1936,7 @@ mod tests {
             &tool,
             crate::core::agent::plan::RunMode::Normal,
             Some(&registry),
+            None,
         )
         .await
         .unwrap();
@@ -1904,6 +1972,7 @@ mod tests {
             &tool,
             crate::core::agent::plan::RunMode::Plan,
             Some(&registry),
+            None,
         )
         .await
         .unwrap();
@@ -1942,6 +2011,7 @@ mod tests {
             &tool,
             crate::core::agent::plan::RunMode::Normal,
             Some(&registry),
+            None,
         )
         .await
         .unwrap();
@@ -2006,6 +2076,7 @@ mod tests {
             &tool,
             crate::core::agent::plan::RunMode::Normal,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -2050,6 +2121,7 @@ mod tests {
             &model,
             &tool,
             crate::core::agent::plan::RunMode::Normal,
+            None,
             None,
         )
         .await
@@ -2107,7 +2179,7 @@ mod tests {
             convo.push(json!({ "role": r, "content": format!("m{i}") }));
         }
 
-        let result = run_turn_cycle(&tx, &json!({}), "m", &[], convo, 8, &mut budget, &model, &tool, crate::core::agent::plan::RunMode::Normal, None)
+        let result = run_turn_cycle(&tx, &json!({}), "m", &[], convo, 8, &mut budget, &model, &tool, crate::core::agent::plan::RunMode::Normal, None, None)
             .await
             .unwrap();
 
@@ -2128,7 +2200,7 @@ mod tests {
         let mut budget = SessionBudget::new(None);
         let convo = vec![json!({ "role": "user", "content": "hi" })];
 
-        let result = run_turn_cycle(&tx, &json!({}), "m", &[], convo, 8, &mut budget, &model, &tool, crate::core::agent::plan::RunMode::Normal, None)
+        let result = run_turn_cycle(&tx, &json!({}), "m", &[], convo, 8, &mut budget, &model, &tool, crate::core::agent::plan::RunMode::Normal, None, None)
             .await
             .unwrap();
 
@@ -2152,7 +2224,7 @@ mod tests {
 
         // max_turns = 0 means unbounded: it must not error out and must keep
         // going past the tool-call turn to return the final answer.
-        let result = run_turn_cycle(&tx, &json!({}), "m", &[], convo, 0, &mut budget, &model, &tool, crate::core::agent::plan::RunMode::Normal, None)
+        let result = run_turn_cycle(&tx, &json!({}), "m", &[], convo, 0, &mut budget, &model, &tool, crate::core::agent::plan::RunMode::Normal, None, None)
             .await
             .unwrap();
 

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -879,6 +879,47 @@ fn latest_user_text(messages: &[serde_json::Value]) -> Option<String> {
     }
 }
 
+/// Soft nudge appended to the system prompt on a session's first substantive
+/// message: without it, the model only ever reaches for `todo` once told
+/// explicitly that it has the tool, instead of proactively planning a
+/// multi-step request the way a plan laid out up front would help with.
+/// Advisory only -- unlike plan mode's read-only gate, nothing enforces this;
+/// the model may ignore it for a request that doesn't warrant a plan.
+const EAGER_TODO_PROMPT_ADDENDUM: &str = "Before substantial work on this request, consider \
+calling `todo` first with a single `init` op to lay out a phased plan covering investigation \
+through implementation and verification, not just the next step. Keep each task to a concise, \
+specific 5-10 word label; `init` only accepts phase names and task-label strings. If you create \
+the list, continue the request in the same turn and avoid re-calling `todo` unless task state \
+materially changes.";
+
+/// True on a session's first substantive user message: exactly one user-role
+/// message in the conversation so far (this one), no todos staged yet, and
+/// the prompt isn't a bare question/exclamation a phased plan would be
+/// overkill for.
+async fn should_suggest_eager_todo_plan(
+    conversation_messages: &[serde_json::Value],
+    todo_registry: &Option<crate::core::agent::todo::TodoRegistry>,
+) -> bool {
+    let user_turns = conversation_messages
+        .iter()
+        .filter(|m| m.get("role").and_then(|r| r.as_str()) == Some("user"))
+        .count();
+    if user_turns != 1 {
+        return false;
+    }
+    let Some(prompt_text) = latest_user_text(conversation_messages) else {
+        return false;
+    };
+    let trimmed = prompt_text.trim_end();
+    if ['?', '！', '？', '!'].iter().any(|c| trimmed.ends_with(*c)) {
+        return false;
+    }
+    match todo_registry {
+        Some(registry) => registry.lock().await.is_empty(),
+        None => true,
+    }
+}
+
 async fn orchestrate_inner(
     events: &mpsc::UnboundedSender<StreamEvent>,
     json_body: &serde_json::Value,
@@ -968,6 +1009,16 @@ async fn orchestrate_inner(
         Some(match system_prompt {
             Some(sys) => format!("{sys}\n\n{addendum}"),
             None => addendum.to_string(),
+        })
+    } else if system_prompt_override.is_none()
+        && should_suggest_eager_todo_plan(&conversation_messages, todo_registry).await
+    {
+        // Child (subagent) runs are excluded above via `system_prompt_override`,
+        // the same gate the memory-recall block already uses to distinguish a
+        // top-level run from a subagent's isolated context.
+        Some(match system_prompt {
+            Some(sys) => format!("{sys}\n\n{EAGER_TODO_PROMPT_ADDENDUM}"),
+            None => EAGER_TODO_PROMPT_ADDENDUM.to_string(),
         })
     } else {
         system_prompt
@@ -1632,6 +1683,57 @@ mod tests {
                 })
                 .collect())
         }
+    }
+
+    fn user_message(text: &str) -> serde_json::Value {
+        json!({ "role": "user", "content": text })
+    }
+
+    fn empty_todo_registry() -> crate::core::agent::todo::TodoRegistry {
+        std::sync::Arc::new(tokio::sync::Mutex::new(
+            crate::core::agent::todo::TodoList::default(),
+        ))
+    }
+
+    fn staged_todo_registry() -> crate::core::agent::todo::TodoRegistry {
+        use crate::core::agent::todo::{TodoItem, TodoList, TodoPhase, TodoStatus};
+        std::sync::Arc::new(tokio::sync::Mutex::new(TodoList {
+            phases: vec![TodoPhase {
+                name: "P".into(),
+                tasks: vec![TodoItem { content: "t1".into(), status: TodoStatus::Pending }],
+            }],
+        }))
+    }
+
+    #[tokio::test]
+    async fn eager_todo_plan_suggested_on_first_substantive_message() {
+        let convo = vec![user_message("build a flappy bird clone")];
+        assert!(should_suggest_eager_todo_plan(&convo, &Some(empty_todo_registry())).await);
+        assert!(should_suggest_eager_todo_plan(&convo, &None).await);
+    }
+
+    #[tokio::test]
+    async fn eager_todo_plan_not_suggested_for_a_bare_question() {
+        let convo = vec![user_message("what's the capital of France?")];
+        assert!(!should_suggest_eager_todo_plan(&convo, &None).await);
+        let convo = vec![user_message("nice work!")];
+        assert!(!should_suggest_eager_todo_plan(&convo, &None).await);
+    }
+
+    #[tokio::test]
+    async fn eager_todo_plan_not_suggested_once_todos_exist() {
+        let convo = vec![user_message("keep going")];
+        assert!(!should_suggest_eager_todo_plan(&convo, &Some(staged_todo_registry())).await);
+    }
+
+    #[tokio::test]
+    async fn eager_todo_plan_not_suggested_past_the_first_user_turn() {
+        let convo = vec![
+            user_message("build a flappy bird clone"),
+            json!({ "role": "assistant", "content": "on it" }),
+            user_message("also add a high score screen"),
+        ];
+        assert!(!should_suggest_eager_todo_plan(&convo, &None).await);
     }
 
     fn tool_call_completion() -> serde_json::Value {

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -81,6 +81,11 @@ pub(crate) struct OrchestrationArgs {
     /// call (built-in reads/writes/exec and MCP) without prompting. Inherited by
     /// dispatched subagents via the cloned parent args.
     pub yolo: bool,
+    /// Read-only plan mode. When `Plan`, mutation-capable tools (write/edit/bash,
+    /// memory_write/skill_write, MCP, subagent dispatch) are neither advertised
+    /// nor executable: the dispatcher hard-denies them with `plan_mode_read_only`,
+    /// stronger than `--yolo`'s prompt suppression (yolo cannot override this).
+    pub run_mode: crate::core::agent::plan::RunMode,
 }
 
 #[async_trait]
@@ -190,6 +195,7 @@ struct CompositeToolInvoker {
     grants: std::sync::Mutex<crate::core::agent::tools::gate::SessionGrants>,
     subagents: Option<SubagentContext>,
     yolo: bool,
+    run_mode: crate::core::agent::plan::RunMode,
 }
 
 impl CompositeToolInvoker {
@@ -463,6 +469,21 @@ impl CompositeToolInvoker {
     }
 }
 
+/// Message for a tool blocked by the project's own deny list, naming the
+/// exact config file so the block is actionable, not mysterious.
+fn denied_by_policy_msg(name: &str, project_root: &std::path::Path) -> String {
+    format!(
+        "ERROR: tool '{name}' denied by project policy (see [tools] deny in {})",
+        crate::core::agent::project::agent_toml_path(project_root).display()
+    )
+}
+
+/// Rejection message for a mutation-capable tool call attempted in
+/// `RunMode::Plan`. Authoritative: the tool never actually runs.
+fn plan_mode_read_only_msg(name: &str) -> String {
+    format!("ERROR: tool '{name}' unavailable in plan_mode_read_only (plan mode is read-only)")
+}
+
 #[async_trait]
 impl ToolInvoker for CompositeToolInvoker {
     async fn invoke(
@@ -523,6 +544,13 @@ impl ToolInvoker for CompositeToolInvoker {
             // fallback: they orchestrate nested runs, not filesystem access.
             if crate::core::agent::subagent::is_subagent_tool(name) {
                 let id = tc.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                // Plan mode blocks subagent dispatch (a subagent could mutate).
+                // They are not advertised in Plan; this is defense in depth
+                // against a stale tool schema. `--yolo` cannot override.
+                if self.run_mode == crate::core::agent::plan::RunMode::Plan {
+                    out.push(ToolOutcome::plain(id, plan_mode_read_only_msg(name)));
+                    continue;
+                }
                 let args: serde_json::Value = tc
                     .get("function")
                     .and_then(|f| f.get("arguments"))
@@ -535,6 +563,13 @@ impl ToolInvoker for CompositeToolInvoker {
             }
             if !is_builtin(name) {
                 let id = tc.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                // Plan mode blocks all MCP tools: their capability is arbitrary
+                // and unknowable, so they are never advertised in Plan and are
+                // hard-denied here as defense in depth. `--yolo` cannot override.
+                if self.run_mode == crate::core::agent::plan::RunMode::Plan {
+                    out.push(ToolOutcome::plain(id, plan_mode_read_only_msg(name)));
+                    continue;
+                }
                 // Deny-listed MCP tools are never advertised, but guard anyway.
                 if self.permissions.is_denied(name) {
                     out.push(ToolOutcome::plain(
@@ -572,6 +607,16 @@ impl ToolInvoker for CompositeToolInvoker {
                 .and_then(|s| serde_json::from_str(s).ok())
                 .unwrap_or(serde_json::Value::Object(Default::default()));
             let tool = lookup(name).expect("is_builtin implies lookup");
+            // Plan mode: mutation-capable builtins (Write/Exec) are hard-denied
+            // BEFORE the normal gate, without a permission prompt, and `--yolo`
+            // cannot override this (unlike the normal prompt suppression below).
+            // Read/Net/workspace-read tools fall through to the usual gate.
+            if self.run_mode == crate::core::agent::plan::RunMode::Plan
+                && matches!(tool.capability, Capability::Write | Capability::Exec)
+            {
+                out.push(ToolOutcome::plain(id, plan_mode_read_only_msg(name)));
+                continue;
+            }
             let snapshot = { self.grants.lock().unwrap().clone() };
             let decision = resolve_decision(
                 tool,
@@ -732,6 +777,7 @@ pub(crate) async fn run_server_side_openai_orchestration(
         system_prompt_override: None,
         subagents_enabled: false,
         yolo: false,
+        run_mode: crate::core::agent::plan::RunMode::Normal,
     };
     run_orchestration_streamed(&tx, json_body, &args).await
 }
@@ -855,7 +901,17 @@ async fn orchestrate_inner(
         system_prompt_override,
         subagents_enabled,
         yolo,
+        run_mode,
     } = args;
+
+    // Per-turn override: the TUI toggles plan mode live via the request body
+    // (like `model`/`max_tokens`), falling back to the session default. Any
+    // caller can only *tighten* to Plan or match the default; the capability
+    // gate below enforces read-only regardless of who set it.
+    let run_mode = json_body
+        .get("run_mode")
+        .and_then(|v| serde_json::from_value::<crate::core::agent::plan::RunMode>(v.clone()).ok())
+        .unwrap_or(*run_mode);
 
     let messages_value = json_body
         .get("messages")
@@ -895,6 +951,15 @@ async fn orchestrate_inner(
         sp
     } else {
         assistant_instructions
+    };
+    let system_prompt = if run_mode == crate::core::agent::plan::RunMode::Plan {
+        let addendum = crate::core::agent::plan::plan_mode_prompt_addendum();
+        Some(match system_prompt {
+            Some(sys) => format!("{sys}\n\n{addendum}"),
+            None => addendum.to_string(),
+        })
+    } else {
+        system_prompt
     };
     if let Some(sys) = system_prompt {
         set_system_prompt(&mut conversation_messages, &sys);
@@ -939,8 +1004,14 @@ async fn orchestrate_inner(
 
     // Advertise MCP tools per agent.toml policy: read-only (the CLI default) does
     // NOT suppress them; only an explicit deny or `default = "deny"` does. Proxy
-    // path uses `allow_all()`, so behavior there is unchanged.
-    retain_advertisable_mcp_tools(&mut openai_tools, &mut tool_to_server, permissions);
+    // path uses `allow_all()`, so behavior there is unchanged. Plan mode never
+    // advertises MCP tools at all: their capability is arbitrary and unknowable.
+    if run_mode == crate::core::agent::plan::RunMode::Plan {
+        openai_tools.clear();
+        tool_to_server.clear();
+    } else {
+        retain_advertisable_mcp_tools(&mut openai_tools, &mut tool_to_server, permissions);
+    }
 
     // Per-run allowlist shared by builtin/subagent/ask advertisement below.
     let allowed_names: Option<std::collections::HashSet<String>> = json_body
@@ -961,6 +1032,19 @@ async fn orchestrate_inner(
             if permissions.is_denied(name) {
                 continue;
             }
+            // Plan mode advertises only read/net builtins; write/exec are hidden
+            // entirely rather than relying on a prompt or execution-time denial.
+            if run_mode == crate::core::agent::plan::RunMode::Plan
+                && crate::core::agent::tools::lookup(name).is_some_and(|t| {
+                    matches!(
+                        t.capability,
+                        crate::core::agent::tools::Capability::Write
+                            | crate::core::agent::tools::Capability::Exec
+                    )
+                })
+            {
+                continue;
+            }
             if let Some(allow) = &allowed_names {
                 if !allow.contains(name) {
                     continue;
@@ -969,9 +1053,9 @@ async fn orchestrate_inner(
             openai_tools.push(schema);
         }
         // Subagent tools are advertised only when this run may dispatch them
-        // (never for a child run, capping recursion depth at one). The dispatch
-        // tool's description lists the resolvable subagent names.
-        if args.subagents_enabled {
+        // (never for a child run, capping recursion depth at one) and the run
+        // isn't in read-only Plan mode (a dispatched subagent could mutate).
+        if args.subagents_enabled && run_mode != crate::core::agent::plan::RunMode::Plan {
             if let Some(root) = project_root {
                 let registry = crate::core::agent::subagent::SubagentRegistry::load(root);
                 for schema in crate::core::agent::subagent::subagent_tool_schemas(&registry) {
@@ -1071,6 +1155,7 @@ async fn orchestrate_inner(
             grants: std::sync::Mutex::new(crate::core::agent::tools::gate::SessionGrants::default()),
             subagents,
             yolo: *yolo,
+            run_mode,
         };
         let result = run_turn_cycle(
             events,
@@ -1815,6 +1900,7 @@ mod tests {
             grants: std::sync::Mutex::new(SessionGrants::default()),
             subagents: None,
             yolo: false,
+            run_mode: crate::core::agent::plan::RunMode::Normal,
         }
     }
 

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -1942,6 +1942,113 @@ mod tests {
         })
     }
 
+    /// A single tool call by name with empty JSON arguments.
+    fn tool_call(id: &str, name: &str) -> serde_json::Value {
+        json!({
+            "id": id,
+            "type": "function",
+            "function": { "name": name, "arguments": "{}" }
+        })
+    }
+
+    #[tokio::test]
+    async fn plan_mode_denies_write_even_with_yolo() {
+        let root = unique_project_root();
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let permissions: PermissionRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let mut invoker = build_prompting_invoker(root.clone(), tx, permissions);
+        invoker.run_mode = crate::core::agent::plan::RunMode::Plan;
+        // --yolo must NOT override the plan-mode read-only gate.
+        invoker.yolo = true;
+
+        let out = invoker.invoke(&[write_call()]).await.unwrap();
+
+        assert_eq!(out.len(), 1);
+        assert!(
+            out[0].content.contains("plan_mode_read_only"),
+            "write must be hard-denied in plan mode: {}",
+            out[0].content
+        );
+        assert!(!root.join("out.txt").exists(), "file must not be written");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn plan_mode_denies_mcp_tool_from_stale_schema() {
+        let root = unique_project_root();
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let permissions: PermissionRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let mut invoker = build_prompting_invoker(root.clone(), tx, permissions);
+        invoker.run_mode = crate::core::agent::plan::RunMode::Plan;
+        invoker.yolo = true;
+
+        // An unknown (non-builtin) name stands in for an MCP tool a stale schema
+        // could still surface; it must be denied before any dispatch.
+        let out = invoker.invoke(&[tool_call("m1", "some_mcp_tool")]).await.unwrap();
+
+        assert_eq!(out.len(), 1);
+        assert!(out[0].content.contains("plan_mode_read_only"), "{}", out[0].content);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn plan_mode_denies_subagent_dispatch() {
+        let root = unique_project_root();
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let permissions: PermissionRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let mut invoker = build_prompting_invoker(root.clone(), tx, permissions);
+        invoker.run_mode = crate::core::agent::plan::RunMode::Plan;
+
+        let out = invoker
+            .invoke(&[tool_call("s1", "dispatch_subagent")])
+            .await
+            .unwrap();
+
+        assert_eq!(out.len(), 1);
+        assert!(out[0].content.contains("plan_mode_read_only"), "{}", out[0].content);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn plan_mode_allows_read_only_builtins() {
+        let root = unique_project_root();
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let permissions: PermissionRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let mut invoker = build_prompting_invoker(root.clone(), tx, permissions);
+        invoker.run_mode = crate::core::agent::plan::RunMode::Plan;
+
+        // `ls` is Read-capable: the plan gate must let it through to the normal
+        // (auto-allowed) path, so it never yields the plan-mode denial.
+        let call = json!({
+            "id": "r1",
+            "type": "function",
+            "function": { "name": "ls", "arguments": "{\"path\":\".\"}" }
+        });
+        let out = invoker.invoke(&[call]).await.unwrap();
+
+        assert_eq!(out.len(), 1);
+        assert!(
+            !out[0].content.contains("plan_mode_read_only"),
+            "read-only builtins must not be blocked by plan mode: {}",
+            out[0].content
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn orchestrate_reads_run_mode_override_from_body() {
+        // The per-turn body override (mirrors model/max_tokens) parses to Plan;
+        // absent/normal falls back to the session default.
+        use crate::core::agent::plan::RunMode;
+        let from_body = |v: serde_json::Value| {
+            v.get("run_mode")
+                .and_then(|x| serde_json::from_value::<RunMode>(x.clone()).ok())
+        };
+        assert_eq!(from_body(json!({"run_mode": "plan"})), Some(RunMode::Plan));
+        assert_eq!(from_body(json!({"run_mode": "normal"})), Some(RunMode::Normal));
+        assert_eq!(from_body(json!({})), None);
+    }
+
     #[tokio::test]
     async fn ask_requires_an_attached_interactive_ui() {
         let root = unique_project_root();

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -1178,6 +1178,8 @@ async fn orchestrate_inner(
             &mut budget,
             &http_model,
             &tools,
+            run_mode,
+            todo_registry.as_ref(),
         )
         .await;
         // On a clean exit, wait for any subagents the model dispatched but never
@@ -1207,6 +1209,8 @@ async fn orchestrate_inner(
             &mut budget,
             &http_model,
             &mcp_tools,
+            run_mode,
+            todo_registry.as_ref(),
         )
         .await
     }
@@ -1313,12 +1317,24 @@ async fn run_turn_cycle(
     budget: &mut SessionBudget,
     model: &dyn ModelInvoker,
     tools: &dyn ToolInvoker,
+    run_mode: crate::core::agent::plan::RunMode,
+    todo_registry: Option<&crate::core::agent::todo::TodoRegistry>,
 ) -> Result<serde_json::Value, String> {
     // `max_turns == 0` means unbounded: the session token budget and user
     // cancellation are the real guards, so an interactive run isn't cut off
     // mid-task by a fixed turn cap.
     let unlimited = max_turns == 0;
     let mut turn: usize = 0;
+    // Mid-run todo upkeep: after a long uninterrupted run of mutating tool
+    // calls with no todo touch, nudge the model once to keep the list honest
+    // rather than only ever reminding it at a full stop -- a task that never
+    // pauses to yield plain text could otherwise go a very long time with a
+    // stale todo list. Local to one cycle (this function runs once per
+    // top-level prompt), so no session-level reset bookkeeping is needed.
+    const MID_RUN_NUDGE_MUTATION_THRESHOLD: u32 = 12;
+    const MID_RUN_NUDGE_MAX_PER_CYCLE: u32 = 2;
+    let mut mutations_since_todo_touch: u32 = 0;
+    let mut mid_run_nudge_count: u32 = 0;
 
     while unlimited || turn < max_turns {
         let _ = events.send(StreamEvent::Step {
@@ -1479,6 +1495,10 @@ async fn run_turn_cycle(
             })
             .collect();
 
+        // Reset wins over any mutations counted in the same batch: touching
+        // `todo` at all means the list was just reconciled, regardless of
+        // what else ran alongside it.
+        let mut todo_touched_this_batch = false;
         for outcome in tool_results {
             let ToolOutcome { id, content, diff } = outcome;
             // A `bash` call that exits non-zero isn't prefixed "ERROR" (that
@@ -1488,6 +1508,12 @@ async fn run_turn_cycle(
             let is_error = content.starts_with("ERROR")
                 || (tool_names.get(id.as_str()) == Some(&"bash")
                     && crate::core::agent::tools::handlers::bash_result_failed(&content));
+            let name = tool_names.get(id.as_str()).copied().unwrap_or("");
+            if name == "todo" {
+                todo_touched_this_batch = true;
+            } else if !is_error && matches!(name, "bash" | "write" | "edit") {
+                mutations_since_todo_touch += 1;
+            }
             let _ = events.send(StreamEvent::ToolResult {
                 id: id.clone(),
                 content: content.clone(),
@@ -1499,6 +1525,43 @@ async fn run_turn_cycle(
                 "tool_call_id": id,
                 "content": content
             }));
+        }
+        if todo_touched_this_batch {
+            mutations_since_todo_touch = 0;
+        } else if mutations_since_todo_touch >= MID_RUN_NUDGE_MUTATION_THRESHOLD
+            && mid_run_nudge_count < MID_RUN_NUDGE_MAX_PER_CYCLE
+            && run_mode == crate::core::agent::plan::RunMode::Normal
+        {
+            let open_count = match todo_registry {
+                Some(registry) => {
+                    let list = registry.lock().await;
+                    list.phases
+                        .iter()
+                        .flat_map(|p| p.tasks.iter())
+                        .filter(|t| {
+                            matches!(
+                                t.status,
+                                crate::core::agent::todo::TodoStatus::Pending
+                                    | crate::core::agent::todo::TodoStatus::InProgress
+                            )
+                        })
+                        .count()
+                }
+                None => 0,
+            };
+            if open_count > 0 {
+                mutations_since_todo_touch = 0;
+                mid_run_nudge_count += 1;
+                let plural = if open_count == 1 { "" } else { "s" };
+                conversation_messages.push(serde_json::json!({
+                    "role": "user",
+                    "content": format!(
+                        "Reminder: {open_count} todo item{plural} still open. If you finished a \
+                         task since the last todo update, mark it done now so progress stays \
+                         visible; otherwise just keep working."
+                    )
+                }));
+            }
         }
         turn += 1;
     }
@@ -1517,11 +1580,16 @@ mod tests {
 
     struct MockModel {
         responses: StdMutex<VecDeque<serde_json::Value>>,
+        // Every request this mock was invoked with, in order -- lets a test
+        // inspect exactly what conversation was sent on a later turn (e.g. to
+        // confirm a hidden mid-run nudge message landed in it).
+        requests: StdMutex<Vec<serde_json::Value>>,
     }
     impl MockModel {
         fn new(responses: Vec<serde_json::Value>) -> Self {
             Self {
                 responses: StdMutex::new(responses.into_iter().collect()),
+                requests: StdMutex::new(Vec::new()),
             }
         }
     }
@@ -1529,9 +1597,10 @@ mod tests {
     impl ModelInvoker for MockModel {
         async fn invoke(
             &self,
-            _request: &serde_json::Value,
+            request: &serde_json::Value,
             _events: &mpsc::UnboundedSender<StreamEvent>,
         ) -> Result<serde_json::Value, String> {
+            self.requests.lock().unwrap().push(request.clone());
             self.responses
                 .lock()
                 .unwrap()
@@ -1602,6 +1671,8 @@ mod tests {
             &mut budget,
             &model,
             &tool,
+            crate::core::agent::plan::RunMode::Normal,
+            None,
         )
         .await
         .unwrap();
@@ -1629,6 +1700,153 @@ mod tests {
             }
         }
         assert!(saw_tool_call && saw_tool_result);
+    }
+
+    fn mutating_tool_call_completion(id: &str, name: &str) -> serde_json::Value {
+        json!({
+            "choices": [{
+                "message": {
+                    "content": serde_json::Value::Null,
+                    "tool_calls": [{
+                        "id": id,
+                        "type": "function",
+                        "function": { "name": name, "arguments": "{}" }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        })
+    }
+
+    fn todo_registry_with_open_task() -> crate::core::agent::todo::TodoRegistry {
+        use crate::core::agent::todo::{TodoItem, TodoList, TodoPhase, TodoStatus};
+        std::sync::Arc::new(tokio::sync::Mutex::new(TodoList {
+            phases: vec![TodoPhase {
+                name: "P".into(),
+                tasks: vec![TodoItem { content: "t1".into(), status: TodoStatus::InProgress }],
+            }],
+        }))
+    }
+
+    fn request_has_nudge(request: &serde_json::Value) -> bool {
+        request["messages"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .any(|m| {
+                m.get("content")
+                    .and_then(|c| c.as_str())
+                    .is_some_and(|s| s.contains("todo item"))
+            })
+    }
+
+    #[tokio::test]
+    async fn mid_run_nudge_fires_after_a_long_uninterrupted_mutation_run() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        // 13 consecutive mutating calls with no todo touch -- one past the
+        // 12-call threshold -- then a clean stop.
+        let mut responses: Vec<serde_json::Value> = (0..13)
+            .map(|i| mutating_tool_call_completion(&format!("call_{i}"), "bash"))
+            .collect();
+        responses.push(json!({ "choices": [{ "message": { "content": "done" }, "finish_reason": "stop" }] }));
+        let model = MockModel::new(responses);
+        let tool = MockTool::default();
+        let mut budget = SessionBudget::new(None);
+        let registry = todo_registry_with_open_task();
+        let convo = vec![json!({ "role": "user", "content": "go" })];
+
+        run_turn_cycle(
+            &tx,
+            &json!({}),
+            "m",
+            &[],
+            convo,
+            0,
+            &mut budget,
+            &model,
+            &tool,
+            crate::core::agent::plan::RunMode::Normal,
+            Some(&registry),
+        )
+        .await
+        .unwrap();
+
+        let requests = model.requests.lock().unwrap();
+        let nudged_requests = requests.iter().filter(|r| request_has_nudge(r)).count();
+        assert!(nudged_requests >= 1, "expected a mid-run nudge after 12+ mutating calls");
+        assert!(nudged_requests <= 2, "must not exceed the per-cycle nudge cap");
+    }
+
+    #[tokio::test]
+    async fn mid_run_nudge_does_not_fire_in_plan_mode_or_without_open_todos() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut responses: Vec<serde_json::Value> = (0..13)
+            .map(|i| mutating_tool_call_completion(&format!("call_{i}"), "bash"))
+            .collect();
+        responses.push(json!({ "choices": [{ "message": { "content": "done" }, "finish_reason": "stop" }] }));
+        let model = MockModel::new(responses);
+        let tool = MockTool::default();
+        let mut budget = SessionBudget::new(None);
+        let registry = todo_registry_with_open_task();
+        let convo = vec![json!({ "role": "user", "content": "go" })];
+
+        run_turn_cycle(
+            &tx,
+            &json!({}),
+            "m",
+            &[],
+            convo,
+            0,
+            &mut budget,
+            &model,
+            &tool,
+            crate::core::agent::plan::RunMode::Plan,
+            Some(&registry),
+        )
+        .await
+        .unwrap();
+        assert!(
+            model.requests.lock().unwrap().iter().all(|r| !request_has_nudge(r)),
+            "plan mode must never get a mid-run nudge"
+        );
+    }
+
+    #[tokio::test]
+    async fn mid_run_nudge_touching_todo_resets_the_mutation_counter() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        // 6 mutating calls, a todo touch, then 6 more -- neither run alone
+        // reaches the 12-call threshold, so no nudge should fire.
+        let mut responses: Vec<serde_json::Value> = (0..6)
+            .map(|i| mutating_tool_call_completion(&format!("a{i}"), "bash"))
+            .collect();
+        responses.push(mutating_tool_call_completion("mid", "todo"));
+        responses.extend((0..6).map(|i| mutating_tool_call_completion(&format!("b{i}"), "edit")));
+        responses.push(json!({ "choices": [{ "message": { "content": "done" }, "finish_reason": "stop" }] }));
+        let model = MockModel::new(responses);
+        let tool = MockTool::default();
+        let mut budget = SessionBudget::new(None);
+        let registry = todo_registry_with_open_task();
+        let convo = vec![json!({ "role": "user", "content": "go" })];
+
+        run_turn_cycle(
+            &tx,
+            &json!({}),
+            "m",
+            &[],
+            convo,
+            0,
+            &mut budget,
+            &model,
+            &tool,
+            crate::core::agent::plan::RunMode::Normal,
+            Some(&registry),
+        )
+        .await
+        .unwrap();
+        assert!(
+            model.requests.lock().unwrap().iter().all(|r| !request_has_nudge(r)),
+            "a todo touch partway through must reset the mutation counter"
+        );
     }
 
     struct FixedTool {
@@ -1684,6 +1902,8 @@ mod tests {
             &mut budget,
             &model,
             &tool,
+            crate::core::agent::plan::RunMode::Normal,
+            None,
         )
         .await
         .unwrap();
@@ -1727,6 +1947,8 @@ mod tests {
             &mut budget,
             &model,
             &tool,
+            crate::core::agent::plan::RunMode::Normal,
+            None,
         )
         .await
         .unwrap_err();
@@ -1783,7 +2005,7 @@ mod tests {
             convo.push(json!({ "role": r, "content": format!("m{i}") }));
         }
 
-        let result = run_turn_cycle(&tx, &json!({}), "m", &[], convo, 8, &mut budget, &model, &tool)
+        let result = run_turn_cycle(&tx, &json!({}), "m", &[], convo, 8, &mut budget, &model, &tool, crate::core::agent::plan::RunMode::Normal, None)
             .await
             .unwrap();
 
@@ -1804,7 +2026,7 @@ mod tests {
         let mut budget = SessionBudget::new(None);
         let convo = vec![json!({ "role": "user", "content": "hi" })];
 
-        let result = run_turn_cycle(&tx, &json!({}), "m", &[], convo, 8, &mut budget, &model, &tool)
+        let result = run_turn_cycle(&tx, &json!({}), "m", &[], convo, 8, &mut budget, &model, &tool, crate::core::agent::plan::RunMode::Normal, None)
             .await
             .unwrap();
 
@@ -1828,7 +2050,7 @@ mod tests {
 
         // max_turns = 0 means unbounded: it must not error out and must keep
         // going past the tool-call turn to return the final answer.
-        let result = run_turn_cycle(&tx, &json!({}), "m", &[], convo, 0, &mut budget, &model, &tool)
+        let result = run_turn_cycle(&tx, &json!({}), "m", &[], convo, 0, &mut budget, &model, &tool, crate::core::agent::plan::RunMode::Normal, None)
             .await
             .unwrap();
 

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -19,7 +19,8 @@ use crate::core::agent::tools::gate::PermissionDecision;
 use crate::core::agent::upstream::{
     collect_mcp_openai_tools, copy_optional_chat_params, execute_mcp_tool_calls,
     extract_choice_message, extract_tool_calls, load_assistant_config, parse_openai_messages,
-    resolve_upstream_for_model, set_system_prompt, stream_openai_chat_completions,
+    repair_dangling_tool_calls, resolve_upstream_for_model, set_system_prompt,
+    stream_openai_chat_completions,
 };
 #[cfg(not(feature = "cli"))]
 use crate::core::server::proxy::router_first_model;
@@ -917,6 +918,16 @@ async fn orchestrate_inner(
         .get("messages")
         .ok_or("Missing required field 'messages'")?;
     let mut conversation_messages = parse_openai_messages(messages_value)?;
+    // Self-heal a conversation an earlier interrupted run may have left with a
+    // tool_calls turn missing one of its results (e.g. the process was killed
+    // while an `ask`/permission prompt was still pending). Providers like
+    // Anthropic reject the entire request on a dangling tool_use, so repair
+    // it here -- the one place every incoming message array passes through --
+    // before it ever reaches a provider.
+    let repaired = repair_dangling_tool_calls(&mut conversation_messages);
+    if repaired > 0 {
+        log::warn!("agent: repaired {repaired} dangling tool call(s) with no prior result");
+    }
 
     let assistant_id = json_body
         .get("assistant_id")

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -575,7 +575,7 @@ impl ToolInvoker for CompositeToolInvoker {
                 if self.permissions.is_denied(name) {
                     out.push(ToolOutcome::plain(
                         id,
-                        format!("ERROR: tool '{name}' denied by project policy"),
+                        denied_by_policy_msg(name, &self.project_root),
                     ));
                     continue;
                 }
@@ -651,9 +651,7 @@ impl ToolInvoker for CompositeToolInvoker {
             }
             let (text, diff) = match decision {
                 Decision::Allow => execute_builtin_with_diff(tool, &args, &self.project_root).await,
-                Decision::HardDeny => {
-                    (format!("ERROR: tool '{name}' denied by project policy"), None)
-                }
+                Decision::HardDeny => (denied_by_policy_msg(name, &self.project_root), None),
                 Decision::Prompt(kind) => {
                     let request_id = next_permission_id();
                     let (tx, rx) = tokio::sync::oneshot::channel();

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -65,6 +65,10 @@ pub(crate) struct OrchestrationArgs {
     pub permission_requests: PermissionRegistry,
     /// Present only when a client can render and answer structured questions.
     pub ask_requests: Option<crate::core::agent::interaction::AskRegistry>,
+    /// Session's canonical todo list. Present for the top-level run only;
+    /// subagent/child runs never receive it (they cannot read or mutate the
+    /// parent's list).
+    pub todo_registry: Option<crate::core::agent::todo::TodoRegistry>,
     /// When set, used verbatim as the system prompt, bypassing project-context
     /// assembly and memory recall/indexing. Set for subagent child runs so a
     /// dispatched subagent gets exactly its definition prompt with no parent
@@ -182,6 +186,7 @@ struct CompositeToolInvoker {
     events: mpsc::UnboundedSender<StreamEvent>,
     permission_requests: PermissionRegistry,
     ask_requests: Option<crate::core::agent::interaction::AskRegistry>,
+    todo_registry: Option<crate::core::agent::todo::TodoRegistry>,
     grants: std::sync::Mutex<crate::core::agent::tools::gate::SessionGrants>,
     subagents: Option<SubagentContext>,
     yolo: bool,
@@ -364,6 +369,98 @@ impl CompositeToolInvoker {
             }
         }
     }
+
+    /// Applies one todo mutation and emits `StreamEvent::TodoUpdate` with the
+    /// full resulting snapshot so session history can reconstruct state.
+    async fn handle_todo_tool(&self, args: &serde_json::Value) -> String {
+        use crate::core::agent::todo::{parse_target, render_result, TodoPhase};
+        let Some(registry) = &self.todo_registry else {
+            return "ERROR [todo_unavailable]: todo tool requires an attached session"
+                .to_string();
+        };
+        let op = args.get("op").and_then(|v| v.as_str()).unwrap_or("");
+        let mut list = registry.lock().await;
+        let result: Result<(), String> = match op {
+            "init" => {
+                let phases = if let Some(list_val) = args.get("list").and_then(|v| v.as_array()) {
+                    list_val
+                        .iter()
+                        .map(|p| {
+                            let name = p.get("phase").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                            let items = p
+                                .get("items")
+                                .and_then(|v| v.as_array())
+                                .map(|arr| {
+                                    arr.iter()
+                                        .filter_map(|v| v.as_str())
+                                        .map(|s| crate::core::agent::todo::TodoItem {
+                                            content: s.to_string(),
+                                            status: crate::core::agent::todo::TodoStatus::Pending,
+                                        })
+                                        .collect()
+                                })
+                                .unwrap_or_default();
+                            TodoPhase { name, tasks: items }
+                        })
+                        .collect()
+                } else if let Some(items) = args.get("items").and_then(|v| v.as_array()) {
+                    vec![TodoPhase {
+                        name: String::new(),
+                        tasks: items
+                            .iter()
+                            .filter_map(|v| v.as_str())
+                            .map(|s| crate::core::agent::todo::TodoItem {
+                                content: s.to_string(),
+                                status: crate::core::agent::todo::TodoStatus::Pending,
+                            })
+                            .collect(),
+                    }]
+                } else {
+                    return "ERROR: init requires 'list' or 'items'".to_string();
+                };
+                list.init(phases)
+            }
+            "start" => match args.get("task").and_then(|v| v.as_str()) {
+                Some(task) => list.start(task),
+                None => return "ERROR: start requires 'task'".to_string(),
+            },
+            "done" => match parse_target(args) {
+                Ok(target) => list.done(target),
+                Err(e) => return format!("ERROR: {e}"),
+            },
+            "drop" => match parse_target(args) {
+                Ok(target) => list.drop_target(target),
+                Err(e) => return format!("ERROR: {e}"),
+            },
+            "rm" => match parse_target(args) {
+                Ok(target) => list.rm(target),
+                Err(e) => return format!("ERROR: {e}"),
+            },
+            "append" => {
+                let phase = args.get("phase").and_then(|v| v.as_str()).unwrap_or("");
+                let items: Vec<String> = args
+                    .get("items")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| arr.iter().filter_map(|v| v.as_str()).map(String::from).collect())
+                    .unwrap_or_default();
+                if phase.is_empty() || items.is_empty() {
+                    return "ERROR: append requires 'phase' and non-empty 'items'".to_string();
+                }
+                list.append(phase, items)
+            }
+            "view" => Ok(()),
+            other => return format!("ERROR: unknown todo op '{other}'"),
+        };
+        match result {
+            Ok(()) => {
+                let snapshot = list.clone();
+                drop(list);
+                let _ = self.events.send(StreamEvent::TodoUpdate { list: snapshot.clone() });
+                render_result(&snapshot)
+            }
+            Err(error) => format!("ERROR: {error}"),
+        }
+    }
 }
 
 #[async_trait]
@@ -403,6 +500,22 @@ impl ToolInvoker for CompositeToolInvoker {
                     .and_then(|value| serde_json::from_str(value).ok())
                     .unwrap_or(serde_json::Value::Object(Default::default()));
                 let content = self.handle_ask_tool(&args).await;
+                out.push(ToolOutcome::plain(id, content));
+                continue;
+            }
+            if name == "todo" {
+                let id = tc
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+                let args: serde_json::Value = tc
+                    .get("function")
+                    .and_then(|f| f.get("arguments"))
+                    .and_then(|v| v.as_str())
+                    .and_then(|value| serde_json::from_str(value).ok())
+                    .unwrap_or(serde_json::Value::Object(Default::default()));
+                let content = self.handle_todo_tool(&args).await;
                 out.push(ToolOutcome::plain(id, content));
                 continue;
             }
@@ -615,6 +728,7 @@ pub(crate) async fn run_server_side_openai_orchestration(
         project_root: None,
         permission_requests: Arc::new(Mutex::new(HashMap::new())),
         ask_requests: None,
+        todo_registry: None,
         system_prompt_override: None,
         subagents_enabled: false,
         yolo: false,
@@ -737,6 +851,7 @@ async fn orchestrate_inner(
         project_root,
         permission_requests,
         ask_requests,
+        todo_registry,
         system_prompt_override,
         subagents_enabled,
         yolo,
@@ -884,6 +999,15 @@ async fn orchestrate_inner(
     {
         openai_tools.push(crate::core::agent::interaction::ask_tool_schema());
     }
+    // Todo bookkeeping is session metadata, not filesystem access, so like
+    // `ask` it's advertised independent of the project_root gate above.
+    if todo_registry.is_some()
+        && allowed_names
+            .as_ref()
+            .is_none_or(|allowed| allowed.contains("todo"))
+    {
+        openai_tools.push(crate::core::agent::todo::todo_tool_schema());
+    }
 
     let (upstream_url, session_api_keys) = resolve_upstream_for_model(
         &model_id,
@@ -943,6 +1067,7 @@ async fn orchestrate_inner(
             events: events.clone(),
             permission_requests: permission_requests.clone(),
             ask_requests: ask_requests.clone(),
+            todo_registry: todo_registry.clone(),
             grants: std::sync::Mutex::new(crate::core::agent::tools::gate::SessionGrants::default()),
             subagents,
             yolo: *yolo,
@@ -1686,6 +1811,7 @@ mod tests {
             events,
             permission_requests: registry,
             ask_requests: None,
+            todo_registry: None,
             grants: std::sync::Mutex::new(SessionGrants::default()),
             subagents: None,
             yolo: false,
@@ -1780,6 +1906,117 @@ mod tests {
         let result: serde_json::Value = serde_json::from_str(&out[0].content).unwrap();
         assert_eq!(result[0]["id"], "scope");
         assert_eq!(result[0]["selected"][0], "Small");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    fn todo_call(id: &str, args: serde_json::Value) -> serde_json::Value {
+        json!({
+            "id": id,
+            "type": "function",
+            "function": {
+                "name": "todo",
+                "arguments": serde_json::to_string(&args).unwrap()
+            }
+        })
+    }
+
+    #[tokio::test]
+    async fn todo_unavailable_without_an_attached_session() {
+        let root = unique_project_root();
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let permissions: PermissionRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let invoker = build_prompting_invoker(root.clone(), tx, permissions);
+
+        let out = invoker
+            .invoke(&[todo_call("t1", json!({"op": "view"}))])
+            .await
+            .unwrap();
+
+        assert_eq!(out.len(), 1);
+        assert!(out[0].content.contains("todo_unavailable"));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn todo_init_promotes_first_task_and_emits_snapshot() {
+        let root = unique_project_root();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let permissions: PermissionRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let mut invoker = build_prompting_invoker(root.clone(), tx, permissions);
+        let todos = crate::core::agent::todo::new_registry();
+        invoker.todo_registry = Some(todos.clone());
+
+        let out = invoker
+            .invoke(&[todo_call(
+                "t1",
+                json!({"op": "init", "list": [{"phase": "Setup", "items": ["a", "b"]}]}),
+            )])
+            .await
+            .unwrap();
+
+        assert_eq!(out.len(), 1);
+        assert!(!out[0].content.starts_with("ERROR"), "got: {}", out[0].content);
+        let result: crate::core::agent::todo::TodoList =
+            serde_json::from_str(&out[0].content).unwrap();
+        assert_eq!(result.active().unwrap().1.content, "a");
+
+        match rx.recv().await.unwrap() {
+            StreamEvent::TodoUpdate { list } => assert_eq!(list, result),
+            event => panic!("expected todo_update, got {event:?}"),
+        }
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn todo_done_advances_active_task() {
+        let root = unique_project_root();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let permissions: PermissionRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let mut invoker = build_prompting_invoker(root.clone(), tx, permissions);
+        let todos = crate::core::agent::todo::new_registry();
+        invoker.todo_registry = Some(todos.clone());
+
+        invoker
+            .invoke(&[todo_call(
+                "t1",
+                json!({"op": "init", "items": ["a", "b"]}),
+            )])
+            .await
+            .unwrap();
+        let _ = rx.recv().await; // drain init's TodoUpdate
+
+        let out = invoker
+            .invoke(&[todo_call("t2", json!({"op": "done", "task": "a"}))])
+            .await
+            .unwrap();
+        assert!(!out[0].content.starts_with("ERROR"), "got: {}", out[0].content);
+        let result: crate::core::agent::todo::TodoList =
+            serde_json::from_str(&out[0].content).unwrap();
+        assert_eq!(result.active().unwrap().1.content, "b");
+        assert_eq!(result.done_total(), (1, 2));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn todo_rm_unknown_task_reports_error() {
+        let root = unique_project_root();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let permissions: PermissionRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let mut invoker = build_prompting_invoker(root.clone(), tx, permissions);
+        let todos = crate::core::agent::todo::new_registry();
+        invoker.todo_registry = Some(todos.clone());
+
+        invoker
+            .invoke(&[todo_call("t1", json!({"op": "init", "items": ["a"]}))])
+            .await
+            .unwrap();
+        let _ = rx.recv().await;
+
+        let out = invoker
+            .invoke(&[todo_call("t2", json!({"op": "rm", "task": "missing"}))])
+            .await
+            .unwrap();
+        assert!(out[0].content.starts_with("ERROR"), "got: {}", out[0].content);
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/src-tauri/src/core/agent/mod.rs
+++ b/src-tauri/src/core/agent/mod.rs
@@ -9,6 +9,7 @@ pub mod context;
 pub mod events;
 #[cfg(feature = "cli")]
 pub mod goal;
+pub mod interaction;
 #[cfg(feature = "cli")]
 pub mod global_config;
 pub mod git;

--- a/src-tauri/src/core/agent/mod.rs
+++ b/src-tauri/src/core/agent/mod.rs
@@ -16,6 +16,7 @@ pub mod git;
 pub mod r#loop;
 pub mod memory;
 pub mod permissions;
+pub mod plan;
 pub mod project;
 pub mod session;
 pub mod skill_hub;

--- a/src-tauri/src/core/agent/mod.rs
+++ b/src-tauri/src/core/agent/mod.rs
@@ -20,6 +20,7 @@ pub mod project;
 pub mod session;
 pub mod skill_hub;
 pub mod skills;
+pub mod todo;
 pub mod subagent;
 pub mod tools;
 pub mod upstream;

--- a/src-tauri/src/core/agent/plan.rs
+++ b/src-tauri/src/core/agent/plan.rs
@@ -1,0 +1,63 @@
+//! Read-only plan mode. A first-class run mode for safe repository exploration
+//! and plan review: the agent may read/search/list/read-file, do web research,
+//! and read memory/skills, but every mutation-capable tool (write/edit/bash,
+//! memory_write/skill_write, MCP, subagent dispatch) is blocked at the core
+//! dispatcher and never advertised to the model. Enforcement is authoritative;
+//! the prompt addendum below is only defense in depth.
+
+use serde::{Deserialize, Serialize};
+
+/// Persisted per-session run mode. `Normal` is the default (normal permission
+/// gate / `--yolo`); `Plan` is read-only by enforcement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RunMode {
+    #[default]
+    Normal,
+    Plan,
+}
+
+/// System-prompt addendum injected when a run is in `RunMode::Plan`. Wording is
+/// defense in depth only: the capability gate rejects mutations regardless.
+pub fn plan_mode_prompt_addendum() -> &'static str {
+    "PLAN MODE (read only): You are exploring to produce a plan. You may only \
+read, search, and list files, do web research, and read memory/skills. You \
+CANNOT edit files, run shell commands, or make any change; those tools are \
+disabled. Investigate thoroughly, then stage the full phased plan by calling \
+the `todo` tool with an `init` action listing every task. When the plan is \
+ready, call `ask` with exactly one question: {\"questions\": [{\"id\": \
+\"plan_review\", \"question\": \"<concise plan summary>\", \"options\": \
+[{\"label\": \"Execute plan\"}, {\"label\": \"Keep planning\"}, {\"label\": \
+\"Exit plan mode\"}]}]}. Do not ask for plan review until the todos are staged."
+}
+
+/// Reserved `ask` question id the TUI special-cases to drive plan-mode
+/// transitions. The model is instructed to emit exactly this id.
+pub const PLAN_REVIEW_QUESTION_ID: &str = "plan_review";
+
+/// The three plan-review option labels, in order.
+pub const EXECUTE_PLAN_LABEL: &str = "Execute plan";
+pub const KEEP_PLANNING_LABEL: &str = "Keep planning";
+pub const EXIT_PLAN_LABEL: &str = "Exit plan mode";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn run_mode_default_is_normal() {
+        assert_eq!(RunMode::default(), RunMode::Normal);
+    }
+
+    #[test]
+    fn run_mode_serializes_snake_case() {
+        assert_eq!(
+            serde_json::to_value(RunMode::Plan).unwrap(),
+            serde_json::json!("plan")
+        );
+        assert_eq!(
+            serde_json::from_value::<RunMode>(serde_json::json!("normal")).unwrap(),
+            RunMode::Normal
+        );
+    }
+}

--- a/src-tauri/src/core/agent/subagent.rs
+++ b/src-tauri/src/core/agent/subagent.rs
@@ -496,6 +496,10 @@ async fn run_subagent(
     let mut child_args = parent_args;
     child_args.system_prompt_override = Some(resolved.definition.system_prompt.clone());
     child_args.subagents_enabled = false;
+    // A subagent's own interactive question (if any) belongs to its parent's
+    // conversation, not a client waiting on this child's ask_requests -- and
+    // no client is attached to a background/child run anyway.
+    child_args.ask_requests = None;
 
     let body = child_body(&resolved, &description, &parent_model, budget_remaining);
 

--- a/src-tauri/src/core/agent/subagent.rs
+++ b/src-tauri/src/core/agent/subagent.rs
@@ -500,6 +500,9 @@ async fn run_subagent(
     // conversation, not a client waiting on this child's ask_requests -- and
     // no client is attached to a background/child run anyway.
     child_args.ask_requests = None;
+    // Subagents cannot read or mutate the parent's todo list (isolated child
+    // context, matching ask_requests above).
+    child_args.todo_registry = None;
 
     let body = child_body(&resolved, &description, &parent_model, budget_remaining);
 

--- a/src-tauri/src/core/agent/todo.rs
+++ b/src-tauri/src/core/agent/todo.rs
@@ -107,6 +107,28 @@ impl TodoList {
             .collect()
     }
 
+    /// Human-readable summary of open (pending/in-progress) work, one line per
+    /// task, or `None` when nothing is open. Used verbatim as the hidden
+    /// reminder body and as the reminder dedup key.
+    pub fn open_summary(&self) -> Option<String> {
+        let mut lines = Vec::new();
+        for phase in &self.phases {
+            for task in &phase.tasks {
+                let marker = match task.status {
+                    TodoStatus::InProgress => "→",
+                    TodoStatus::Pending => "•",
+                    _ => continue,
+                };
+                if phase.name.is_empty() {
+                    lines.push(format!("{marker} {}", task.content));
+                } else {
+                    lines.push(format!("{marker} [{}] {}", phase.name, task.content));
+                }
+            }
+        }
+        (!lines.is_empty()).then(|| lines.join("\n"))
+    }
+
     fn find_task_mut(&mut self, content: &str) -> Option<(&mut TodoPhase, usize)> {
         for phase in &mut self.phases {
             if let Some(idx) = phase.tasks.iter().position(|t| t.content == content) {
@@ -501,6 +523,24 @@ mod tests {
         assert_eq!(
             restored, list,
             "resume/branch reconstruction round-trips exactly"
+        );
+    }
+
+    #[test]
+    fn open_summary_lists_open_work_and_is_none_when_done() {
+        let mut list = TodoList::default();
+        assert_eq!(list.open_summary(), None, "empty list has no open work");
+        list.init(vec![phase("Build", &["a", "b"])]).unwrap();
+        // 'a' is promoted to in-progress, 'b' stays pending.
+        assert_eq!(
+            list.open_summary().unwrap(),
+            "→ [Build] a\n• [Build] b"
+        );
+        list.done(Target::All).unwrap();
+        assert_eq!(
+            list.open_summary(),
+            None,
+            "completed/abandoned work is not open"
         );
     }
 

--- a/src-tauri/src/core/agent/todo.rs
+++ b/src-tauri/src/core/agent/todo.rs
@@ -1,0 +1,523 @@
+//! Canonical session todo list: phased tasks the agent declares and updates
+//! through the `todo` tool, projected into a compact TUI widget. Core owns
+//! mutations, the single-active-task invariant, and persistence; the TUI owns
+//! rendering and user-initiated mutations (which flow back through the same
+//! `TodoList` API).
+
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+use tokio::sync::Mutex;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TodoStatus {
+    Pending,
+    InProgress,
+    Completed,
+    Abandoned,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TodoItem {
+    pub content: String,
+    pub status: TodoStatus,
+}
+
+impl TodoItem {
+    fn pending(content: String) -> Self {
+        Self {
+            content,
+            status: TodoStatus::Pending,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TodoPhase {
+    pub name: String,
+    pub tasks: Vec<TodoItem>,
+}
+
+/// Shared session todo state. Cloned into `OrchestrationArgs`; child/subagent
+/// runs never receive it (see `subagent::run_subagent`), so subagents cannot
+/// read or mutate the parent's list.
+pub type TodoRegistry = Arc<Mutex<TodoList>>;
+
+pub fn new_registry() -> TodoRegistry {
+    Arc::new(Mutex::new(TodoList::default()))
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TodoList {
+    pub phases: Vec<TodoPhase>,
+}
+
+/// Target selector for `done`/`drop`/`rm`: a single task by content, every
+/// task in a named phase, or every task in the list.
+pub enum Target<'a> {
+    Task(&'a str),
+    Phase(&'a str),
+    All,
+}
+
+impl TodoList {
+    /// True once any task exists (used to gate reminders/widget display).
+    pub fn is_empty(&self) -> bool {
+        self.phases.iter().all(|p| p.tasks.is_empty())
+    }
+
+    pub fn done_total(&self) -> (usize, usize) {
+        let mut done = 0;
+        let mut total = 0;
+        for phase in &self.phases {
+            for task in &phase.tasks {
+                total += 1;
+                if matches!(task.status, TodoStatus::Completed | TodoStatus::Abandoned) {
+                    done += 1;
+                }
+            }
+        }
+        (done, total)
+    }
+
+    /// The single in-progress task, if any, as `(phase, task)`.
+    pub fn active(&self) -> Option<(&TodoPhase, &TodoItem)> {
+        self.phases.iter().find_map(|phase| {
+            phase
+                .tasks
+                .iter()
+                .find(|t| t.status == TodoStatus::InProgress)
+                .map(|t| (phase, t))
+        })
+    }
+
+    /// Up to `n` pending tasks in phase/task order, skipping the active one.
+    pub fn next_pending(&self, n: usize) -> Vec<(&str, &str)> {
+        self.phases
+            .iter()
+            .flat_map(|phase| {
+                phase
+                    .tasks
+                    .iter()
+                    .filter(|t| t.status == TodoStatus::Pending)
+                    .map(move |t| (phase.name.as_str(), t.content.as_str()))
+            })
+            .take(n)
+            .collect()
+    }
+
+    fn find_task_mut(&mut self, content: &str) -> Option<(&mut TodoPhase, usize)> {
+        for phase in &mut self.phases {
+            if let Some(idx) = phase.tasks.iter().position(|t| t.content == content) {
+                return Some((phase, idx));
+            }
+        }
+        None
+    }
+
+    fn task_exists(&self, content: &str) -> bool {
+        self.phases
+            .iter()
+            .any(|p| p.tasks.iter().any(|t| t.content == content))
+    }
+
+    fn phase_exists(&self, name: &str) -> bool {
+        self.phases.iter().any(|p| p.name == name)
+    }
+
+    /// After a mutation leaves no task `InProgress`, promote the earliest
+    /// `Pending` task (phase order, then task order) to `InProgress`.
+    fn promote_next(&mut self) {
+        if self.active().is_some() {
+            return;
+        }
+        for phase in &mut self.phases {
+            if let Some(task) = phase
+                .tasks
+                .iter_mut()
+                .find(|t| t.status == TodoStatus::Pending)
+            {
+                task.status = TodoStatus::InProgress;
+                return;
+            }
+        }
+    }
+
+    /// Replace the whole list. `list` is `[{phase, items}]`; a flat `items`
+    /// array is wrapped into a single unnamed phase (`""`).
+    pub fn init(&mut self, phases: Vec<TodoPhase>) -> Result<(), String> {
+        let mut names = std::collections::HashSet::new();
+        for phase in &phases {
+            if !names.insert(phase.name.as_str()) {
+                return Err(format!("duplicate phase name '{}'", phase.name));
+            }
+            let mut tasks = std::collections::HashSet::new();
+            for task in &phase.tasks {
+                if task.content.trim().is_empty() {
+                    return Err("task content must not be empty".to_string());
+                }
+                if !tasks.insert(task.content.as_str()) {
+                    return Err(format!("duplicate task '{}'", task.content));
+                }
+            }
+        }
+        // Cross-phase duplicates are also rejected (content is a stable id).
+        let mut all_tasks = std::collections::HashSet::new();
+        for phase in &phases {
+            for task in &phase.tasks {
+                if !all_tasks.insert(task.content.as_str()) {
+                    return Err(format!("duplicate task '{}' across phases", task.content));
+                }
+            }
+        }
+        self.phases = phases;
+        self.promote_next();
+        Ok(())
+    }
+
+    /// Mark exactly one task `InProgress`, demoting any other in-progress
+    /// task back to `Pending` first (the single-active invariant).
+    pub fn start(&mut self, content: &str) -> Result<(), String> {
+        if !self.task_exists(content) {
+            return Err(format!("unknown task '{content}'"));
+        }
+        for phase in &mut self.phases {
+            for task in &mut phase.tasks {
+                if task.status == TodoStatus::InProgress {
+                    task.status = TodoStatus::Pending;
+                }
+            }
+        }
+        let (phase, idx) = self.find_task_mut(content).expect("checked above");
+        phase.tasks[idx].status = TodoStatus::InProgress;
+        Ok(())
+    }
+
+    fn set_status(&mut self, target: Target, status: TodoStatus) -> Result<(), String> {
+        match target {
+            Target::Task(content) => {
+                if !self.task_exists(content) {
+                    return Err(format!("unknown task '{content}'"));
+                }
+                let (phase, idx) = self.find_task_mut(content).expect("checked above");
+                phase.tasks[idx].status = status;
+            }
+            Target::Phase(name) => {
+                if !self.phase_exists(name) {
+                    return Err(format!("unknown phase '{name}'"));
+                }
+                for phase in self.phases.iter_mut().filter(|p| p.name == name) {
+                    for task in &mut phase.tasks {
+                        if matches!(task.status, TodoStatus::Pending | TodoStatus::InProgress) {
+                            task.status = status;
+                        }
+                    }
+                }
+            }
+            Target::All => {
+                for phase in &mut self.phases {
+                    for task in &mut phase.tasks {
+                        if matches!(task.status, TodoStatus::Pending | TodoStatus::InProgress) {
+                            task.status = status;
+                        }
+                    }
+                }
+            }
+        }
+        self.promote_next();
+        Ok(())
+    }
+
+    /// Complete targets. Pending/in-progress only; already-terminal tasks are
+    /// left untouched (no-op, not an error) when targeting a phase/all.
+    pub fn done(&mut self, target: Target) -> Result<(), String> {
+        self.set_status(target, TodoStatus::Completed)
+    }
+
+    /// Abandon (cancel) targets, distinct from `rm` (delete). Preserved in
+    /// the list as a record of intentional cancellation.
+    pub fn drop_target(&mut self, target: Target) -> Result<(), String> {
+        self.set_status(target, TodoStatus::Abandoned)
+    }
+
+    /// Remove targets outright.
+    pub fn rm(&mut self, target: Target) -> Result<(), String> {
+        match target {
+            Target::Task(content) => {
+                if !self.task_exists(content) {
+                    return Err(format!("unknown task '{content}'"));
+                }
+                for phase in &mut self.phases {
+                    phase.tasks.retain(|t| t.content != content);
+                }
+            }
+            Target::Phase(name) => {
+                if !self.phase_exists(name) {
+                    return Err(format!("unknown phase '{name}'"));
+                }
+                self.phases.retain(|p| p.name != name);
+            }
+            Target::All => self.phases.clear(),
+        }
+        self.phases
+            .retain(|p| !p.tasks.is_empty() || !p.name.is_empty());
+        self.promote_next();
+        Ok(())
+    }
+
+    /// Append pending tasks to `phase`, creating it if absent.
+    pub fn append(&mut self, phase: &str, items: Vec<String>) -> Result<(), String> {
+        for content in &items {
+            if content.trim().is_empty() {
+                return Err("task content must not be empty".to_string());
+            }
+            if self.task_exists(content) {
+                return Err(format!("duplicate task '{content}'"));
+            }
+        }
+        let mut seen = std::collections::HashSet::new();
+        for content in &items {
+            if !seen.insert(content.as_str()) {
+                return Err(format!("duplicate task '{content}' in append"));
+            }
+        }
+        let target = if let Some(phase) = self.phases.iter_mut().find(|p| p.name == phase) {
+            phase
+        } else {
+            self.phases.push(TodoPhase {
+                name: phase.to_string(),
+                tasks: Vec::new(),
+            });
+            self.phases.last_mut().expect("just pushed")
+        };
+        target
+            .tasks
+            .extend(items.into_iter().map(TodoItem::pending));
+        self.promote_next();
+        Ok(())
+    }
+}
+
+/// Parse a `target(...)` tool argument shaped `{"task": "..."}`,
+/// `{"phase": "..."}`, or `{"all": true}` into a `Target`.
+pub fn parse_target(args: &serde_json::Value) -> Result<Target<'_>, String> {
+    if let Some(task) = args.get("task").and_then(|v| v.as_str()) {
+        return Ok(Target::Task(task));
+    }
+    if let Some(phase) = args.get("phase").and_then(|v| v.as_str()) {
+        return Ok(Target::Phase(phase));
+    }
+    if args.get("all").and_then(|v| v.as_bool()) == Some(true) {
+        return Ok(Target::All);
+    }
+    Err("target requires exactly one of: task, phase, all".to_string())
+}
+
+pub fn todo_tool_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "function",
+        "function": {
+            "name": "todo",
+            "description": "Manage the canonical session todo list: init/start/done/drop/rm/append/view. One call applies one operation.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "op": {
+                        "type": "string",
+                        "enum": ["init", "start", "done", "drop", "rm", "append", "view"]
+                    },
+                    "list": {
+                        "type": "array",
+                        "description": "For init: [{phase, items}]",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "phase": { "type": "string" },
+                                "items": { "type": "array", "items": { "type": "string" } }
+                            },
+                            "required": ["phase", "items"]
+                        }
+                    },
+                    "items": {
+                        "type": "array",
+                        "description": "For init (flat, single unnamed phase) or append.",
+                        "items": { "type": "string" }
+                    },
+                    "task": { "type": "string", "description": "Target task content, for start/done/drop/rm/append(phase)." },
+                    "phase": { "type": "string", "description": "Target phase name, for done/drop/rm/append." },
+                    "all": { "type": "boolean", "description": "Target every task, for done/drop/rm." }
+                },
+                "required": ["op"]
+            }
+        }
+    })
+}
+
+/// Render the tool result: on success, the full resulting snapshot so
+/// session history can reconstruct state on resume/branch.
+pub fn render_result(list: &TodoList) -> String {
+    serde_json::to_string(list).unwrap_or_else(|e| format!("ERROR: could not encode todos: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn phase(name: &str, items: &[&str]) -> TodoPhase {
+        TodoPhase {
+            name: name.to_string(),
+            tasks: items
+                .iter()
+                .map(|s| TodoItem::pending(s.to_string()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn init_promotes_the_first_task() {
+        let mut list = TodoList::default();
+        list.init(vec![phase("Setup", &["a", "b"])]).unwrap();
+        assert_eq!(list.active().unwrap().1.content, "a");
+        assert_eq!(list.done_total(), (0, 2));
+    }
+
+    #[test]
+    fn init_rejects_duplicate_phase_and_task_names() {
+        let mut list = TodoList::default();
+        assert!(list
+            .init(vec![phase("A", &["x"]), phase("A", &["y"])])
+            .is_err());
+        assert!(list.init(vec![phase("A", &["x", "x"])]).is_err());
+        assert!(list
+            .init(vec![phase("A", &["x"]), phase("B", &["x"])])
+            .is_err());
+        // A rejected init leaves prior state untouched (atomicity).
+        assert!(list.is_empty());
+    }
+
+    #[test]
+    fn start_enforces_single_active_task() {
+        let mut list = TodoList::default();
+        list.init(vec![phase("A", &["a", "b"])]).unwrap();
+        list.start("b").unwrap();
+        assert_eq!(list.active().unwrap().1.content, "b");
+        assert_eq!(
+            list.phases[0].tasks[0].status,
+            TodoStatus::Pending,
+            "starting b must demote a"
+        );
+        assert!(list.start("missing").is_err());
+    }
+
+    #[test]
+    fn completing_active_task_promotes_the_next_pending() {
+        let mut list = TodoList::default();
+        list.init(vec![phase("A", &["a", "b"])]).unwrap();
+        list.done(Target::Task("a")).unwrap();
+        assert_eq!(list.active().unwrap().1.content, "b");
+        assert_eq!(list.done_total(), (1, 2));
+    }
+
+    #[test]
+    fn abandoning_active_task_promotes_the_next_pending() {
+        let mut list = TodoList::default();
+        list.init(vec![phase("A", &["a", "b"])]).unwrap();
+        list.drop_target(Target::Task("a")).unwrap();
+        assert_eq!(list.phases[0].tasks[0].status, TodoStatus::Abandoned);
+        assert_eq!(list.active().unwrap().1.content, "b");
+    }
+
+    #[test]
+    fn done_phase_completes_open_tasks_only() {
+        let mut list = TodoList::default();
+        list.init(vec![phase("A", &["a", "b", "c"])]).unwrap();
+        list.drop_target(Target::Task("b")).unwrap();
+        list.done(Target::Phase("A")).unwrap();
+        assert_eq!(list.phases[0].tasks[0].status, TodoStatus::Completed);
+        assert_eq!(
+            list.phases[0].tasks[1].status,
+            TodoStatus::Abandoned,
+            "already-abandoned stays abandoned"
+        );
+        assert_eq!(list.phases[0].tasks[2].status, TodoStatus::Completed);
+    }
+
+    #[test]
+    fn rm_deletes_and_drop_preserves_record() {
+        let mut list = TodoList::default();
+        list.init(vec![phase("A", &["a", "b"])]).unwrap();
+        list.drop_target(Target::Task("a")).unwrap();
+        assert!(
+            list.task_exists("a"),
+            "drop preserves the task as abandoned"
+        );
+        list.rm(Target::Task("a")).unwrap();
+        assert!(!list.task_exists("a"), "rm deletes outright");
+    }
+
+    #[test]
+    fn rm_missing_target_is_atomic_error() {
+        let mut list = TodoList::default();
+        list.init(vec![phase("A", &["a"])]).unwrap();
+        let before = list.clone();
+        assert!(list.rm(Target::Task("missing")).is_err());
+        assert!(list.rm(Target::Phase("missing")).is_err());
+        assert_eq!(list, before, "failed rm must not mutate state");
+    }
+
+    #[test]
+    fn append_creates_phase_and_rejects_duplicates() {
+        let mut list = TodoList::default();
+        list.init(vec![phase("A", &["a"])]).unwrap();
+        list.append("B", vec!["b".into(), "c".into()]).unwrap();
+        assert_eq!(list.phases[1].name, "B");
+        assert!(
+            list.append("B", vec!["a".into()]).is_err(),
+            "cross-phase duplicate rejected"
+        );
+        assert!(list.append("B", vec!["d".into(), "d".into()]).is_err());
+    }
+
+    #[test]
+    fn next_pending_skips_the_active_task() {
+        let mut list = TodoList::default();
+        list.init(vec![phase("A", &["a", "b", "c", "d"])]).unwrap();
+        let preview = list.next_pending(3);
+        assert_eq!(preview.len(), 3);
+        assert!(
+            preview.iter().all(|(_, t)| *t != "a"),
+            "active task excluded"
+        );
+    }
+
+    #[test]
+    fn round_trips_through_serde_for_persistence() {
+        let mut list = TodoList::default();
+        list.init(vec![phase("A", &["a", "b"])]).unwrap();
+        list.drop_target(Target::Task("b")).unwrap();
+        let json = serde_json::to_string(&list).unwrap();
+        let restored: TodoList = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            restored, list,
+            "resume/branch reconstruction round-trips exactly"
+        );
+    }
+
+    #[test]
+    fn parse_target_reads_task_phase_and_all() {
+        assert!(matches!(
+            parse_target(&serde_json::json!({"task": "x"})),
+            Ok(Target::Task("x"))
+        ));
+        assert!(matches!(
+            parse_target(&serde_json::json!({"phase": "P"})),
+            Ok(Target::Phase("P"))
+        ));
+        assert!(matches!(
+            parse_target(&serde_json::json!({"all": true})),
+            Ok(Target::All)
+        ));
+        assert!(parse_target(&serde_json::json!({})).is_err());
+    }
+}

--- a/src-tauri/src/core/agent/todo.rs
+++ b/src-tauri/src/core/agent/todo.rs
@@ -198,12 +198,43 @@ impl TodoList {
         Ok(())
     }
 
-    /// Mark exactly one task `InProgress`, demoting any other in-progress
-    /// task back to `Pending` first (the single-active invariant).
+    /// Confirm the current task is `InProgress`. Tasks advance in phase and task
+    /// order, so an agent cannot jump ahead of open work.
     pub fn start(&mut self, content: &str) -> Result<(), String> {
-        if !self.task_exists(content) {
-            return Err(format!("unknown task '{content}'"));
+        let (target_phase, target_task) = self
+            .phases
+            .iter()
+            .enumerate()
+            .find_map(|(phase_index, phase)| {
+                phase
+                    .tasks
+                    .iter()
+                    .position(|task| task.content == content)
+                    .map(|task_index| (phase_index, task_index))
+            })
+            .ok_or_else(|| format!("unknown task '{content}'"))?;
+
+        if self.phases[target_phase].tasks[target_task].status == TodoStatus::InProgress {
+            return Ok(());
         }
+        if self.phases[target_phase].tasks[target_task].status != TodoStatus::Pending {
+            return Err(format!("task '{content}' is not pending"));
+        }
+
+        'phases: for (phase_index, phase) in self.phases.iter().enumerate() {
+            for (task_index, task) in phase.tasks.iter().enumerate() {
+                if (phase_index, task_index) == (target_phase, target_task) {
+                    break 'phases;
+                }
+                if !matches!(task.status, TodoStatus::Completed | TodoStatus::Abandoned) {
+                    return Err(format!(
+                        "cannot start '{content}' before completing or abandoning '{}'",
+                        task.content
+                    ));
+                }
+            }
+        }
+
         for phase in &mut self.phases {
             for task in &mut phase.tasks {
                 if task.status == TodoStatus::InProgress {
@@ -211,8 +242,7 @@ impl TodoList {
                 }
             }
         }
-        let (phase, idx) = self.find_task_mut(content).expect("checked above");
-        phase.tasks[idx].status = TodoStatus::InProgress;
+        self.phases[target_phase].tasks[target_task].status = TodoStatus::InProgress;
         Ok(())
     }
 
@@ -341,7 +371,7 @@ pub fn todo_tool_schema() -> serde_json::Value {
         "type": "function",
         "function": {
             "name": "todo",
-            "description": "Manage the canonical session todo list: init/start/done/drop/rm/append/view. One call applies one operation.",
+            "description": "Manage the canonical session todo list: init/start/done/drop/rm/append/view. One call applies one operation. Tasks advance automatically in phase and task order after done or drop; start only confirms the current task.",
             "parameters": {
                 "type": "object",
                 "properties": {
@@ -419,17 +449,29 @@ mod tests {
     }
 
     #[test]
-    fn start_enforces_single_active_task() {
+    fn start_accepts_only_the_current_task() {
         let mut list = TodoList::default();
         list.init(vec![phase("A", &["a", "b"])]).unwrap();
-        list.start("b").unwrap();
-        assert_eq!(list.active().unwrap().1.content, "b");
-        assert_eq!(
-            list.phases[0].tasks[0].status,
-            TodoStatus::Pending,
-            "starting b must demote a"
-        );
+
+        list.start("a").unwrap();
+        assert_eq!(list.active().unwrap().1.content, "a");
+        assert!(list.start("b").is_err());
         assert!(list.start("missing").is_err());
+    }
+
+    #[test]
+    fn start_rejects_a_task_after_an_open_earlier_phase() {
+        let mut list = TodoList::default();
+        list.init(vec![
+            phase("Phase 1", &["one"]),
+            phase("Phase 2", &["two"]),
+            phase("Phase 5", &["five"]),
+        ])
+        .unwrap();
+        list.done(Target::Phase("Phase 1")).unwrap();
+
+        assert!(list.start("five").is_err());
+        assert_eq!(list.active().unwrap().1.content, "two");
     }
 
     #[test]
@@ -499,6 +541,13 @@ mod tests {
             "cross-phase duplicate rejected"
         );
         assert!(list.append("B", vec!["d".into(), "d".into()]).is_err());
+    }
+
+    #[test]
+    fn todo_schema_explains_ordered_progression() {
+        let schema = todo_tool_schema();
+        let description = schema["function"]["description"].as_str().unwrap();
+        assert!(description.contains("start only confirms the current task"));
     }
 
     #[test]

--- a/src-tauri/src/core/agent/upstream.rs
+++ b/src-tauri/src/core/agent/upstream.rs
@@ -116,6 +116,69 @@ pub(crate) fn parse_openai_messages(
     Ok(out)
 }
 
+/// Repairs a "dangling" tool-call turn: an assistant message with
+/// `tool_calls` whose ids don't all have a matching `role: "tool"` reply
+/// immediately after. Anthropic (and some other providers) reject the whole
+/// request outright when this happens, rather than just the offending turn.
+///
+/// This can happen if a previous run was interrupted before a tool result was
+/// ever recorded -- e.g. the process crashed or was force-killed while an
+/// `ask`/permission prompt was still pending -- and the incomplete turn was
+/// then persisted and later resumed/replayed. Insert a synthetic error result
+/// for each missing id so the conversation is always well-formed by the time
+/// it leaves this process, regardless of how the gap was introduced. Returns
+/// the number of ids repaired.
+pub(crate) fn repair_dangling_tool_calls(messages: &mut Vec<serde_json::Value>) -> usize {
+    let mut repaired = 0;
+    let mut i = 0;
+    while i < messages.len() {
+        let ids: Vec<String> = messages[i]
+            .get("tool_calls")
+            .and_then(|v| v.as_array())
+            .map(|calls| {
+                calls
+                    .iter()
+                    .filter_map(|tc| tc.get("id").and_then(|v| v.as_str()).map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if ids.is_empty() {
+            i += 1;
+            continue;
+        }
+        // A tool-call turn's replies are the run of `role: "tool"` messages
+        // immediately following it; the run ends at the next message that
+        // isn't a tool reply.
+        let mut answered: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        let mut j = i + 1;
+        while j < messages.len()
+            && messages[j].get("role").and_then(|v| v.as_str()) == Some("tool")
+        {
+            if let Some(id) = messages[j].get("tool_call_id").and_then(|v| v.as_str()) {
+                answered.insert(id);
+            }
+            j += 1;
+        }
+        let missing: Vec<&String> = ids.iter().filter(|id| !answered.contains(id.as_str())).collect();
+        for id in &missing {
+            messages.insert(
+                j,
+                serde_json::json!({
+                    "role": "tool",
+                    "tool_call_id": id,
+                    "content": "ERROR: this tool call was interrupted before it produced a \
+                        result (e.g. an unanswered question or a cancelled run); treat it as \
+                        failed.",
+                }),
+            );
+            j += 1;
+        }
+        repaired += missing.len();
+        i = j;
+    }
+    repaired
+}
+
 pub(crate) fn set_system_prompt(messages: &mut Vec<serde_json::Value>, system_prompt: &str) {
     messages.retain(|m| m.get("role").and_then(|r| r.as_str()) != Some("system"));
     messages.insert(
@@ -925,6 +988,91 @@ mod tests {
         // A plain assistant/user turn with null content is still invalid.
         let messages = json!([{ "role": "assistant", "content": null }]);
         assert!(parse_openai_messages(&messages).is_err());
+    }
+
+    #[test]
+    fn repair_leaves_well_formed_conversation_untouched() {
+        let mut messages = vec![
+            json!({ "role": "user", "content": "hi" }),
+            json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": { "name": "read", "arguments": "{}" }
+                }]
+            }),
+            json!({ "role": "tool", "tool_call_id": "call_1", "content": "file contents" }),
+            json!({ "role": "assistant", "content": "done" }),
+        ];
+        let before = messages.clone();
+        assert_eq!(repair_dangling_tool_calls(&mut messages), 0);
+        assert_eq!(messages, before);
+    }
+
+    #[test]
+    fn repair_inserts_synthetic_result_for_a_fully_missing_tool_reply() {
+        // An `ask`-style call interrupted before it ever produced a result --
+        // e.g. the process was killed while the prompt was still pending.
+        let mut messages = vec![
+            json!({ "role": "user", "content": "make cat slide" }),
+            json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "toolu_ask",
+                    "type": "function",
+                    "function": { "name": "ask", "arguments": "{}" }
+                }]
+            }),
+            json!({ "role": "user", "content": "next message, no reply ever recorded" }),
+        ];
+        assert_eq!(repair_dangling_tool_calls(&mut messages), 1);
+        assert_eq!(messages.len(), 4);
+        assert_eq!(messages[2]["role"], "tool");
+        assert_eq!(messages[2]["tool_call_id"], "toolu_ask");
+        assert!(messages[2]["content"].as_str().unwrap().starts_with("ERROR"));
+        assert_eq!(messages[3]["content"], "next message, no reply ever recorded");
+    }
+
+    #[test]
+    fn repair_fills_only_the_missing_id_in_a_multi_call_turn() {
+        // Two tool calls in one turn; only one got a reply before the gap.
+        let mut messages = vec![
+            json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [
+                    { "id": "call_a", "type": "function", "function": { "name": "read", "arguments": "{}" } },
+                    { "id": "call_b", "type": "function", "function": { "name": "ask", "arguments": "{}" } },
+                ]
+            }),
+            json!({ "role": "tool", "tool_call_id": "call_a", "content": "file contents" }),
+        ];
+        assert_eq!(repair_dangling_tool_calls(&mut messages), 1);
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[1]["tool_call_id"], "call_a");
+        assert_eq!(messages[2]["role"], "tool");
+        assert_eq!(messages[2]["tool_call_id"], "call_b");
+    }
+
+    #[test]
+    fn repair_handles_a_dangling_call_at_the_end_of_the_conversation() {
+        // No trailing message at all after the unanswered tool call.
+        let mut messages = vec![json!({
+            "role": "assistant",
+            "content": null,
+            "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": { "name": "ask", "arguments": "{}" }
+            }]
+        })];
+        assert_eq!(repair_dangling_tool_calls(&mut messages), 1);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[1]["role"], "tool");
+        assert_eq!(messages[1]["tool_call_id"], "call_1");
     }
 
     #[test]

--- a/src-tauri/src/core/cli/mod.rs
+++ b/src-tauri/src/core/cli/mod.rs
@@ -530,6 +530,7 @@ fn build_cli_orchestration_args(
         project_root: Some(project_root),
         permission_requests,
         ask_requests: None,
+        todo_registry: None,
         system_prompt_override: None,
         subagents_enabled: true,
         yolo,
@@ -961,6 +962,9 @@ async fn print_event(ev: StreamEvent, registry: &PermissionRegistry) {
         StreamEvent::AskRequest { .. } => {
             eprintln!("\n\x1b[31m[error] interactive ask requires `jan agent ui`\x1b[0m")
         }
+        // The non-interactive CLI doesn't persist session state; a todo update
+        // is silently dropped here (mirrors MessagesUpdated below).
+        StreamEvent::TodoUpdate { .. } => {}
         // The non-interactive CLI doesn't persist session state, so
         // MessagesUpdated is a no-op here.
         StreamEvent::MessagesUpdated { .. } => {}

--- a/src-tauri/src/core/cli/mod.rs
+++ b/src-tauri/src/core/cli/mod.rs
@@ -534,6 +534,7 @@ fn build_cli_orchestration_args(
         system_prompt_override: None,
         subagents_enabled: true,
         yolo,
+        run_mode: crate::core::agent::plan::RunMode::Normal,
     }
 }
 

--- a/src-tauri/src/core/cli/mod.rs
+++ b/src-tauri/src/core/cli/mod.rs
@@ -529,6 +529,7 @@ fn build_cli_orchestration_args(
         permissions,
         project_root: Some(project_root),
         permission_requests,
+        ask_requests: None,
         system_prompt_override: None,
         subagents_enabled: true,
         yolo,
@@ -956,6 +957,9 @@ async fn print_event(ev: StreamEvent, registry: &PermissionRegistry) {
         }
         StreamEvent::Error { code, message } => {
             eprintln!("\n\x1b[31m[error] {code}: {message}\x1b[0m")
+        }
+        StreamEvent::AskRequest { .. } => {
+            eprintln!("\n\x1b[31m[error] interactive ask requires `jan agent ui`\x1b[0m")
         }
         // The non-interactive CLI doesn't persist session state, so
         // MessagesUpdated is a no-op here.

--- a/src-tauri/src/core/cli/mod.rs
+++ b/src-tauri/src/core/cli/mod.rs
@@ -519,6 +519,7 @@ fn build_cli_orchestration_args(
     mcp_settings: McpSettings,
     permission_requests: PermissionRegistry,
     yolo: bool,
+    plan: bool,
 ) -> OrchestrationArgs {
     OrchestrationArgs {
         client: reqwest::Client::new(),
@@ -534,7 +535,11 @@ fn build_cli_orchestration_args(
         system_prompt_override: None,
         subagents_enabled: true,
         yolo,
-        run_mode: crate::core::agent::plan::RunMode::Normal,
+        run_mode: if plan {
+            crate::core::agent::plan::RunMode::Plan
+        } else {
+            crate::core::agent::plan::RunMode::Normal
+        },
     }
 }
 
@@ -613,6 +618,7 @@ fn prepare_agent_session(
     max_turns_override: Option<u32>,
     overrides: ProviderOverrides,
     yolo: bool,
+    plan: bool,
 ) -> Result<AgentSession, String> {
     let project_root = resolve_project_root(project);
     ensure_project(&project_root)?;
@@ -697,6 +703,7 @@ fn prepare_agent_session(
         mcp_settings,
         permission_requests.clone(),
         yolo,
+        plan,
     );
 
     Ok(AgentSession {
@@ -760,8 +767,10 @@ fn prepare_agent_run(
     yolo: bool,
     resume: Option<ResumeTarget>,
 ) -> Result<PreparedRun, String> {
+    // Non-interactive runs (`agent run`/`step`) have no plan-review handoff, so
+    // plan mode stays a TUI-only startup option.
     let session =
-        prepare_agent_session(project, model_override, max_turns_override, overrides, yolo)?;
+        prepare_agent_session(project, model_override, max_turns_override, overrides, yolo, false)?;
     let project_root = resolve_project_root(project);
     let (clean_task, injected) = path_refs::resolve_references(task, &project_root);
     let final_task = if injected.is_empty() {
@@ -897,9 +906,10 @@ pub async fn cli_agent_ui(
     images: Vec<String>,
     overrides: ProviderOverrides,
     yolo: bool,
+    plan: bool,
     resume: Option<ResumeTarget>,
 ) -> Result<(), String> {
-    let session = prepare_agent_session(project, model, max_turns, overrides, yolo)?;
+    let session = prepare_agent_session(project, model, max_turns, overrides, yolo, plan)?;
     // TUI threads persist under the project's .jan/agent dir, separate from the
     // desktop store, so continuing here never mutates desktop threads.
     let project_root = resolve_project_root(project);

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -3496,8 +3496,8 @@ const SLASH_COMMANDS: &[SlashCommand] = &[
     },
     SlashCommand {
         name: "/plan",
-        hint: "[exit]",
-        description: "Enter read-only plan mode (bare) or /plan exit to leave",
+        hint: "[exit|text]",
+        description: "Enter read-only plan mode, optionally seeding it with a message; /plan exit to leave",
     },
     SlashCommand {
         name: "/todo",
@@ -3689,39 +3689,46 @@ fn goal_command(app: &mut App, arg: &str) {
     }
 }
 
-/// `/plan` dispatcher: bare enters read-only plan mode, `/plan exit` leaves it.
-/// Only settable while idle so it never races the live tool set of a running
-/// turn (spec). Enforcement is at the core dispatcher; this just flips the
-/// per-turn flag forwarded in `App::body()` and persists it.
+/// `/plan` dispatcher: bare enters read-only plan mode, `/plan exit` leaves
+/// it, and `/plan <text>` enters plan mode (if not already in it) and
+/// immediately submits `<text>` as the first message to investigate — same
+/// convenience as seeding the bare TUI with a task. Only settable while idle
+/// so it never races the live tool set of a running turn (spec). Enforcement
+/// is at the core dispatcher; this just flips the per-turn flag forwarded in
+/// `App::body()` and persists it.
 fn plan_command(app: &mut App, arg: &str) {
     use crate::core::agent::plan::RunMode;
     if app.status != Status::Idle {
         app.note("plan mode is only settable while idle");
         return;
     }
-    match arg.trim() {
-        "exit" => {
-            if app.run_mode == RunMode::Plan {
-                app.run_mode = RunMode::Normal;
-                app.persist();
-                app.note("exited plan mode (normal execution)");
-            } else {
-                app.note("not in plan mode");
-            }
-        }
-        "" => {
-            if app.run_mode == RunMode::Plan {
-                app.note("already in plan mode (/plan exit to leave)");
-                return;
-            }
-            app.run_mode = RunMode::Plan;
+    let arg = arg.trim();
+    if arg == "exit" {
+        if app.run_mode == RunMode::Plan {
+            app.run_mode = RunMode::Normal;
             app.persist();
-            app.note("◈ PLAN · read only — investigate, then propose a plan for review");
-            if app.goal.is_some() {
-                app.note("active goal paused while planning; it resumes on exit");
-            }
+            app.note("exited plan mode (normal execution)");
+        } else {
+            app.note("not in plan mode");
         }
-        other => app.note(&format!("usage: /plan [exit]  (got '{other}')")),
+        return;
+    }
+    if app.run_mode == RunMode::Plan {
+        if arg.is_empty() {
+            app.note("already in plan mode (/plan exit to leave)");
+        } else {
+            app.submit_user(arg.to_string());
+        }
+        return;
+    }
+    app.run_mode = RunMode::Plan;
+    app.persist();
+    app.note("◈ PLAN · read only — investigate, then propose a plan for review");
+    if app.goal.is_some() {
+        app.note("active goal paused while planning; it resumes on exit");
+    }
+    if !arg.is_empty() {
+        app.submit_user(arg.to_string());
     }
 }
 
@@ -8017,6 +8024,32 @@ mod tests {
         assert_eq!(app.run_mode, RunMode::Normal, "must not switch mid-turn");
         let text: String = app.transcript.iter().map(line_text).collect();
         assert!(text.contains("only settable while idle"), "note: {text}");
+    }
+
+    #[tokio::test]
+    async fn plan_command_with_text_enters_plan_and_submits_it() {
+        use crate::core::agent::plan::RunMode;
+        let mut app = test_app();
+        run_command(&mut app, "plan make a html cat slide. use 3 subagents to research").await;
+        assert_eq!(app.run_mode, RunMode::Plan, "text arg must also enter plan mode");
+        assert_eq!(app.status, Status::Running, "seeded text must start a turn");
+        let text: String = app.transcript.iter().map(line_text).collect();
+        assert!(
+            text.contains("make a html cat slide"),
+            "seeded text must render as the user's message: {text}"
+        );
+    }
+
+    #[tokio::test]
+    async fn plan_command_with_text_while_already_planning_just_submits() {
+        use crate::core::agent::plan::RunMode;
+        let mut app = test_app();
+        app.run_mode = RunMode::Plan;
+        run_command(&mut app, "plan investigate the auth module").await;
+        assert_eq!(app.run_mode, RunMode::Plan);
+        assert_eq!(app.status, Status::Running);
+        let text: String = app.transcript.iter().map(line_text).collect();
+        assert!(text.contains("investigate the auth module"), "{text}");
     }
 
     #[test]

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -271,6 +271,133 @@ struct PathHintItem {
     is_dir: bool,
 }
 
+struct PendingAsk {
+    request_id: String,
+    request: crate::core::agent::interaction::AskRequest,
+    answers: Vec<crate::core::agent::interaction::QuestionResult>,
+    question_index: usize,
+    selected: usize,
+    editing_custom: bool,
+    custom_input: String,
+    rect: Rect,
+    row_hitboxes: Vec<(u16, usize)>,
+}
+
+impl PendingAsk {
+    fn new(request_id: String, request: crate::core::agent::interaction::AskRequest) -> Self {
+        let answers = request
+            .questions
+            .iter()
+            .map(|question| crate::core::agent::interaction::QuestionResult {
+                id: question.id.clone(),
+                selected: Vec::new(),
+                custom_input: None,
+            })
+            .collect();
+        Self {
+            request_id,
+            request,
+            answers,
+            question_index: 0,
+            selected: 0,
+            editing_custom: false,
+            custom_input: String::new(),
+            rect: Rect::default(),
+            row_hitboxes: Vec::new(),
+        }
+    }
+
+    fn question(&self) -> &crate::core::agent::interaction::Question {
+        &self.request.questions[self.question_index]
+    }
+    fn row_count(&self) -> usize {
+        self.question().options.len() + 1 + usize::from(self.question().multi)
+    }
+
+    fn move_selection(&mut self, delta: isize) {
+        self.selected =
+            (self.selected as isize + delta).rem_euclid(self.row_count() as isize) as usize;
+    }
+
+    fn move_question(&mut self, delta: isize) {
+        let last = self.request.questions.len().saturating_sub(1) as isize;
+        self.question_index = (self.question_index as isize + delta).clamp(0, last) as usize;
+        self.selected = 0;
+        self.editing_custom = false;
+        self.custom_input.clear();
+    }
+
+    fn all_answered(&self) -> bool {
+        self.answers
+            .iter()
+            .all(|answer| !answer.selected.is_empty() || answer.custom_input.is_some())
+    }
+
+    /// Apply the highlighted row. Returns true once every question is answered.
+    fn choose(&mut self) -> bool {
+        let option_count = self.question().options.len();
+        let multi = self.question().multi;
+        if multi && self.selected == option_count + 1 {
+            return self.advance_or_finish();
+        }
+        if self.selected == option_count {
+            self.editing_custom = true;
+            self.custom_input = self.answers[self.question_index]
+                .custom_input
+                .clone()
+                .unwrap_or_default();
+            return false;
+        }
+        let label = self.question().options[self.selected].label.clone();
+        let answer = &mut self.answers[self.question_index];
+        answer.custom_input = None;
+        if multi {
+            if let Some(index) = answer.selected.iter().position(|item| item == &label) {
+                answer.selected.remove(index);
+            } else {
+                answer.selected.push(label);
+            }
+            false
+        } else {
+            answer.selected = vec![label];
+            self.advance_or_finish()
+        }
+    }
+
+    fn accept_custom(&mut self) -> bool {
+        let value = self.custom_input.trim().to_string();
+        if value.is_empty() {
+            return false;
+        }
+        let id = self.question().id.clone();
+        self.answers[self.question_index] = crate::core::agent::interaction::QuestionResult {
+            id,
+            selected: Vec::new(),
+            custom_input: Some(value),
+        };
+        self.editing_custom = false;
+        self.advance_or_finish()
+    }
+
+    fn advance_or_finish(&mut self) -> bool {
+        if self.question_index + 1 < self.request.questions.len() {
+            self.move_question(1);
+            return false;
+        }
+        if self.all_answered() {
+            true
+        } else {
+            self.question_index = self
+                .answers
+                .iter()
+                .position(|answer| answer.selected.is_empty() && answer.custom_input.is_none())
+                .unwrap_or(self.question_index);
+            self.selected = 0;
+            false
+        }
+    }
+}
+
 struct App {
     model: String,
     /// Fast model for the `smol` role, used by `/goal` evaluation. Defaults to
@@ -374,6 +501,8 @@ struct App {
     /// front is shown/answerable at a time, later ones queue and surface once
     /// the front resolves so no requester is silently dropped/left hanging.
     pending_queue: std::collections::VecDeque<Pending>,
+    /// Structured questions waiting for this TUI, oldest first.
+    ask_queue: std::collections::VecDeque<PendingAsk>,
     picker: Option<Picker>,
     /// Lines scrolled back from the tail; 0 pins the view to the bottom so new
     /// content follows. Non-zero survives streaming so scroll-back stays usable.
@@ -528,6 +657,7 @@ impl App {
             tokens: 0,
             detail: String::new(),
             pending_queue: std::collections::VecDeque::new(),
+            ask_queue: std::collections::VecDeque::new(),
             picker: None,
             scrollback: 0,
             want_start: false,
@@ -608,6 +738,7 @@ impl App {
         self.assistant_buf.clear();
         self.message_queue.clear();
         self.pending_queue.clear();
+        self.ask_queue.clear();
         self.pending_images.clear();
         self.tokens = 0;
         self.turn = (0, 0);
@@ -1311,6 +1442,12 @@ impl App {
                     subagent: None,
                 });
             }
+            StreamEvent::AskRequest {
+                request_id,
+                request,
+            } => self
+                .ask_queue
+                .push_back(PendingAsk::new(request_id, request)),
             StreamEvent::SubagentStart { run_id, name } => {
                 // Open a live rolling panel for this run; several may be active.
                 self.finalize_tool_group();
@@ -2302,7 +2439,7 @@ pub async fn run(
     resume: Option<ResumeTarget>,
 ) -> Result<(), String> {
     let AgentSession {
-        args,
+        mut args,
         permission_requests,
         model,
         smol_model,
@@ -2313,6 +2450,8 @@ pub async fn run(
         mcp_servers,
         mcp_task,
     } = session;
+    let ask_requests = crate::core::agent::interaction::new_registry();
+    args.ask_requests = Some(ask_requests.clone());
     let args = Arc::new(args);
 
     enable_raw_mode().map_err(|e| e.to_string())?;
@@ -2349,6 +2488,7 @@ pub async fn run(
         &mut terminal,
         &args,
         &permission_requests,
+        &ask_requests,
         &mut app,
         initial_task,
         mcp_task,
@@ -2372,6 +2512,7 @@ async fn chat_loop<B: Backend>(
     terminal: &mut Terminal<B>,
     args: &Arc<OrchestrationArgs>,
     registry: &PermissionRegistry,
+    ask_requests: &crate::core::agent::interaction::AskRegistry,
     app: &mut App,
     initial_task: Option<String>,
     mut mcp_task: Option<tokio::task::JoinHandle<Vec<String>>>,
@@ -2446,7 +2587,9 @@ async fn chat_loop<B: Backend>(
                 while event::poll(Duration::ZERO).unwrap_or(false) {
                     match event::read() {
                         Ok(Event::Key(key)) => {
-                            handle_key(app, key, registry, &mut current, mcp_servers).await;
+                            if !handle_ask_key(app, key, ask_requests).await {
+                                handle_key(app, key, registry, &mut current, mcp_servers).await;
+                            }
                             if app.mouse_capture != mouse_capture_active {
                                 mouse_capture_active = app.mouse_capture;
                                 // Written straight to stdout (not through the generic
@@ -2465,7 +2608,11 @@ async fn chat_loop<B: Backend>(
                                 app.input_insert(c);
                             }
                         }
-                        Ok(Event::Mouse(mouse)) => handle_mouse(app, mouse),
+                        Ok(Event::Mouse(mouse)) => {
+                            if !handle_ask_mouse(app, mouse, ask_requests).await {
+                                handle_mouse(app, mouse);
+                            }
+                        }
                         _ => {}
                     }
                 }
@@ -2572,6 +2719,7 @@ async fn chat_loop<B: Backend>(
     if let Some(c) = current {
         c.handle.abort();
     }
+    crate::core::agent::interaction::cancel_all(ask_requests).await;
     Ok(())
 }
 
@@ -2611,6 +2759,113 @@ fn handle_mouse(app: &mut App, mouse: MouseEvent) {
     if let Some(Some(idx)) = app.row_index.get(absolute) {
         app.toggle_region(*idx);
     }
+}
+
+async fn resolve_front_ask(
+    app: &mut App,
+    registry: &crate::core::agent::interaction::AskRegistry,
+    cancelled: bool,
+) {
+    let Some(ask) = app.ask_queue.pop_front() else {
+        return;
+    };
+    let outcome = if cancelled {
+        Err(crate::core::agent::interaction::AskError::Cancelled)
+    } else {
+        Ok(ask.answers)
+    };
+    let _ = crate::core::agent::interaction::respond(registry, &ask.request_id, outcome).await;
+}
+
+/// Handle keys owned by the front interactive question. Returns false only for
+/// global Ctrl-C/Ctrl-D, which must continue into the normal run cancellation
+/// path after every ask waiter has been released.
+async fn handle_ask_key(
+    app: &mut App,
+    key: KeyEvent,
+    registry: &crate::core::agent::interaction::AskRegistry,
+) -> bool {
+    if app.ask_queue.is_empty() {
+        return false;
+    }
+    if key.kind != KeyEventKind::Press {
+        return true;
+    }
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    if ctrl && matches!(key.code, KeyCode::Char('c') | KeyCode::Char('d')) {
+        crate::core::agent::interaction::cancel_all(registry).await;
+        app.ask_queue.clear();
+        return false;
+    }
+    if key.code == KeyCode::Esc {
+        resolve_front_ask(app, registry, true).await;
+        return true;
+    }
+
+    let mut submit = false;
+    {
+        let ask = app.ask_queue.front_mut().expect("checked non-empty above");
+        if ask.editing_custom {
+            match key.code {
+                KeyCode::Enter => submit = ask.accept_custom(),
+                KeyCode::Backspace => {
+                    ask.custom_input.pop();
+                }
+                KeyCode::Char(ch) if !ctrl => ask.custom_input.push(ch),
+                _ => {}
+            }
+        } else {
+            match key.code {
+                KeyCode::Up => ask.move_selection(-1),
+                KeyCode::Down => ask.move_selection(1),
+                KeyCode::Left => ask.move_question(-1),
+                KeyCode::Right => ask.move_question(1),
+                KeyCode::Char(' ') if ask.question().multi => {
+                    submit = ask.choose();
+                }
+                KeyCode::Enter => submit = ask.choose(),
+                _ => {}
+            }
+        }
+    }
+    if submit {
+        resolve_front_ask(app, registry, false).await;
+    }
+    true
+}
+
+async fn handle_ask_mouse(
+    app: &mut App,
+    mouse: MouseEvent,
+    registry: &crate::core::agent::interaction::AskRegistry,
+) -> bool {
+    let Some(ask) = app.ask_queue.front_mut() else {
+        return false;
+    };
+    if !matches!(mouse.kind, MouseEventKind::Down(MouseButton::Left)) {
+        return true;
+    }
+    let inside = mouse.column >= ask.rect.x
+        && mouse.column < ask.rect.x.saturating_add(ask.rect.width)
+        && mouse.row >= ask.rect.y
+        && mouse.row < ask.rect.y.saturating_add(ask.rect.height);
+    if !inside {
+        return true;
+    }
+    let Some((_, selected)) = ask
+        .row_hitboxes
+        .iter()
+        .find(|(row, _)| *row == mouse.row)
+        .copied()
+    else {
+        return true;
+    };
+    ask.selected = selected;
+    let submit = ask.choose();
+    if submit {
+        resolve_front_ask(app, registry, false).await;
+    }
+    true
 }
 
 async fn handle_key(
@@ -4082,9 +4337,21 @@ fn draw(f: &mut Frame, app: &mut App) {
     f.render_widget(path_line(app), chunks[3]);
     f.render_widget(footer(app), chunks[4]);
 
-    // Dock the permission prompt directly above the input box, growing upward
-    // and clamped to the body area so it never overruns the transcript.
-    if let Some(pending) = app.pending() {
+    // An interactive question owns the dock while active. Permission prompts
+    // remain queued behind it and surface as soon as the question resolves.
+    if !app.ask_queue.is_empty() {
+        let queue_len = app.ask_queue.len();
+        let ask = app.ask_queue.front_mut().expect("checked non-empty above");
+        let height = (ask.row_count() as u16 + 4).min(chunks[1].height);
+        let y = chunks[2].y.saturating_sub(height).max(chunks[1].y);
+        let rect = ratatui::layout::Rect {
+            x: chunks[2].x,
+            y,
+            width: chunks[2].width,
+            height,
+        };
+        draw_ask(f, rect, ask, queue_len);
+    } else if let Some(pending) = app.pending() {
         let detail_rows = 1
             + u16::from(pending.path.is_some() || pending.command.is_some())
             + u16::from(pending.subagent.is_some());
@@ -4100,9 +4367,8 @@ fn draw(f: &mut Frame, app: &mut App) {
         };
         draw_permission(f, rect, pending, app.pending_queue.len());
     } else {
-        // Dock the slash-command hints above the input box, growing upward and
-        // clamped to the body so they never overrun the transcript. Mutually
-        // exclusive with the permission prompt (that only shows while running).
+        // Dock the slash-command hints above the input box, growing upward
+        // and clamped to the body so they never overrun the transcript.
         let matches = app.slash_matches();
         if !matches.is_empty() {
             let height = (matches.len() as u16 + 2).min(chunks[1].height);
@@ -4115,8 +4381,6 @@ fn draw(f: &mut Frame, app: &mut App) {
             };
             draw_slash_hints(f, rect, &matches, app.slash_selected);
         } else if app.has_path_hints() {
-            // Dock the file-path hints above the input box, same layout as
-            // slash hints. Only shows when no slash hints are active.
             let height = (app.path_hints.len() as u16 + 2).min(chunks[1].height);
             let y = chunks[2].y.saturating_sub(height).max(chunks[1].y);
             let rect = ratatui::layout::Rect {
@@ -4128,6 +4392,124 @@ fn draw(f: &mut Frame, app: &mut App) {
             draw_path_hints(f, rect, &app.path_hints, app.path_hint_selected);
         }
     }
+}
+
+fn draw_ask(f: &mut Frame, area: Rect, ask: &mut PendingAsk, queue_len: usize) {
+    use ratatui::widgets::{Clear, List, ListItem, ListState};
+
+    let question = ask.question().clone();
+    let answer = ask.answers[ask.question_index].clone();
+    let dim = Style::new().dark_gray();
+    let title = if queue_len > 1 {
+        format!(
+            " question {}/{} · request 1/{queue_len} ",
+            ask.question_index + 1,
+            ask.request.questions.len()
+        )
+    } else {
+        format!(
+            " question {}/{} ",
+            ask.question_index + 1,
+            ask.request.questions.len()
+        )
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::new().cyan())
+        .title(Span::styled(title, Style::new().on_cyan().black().bold()));
+    let inner = block.inner(area);
+    let rows = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Min(ask.row_count() as u16),
+        Constraint::Length(1),
+    ])
+    .split(inner);
+
+    let mut items = Vec::with_capacity(ask.row_count());
+    for (index, option) in question.options.iter().enumerate() {
+        let selected = answer.selected.iter().any(|label| label == &option.label);
+        let mark = if question.multi {
+            if selected {
+                "[x] "
+            } else {
+                "[ ] "
+            }
+        } else if selected {
+            "● "
+        } else {
+            "○ "
+        };
+        let mut spans = vec![
+            Span::styled(mark, Style::new().cyan()),
+            Span::raw(option.label.clone()),
+        ];
+        if question.recommended == Some(index) {
+            spans.push(Span::styled("  recommended", Style::new().green().dim()));
+        }
+        if let Some(description) = &option.description {
+            spans.push(Span::styled(format!("  {description}"), dim));
+        }
+        items.push(ListItem::new(Line::from(spans)));
+    }
+    let custom_mark = if question.multi {
+        if answer.custom_input.is_some() {
+            "[x] "
+        } else {
+            "[ ] "
+        }
+    } else if answer.custom_input.is_some() {
+        "● "
+    } else {
+        "○ "
+    };
+    items.push(ListItem::new(Line::from(vec![
+        Span::styled(custom_mark, Style::new().cyan()),
+        Span::raw("Other (type your own)"),
+    ])));
+    if question.multi {
+        items.push(ListItem::new(Line::styled(
+            "Submit answers",
+            Style::new().green().bold(),
+        )));
+    }
+
+    ask.rect = area;
+    ask.row_hitboxes = (0..items.len())
+        .filter_map(|index| {
+            let y = rows[1].y.saturating_add(index as u16);
+            (y < rows[1].y.saturating_add(rows[1].height)).then_some((y, index))
+        })
+        .collect();
+
+    f.render_widget(Clear, area);
+    f.render_widget(block, area);
+    f.render_widget(
+        Paragraph::new(Line::styled(question.question, Style::new().bold())),
+        rows[0],
+    );
+    let list = List::new(items)
+        .highlight_style(Style::new().reversed().bold())
+        .highlight_symbol("▶ ");
+    let mut state = ListState::default();
+    state.select(Some(ask.selected));
+    f.render_stateful_widget(list, rows[1], &mut state);
+    let help = if ask.editing_custom {
+        Line::from(vec![
+            Span::styled("Other: ", Style::new().cyan()),
+            Span::raw(ask.custom_input.clone()),
+            Span::styled("█", Style::new().cyan()),
+        ])
+    } else {
+        Line::styled(
+            if question.multi {
+                "↑↓ move · Space toggle · Enter choose · ←→ question · Esc cancel"
+            } else {
+                "↑↓ move · Enter choose · ←→ question · Esc cancel"
+            },
+            dim,
+        )
+    };
+    f.render_widget(Paragraph::new(help), rows[2]);
 }
 
 /// Slash-command hint popup: one row per match (`/name [hint]  description`),
@@ -4589,13 +4971,14 @@ fn footer(app: &App) -> Paragraph<'static> {
 mod tests {
     use super::{
         build_user_message, clipboard_path, diff_lines, group_activity, group_detail_lines,
-        group_summary, handle_key, handle_mouse, image_mime, input_content_lines, is_table_separator, load_image_file,
-        message_text, open_config_screen, parse_command, render_table, run_command,
-        restore_goal, running_group_row, split_reasoning, subagent_activity,
-        subagent_name_from_run_id, summarize_result, tool_activity, tool_finished,
-        transcript_top_padding, user_content_parts, App, CurrentRun, Pending, PendingImage,
-        apply_resume, PickerKind, ResumeTarget, SnapshotJob, Status, DIFF_MAX_ROWS,
-        SLASH_COMMANDS, SPINNER,
+        apply_resume, build_user_message, clipboard_path, diff_lines, group_activity, group_detail_lines,
+        group_summary, handle_ask_key, handle_ask_mouse, handle_key, handle_mouse, image_mime,
+        input_content_lines, is_table_separator, load_image_file, message_text,
+        open_config_screen, parse_command, render_table, restore_goal, run_command,
+        running_group_row, split_reasoning, subagent_activity, subagent_name_from_run_id,
+        summarize_result, tool_activity, tool_finished, transcript_top_padding,
+        user_content_parts, App, CurrentRun, Pending, PendingImage, PickerKind, ResumeTarget,
+        SnapshotJob, Status, DIFF_MAX_ROWS, SLASH_COMMANDS, SPINNER,
     };
     use ratatui::crossterm::event::{
         KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
@@ -4722,6 +5105,149 @@ mod tests {
         assert_eq!(p.selected, 0);
         p.move_selection(1);
         assert_eq!(p.selected, 1);
+    }
+
+    fn ask_request(
+        multi: bool,
+        two_questions: bool,
+    ) -> crate::core::agent::interaction::AskRequest {
+        let mut questions = vec![json!({
+            "id": "scope",
+            "question": "Which scope?",
+            "options": [{"label": "Small"}, {"label": "Large", "description": "Everything"}],
+            "multi": multi,
+            "recommended": 0
+        })];
+        if two_questions {
+            questions.push(json!({
+                "id": "speed",
+                "question": "Which speed?",
+                "options": [{"label": "Fast"}, {"label": "Careful"}]
+            }));
+        }
+        crate::core::agent::interaction::AskRequest::parse(&json!({
+            "questions": questions
+        }))
+        .unwrap()
+    }
+
+    async fn press_ask(
+        app: &mut App,
+        registry: &crate::core::agent::interaction::AskRegistry,
+        code: KeyCode,
+    ) {
+        assert!(handle_ask_key(app, KeyEvent::new(code, KeyModifiers::NONE), registry,).await);
+    }
+
+    #[tokio::test]
+    async fn ask_keyboard_preserves_answers_across_questions() {
+        let mut app = test_app();
+        let registry = crate::core::agent::interaction::new_registry();
+        let (request_id, receiver) = crate::core::agent::interaction::register(&registry).await;
+        app.apply(StreamEvent::AskRequest {
+            request_id,
+            request: ask_request(false, true),
+        });
+
+        press_ask(&mut app, &registry, KeyCode::Enter).await;
+        assert_eq!(app.ask_queue.front().unwrap().question_index, 1);
+        press_ask(&mut app, &registry, KeyCode::Left).await;
+        assert_eq!(
+            app.ask_queue.front().unwrap().answers[0].selected,
+            vec!["Small"]
+        );
+        press_ask(&mut app, &registry, KeyCode::Right).await;
+        press_ask(&mut app, &registry, KeyCode::Down).await;
+        press_ask(&mut app, &registry, KeyCode::Enter).await;
+
+        assert!(app.ask_queue.is_empty(), "final answer did not submit");
+        assert!(
+            registry.lock().await.is_empty(),
+            "ask sender was not resolved"
+        );
+        let answers = receiver.await.unwrap().unwrap();
+        assert_eq!(answers[0].selected, vec!["Small"]);
+        assert_eq!(answers[1].selected, vec!["Careful"]);
+        assert!(app.ask_queue.is_empty());
+    }
+
+    #[tokio::test]
+    async fn ask_keyboard_handles_multi_select_and_cancellation() {
+        let mut app = test_app();
+        let registry = crate::core::agent::interaction::new_registry();
+        let (request_id, receiver) = crate::core::agent::interaction::register(&registry).await;
+        app.apply(StreamEvent::AskRequest {
+            request_id,
+            request: ask_request(true, false),
+        });
+
+        press_ask(&mut app, &registry, KeyCode::Char(' ')).await;
+        for _ in 0..3 {
+            press_ask(&mut app, &registry, KeyCode::Down).await;
+        }
+        press_ask(&mut app, &registry, KeyCode::Enter).await;
+        assert!(app.ask_queue.is_empty(), "multi-select did not submit");
+        assert!(
+            registry.lock().await.is_empty(),
+            "ask sender was not resolved"
+        );
+        let answers = receiver.await.unwrap().unwrap();
+        assert_eq!(answers[0].selected, vec!["Small"]);
+
+        let (request_id, receiver) = crate::core::agent::interaction::register(&registry).await;
+        app.apply(StreamEvent::AskRequest {
+            request_id,
+            request: ask_request(false, false),
+        });
+        press_ask(&mut app, &registry, KeyCode::Esc).await;
+        assert!(matches!(
+            receiver.await.unwrap(),
+            Err(crate::core::agent::interaction::AskError::Cancelled)
+        ));
+        assert!(app.ask_queue.is_empty());
+    }
+
+    #[tokio::test]
+    async fn ask_mouse_opens_custom_editor_and_submits_text() {
+        use ratatui::{backend::TestBackend, Terminal};
+        let mut app = test_app();
+        let registry = crate::core::agent::interaction::new_registry();
+        let (request_id, receiver) = crate::core::agent::interaction::register(&registry).await;
+        app.apply(StreamEvent::AskRequest {
+            request_id,
+            request: ask_request(false, false),
+        });
+        let mut terminal = Terminal::new(TestBackend::new(36, 24)).unwrap();
+        terminal.draw(|frame| super::draw(frame, &mut app)).unwrap();
+        let other_row = app.ask_queue.front().unwrap().row_hitboxes[2].0;
+
+        assert!(
+            handle_ask_mouse(
+                &mut app,
+                MouseEvent {
+                    kind: MouseEventKind::Down(MouseButton::Left),
+                    column: 2,
+                    row: other_row,
+                    modifiers: KeyModifiers::NONE,
+                },
+                &registry,
+            )
+            .await
+        );
+        assert!(app.ask_queue.front().unwrap().editing_custom);
+        for ch in "custom answer".chars() {
+            press_ask(&mut app, &registry, KeyCode::Char(ch)).await;
+        }
+        press_ask(&mut app, &registry, KeyCode::Enter).await;
+
+        assert!(app.ask_queue.is_empty(), "custom answer did not submit");
+        assert!(
+            registry.lock().await.is_empty(),
+            "ask sender was not resolved"
+        );
+        let answers = receiver.await.unwrap().unwrap();
+        assert_eq!(answers[0].custom_input.as_deref(), Some("custom answer"));
+        assert!(app.ask_queue.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -587,6 +587,15 @@ struct App {
     /// Open-work summary last surfaced as a reminder, so the same reminder never
     /// fires twice in a row without the state changing (reminder dedup).
     last_todo_reminder: Option<String>,
+    /// Stop-time reminders sent so far this prompt cycle; caps at
+    /// `TODO_REMINDER_MAX` so a summary that keeps changing slightly can't
+    /// nag indefinitely even though the same-summary dedup above wouldn't
+    /// catch it.
+    reminder_count: u32,
+    /// True right after a reminder fires, cleared the moment any tool result
+    /// lands. Blocks a second reminder from piling onto one the model hasn't
+    /// had a chance to act on yet.
+    reminder_awaiting_progress: bool,
 }
 
 /// Braille throbber frames for in-progress rows (e.g. awaiting a subagent).
@@ -719,6 +728,8 @@ impl App {
             todo_call_this_turn: false,
             todo_ok_this_turn: false,
             last_todo_reminder: None,
+            reminder_count: 0,
+            reminder_awaiting_progress: false,
         }
     }
 
@@ -796,6 +807,8 @@ impl App {
         self.todo_call_this_turn = false;
         self.todo_ok_this_turn = false;
         self.last_todo_reminder = None;
+        self.reminder_count = 0;
+        self.reminder_awaiting_progress = false;
     }
 
     /// Append a dim single-line status note (command output, cancel, errors).
@@ -1176,8 +1189,14 @@ impl App {
         self.todo_call_this_turn = false;
         self.todo_ok_this_turn = false;
         // A fresh user turn is new context: allow the next boundary to remind
-        // again even if the open work is unchanged (dedup is "twice in a row").
+        // again even if the open work is unchanged (dedup is "twice in a row"),
+        // and rearm the per-cycle reminder budget. A reminder's own follow-up
+        // turn (`submit_reminder`, below) deliberately does NOT reset these --
+        // the count must persist across the very continuation it triggers, or
+        // the cap could never actually be reached.
         self.last_todo_reminder = None;
+        self.reminder_count = 0;
+        self.reminder_awaiting_progress = false;
         self.want_start = true;
         self.persist();
     }
@@ -1208,9 +1227,15 @@ impl App {
     /// Fires at most one hidden reminder when open work remains and the assistant
     /// yielded as if finished. Suppressed while an ask/permission is pending, a
     /// goal/plan transition already queued the next turn, another message is
-    /// armed, or the agent already updated todos this turn. A todo mutation that
-    /// failed this turn queues one retry reminder instead.
-    fn maybe_inject_todo_reminder(&mut self, normal: bool, no_answer: bool) {
+    /// armed, the agent already updated todos this turn, the assistant's own
+    /// final text is itself asking the user something, a prior reminder is
+    /// still unanswered, or the per-cycle reminder budget is spent. A todo
+    /// mutation that failed this turn queues one retry reminder instead.
+    fn maybe_inject_todo_reminder(&mut self, normal: bool, no_answer: bool, answer: &str) {
+        /// Reminders fired per prompt cycle before the policy goes quiet, even
+        /// if the open-work summary keeps changing slightly (the same-summary
+        /// dedup below only catches an unchanged summary, not a moving one).
+        const TODO_REMINDER_MAX: u32 = 3;
         // A goal/plan continuation or a queued message already owns the next
         // turn; a pending ask/permission blocks the boundary; plan mode is a
         // read-only exploration where todos are only staged for handoff.
@@ -1229,6 +1254,18 @@ impl App {
                 return;
             }
         }
+        // The assistant may be legitimately waiting on the user (a plain-text
+        // question, or a "let me know"/"please confirm" cue) rather than
+        // idling mid-task -- nudging "keep working" here would talk over its
+        // own question.
+        if assistant_is_awaiting_user_answer(answer) {
+            return;
+        }
+        // A prior reminder hasn't seen any follow-up action yet, or the
+        // per-cycle budget is already spent: stay silent rather than pile on.
+        if self.reminder_awaiting_progress || self.reminder_count >= TODO_REMINDER_MAX {
+            return;
+        }
         let Some(summary) = self.todos.open_summary() else {
             return;
         };
@@ -1246,6 +1283,8 @@ impl App {
             )
         };
         self.last_todo_reminder = Some(summary);
+        self.reminder_count += 1;
+        self.reminder_awaiting_progress = true;
         self.submit_reminder(text);
     }
 
@@ -1551,6 +1590,11 @@ impl App {
             } => {
                 // Clear the throbber for an awaited subagent once its result lands.
                 self.awaiting.retain(|(await_id, ..)| await_id != &id);
+                // Any tool result means the model took some action since the last
+                // reminder fired; let a later stop remind again if work is still
+                // open. Set unconditionally, before the grouped-call early return
+                // below, so it applies no matter how the result renders.
+                self.reminder_awaiting_progress = false;
                 // Grouped calls are already represented by the group row; retain
                 // their result on the group so an expand can show it later.
                 if self.grouped_ids.contains(&id) {
@@ -1736,7 +1780,7 @@ impl App {
         let answer = self.take_answer();
         if !answer.is_empty() {
             self.history
-                .push(serde_json::json!({ "role": "assistant", "content": answer }));
+                .push(serde_json::json!({ "role": "assistant", "content": answer.clone() }));
         }
         // Cache this turn's output rate from the single `usage` sample and its
         // streaming duration, before `run_started` is cleared below. Holds
@@ -1786,7 +1830,7 @@ impl App {
         self.dequeue_next();
         // Reminder policy runs last: only if nothing else already claimed the
         // next turn (goal eval, a dequeued message) and open work remains.
-        self.maybe_inject_todo_reminder(normal, no_answer);
+        self.maybe_inject_todo_reminder(normal, no_answer, &answer);
         self.persist();
     }
 
@@ -2393,6 +2437,79 @@ fn has_answer_text(buf: &str) -> bool {
     split_reasoning(buf)
         .iter()
         .any(|(reasoning, seg)| !reasoning && !seg.trim().is_empty())
+}
+
+/// A leading markdown list/blockquote marker (`> `, `- `, `1. `), stripped
+/// before checking whether a line reads as a question.
+fn markdown_prefix_re() -> &'static regex::Regex {
+    static RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    RE.get_or_init(|| regex::Regex::new(r"^(?:>\s*)?(?:(?:[-*+]|\d+[.)])\s+)*").unwrap())
+}
+
+/// A leading label like `Q:`, `Question 2:`, `Ask:`.
+fn prompt_label_re() -> &'static regex::Regex {
+    static RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    RE.get_or_init(|| regex::Regex::new(r"(?i)^(?:q(?:uestion)?|ask)\s*\d*\s*[:.)-]\s*").unwrap())
+}
+
+/// A line starting with a question word (what/how/can/should/...).
+fn question_word_re() -> &'static regex::Regex {
+    static RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    RE.get_or_init(|| {
+        regex::Regex::new(
+            r"(?i)^(?:what|which|when|where|why|how|who|whom|whose|do|does|did|can|could|would|will|should|is|are|am|may|shall)\b",
+        )
+        .unwrap()
+    })
+}
+
+/// A line directly addressing the user ("you", "your", "we", "our").
+fn user_directed_re() -> &'static regex::Regex {
+    static RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    RE.get_or_init(|| regex::Regex::new(r"(?i)\b(?:you|your|we|our)\b").unwrap())
+}
+
+/// An explicit request for the user to respond ("let me know", "please
+/// confirm"), independent of a trailing question mark.
+fn response_cue_re() -> &'static regex::Regex {
+    static RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    RE.get_or_init(|| {
+        regex::Regex::new(
+            r"(?i)^(?:please\s+)?(?:confirm|reply|choose|pick|decide|advise)\b|^(?:please\s+)?answer\b|^(?:please\s+)?(?:let\s+me\s+know|tell\s+me)\b",
+        )
+        .unwrap()
+    })
+}
+
+/// True when the assistant's final line reads as a question or an explicit
+/// request for the user to respond, rather than the model idling mid-task
+/// with work still open. A plain-text cue counts just as much as the
+/// structured `ask` tool -- either way, the todo reminder must not talk over
+/// the assistant's own question by nudging it to "keep working."
+fn assistant_is_awaiting_user_answer(text: &str) -> bool {
+    let Some(last_line) = text
+        .split(['\n', '\r'])
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .next_back()
+    else {
+        return false;
+    };
+    let without_markdown = markdown_prefix_re().replace(last_line, "");
+    let without_markdown = without_markdown.trim();
+    let without_label = prompt_label_re().replace(without_markdown, "");
+    let without_label = without_label.trim();
+    let had_label = without_label != without_markdown;
+    let is_question = without_label.ends_with('?') || without_label.ends_with('？');
+    if is_question
+        && (had_label
+            || question_word_re().is_match(without_label)
+            || user_directed_re().is_match(without_label))
+    {
+        return true;
+    }
+    let without_trailing_punct = without_label.trim_end_matches(['.', '!', '?', '。', '！', '？']);
+    response_cue_re().is_match(without_trailing_punct)
 }
 
 fn think_re() -> &'static regex::Regex {
@@ -5730,12 +5847,11 @@ fn footer(app: &App) -> Paragraph<'static> {
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_resume, build_user_message, clipboard_path, diff_lines, group_activity,
-        group_detail_lines,
-        group_summary, handle_ask_key, handle_ask_mouse, handle_key, handle_mouse, image_mime,
-        input_content_lines, is_table_separator, load_image_file, message_text,
-        open_config_screen, parse_command, render_table, restore_goal, restore_run_mode,
-        restore_todos, run_command,
+        apply_resume, assistant_is_awaiting_user_answer, build_user_message, clipboard_path,
+        diff_lines, group_activity, group_detail_lines, group_summary, handle_ask_key,
+        handle_ask_mouse, handle_key, handle_mouse, image_mime, input_content_lines,
+        is_table_separator, load_image_file, message_text, open_config_screen, parse_command,
+        render_table, restore_goal, restore_run_mode, restore_todos, run_command,
         running_group_row, split_reasoning, subagent_activity, subagent_name_from_run_id,
         summarize_result, tokens_per_second, tool_activity, tool_finished, transcript_top_padding,
         user_content_parts, App, CurrentRun, Pending, PendingImage, PickerKind, ResumeTarget,
@@ -8433,8 +8549,13 @@ mod tests {
 
     /// A clean assistant turn that yielded a final answer (the reminder boundary).
     fn finish_clean_turn(app: &mut App) {
+        finish_clean_turn_with_answer(app, "all set");
+    }
+
+    /// Like `finish_clean_turn`, but with a caller-chosen final answer text.
+    fn finish_clean_turn_with_answer(app: &mut App, text: &str) {
         app.status = Status::Running;
-        app.apply(StreamEvent::Token { text: "all set".into() });
+        app.apply(StreamEvent::Token { text: text.into() });
         app.on_done("stop".into(), None);
     }
 
@@ -8535,6 +8656,77 @@ mod tests {
         finish_clean_turn(&mut app);
         assert!(app.want_start, "a failed mutation queues one retry reminder");
         assert!(last_history_content(&app).contains("failed"));
+    }
+
+    #[test]
+    fn awaiting_user_answer_detects_plain_questions_and_response_cues() {
+        assert!(assistant_is_awaiting_user_answer("Which approach do you want?"));
+        assert!(assistant_is_awaiting_user_answer("Q: proceed with the migration?"));
+        assert!(assistant_is_awaiting_user_answer(
+            "I've drafted both options.\nLet me know which one to build."
+        ));
+        assert!(assistant_is_awaiting_user_answer("Please confirm before I continue."));
+        assert!(!assistant_is_awaiting_user_answer("Done, the tests pass."));
+        assert!(!assistant_is_awaiting_user_answer(
+            "This uses a well-known algorithm, is it fast enough already? It runs in O(n)."
+        ));
+        assert!(!assistant_is_awaiting_user_answer(""));
+    }
+
+    #[test]
+    fn todo_reminder_suppressed_when_assistant_is_asking_a_question() {
+        let mut app = test_app();
+        seed_open_todos(&mut app);
+        finish_clean_turn_with_answer(&mut app, "Which database should I use, Postgres or MySQL?");
+        assert!(
+            !app.want_start,
+            "a plain-text question must not be talked over by the todo reminder"
+        );
+    }
+
+    #[test]
+    fn todo_reminder_stops_after_max_reminders_even_as_summary_changes() {
+        let mut app = test_app();
+        seed_open_todos(&mut app);
+        for i in 0..3 {
+            app.want_start = false;
+            finish_clean_turn(&mut app);
+            assert!(app.want_start, "reminder {i} of the 3-reminder budget must fire");
+            app.reminder_awaiting_progress = false;
+            // Vary the open-work summary each round so the same-summary dedup
+            // alone could never explain a stop -- only the hard cap should.
+            app.todos.phases[0].tasks[0].content = format!("t1-{i}");
+        }
+        app.want_start = false;
+        finish_clean_turn(&mut app);
+        assert!(!app.want_start, "the 4th reminder must be suppressed by the per-cycle cap");
+    }
+
+    #[test]
+    fn todo_reminder_waits_for_progress_before_firing_again() {
+        let mut app = test_app();
+        seed_open_todos(&mut app);
+        finish_clean_turn(&mut app);
+        assert!(app.want_start);
+        app.want_start = false;
+        // Change the summary so dedup alone wouldn't suppress a second fire,
+        // but no tool result has landed since the reminder: still silent.
+        app.todos.phases[0].tasks[0].content = "t1-changed".into();
+        finish_clean_turn(&mut app);
+        assert!(
+            !app.want_start,
+            "an unanswered reminder must not be followed by another before any progress"
+        );
+        // A tool result lands (any tool, not just todo) -- progress happened.
+        app.apply(StreamEvent::ToolResult {
+            id: "x".into(),
+            content: "ok".into(),
+            is_error: false,
+            diff: None,
+        });
+        app.todos.phases[0].tasks[0].content = "t1-changed-again".into();
+        finish_clean_turn(&mut app);
+        assert!(app.want_start, "a reminder may fire again once progress happened");
     }
 
     fn todos_from(

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -8042,8 +8042,8 @@ mod tests {
         assert_eq!(summarize_result("abcdefgh", 4), "abc…");
     }
 
-    #[test]
-    fn apply_resume_latest_restores_history_and_model() {
+    #[tokio::test]
+    async fn apply_resume_latest_restores_history_and_model() {
         let mut app = test_app();
         let history = vec![
             json!({ "role": "user", "content": "first" }),
@@ -8055,7 +8055,7 @@ mod tests {
 
         let mut fresh = test_app();
         fresh.agent_dir = app.agent_dir.clone();
-        apply_resume(&mut fresh, &ResumeTarget::Latest);
+        apply_resume(&mut fresh, &ResumeTarget::Latest).await;
 
         assert_eq!(fresh.thread_id.as_deref(), Some(id.as_str()));
         assert_eq!(fresh.history, history);
@@ -8077,10 +8077,10 @@ mod tests {
         assert_eq!(super::super::list_threads_in(&app.agent_dir).unwrap().len(), 1);
     }
 
-    #[test]
-    fn apply_resume_notes_when_nothing_to_resume() {
+    #[tokio::test]
+    async fn apply_resume_notes_when_nothing_to_resume() {
         let mut app = test_app();
-        apply_resume(&mut app, &ResumeTarget::Latest);
+        apply_resume(&mut app, &ResumeTarget::Latest).await;
         let joined: String = app
             .transcript
             .iter()

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -1908,6 +1908,13 @@ impl App {
         // snapshot readiness); otherwise the loop starts it once ready and the
         // cancel is silently undone.
         self.want_start = false;
+        self.subagents.clear();
+        self.awaiting.clear();
+        // A call whose args were still streaming (no ToolCall event yet) never
+        // gets its "Preparing X" throbber cleared by that event once cancelled
+        // -- it would otherwise linger in the transcript forever, looking like
+        // work is still happening after "cancelled" has already printed.
+        self.starting.clear();
         self.detail = "cancelled".to_string();
         self.scrollback = 0;
         self.gap(Kind::Meta);
@@ -7088,14 +7095,39 @@ mod tests {
         // Submit while the run is still gated on model/MCP/snapshot readiness:
         // want_start is armed but no run has spawned yet.
         app.submit_user("do a thing".into());
+        app.apply(StreamEvent::SubagentStart {
+            run_id: "sub-reviewer-1".into(),
+            name: "reviewer".into(),
+        });
+        app.apply(StreamEvent::ToolCall {
+            id: "a1".into(),
+            name: "await_subagent".into(),
+            args: json!({ "run_id": "sub-reviewer-1" }),
+        });
+        // A second call whose args are still streaming in (no ToolCall event
+        // yet, just the throbber-only ToolCallStarted).
+        app.apply(StreamEvent::ToolCallStarted {
+            id: "w1".into(),
+            name: "write".into(),
+        });
         assert!(app.want_start, "submit should arm want_start");
         assert_eq!(app.status, Status::Running);
+        assert_eq!(app.subagents.len(), 1);
+        assert_eq!(app.awaiting.len(), 1);
+        assert_eq!(app.starting.len(), 1);
+
         app.cancel_run();
         assert!(
             !app.want_start,
             "cancel must drop the pending start or the loop re-spawns it"
         );
         assert_eq!(app.status, Status::Idle);
+        assert!(app.subagents.is_empty(), "cancel must clear live subagent rows");
+        assert!(app.awaiting.is_empty(), "cancel must clear awaited-subagent state");
+        assert!(
+            app.starting.is_empty(),
+            "cancel must clear a still-streaming call's throbber, or it lingers forever"
+        );
     }
 
     #[test]

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -545,6 +545,10 @@ struct App {
     /// Wall-clock baseline for the last spinner advance; moved forward by whole
     /// frames only so leftover sub-frame time carries into the next tick.
     last_spinner_advance: Instant,
+    /// Output tokens/sec of the last completed turn, cached so the header holds a
+    /// steady value between turns instead of flickering to 0. Cleared at turn
+    /// start; recomputed from the turn's `usage` sample at `on_done`.
+    tokens_per_sec: Option<f64>,
     /// Transcript viewport rect from the last draw, for mapping mouse clicks
     /// to rows.
     transcript_rect: Rect,
@@ -701,6 +705,7 @@ impl App {
             starting: Vec::new(),
             spinner_frame: 0,
             last_spinner_advance: Instant::now(),
+            tokens_per_sec: None,
             transcript_rect: Rect::default(),
             last_scroll: 0,
             row_index: Vec::new(),
@@ -777,6 +782,7 @@ impl App {
         self.ask_queue.clear();
         self.pending_images.clear();
         self.tokens = 0;
+        self.tokens_per_sec = None;
         self.turn = (0, 0);
         self.detail.clear();
         self.scrollback = 0;
@@ -1162,6 +1168,7 @@ impl App {
         self.status = Status::Running;
         self.run_started = Some(Instant::now());
         self.turn = (0, 0);
+        self.tokens_per_sec = None;
         self.scrollback = 0;
         self.todo_call_this_turn = false;
         self.todo_ok_this_turn = false;
@@ -1186,6 +1193,7 @@ impl App {
         self.status = Status::Running;
         self.run_started = Some(Instant::now());
         self.turn = (0, 0);
+        self.tokens_per_sec = None;
         self.scrollback = 0;
         self.todo_call_this_turn = false;
         self.todo_ok_this_turn = false;
@@ -1726,6 +1734,16 @@ impl App {
         if !answer.is_empty() {
             self.history
                 .push(serde_json::json!({ "role": "assistant", "content": answer }));
+        }
+        // Cache this turn's output rate from the single `usage` sample and its
+        // streaming duration, before `run_started` is cleared below. Holds
+        // steady in the header until the next turn resets it.
+        if let (Some(out), Some(started)) = (
+            usage.as_ref().and_then(|u| u.completion_tokens),
+            self.run_started,
+        ) {
+            self.tokens_per_sec =
+                Some(tokens_per_second(out, started.elapsed().as_millis() as u64));
         }
         self.tokens = usage.and_then(|u| u.total_tokens).unwrap_or(self.tokens);
         self.status = Status::Idle;
@@ -5156,6 +5174,13 @@ fn draw_picker(f: &mut Frame, area: ratatui::layout::Rect, picker: &Picker) {
 }
 
 /// Render a duration as a compact `"12s"` / `"3m12s"` / `"1h04m"` label.
+/// Output tokens per second, flooring the duration at 100ms so a near-instant
+/// turn cannot produce a divide-by-tiny spike.
+fn tokens_per_second(output_tokens: u64, duration_ms: u64) -> f64 {
+    let d = duration_ms.max(100);
+    output_tokens as f64 * 1000.0 / d as f64
+}
+
 fn format_elapsed(secs: u64) -> String {
     if secs < 60 {
         format!("{secs}s")
@@ -5184,6 +5209,12 @@ fn header(app: &App) -> Paragraph<'static> {
         Span::styled(" jan agent ", Style::new().on_blue().white().bold()),
         Span::raw(format!("  {}  ", app.model)),
     ];
+    // Wall-clock (local) segment, mirroring the reference status line's leading
+    // HH:MM:SS. Recomputed each frame so it ticks in place.
+    spans.push(Span::styled(
+        format!("  {}", chrono::Local::now().format("%H:%M:%S")),
+        Style::new().dim(),
+    ));
     spans.push(Span::raw(format!("  {turn}")));
     if app.tokens > 0 {
         spans.push(Span::raw(format!(
@@ -5196,6 +5227,11 @@ fn header(app: &App) -> Paragraph<'static> {
         spans.push(Span::raw(format!("ctx 0/{}K  ", app.context_window / 1000)));
     }
     spans.push(Span::styled(elapsed, Style::new().dim()));
+    // Output rate segment: last completed turn's tokens/sec, cached so it holds
+    // steady instead of flickering to 0 between turns.
+    if let Some(rate) = app.tokens_per_sec {
+        spans.push(Span::styled(format!("  {rate:.1}/s"), Style::new().dim()));
+    }
     // Active-goal indicator: `◎ /goal active <duration>` (cyan while running,
     // green once achieved), so an unattended run shows the goal is still live.
     if let Some(goal) = app.goal.as_ref() {
@@ -5475,7 +5511,7 @@ mod tests {
         open_config_screen, parse_command, render_table, restore_goal, restore_run_mode,
         restore_todos, run_command,
         running_group_row, split_reasoning, subagent_activity, subagent_name_from_run_id,
-        summarize_result, tool_activity, tool_finished, transcript_top_padding,
+        summarize_result, tokens_per_second, tool_activity, tool_finished, transcript_top_padding,
         user_content_parts, App, CurrentRun, Pending, PendingImage, PickerKind, ResumeTarget,
         SnapshotJob, Status, DIFF_MAX_ROWS, SLASH_COMMANDS, SPINNER, SPINNER_ADVANCE_MS,
     };
@@ -5515,6 +5551,19 @@ mod tests {
             selected: 0,
             subagent: None,
         }
+    }
+
+    #[test]
+    fn tokens_per_second_floors_duration_at_100ms() {
+        // 100 tokens over exactly 1s -> 100/s.
+        assert_eq!(tokens_per_second(100, 1000), 100.0);
+        // Sub-100ms durations are floored at 100ms, so no divide-by-tiny spike:
+        // 10 tokens / 0ms and / 100ms both yield 100/s, not infinity.
+        assert_eq!(tokens_per_second(10, 0), 100.0);
+        assert_eq!(tokens_per_second(10, 50), 100.0);
+        assert_eq!(tokens_per_second(10, 100), 100.0);
+        // Zero output is a clean 0, never NaN.
+        assert_eq!(tokens_per_second(0, 500), 0.0);
     }
 
     #[test]

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -144,6 +144,9 @@ enum PickerKind {
     RewindScope,
     /// Read-only view of `~/.jan/config.toml` providers (`/config`). Enter closes.
     ViewConfig,
+    /// `/todo` editor: browse the phased list and mutate the selected task
+    /// (done/drop/rm) through the same canonical `TodoList` the model uses.
+    Todo,
 }
 
 /// Interactive list overlay (`/resume` threads, `/model` models, `/mcp`
@@ -163,6 +166,7 @@ impl Picker {
             PickerKind::RewindMessage => " rewind to message ",
             PickerKind::RewindScope => " restore ",
             PickerKind::ViewConfig => " provider config ",
+            PickerKind::Todo => " todo ",
         }
     }
 
@@ -174,6 +178,7 @@ impl Picker {
             PickerKind::RewindMessage => " ↑/↓ select   Enter choose   Esc cancel",
             PickerKind::RewindScope => " ↑/↓ select   Enter restore   Esc cancel",
             PickerKind::ViewConfig => " set via: jan config set --provider <id> ...   Esc close",
+            PickerKind::Todo => " ↑/↓ select   d done   x abandon   r remove   Esc close",
         }
     }
 }
@@ -560,6 +565,15 @@ struct App {
     /// Canonical session todo list projection, kept in sync via
     /// `StreamEvent::TodoUpdate`. Empty = no todos declared this session.
     todos: crate::core::agent::todo::TodoList,
+    /// Set when the model issued a `todo` tool call in the current turn; cleared
+    /// at each turn start. Drives the reminder suppression / retry policy.
+    todo_call_this_turn: bool,
+    /// Set when a `todo` mutation succeeded this turn (a `TodoUpdate` arrived);
+    /// a call without a success means the mutation failed (retry reminder).
+    todo_ok_this_turn: bool,
+    /// Open-work summary last surfaced as a reminder, so the same reminder never
+    /// fires twice in a row without the state changing (reminder dedup).
+    last_todo_reminder: Option<String>,
 }
 
 /// Braille throbber frames for in-progress rows (e.g. awaiting a subagent).
@@ -684,6 +698,9 @@ impl App {
             mouse_capture: true,
             message_queue: std::collections::VecDeque::new(),
             todos: crate::core::agent::todo::TodoList::default(),
+            todo_call_this_turn: false,
+            todo_ok_this_turn: false,
+            last_todo_reminder: None,
         }
     }
 
@@ -754,6 +771,12 @@ impl App {
         self.detail.clear();
         self.scrollback = 0;
         self.last_kind = Kind::None;
+        // A fresh session drops the todo projection and reminder state; the
+        // model re-declares work with a new `todo init`.
+        self.todos = crate::core::agent::todo::TodoList::default();
+        self.todo_call_this_turn = false;
+        self.todo_ok_this_turn = false;
+        self.last_todo_reminder = None;
     }
 
     /// Append a dim single-line status note (command output, cancel, errors).
@@ -1117,8 +1140,79 @@ impl App {
         self.run_started = Some(Instant::now());
         self.turn = (0, 0);
         self.scrollback = 0;
+        self.todo_call_this_turn = false;
+        self.todo_ok_this_turn = false;
+        // A fresh user turn is new context: allow the next boundary to remind
+        // again even if the open work is unchanged (dedup is "twice in a row").
+        self.last_todo_reminder = None;
         self.want_start = true;
         self.persist();
+    }
+
+    /// Inject a hidden todo reminder and continue with one more model turn. The
+    /// reminder text enters the conversation (so the model sees it) but renders
+    /// as a dim system note, never a user-authored transcript row.
+    fn submit_reminder(&mut self, text: String) {
+        self.history
+            .push(serde_json::json!({ "role": "user", "content": text }));
+        self.gap(Kind::Meta);
+        self.push(Line::styled(
+            "◈ todo reminder — unfinished work, continuing".to_string(),
+            Style::new().dim(),
+        ));
+        self.status = Status::Running;
+        self.run_started = Some(Instant::now());
+        self.turn = (0, 0);
+        self.scrollback = 0;
+        self.todo_call_this_turn = false;
+        self.todo_ok_this_turn = false;
+        self.want_start = true;
+        self.persist();
+    }
+
+    /// Reminder policy (spec: one bounded reminder at a clean turn boundary).
+    /// Fires at most one hidden reminder when open work remains and the assistant
+    /// yielded as if finished. Suppressed while an ask/permission is pending, a
+    /// goal/plan transition already queued the next turn, another message is
+    /// armed, or the agent already updated todos this turn. A todo mutation that
+    /// failed this turn queues one retry reminder instead.
+    fn maybe_inject_todo_reminder(&mut self, normal: bool, no_answer: bool) {
+        // A goal/plan continuation or a queued message already owns the next
+        // turn; a pending ask/permission blocks the boundary; plan mode is a
+        // read-only exploration where todos are only staged for handoff.
+        if self.want_start
+            || self.goal_eval_pending
+            || self.run_mode == crate::core::agent::plan::RunMode::Plan
+            || !self.ask_queue.is_empty()
+        {
+            return;
+        }
+        let failed = self.todo_call_this_turn && !self.todo_ok_this_turn;
+        if !failed {
+            // The agent actively managed todos this turn (or the turn ended
+            // abnormally/emptily): don't nag.
+            if self.todo_call_this_turn || !normal || no_answer {
+                return;
+            }
+        }
+        let Some(summary) = self.todos.open_summary() else {
+            return;
+        };
+        // Dedup: the same open-work summary never reminds twice in a row.
+        if self.last_todo_reminder.as_deref() == Some(summary.as_str()) {
+            return;
+        }
+        let text = if failed {
+            format!(
+                "Reminder: your last todo update failed and unfinished work remains:\n{summary}\n\nRetry the update or continue the work; call `todo` to record progress."
+            )
+        } else {
+            format!(
+                "Reminder: unfinished todos remain:\n{summary}\n\nContinue the work, or call `todo` to mark items done/abandoned."
+            )
+        };
+        self.last_todo_reminder = Some(summary);
+        self.submit_reminder(text);
     }
 
     /// Dequeue the next message from the queue and submit it. Called after
@@ -1217,7 +1311,11 @@ impl App {
         // Persist metadata when snapshots, a goal, or plan mode are present; each
         // must survive restart/resume even in a non-git project (no snapshots).
         let planning = self.run_mode == crate::core::agent::plan::RunMode::Plan;
-        if self.base_snapshot.is_none() && self.goal.is_none() && !planning {
+        if self.base_snapshot.is_none()
+            && self.goal.is_none()
+            && !planning
+            && self.todos.is_empty()
+        {
             return None;
         }
         let mut meta = serde_json::Map::new();
@@ -1236,6 +1334,13 @@ impl App {
             meta.insert(
                 "run_mode".to_string(),
                 serde_json::to_value(self.run_mode).unwrap_or(serde_json::Value::Null),
+            );
+        }
+        // Persist the canonical todos so resume/branch reconstructs the list.
+        if !self.todos.is_empty() {
+            meta.insert(
+                "todos".to_string(),
+                serde_json::to_value(&self.todos).unwrap_or(serde_json::Value::Null),
             );
         }
         Some(serde_json::Value::Object(meta))
@@ -1361,6 +1466,11 @@ impl App {
                 // The full call (with parsed args) supersedes its in-progress
                 // throbber.
                 self.starting.retain(|(sid, _)| sid != &id);
+                // Track todo activity this turn so the reminder policy can tell
+                // an engaged turn (mutated todos) from a stalled one.
+                if name == "todo" {
+                    self.todo_call_this_turn = true;
+                }
                 // Awaiting a subagent is a long block: show a live throbber row
                 // (advanced each render tick) instead of a static grouped row,
                 // cleared when its result arrives.
@@ -1528,6 +1638,9 @@ impl App {
             }
             StreamEvent::TodoUpdate { list } => {
                 self.todos = list;
+                // A snapshot only arrives on a successful mutation; its absence
+                // after a todo call means the mutation failed (retry reminder).
+                self.todo_ok_this_turn = true;
             }
         }
     }
@@ -1627,6 +1740,9 @@ impl App {
         }
         // Auto-dequeue the next queued message, if any
         self.dequeue_next();
+        // Reminder policy runs last: only if nothing else already claimed the
+        // next turn (goal eval, a dequeued message) and open work remains.
+        self.maybe_inject_todo_reminder(normal, no_answer);
         self.persist();
     }
 
@@ -2507,7 +2623,7 @@ pub async fn run(
     // A failed resume is not fatal: the note explains why and the blank session
     // the user already has stays usable.
     if let Some(target) = &resume {
-        apply_resume(&mut app, target);
+        apply_resume(&mut app, target).await;
         if app.thread_id.is_none() {
             app.note("starting a new session");
         }
@@ -3056,12 +3172,45 @@ async fn handle_key(
                 item.checkbox = Some(enable);
                 toggle_mcp_server(app, mcp_servers, name, enable);
             }
+            // `/todo` editor: d/Enter = done, x = abandon (drop), r = remove.
+            // Each mutates the canonical list and rebuilds the overlay in place;
+            // opening/closing the view itself never mutates state.
+            KeyCode::Char('d') | KeyCode::Char('x') | KeyCode::Char('r') | KeyCode::Enter
+                if picker.kind == PickerKind::Todo =>
+            {
+                let code = key.code;
+                let content = picker.items.get(picker.selected).map(|i| i.value.clone());
+                // (picker borrow ends here; nothing below reads it before rebuild)
+                if let Some(content) = content {
+                    use crate::core::agent::todo::Target;
+                    let result = match code {
+                        KeyCode::Char('x') => {
+                            apply_todo_mutation(app, |l| l.drop_target(Target::Task(&content))).await
+                        }
+                        KeyCode::Char('r') => {
+                            apply_todo_mutation(app, |l| l.rm(Target::Task(&content))).await
+                        }
+                        _ => apply_todo_mutation(app, |l| l.done(Target::Task(&content))).await,
+                    };
+                    if let Err(e) = result {
+                        app.note(&format!("todo update failed: {e}"));
+                    }
+                    // Rebuild from the mutated list; close once nothing remains.
+                    if app.todos.is_empty() {
+                        app.picker = None;
+                    } else if let Some(picker) = app.picker.as_mut() {
+                        picker.items = build_todo_items(&app.todos);
+                        picker.selected =
+                            picker.selected.min(picker.items.len().saturating_sub(1));
+                    }
+                }
+            }
             KeyCode::Enter => {
                 let kind = picker.kind;
                 let value = picker.items[picker.selected].value.clone();
                 app.picker = None;
                 match kind {
-                    PickerKind::ResumeThread => resume_thread(app, &value),
+                    PickerKind::ResumeThread => resume_thread(app, &value).await,
                     PickerKind::SelectModel => app.set_model(value),
                     PickerKind::ToggleMcp => {}
                     PickerKind::RewindMessage => {
@@ -3075,6 +3224,8 @@ async fn handle_key(
                         }
                     }
                     PickerKind::ViewConfig => {}
+                    // Todo Enter is handled by the guarded action arm above.
+                    PickerKind::Todo => {}
                 }
             }
             KeyCode::Esc | KeyCode::Char('q') if !ctrl => {
@@ -3297,6 +3448,11 @@ const SLASH_COMMANDS: &[SlashCommand] = &[
         description: "Enter read-only plan mode (bare) or /plan exit to leave",
     },
     SlashCommand {
+        name: "/todo",
+        hint: "[add [phase|] text]",
+        description: "Open the todo editor (bare) or /todo add ... to append a task",
+    },
+    SlashCommand {
         name: "/threads",
         hint: "",
         description: "List saved threads for this project",
@@ -3406,7 +3562,7 @@ async fn run_command(app: &mut App, line: &str) {
             if arg.is_empty() {
                 open_thread_picker(app);
             } else {
-                resume_thread(app, arg);
+                resume_thread(app, arg).await;
             }
         }
         "model" => {
@@ -3420,6 +3576,7 @@ async fn run_command(app: &mut App, line: &str) {
         "config" => open_config_screen(app),
         "goal" => goal_command(app, arg),
         "plan" => plan_command(app, arg),
+        "todo" => todo_command(app, arg).await,
         "cancel" => cancel_command(app, arg),
         "quit" | "exit" => app.should_quit = true,
         other => app.note(&format!("unknown command '/{other}' (try /help)")),
@@ -3513,6 +3670,96 @@ fn plan_command(app: &mut App, arg: &str) {
             }
         }
         other => app.note(&format!("usage: /plan [exit]  (got '{other}')")),
+    }
+}
+
+/// Apply one user-initiated todo mutation to the canonical `TodoList`. Prefers
+/// the shared registry (the model's source of truth) so agent and user share one
+/// state; falls back to the local projection when no live session is attached
+/// (e.g. tests). Syncs the TUI projection and persists on success.
+async fn apply_todo_mutation(
+    app: &mut App,
+    op: impl FnOnce(&mut crate::core::agent::todo::TodoList) -> Result<(), String>,
+) -> Result<(), String> {
+    if let Some(args) = app.args.clone() {
+        if let Some(registry) = args.todo_registry.as_ref() {
+            let mut list = registry.lock().await;
+            op(&mut list)?;
+            app.todos = list.clone();
+            app.persist();
+            return Ok(());
+        }
+    }
+    let mut list = app.todos.clone();
+    op(&mut list)?;
+    app.todos = list;
+    app.persist();
+    Ok(())
+}
+
+/// Build the `/todo` editor rows: one per task, in phase/task order, prefixed by
+/// a status glyph. `value` is the task content (its stable mutation id).
+fn build_todo_items(todos: &crate::core::agent::todo::TodoList) -> Vec<PickerItem> {
+    use crate::core::agent::todo::TodoStatus;
+    let mut items = Vec::new();
+    for phase in &todos.phases {
+        for task in &phase.tasks {
+            let marker = match task.status {
+                TodoStatus::InProgress => "▸",
+                TodoStatus::Pending => "○",
+                TodoStatus::Completed => "✔",
+                TodoStatus::Abandoned => "✗",
+            };
+            items.push(PickerItem {
+                value: task.content.clone(),
+                label: format!("{marker} {}", task.content),
+                hint: (!phase.name.is_empty()).then(|| phase.name.clone()),
+                checkbox: None,
+            });
+        }
+    }
+    items
+}
+
+/// Open the `/todo` editor overlay over the current phased list.
+fn open_todo_picker(app: &mut App) {
+    if app.todos.is_empty() {
+        app.note("no todos yet — the agent declares them, or add one: /todo add TEXT");
+        return;
+    }
+    app.picker = Some(Picker {
+        kind: PickerKind::Todo,
+        items: build_todo_items(&app.todos),
+        selected: 0,
+    });
+}
+
+/// `/todo` handler. Bare opens the editor overlay; `/todo add [PHASE |] TEXT`
+/// appends a pending task through the canonical `append` op (default phase
+/// "Tasks"), so a user-added task is indistinguishable from a model-added one.
+async fn todo_command(app: &mut App, arg: &str) {
+    let arg = arg.trim();
+    if arg.is_empty() {
+        open_todo_picker(app);
+        return;
+    }
+    let Some(rest) = arg.strip_prefix("add") else {
+        app.note("usage: /todo   (open editor)   |   /todo add [PHASE |] TEXT");
+        return;
+    };
+    let rest = rest.trim();
+    let (phase, text) = match rest.split_once('|') {
+        Some((p, t)) => (p.trim().to_string(), t.trim().to_string()),
+        None => ("Tasks".to_string(), rest.to_string()),
+    };
+    if text.is_empty() {
+        app.note("usage: /todo add [PHASE |] TEXT");
+        return;
+    }
+    let phase_label = phase.clone();
+    match apply_todo_mutation(app, move |list| list.append(&phase, vec![text])).await {
+        Ok(()) => app.note(&format!("added todo to '{phase_label}'")),
+        Err(e) => app.note(&format!("todo add failed: {e}")),
     }
 }
 
@@ -3874,6 +4121,21 @@ fn restore_run_mode(app: &mut App, metadata: Option<&serde_json::Value>) {
     }
 }
 
+/// Reload the canonical todo list for a resumed thread from its persisted
+/// metadata into the TUI projection. The caller also mirrors it into the shared
+/// registry so the model's next `todo` op operates on the reconstructed state.
+fn restore_todos(app: &mut App, metadata: Option<&serde_json::Value>) {
+    app.todos = crate::core::agent::todo::TodoList::default();
+    app.last_todo_reminder = None;
+    let Some(meta) = metadata else { return };
+    if let Some(todos) = meta
+        .get("todos")
+        .and_then(|v| serde_json::from_value::<crate::core::agent::todo::TodoList>(v.clone()).ok())
+    {
+        app.todos = todos;
+    }
+}
+
 /// Open the double-Esc rewind picker listing the conversation's user messages.
 fn open_rewind_picker(app: &mut App) {
     let mut items = Vec::new();
@@ -4010,15 +4272,15 @@ fn rebuild_transcript(app: &mut App) {
     }
 }
 
-fn resume_thread(app: &mut App, id_arg: &str) {
-    apply_resume(app, &ResumeTarget::Id(id_arg.to_string()));
+async fn resume_thread(app: &mut App, id_arg: &str) {
+    apply_resume(app, &ResumeTarget::Id(id_arg.to_string())).await;
 }
 
 /// Resolve a resume target and load it into the app, reporting why not when it
 /// cannot be resolved. The session is left untouched on failure.
-fn apply_resume(app: &mut App, target: &ResumeTarget) {
+async fn apply_resume(app: &mut App, target: &ResumeTarget) {
     match super::find_resume_thread(&app.agent_dir, target) {
-        Ok(thread) => load_thread(app, &thread),
+        Ok(thread) => load_thread(app, &thread).await,
         Err(e) => app.note(&e),
     }
 }
@@ -4026,7 +4288,7 @@ fn apply_resume(app: &mut App, target: &ResumeTarget) {
 /// Replace the live session with a saved thread's state: history, transcript,
 /// snapshots, goal, and model. Only user/assistant text is replayed (tool calls
 /// are not persisted as messages).
-fn load_thread(app: &mut App, thread: &serde_json::Value) {
+async fn load_thread(app: &mut App, thread: &serde_json::Value) {
     let full_id = thread.get("id").and_then(|v| v.as_str()).unwrap_or_default();
 
     let (messages, skipped) = match super::cli_read_messages_lenient(&app.agent_dir, full_id) {
@@ -4052,6 +4314,14 @@ fn load_thread(app: &mut App, thread: &serde_json::Value) {
     restore_snapshots(app, thread.get("metadata"));
     restore_goal(app, thread.get("metadata"));
     restore_run_mode(app, thread.get("metadata"));
+    restore_todos(app, thread.get("metadata"));
+    // Mirror the reconstructed todos into the shared registry so the model's
+    // next `todo` mutation operates on the resumed state, not an empty list.
+    if let Some(args) = app.args.as_ref() {
+        if let Some(registry) = args.todo_registry.as_ref() {
+            *registry.lock().await = app.todos.clone();
+        }
+    }
 
     // Adopt the thread's model so continuation stays coherent.
     if let Some(model) = thread
@@ -4258,16 +4528,40 @@ fn transcript_top_padding(total: u16, inner_h: u16) -> u16 {
 
 fn draw(f: &mut Frame, app: &mut App) {
     let input_h = input_box_height(app, f.area().width);
-    let chunks = Layout::vertical([
-        Constraint::Length(1),
-        Constraint::Min(1),
-        Constraint::Length(input_h),
-        Constraint::Length(1),  // path line
-        Constraint::Length(1),  // footer
-    ])
-    .split(f.area());
+    // A one-line compact todo strip sits just below the header when todos exist
+    // and no overlay is open. Kept out of the layout otherwise so a todo-free
+    // session (or an open picker) renders exactly as before.
+    let show_todo = app.picker.is_none() && !app.todos.is_empty();
+    let raw = if show_todo {
+        Layout::vertical([
+            Constraint::Length(1), // header
+            Constraint::Length(1), // todo strip
+            Constraint::Min(1),
+            Constraint::Length(input_h),
+            Constraint::Length(1), // path line
+            Constraint::Length(1), // footer
+        ])
+        .split(f.area())
+    } else {
+        Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Min(1),
+            Constraint::Length(input_h),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(f.area())
+    };
+    let todo_area = show_todo.then(|| raw[1]);
+    // Remap to a stable [header, body, input, path, footer] so the rest of draw
+    // is indifferent to whether the strip is present.
+    let base = if show_todo { 1 } else { 0 };
+    let chunks = [raw[0], raw[base + 1], raw[base + 2], raw[base + 3], raw[base + 4]];
 
     f.render_widget(header(app), chunks[0]);
+    if let Some(area) = todo_area {
+        f.render_widget(todo_strip(app), area);
+    }
 
     // Top/bottom borders only, so wrapping uses the full width; the two border
     // rows reduce the vertical viewport. Cache the width so flushed tables wrap.
@@ -4904,6 +5198,37 @@ fn header(app: &App) -> Paragraph<'static> {
     Paragraph::new(Line::from(spans))
 }
 
+/// Compact one-line todo widget: `☑ done/total · ▸ [phase] active · next: a, b, c`.
+/// Reads only the data-access helpers on `TodoList`; rendering never mutates.
+fn todo_strip(app: &App) -> Paragraph<'static> {
+    let (done, total) = app.todos.done_total();
+    let mut spans = vec![
+        Span::styled(format!(" ☑ {done}/{total}"), Style::new().cyan().bold()),
+    ];
+    if let Some((phase, task)) = app.todos.active() {
+        let active = if phase.name.is_empty() {
+            format!("  ▸ {}", task.content)
+        } else {
+            format!("  ▸ [{}] {}", phase.name, task.content)
+        };
+        spans.push(Span::styled(active, Style::new().white()));
+    }
+    let next = app.todos.next_pending(3);
+    if !next.is_empty() {
+        let preview = next
+            .iter()
+            .map(|(_, t)| *t)
+            .collect::<Vec<_>>()
+            .join(", ");
+        spans.push(Span::styled(
+            format!("  next: {preview}"),
+            Style::new().dim(),
+        ));
+    }
+    spans.push(Span::styled("   /todo".to_string(), Style::new().dark_gray()));
+    Paragraph::new(Line::from(spans))
+}
+
 /// Max content rows the input box grows to before it scrolls internally.
 const MAX_INPUT_ROWS: u16 = 8;
 
@@ -5124,7 +5449,7 @@ mod tests {
         group_summary, handle_ask_key, handle_ask_mouse, handle_key, handle_mouse, image_mime,
         input_content_lines, is_table_separator, load_image_file, message_text,
         open_config_screen, parse_command, render_table, restore_goal, restore_run_mode,
-        run_command,
+        restore_todos, run_command,
         running_group_row, split_reasoning, subagent_activity, subagent_name_from_run_id,
         summarize_result, tool_activity, tool_finished, transcript_top_padding,
         user_content_parts, App, CurrentRun, Pending, PendingImage, PickerKind, ResumeTarget,
@@ -7600,6 +7925,166 @@ mod tests {
         // Old threads / normal sessions keep clean, backward-compatible metadata.
         let app = test_app();
         assert!(app.thread_metadata().is_none());
+    }
+
+    // ── session todo: reminder policy, editor, persistence ─────────────────
+
+    fn seed_open_todos(app: &mut App) {
+        use crate::core::agent::todo::{TodoItem, TodoList, TodoPhase, TodoStatus};
+        app.todos = TodoList {
+            phases: vec![TodoPhase {
+                name: "P".into(),
+                tasks: vec![
+                    TodoItem { content: "t1".into(), status: TodoStatus::InProgress },
+                    TodoItem { content: "t2".into(), status: TodoStatus::Pending },
+                ],
+            }],
+        };
+    }
+
+    /// A clean assistant turn that yielded a final answer (the reminder boundary).
+    fn finish_clean_turn(app: &mut App) {
+        app.status = Status::Running;
+        app.apply(StreamEvent::Token { text: "all set".into() });
+        app.on_done("stop".into(), None);
+    }
+
+    fn last_history_content(app: &App) -> String {
+        app.history
+            .last()
+            .and_then(|m| m.get("content"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string()
+    }
+
+    #[test]
+    fn todo_reminder_fires_once_at_clean_boundary_with_open_work() {
+        let mut app = test_app();
+        seed_open_todos(&mut app);
+        finish_clean_turn(&mut app);
+        assert!(app.want_start, "open work must queue one continuation turn");
+        let injected = last_history_content(&app);
+        assert!(injected.contains("unfinished todos"), "got: {injected}");
+        assert!(injected.contains("t1") && injected.contains("t2"));
+        // The reminder is hidden: no user-authored `› ` row in the transcript.
+        let rows: String = app.transcript.iter().map(line_text).collect();
+        assert!(!rows.contains("› "), "reminder must not render as a user row");
+    }
+
+    #[test]
+    fn todo_reminder_suppressed_when_agent_updated_todos_this_turn() {
+        let mut app = test_app();
+        seed_open_todos(&mut app);
+        // A successful todo mutation happened this turn: the agent is engaged.
+        app.todo_call_this_turn = true;
+        app.todo_ok_this_turn = true;
+        finish_clean_turn(&mut app);
+        assert!(!app.want_start, "an engaged turn must not be nagged");
+    }
+
+    #[test]
+    fn todo_reminder_suppressed_in_plan_mode() {
+        use crate::core::agent::plan::RunMode;
+        let mut app = test_app();
+        app.run_mode = RunMode::Plan;
+        seed_open_todos(&mut app);
+        finish_clean_turn(&mut app);
+        assert!(!app.want_start, "plan mode stages todos, never auto-executes");
+    }
+
+    #[test]
+    fn todo_reminder_suppressed_when_no_answer() {
+        let mut app = test_app();
+        seed_open_todos(&mut app);
+        // A stop with no answer text is an abnormal finish, not a clean yield.
+        app.status = Status::Running;
+        app.on_done("stop".into(), None);
+        assert!(!app.want_start);
+    }
+
+    #[tokio::test]
+    async fn todo_reminder_suppressed_while_ask_pending() {
+        let mut app = test_app();
+        seed_open_todos(&mut app);
+        let registry = crate::core::agent::interaction::new_registry();
+        let (request_id, _rx) = crate::core::agent::interaction::register(&registry).await;
+        app.apply(StreamEvent::AskRequest {
+            request_id,
+            request: ask_request(false, false),
+        });
+        finish_clean_turn(&mut app);
+        assert!(!app.want_start, "a pending ask blocks the reminder boundary");
+    }
+
+    #[test]
+    fn todo_reminder_deduplicates_repeats() {
+        let mut app = test_app();
+        seed_open_todos(&mut app);
+        finish_clean_turn(&mut app);
+        assert!(app.want_start);
+        assert!(last_history_content(&app).contains("unfinished todos"));
+        // The loop consumes want_start when it spawns the continuation run.
+        app.want_start = false;
+        // Model responds without changing todos and yields again: the same open
+        // summary must not fire a second identical reminder.
+        finish_clean_turn(&mut app);
+        assert!(!app.want_start, "identical reminder must not repeat");
+        assert!(
+            !last_history_content(&app).contains("unfinished todos"),
+            "last message should be the assistant answer, not a repeat reminder"
+        );
+    }
+
+    #[test]
+    fn todo_reminder_retries_after_failed_mutation() {
+        let mut app = test_app();
+        seed_open_todos(&mut app);
+        // A todo call this turn with no success snapshot = a failed mutation.
+        app.todo_call_this_turn = true;
+        app.todo_ok_this_turn = false;
+        finish_clean_turn(&mut app);
+        assert!(app.want_start, "a failed mutation queues one retry reminder");
+        assert!(last_history_content(&app).contains("failed"));
+    }
+
+    #[tokio::test]
+    async fn todo_editor_mutations_update_the_canonical_list() {
+        let mut app = test_app();
+        // Add through the same `append` op the model uses.
+        run_command(&mut app, "todo add Build | ship it").await;
+        assert_eq!(app.todos.done_total(), (0, 1));
+        assert_eq!(app.todos.active().unwrap().1.content, "ship it");
+        // Mark it done via the editor helper; the projection reflects it.
+        super::apply_todo_mutation(&mut app, |l| {
+            l.done(crate::core::agent::todo::Target::Task("ship it"))
+        })
+        .await
+        .unwrap();
+        assert_eq!(app.todos.done_total(), (1, 1));
+    }
+
+    #[tokio::test]
+    async fn todo_command_bare_opens_editor_overlay() {
+        let mut app = test_app();
+        run_command(&mut app, "todo add first").await;
+        run_command(&mut app, "todo").await;
+        assert!(matches!(
+            app.picker.as_ref().map(|p| p.kind),
+            Some(PickerKind::Todo)
+        ));
+    }
+
+    #[test]
+    fn todos_persist_and_restore_via_thread_metadata() {
+        let mut app = test_app();
+        seed_open_todos(&mut app);
+        let meta = app.thread_metadata().expect("todos force metadata");
+        assert!(meta.get("todos").is_some());
+
+        let mut restored = test_app();
+        restore_todos(&mut restored, Some(&meta));
+        assert_eq!(restored.todos, app.todos, "resume/branch reconstructs todos");
     }
 
     #[tokio::test]

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -6962,6 +6962,7 @@ mod tests {
         assert!(panel.calls.first().unwrap().contains("cmd0"));
         assert!(panel.calls.last().unwrap().contains("cmd6"));
         // The live panel renders only the last SUBAGENT_WINDOW calls.
+        use ratatui::{backend::TestBackend, Terminal};
         let render = |app: &mut App| {
             let mut terminal = Terminal::new(TestBackend::new(80, 30)).unwrap();
             terminal.draw(|f| super::draw(f, app)).unwrap();
@@ -7002,56 +7003,6 @@ mod tests {
         assert_eq!(alpha.calls.len(), 0, "beta's call must not land on alpha");
         assert_eq!(beta.calls.len(), 1);
         assert!(beta.calls.last().unwrap().contains("beta-cmd"));
-    }
-
-    #[test]
-    fn running_subagent_row_shows_latest_activity() {
-        use ratatui::{backend::TestBackend, Terminal};
-        let render = |app: &mut App| {
-            let mut terminal = Terminal::new(TestBackend::new(80, 40)).unwrap();
-            terminal.draw(|f| super::draw(f, app)).unwrap();
-            let buf = terminal.backend().buffer().clone();
-            (0..buf.area.height)
-                .map(|y| (0..buf.area.width).map(|x| buf[(x, y)].symbol()).collect::<String>())
-                .collect::<Vec<_>>()
-                .join("\n")
-        };
-        let row = |screen: &str, needle: &str| {
-            screen
-                .lines()
-                .find(|l| l.contains(needle))
-                .unwrap()
-                .trim_end()
-                .to_string()
-        };
-        let mut app = test_app();
-        app.apply(StreamEvent::SubagentStart {
-            run_id: "r1".into(),
-            name: "cat-news".into(),
-        });
-        // No tool call yet: the row is name-only, with no trailing activity text.
-        let before = render(&mut app);
-        assert!(
-            row(&before, "cat-news").ends_with("cat-news"),
-            "no-call row must be name only: {before}"
-        );
-        // A tool call lands: the row gains the latest activity label after the name.
-        app.apply(wrap(
-            "r1",
-            "cat-news",
-            StreamEvent::ToolCall {
-                id: "c0".into(),
-                name: "grep".into(),
-                args: json!({ "pattern": "viral cats" }),
-            },
-        ));
-        let after = render(&mut app);
-        let line = row(&after, "cat-news");
-        assert!(line.contains("cat-news"), "row keeps the name: {after}");
-        assert!(
-            line.contains("viral cats"),
-            "row must show latest activity: {after}"
-        );
     }
 
     #[test]

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -2498,6 +2498,9 @@ pub async fn run(
     let mut app = App::new(model, max_turns, context_window, reserve_tokens, max_tokens, agent_dir, project_root, repo_root);
     app.smol_model = smol_model;
     app.args = Some(args.clone());
+    // Adopt the session's startup run mode (e.g. `--plan`) so the header badge
+    // shows immediately; a resumed thread overrides this via restore_run_mode.
+    app.run_mode = args.run_mode;
     if args.yolo {
         app.note("--yolo: sandbox disabled, all tool calls auto-approved without prompting");
     }
@@ -2508,6 +2511,9 @@ pub async fn run(
         if app.thread_id.is_none() {
             app.note("starting a new session");
         }
+    }
+    if app.run_mode == crate::core::agent::plan::RunMode::Plan {
+        app.note("◈ PLAN · read only — investigate, then propose a plan for review");
     }
     for path in &initial_images {
         match load_image_file(path) {

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -4680,8 +4680,10 @@ fn draw(f: &mut Frame, app: &mut App) {
     // A multi-line todo tree HUD sits just below the header when todos exist and
     // no overlay is open, sized to its bounded row count. Kept out of the layout
     // otherwise so a todo-free session (or an open picker) renders exactly as
-    // before.
-    let todo_h = todo_hud_height(app);
+    // before. Built at most once per frame -- its line count sizes the layout
+    // and the same lines are reused for the actual render below.
+    let todo_lines = (app.picker.is_none() && !app.todos.is_empty()).then(|| todo_hud(app));
+    let todo_h = todo_lines.as_ref().map_or(0, |l| l.len() as u16);
     let show_todo = todo_h > 0;
     let raw = if show_todo {
         Layout::vertical([
@@ -4711,7 +4713,9 @@ fn draw(f: &mut Frame, app: &mut App) {
 
     f.render_widget(header(app), chunks[0]);
     if let Some(area) = todo_area {
-        f.render_widget(Paragraph::new(todo_hud(app)), area);
+        // `show_todo` (and thus `todo_area`) is only `Some` when `todo_lines`
+        // was built above.
+        f.render_widget(Paragraph::new(todo_lines.unwrap()), area);
     }
 
     // Top/bottom borders only, so wrapping uses the full width; the two border
@@ -5426,12 +5430,15 @@ fn todo_hud(app: &App) -> Vec<Line<'static>> {
     let multi = phases.len() > 1;
     let width = app.render_width() as usize;
 
+    // Which phase holds the in-progress task, if any; used both for the root
+    // row's `idx/count` suffix and to pick which phase expands its tasks below.
+    let active_idx = phases
+        .iter()
+        .position(|p| p.tasks.iter().any(|t| t.status == TodoStatus::InProgress));
+
     // Root row: `Todos`, plus ` · idx/count` when multi-phase, plus the hint.
     let mut root = vec![Span::styled("Todos", Style::new().cyan().bold())];
     if multi {
-        let active_idx = phases
-            .iter()
-            .position(|p| p.tasks.iter().any(|t| t.status == TodoStatus::InProgress));
         // ponytail: no active task (all done, or none started) → count fully
         // finished phases so a completed plan reads `N/N`.
         let idx = active_idx.map(|i| i + 1).unwrap_or_else(|| {
@@ -5474,9 +5481,6 @@ fn todo_hud(app: &App) -> Vec<Line<'static>> {
     };
 
     if multi {
-        let active_idx = phases
-            .iter()
-            .position(|p| p.tasks.iter().any(|t| t.status == TodoStatus::InProgress));
         for (pi, phase) in phases.iter().enumerate() {
             let is_last = pi + 1 == phases.len();
             let done = phase
@@ -5509,16 +5513,6 @@ fn todo_hud(app: &App) -> Vec<Line<'static>> {
 
     lines.truncate(MAX_TODO_ROWS);
     lines
-}
-
-/// Rows the todo HUD occupies in the layout: 0 when hidden (empty list or an
-/// open picker), otherwise the bounded HUD line count. Mirrors
-/// `input_box_height` so `draw` can size the layout and render consistently.
-fn todo_hud_height(app: &App) -> u16 {
-    if app.picker.is_some() || app.todos.is_empty() {
-        return 0;
-    }
-    todo_hud(app).len() as u16
 }
 
 /// Max content rows the input box grows to before it scrolls internally.
@@ -8639,24 +8633,37 @@ mod tests {
         );
     }
 
+    /// `draw` hides the HUD (reserves 0 layout rows) exactly when the picker is
+    /// open or there are no todos; this mirrors that same guard directly rather
+    /// than through a dedicated height helper, since `draw` now builds the HUD
+    /// once and sizes the layout from its own line count (see `draw`'s
+    /// `todo_lines` local).
+    fn todo_hud_height(app: &App) -> usize {
+        if app.picker.is_some() || app.todos.is_empty() {
+            0
+        } else {
+            super::todo_hud(app).len()
+        }
+    }
+
     #[test]
     fn todo_hud_height_zero_when_hidden_and_bounded_otherwise() {
         use crate::core::agent::todo::TodoStatus::*;
         // Empty list: no rows reserved.
         let mut app = test_app();
-        assert_eq!(super::todo_hud_height(&app), 0);
+        assert_eq!(todo_hud_height(&app), 0);
         // Non-empty: at least the root plus a task, capped under MAX_TODO_ROWS.
         app.todos = todos_from(vec![("only", vec![("t", InProgress)])]);
-        let h = super::todo_hud_height(&app);
-        assert!(h >= 2 && h as usize <= super::MAX_TODO_ROWS, "bounded height, got {h}");
+        let h = todo_hud_height(&app);
+        assert!(h >= 2 && h <= super::MAX_TODO_ROWS, "bounded height, got {h}");
         // A picker overlay hides the HUD entirely.
         super::open_todo_picker(&mut app);
-        assert_eq!(super::todo_hud_height(&app), 0, "picker suppresses the HUD");
+        assert_eq!(todo_hud_height(&app), 0, "picker suppresses the HUD");
         // A huge single phase stays clamped at the ceiling.
         let mut app = test_app();
         let many: Vec<(&str, _)> = (0..50).map(|_| ("x", Pending)).collect();
         app.todos = todos_from(vec![("only", many)]);
-        assert_eq!(super::todo_hud_height(&app) as usize, super::MAX_TODO_ROWS);
+        assert_eq!(todo_hud_height(&app), super::MAX_TODO_ROWS);
     }
 
     #[tokio::test]

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -6578,7 +6578,6 @@ mod tests {
         assert!(panel.calls.first().unwrap().contains("cmd0"));
         assert!(panel.calls.last().unwrap().contains("cmd6"));
         // The live panel renders only the last SUBAGENT_WINDOW calls.
-        use ratatui::{backend::TestBackend, Terminal};
         let render = |app: &mut App| {
             let mut terminal = Terminal::new(TestBackend::new(80, 30)).unwrap();
             terminal.draw(|f| super::draw(f, app)).unwrap();
@@ -6619,6 +6618,56 @@ mod tests {
         assert_eq!(alpha.calls.len(), 0, "beta's call must not land on alpha");
         assert_eq!(beta.calls.len(), 1);
         assert!(beta.calls.last().unwrap().contains("beta-cmd"));
+    }
+
+    #[test]
+    fn running_subagent_row_shows_latest_activity() {
+        use ratatui::{backend::TestBackend, Terminal};
+        let render = |app: &mut App| {
+            let mut terminal = Terminal::new(TestBackend::new(80, 40)).unwrap();
+            terminal.draw(|f| super::draw(f, app)).unwrap();
+            let buf = terminal.backend().buffer().clone();
+            (0..buf.area.height)
+                .map(|y| (0..buf.area.width).map(|x| buf[(x, y)].symbol()).collect::<String>())
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        let row = |screen: &str, needle: &str| {
+            screen
+                .lines()
+                .find(|l| l.contains(needle))
+                .unwrap()
+                .trim_end()
+                .to_string()
+        };
+        let mut app = test_app();
+        app.apply(StreamEvent::SubagentStart {
+            run_id: "r1".into(),
+            name: "cat-news".into(),
+        });
+        // No tool call yet: the row is name-only, with no trailing activity text.
+        let before = render(&mut app);
+        assert!(
+            row(&before, "cat-news").ends_with("cat-news"),
+            "no-call row must be name only: {before}"
+        );
+        // A tool call lands: the row gains the latest activity label after the name.
+        app.apply(wrap(
+            "r1",
+            "cat-news",
+            StreamEvent::ToolCall {
+                id: "c0".into(),
+                name: "grep".into(),
+                args: json!({ "pattern": "viral cats" }),
+            },
+        ));
+        let after = render(&mut app);
+        let line = row(&after, "cat-news");
+        assert!(line.contains("cat-news"), "row keeps the name: {after}");
+        assert!(
+            line.contains("viral cats"),
+            "row must show latest activity: {after}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -4587,14 +4587,16 @@ fn transcript_top_padding(total: u16, inner_h: u16) -> u16 {
 
 fn draw(f: &mut Frame, app: &mut App) {
     let input_h = input_box_height(app, f.area().width);
-    // A one-line compact todo strip sits just below the header when todos exist
-    // and no overlay is open. Kept out of the layout otherwise so a todo-free
-    // session (or an open picker) renders exactly as before.
-    let show_todo = app.picker.is_none() && !app.todos.is_empty();
+    // A multi-line todo tree HUD sits just below the header when todos exist and
+    // no overlay is open, sized to its bounded row count. Kept out of the layout
+    // otherwise so a todo-free session (or an open picker) renders exactly as
+    // before.
+    let todo_h = todo_hud_height(app);
+    let show_todo = todo_h > 0;
     let raw = if show_todo {
         Layout::vertical([
             Constraint::Length(1), // header
-            Constraint::Length(1), // todo strip
+            Constraint::Length(todo_h), // todo HUD
             Constraint::Min(1),
             Constraint::Length(input_h),
             Constraint::Length(1), // path line
@@ -4619,7 +4621,7 @@ fn draw(f: &mut Frame, app: &mut App) {
 
     f.render_widget(header(app), chunks[0]);
     if let Some(area) = todo_area {
-        f.render_widget(todo_strip(app), area);
+        f.render_widget(Paragraph::new(todo_hud(app)), area);
     }
 
     // Top/bottom borders only, so wrapping uses the full width; the two border
@@ -5275,35 +5277,158 @@ fn header(app: &App) -> Paragraph<'static> {
     Paragraph::new(Line::from(spans))
 }
 
-/// Compact one-line todo widget: `☑ done/total · ▸ [phase] active · next: a, b, c`.
-/// Reads only the data-access helpers on `TodoList`; rendering never mutates.
-fn todo_strip(app: &App) -> Paragraph<'static> {
-    let (done, total) = app.todos.done_total();
-    let mut spans = vec![
-        Span::styled(format!(" ☑ {done}/{total}"), Style::new().cyan().bold()),
-    ];
-    if let Some((phase, task)) = app.todos.active() {
-        let active = if phase.name.is_empty() {
-            format!("  ▸ {}", task.content)
-        } else {
-            format!("  ▸ [{}] {}", phase.name, task.content)
-        };
-        spans.push(Span::styled(active, Style::new().white()));
+/// Hard ceiling on HUD rows so a huge plan can't crowd out the transcript.
+const MAX_TODO_ROWS: usize = 10;
+/// Per-phase task cap before a `+N more` summary row is shown.
+const TODO_TASK_CAP: usize = 8;
+
+/// Tree connector: `└─` for the last row at a nesting level, `├─` otherwise.
+fn tree_connector(is_last: bool) -> &'static str {
+    if is_last {
+        "└─"
+    } else {
+        "├─"
     }
-    let next = app.todos.next_pending(3);
-    if !next.is_empty() {
-        let preview = next
+}
+
+/// One task row: `<indent><connector> <glyph> <text>`, styled by status.
+/// Pending is dim, in-progress accent, completed dim+strikethrough, abandoned
+/// red+strikethrough with a distinct `☒` glyph.
+fn todo_task_line(
+    indent: &str,
+    is_last: bool,
+    task: &crate::core::agent::todo::TodoItem,
+    max: usize,
+) -> Line<'static> {
+    use crate::core::agent::todo::TodoStatus;
+    let (glyph, style) = match task.status {
+        TodoStatus::Pending => ("☐", Style::new().dim()),
+        TodoStatus::InProgress => ("☐", Style::new().cyan()),
+        TodoStatus::Completed => ("☑", Style::new().dim().add_modifier(Modifier::CROSSED_OUT)),
+        TodoStatus::Abandoned => ("☒", Style::new().red().add_modifier(Modifier::CROSSED_OUT)),
+    };
+    Line::from(vec![
+        Span::styled(
+            format!("{indent}{} ", tree_connector(is_last)),
+            Style::new().dark_gray(),
+        ),
+        Span::styled(format!("{glyph} "), style),
+        Span::styled(truncate(&task.content, max), style),
+    ])
+}
+
+/// Multi-line tree HUD for the session todos, capped at `MAX_TODO_ROWS`:
+///
+/// ```text
+/// Todos · 1/2   /todo
+///  └─ backend · 1/3
+///      ├─ ☑ scaffold
+///      └─ ☐ wire routes
+/// ```
+///
+/// Single-phase lists skip the redundant phase header and nest tasks directly
+/// under `Todos`. Multi-phase lists show one connected row per phase with its
+/// `· done/total` progress; only the active phase (the one holding the
+/// in-progress task) expands its task rows, the rest stay header-only.
+fn todo_hud(app: &App) -> Vec<Line<'static>> {
+    use crate::core::agent::todo::TodoStatus;
+    let phases = &app.todos.phases;
+    let multi = phases.len() > 1;
+    let width = app.render_width() as usize;
+
+    // Root row: `Todos`, plus ` · idx/count` when multi-phase, plus the hint.
+    let mut root = vec![Span::styled("Todos", Style::new().cyan().bold())];
+    if multi {
+        let active_idx = phases
             .iter()
-            .map(|(_, t)| *t)
-            .collect::<Vec<_>>()
-            .join(", ");
-        spans.push(Span::styled(
-            format!("  next: {preview}"),
-            Style::new().dim(),
+            .position(|p| p.tasks.iter().any(|t| t.status == TodoStatus::InProgress));
+        // ponytail: no active task (all done, or none started) → count fully
+        // finished phases so a completed plan reads `N/N`.
+        let idx = active_idx.map(|i| i + 1).unwrap_or_else(|| {
+            phases
+                .iter()
+                .filter(|p| {
+                    p.tasks
+                        .iter()
+                        .all(|t| matches!(t.status, TodoStatus::Completed | TodoStatus::Abandoned))
+                })
+                .count()
+                .max(1)
+        });
+        root.push(Span::styled(
+            format!(" · {idx}/{}", phases.len()),
+            Style::new().cyan(),
         ));
     }
-    spans.push(Span::styled("   /todo".to_string(), Style::new().dark_gray()));
-    Paragraph::new(Line::from(spans))
+    root.push(Span::styled("   /todo".to_string(), Style::new().dark_gray()));
+    let mut lines = vec![Line::from(root)];
+
+    // Which task rows to emit for a phase, capped with a `+N more` summary.
+    // ponytail: flat cap over all statuses (completed included, so their
+    // strikethrough shows); no completed-omission viewport for v1.
+    let push_tasks = |lines: &mut Vec<Line<'static>>, indent: &str, tasks: &[crate::core::agent::todo::TodoItem]| {
+        let shown = tasks.len().min(TODO_TASK_CAP);
+        let has_more = tasks.len() > shown;
+        let max = width.saturating_sub(indent.chars().count() + 4).max(8);
+        for (i, task) in tasks.iter().take(shown).enumerate() {
+            let is_last = !has_more && i + 1 == shown;
+            lines.push(todo_task_line(indent, is_last, task, max));
+        }
+        if has_more {
+            let more = tasks.len() - shown;
+            lines.push(Line::from(vec![Span::styled(
+                format!("{indent}{} +{more} more", tree_connector(true)),
+                Style::new().dark_gray(),
+            )]));
+        }
+    };
+
+    if multi {
+        let active_idx = phases
+            .iter()
+            .position(|p| p.tasks.iter().any(|t| t.status == TodoStatus::InProgress));
+        for (pi, phase) in phases.iter().enumerate() {
+            let is_last = pi + 1 == phases.len();
+            let done = phase
+                .tasks
+                .iter()
+                .filter(|t| matches!(t.status, TodoStatus::Completed | TodoStatus::Abandoned))
+                .count();
+            let active = Some(pi) == active_idx;
+            let style = if active {
+                Style::new().bold()
+            } else {
+                Style::new().dim()
+            };
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!(" {} ", tree_connector(is_last)),
+                    Style::new().dark_gray(),
+                ),
+                Span::styled(phase.name.clone(), style),
+                Span::styled(format!(" · {done}/{}", phase.tasks.len()), style),
+            ]));
+            // Only the active phase expands its tasks; others stay header-only.
+            if active {
+                push_tasks(&mut lines, "     ", &phase.tasks);
+            }
+        }
+    } else if let Some(phase) = phases.first() {
+        push_tasks(&mut lines, " ", &phase.tasks);
+    }
+
+    lines.truncate(MAX_TODO_ROWS);
+    lines
+}
+
+/// Rows the todo HUD occupies in the layout: 0 when hidden (empty list or an
+/// open picker), otherwise the bounded HUD line count. Mirrors
+/// `input_box_height` so `draw` can size the layout and render consistently.
+fn todo_hud_height(app: &App) -> u16 {
+    if app.picker.is_some() || app.todos.is_empty() {
+        return 0;
+    }
+    todo_hud(app).len() as u16
 }
 
 /// Max content rows the input box grows to before it scrolls internally.
@@ -8243,6 +8368,122 @@ mod tests {
         finish_clean_turn(&mut app);
         assert!(app.want_start, "a failed mutation queues one retry reminder");
         assert!(last_history_content(&app).contains("failed"));
+    }
+
+    fn todos_from(
+        phases: Vec<(&str, Vec<(&str, crate::core::agent::todo::TodoStatus)>)>,
+    ) -> crate::core::agent::todo::TodoList {
+        use crate::core::agent::todo::{TodoItem, TodoList, TodoPhase};
+        TodoList {
+            phases: phases
+                .into_iter()
+                .map(|(name, tasks)| TodoPhase {
+                    name: name.into(),
+                    tasks: tasks
+                        .into_iter()
+                        .map(|(content, status)| TodoItem {
+                            content: content.into(),
+                            status,
+                        })
+                        .collect(),
+                })
+                .collect(),
+        }
+    }
+
+    fn crossed_out(line: &ratatui::text::Line) -> bool {
+        line.spans
+            .iter()
+            .any(|s| s.style.add_modifier.contains(Modifier::CROSSED_OUT))
+    }
+
+    #[test]
+    fn single_phase_todo_hud_renders_tree_lines() {
+        use crate::core::agent::todo::TodoStatus::*;
+        let mut app = test_app();
+        app.todos = todos_from(vec![(
+            "only",
+            vec![
+                ("alpha", InProgress),
+                ("beta", Pending),
+                ("gamma", Completed),
+            ],
+        )]);
+        let lines: Vec<String> = super::todo_hud(&app).iter().map(line_text).collect();
+        // Root row: `Todos` + hint, no phase-count suffix for a single phase.
+        assert!(lines[0].contains("Todos"), "{lines:?}");
+        assert!(lines[0].contains("/todo"), "{lines:?}");
+        assert!(!lines[0].contains(" · "), "single phase has no idx/count: {lines:?}");
+        // No redundant phase header: tasks nest directly under the root.
+        assert!(!lines.iter().any(|l| l.contains("only")), "{lines:?}");
+        // Glyphs per status and connectors: non-last `├─`, last `└─`.
+        assert!(lines[1].contains("├─") && lines[1].contains("☐ alpha"), "{lines:?}");
+        assert!(lines[2].contains("├─") && lines[2].contains("☐ beta"), "{lines:?}");
+        assert!(lines[3].contains("└─") && lines[3].contains("☑ gamma"), "{lines:?}");
+    }
+
+    #[test]
+    fn multi_phase_todo_hud_collapses_inactive_phases() {
+        use crate::core::agent::todo::TodoStatus::*;
+        let mut app = test_app();
+        app.todos = todos_from(vec![
+            ("backend", vec![("scaffold", Completed), ("routes", InProgress)]),
+            ("frontend", vec![("ui", Pending), ("polish", Pending)]),
+        ]);
+        let hud = super::todo_hud(&app);
+        let lines: Vec<String> = hud.iter().map(line_text).collect();
+        // Root carries the active-phase/count suffix when multi-phase.
+        assert!(lines[0].contains("Todos") && lines[0].contains("· 1/2"), "{lines:?}");
+        // Each phase gets a connected header with its own done/total.
+        assert!(lines.iter().any(|l| l.contains("backend") && l.contains("· 1/2")), "{lines:?}");
+        assert!(lines.iter().any(|l| l.contains("frontend") && l.contains("· 0/2")), "{lines:?}");
+        // Active phase (backend) expands its tasks; inactive phase collapses.
+        assert!(lines.iter().any(|l| l.contains("routes")), "active tasks shown: {lines:?}");
+        assert!(!lines.iter().any(|l| l.contains("ui") || l.contains("polish")),
+            "inactive phase tasks stay collapsed: {lines:?}");
+    }
+
+    #[test]
+    fn completed_and_abandoned_todos_render_distinctly() {
+        use crate::core::agent::todo::TodoStatus::*;
+        let mut app = test_app();
+        app.todos = todos_from(vec![(
+            "only",
+            vec![("shipped", Completed), ("dropped", Abandoned)],
+        )]);
+        let hud = super::todo_hud(&app);
+        let done = hud.iter().find(|l| line_text(l).contains("shipped")).unwrap();
+        let gone = hud.iter().find(|l| line_text(l).contains("dropped")).unwrap();
+        // Completed: checked glyph + strikethrough.
+        assert!(line_text(done).contains("☑"), "{:?}", line_text(done));
+        assert!(crossed_out(done), "completed is struck through");
+        // Abandoned: distinct glyph, strikethrough, and a red accent.
+        assert!(line_text(gone).contains("☒"), "{:?}", line_text(gone));
+        assert!(crossed_out(gone), "abandoned is struck through");
+        assert!(
+            gone.spans.iter().any(|s| s.style.fg == Some(ratatui::style::Color::Red)),
+            "abandoned carries a red accent to distinguish it from completed"
+        );
+    }
+
+    #[test]
+    fn todo_hud_height_zero_when_hidden_and_bounded_otherwise() {
+        use crate::core::agent::todo::TodoStatus::*;
+        // Empty list: no rows reserved.
+        let mut app = test_app();
+        assert_eq!(super::todo_hud_height(&app), 0);
+        // Non-empty: at least the root plus a task, capped under MAX_TODO_ROWS.
+        app.todos = todos_from(vec![("only", vec![("t", InProgress)])]);
+        let h = super::todo_hud_height(&app);
+        assert!(h >= 2 && h as usize <= super::MAX_TODO_ROWS, "bounded height, got {h}");
+        // A picker overlay hides the HUD entirely.
+        super::open_todo_picker(&mut app);
+        assert_eq!(super::todo_hud_height(&app), 0, "picker suppresses the HUD");
+        // A huge single phase stays clamped at the ceiling.
+        let mut app = test_app();
+        let many: Vec<(&str, _)> = (0..50).map(|_| ("x", Pending)).collect();
+        app.todos = todos_from(vec![("only", many)]);
+        assert_eq!(super::todo_hud_height(&app) as usize, super::MAX_TODO_ROWS);
     }
 
     #[tokio::test]

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -5117,7 +5117,8 @@ mod tests {
         apply_resume, build_user_message, clipboard_path, diff_lines, group_activity, group_detail_lines,
         group_summary, handle_ask_key, handle_ask_mouse, handle_key, handle_mouse, image_mime,
         input_content_lines, is_table_separator, load_image_file, message_text,
-        open_config_screen, parse_command, render_table, restore_goal, run_command,
+        open_config_screen, parse_command, render_table, restore_goal, restore_run_mode,
+        run_command,
         running_group_row, split_reasoning, subagent_activity, subagent_name_from_run_id,
         summarize_result, tool_activity, tool_finished, transcript_top_padding,
         user_content_parts, App, CurrentRun, Pending, PendingImage, PickerKind, ResumeTarget,
@@ -7395,6 +7396,11 @@ mod tests {
         assert!(SLASH_COMMANDS.iter().any(|c| c.name == "/goal"));
     }
 
+    #[test]
+    fn plan_is_a_registered_command() {
+        assert!(SLASH_COMMANDS.iter().any(|c| c.name == "/plan"));
+    }
+
     #[tokio::test]
     async fn goal_set_stores_condition_and_starts_a_turn() {
         let mut app = test_app();
@@ -7516,6 +7522,204 @@ mod tests {
         assert_eq!(g.turns, 2);
         assert_eq!(g.last_reason, "one failing");
         assert!(g.is_active());
+    }
+
+    fn plan_review_request() -> crate::core::agent::interaction::AskRequest {
+        crate::core::agent::interaction::AskRequest::parse(&json!({
+            "questions": [{
+                "id": crate::core::agent::plan::PLAN_REVIEW_QUESTION_ID,
+                "question": "Ready to execute?",
+                "options": [
+                    {"label": crate::core::agent::plan::EXECUTE_PLAN_LABEL},
+                    {"label": crate::core::agent::plan::KEEP_PLANNING_LABEL},
+                    {"label": crate::core::agent::plan::EXIT_PLAN_LABEL},
+                ]
+            }]
+        }))
+        .unwrap()
+    }
+
+    fn staged_todos() -> crate::core::agent::todo::TodoList {
+        use crate::core::agent::todo::{TodoItem, TodoList, TodoPhase, TodoStatus};
+        TodoList {
+            phases: vec![TodoPhase {
+                name: "Plan".into(),
+                tasks: vec![TodoItem {
+                    content: "do the thing".into(),
+                    status: TodoStatus::Pending,
+                }],
+            }],
+        }
+    }
+
+    #[tokio::test]
+    async fn plan_command_enters_and_exits_while_idle() {
+        use crate::core::agent::plan::RunMode;
+        let mut app = test_app();
+        run_command(&mut app, "plan").await;
+        assert_eq!(app.run_mode, RunMode::Plan);
+        run_command(&mut app, "plan exit").await;
+        assert_eq!(app.run_mode, RunMode::Normal);
+    }
+
+    #[tokio::test]
+    async fn plan_command_rejected_while_running() {
+        use crate::core::agent::plan::RunMode;
+        let mut app = test_app();
+        app.status = Status::Running;
+        run_command(&mut app, "plan").await;
+        assert_eq!(app.run_mode, RunMode::Normal, "must not switch mid-turn");
+        let text: String = app.transcript.iter().map(line_text).collect();
+        assert!(text.contains("only settable while idle"), "note: {text}");
+    }
+
+    #[test]
+    fn run_mode_persists_and_restores_via_thread_metadata() {
+        use crate::core::agent::plan::RunMode;
+        let mut app = test_app();
+        app.run_mode = RunMode::Plan;
+        let meta = app.thread_metadata().expect("metadata present in plan mode");
+        assert_eq!(meta.get("run_mode").and_then(|v| v.as_str()), Some("plan"));
+
+        let mut restored = test_app();
+        restore_run_mode(&mut restored, Some(&meta));
+        assert_eq!(restored.run_mode, RunMode::Plan);
+        // Resume must never auto-execute a saved plan.
+        assert_eq!(restored.status, Status::Idle);
+        assert!(restored.message_queue.is_empty());
+    }
+
+    #[test]
+    fn normal_mode_omits_run_mode_from_metadata() {
+        // Old threads / normal sessions keep clean, backward-compatible metadata.
+        let app = test_app();
+        assert!(app.thread_metadata().is_none());
+    }
+
+    #[tokio::test]
+    async fn plan_review_execute_switches_normal_and_queues_continuation() {
+        use crate::core::agent::plan::RunMode;
+        let mut app = test_app();
+        app.run_mode = RunMode::Plan;
+        app.apply(StreamEvent::TodoUpdate { list: staged_todos() });
+        app.status = Status::Running; // an in-flight turn owns the ask
+        let registry = crate::core::agent::interaction::new_registry();
+        let (request_id, receiver) = crate::core::agent::interaction::register(&registry).await;
+        app.apply(StreamEvent::AskRequest {
+            request_id,
+            request: plan_review_request(),
+        });
+        // Default selection 0 = "Execute plan"; Enter submits.
+        press_ask(&mut app, &registry, KeyCode::Enter).await;
+        assert_eq!(app.run_mode, RunMode::Normal);
+        assert!(
+            app.message_queue
+                .iter()
+                .any(|m| m.as_str() == "Proceed with the plan."),
+            "execute must queue a continuation turn"
+        );
+        let answers = receiver.await.unwrap().unwrap();
+        assert_eq!(
+            answers[0].selected,
+            vec![crate::core::agent::plan::EXECUTE_PLAN_LABEL]
+        );
+    }
+
+    #[tokio::test]
+    async fn plan_review_execute_without_todos_stays_in_plan() {
+        use crate::core::agent::plan::RunMode;
+        let mut app = test_app();
+        app.run_mode = RunMode::Plan; // no todos staged
+        app.status = Status::Running;
+        let registry = crate::core::agent::interaction::new_registry();
+        let (request_id, _receiver) = crate::core::agent::interaction::register(&registry).await;
+        app.apply(StreamEvent::AskRequest {
+            request_id,
+            request: plan_review_request(),
+        });
+        press_ask(&mut app, &registry, KeyCode::Enter).await;
+        // Atomic handoff: no staged plan => stay in Plan, no continuation.
+        assert_eq!(app.run_mode, RunMode::Plan);
+        assert!(app.message_queue.is_empty());
+        let text: String = app.transcript.iter().map(line_text).collect();
+        assert!(text.contains("no plan staged"), "note: {text}");
+    }
+
+    #[tokio::test]
+    async fn plan_review_keep_planning_stays_in_plan() {
+        use crate::core::agent::plan::RunMode;
+        let mut app = test_app();
+        app.run_mode = RunMode::Plan;
+        app.apply(StreamEvent::TodoUpdate { list: staged_todos() });
+        app.status = Status::Running;
+        let registry = crate::core::agent::interaction::new_registry();
+        let (request_id, _receiver) = crate::core::agent::interaction::register(&registry).await;
+        app.apply(StreamEvent::AskRequest {
+            request_id,
+            request: plan_review_request(),
+        });
+        press_ask(&mut app, &registry, KeyCode::Down).await; // -> Keep planning
+        press_ask(&mut app, &registry, KeyCode::Enter).await;
+        assert_eq!(app.run_mode, RunMode::Plan);
+        assert!(app.message_queue.is_empty(), "keep planning must not execute");
+    }
+
+    #[tokio::test]
+    async fn plan_review_exit_returns_to_normal_without_execution() {
+        use crate::core::agent::plan::RunMode;
+        let mut app = test_app();
+        app.run_mode = RunMode::Plan;
+        app.apply(StreamEvent::TodoUpdate { list: staged_todos() });
+        app.status = Status::Running;
+        let registry = crate::core::agent::interaction::new_registry();
+        let (request_id, _receiver) = crate::core::agent::interaction::register(&registry).await;
+        app.apply(StreamEvent::AskRequest {
+            request_id,
+            request: plan_review_request(),
+        });
+        press_ask(&mut app, &registry, KeyCode::Down).await;
+        press_ask(&mut app, &registry, KeyCode::Down).await; // -> Exit plan mode
+        press_ask(&mut app, &registry, KeyCode::Enter).await;
+        assert_eq!(app.run_mode, RunMode::Normal);
+        assert!(app.message_queue.is_empty(), "exit must not auto-execute");
+    }
+
+    #[tokio::test]
+    async fn cancelling_plan_review_leaves_plan_enabled() {
+        use crate::core::agent::plan::RunMode;
+        let mut app = test_app();
+        app.run_mode = RunMode::Plan;
+        app.status = Status::Running;
+        let registry = crate::core::agent::interaction::new_registry();
+        let (request_id, receiver) = crate::core::agent::interaction::register(&registry).await;
+        app.apply(StreamEvent::AskRequest {
+            request_id,
+            request: plan_review_request(),
+        });
+        press_ask(&mut app, &registry, KeyCode::Esc).await; // cancel the review
+        assert!(app.ask_queue.is_empty(), "review wait must be cleared");
+        assert_eq!(app.run_mode, RunMode::Plan, "cancel must not change mode");
+        assert!(matches!(
+            receiver.await.unwrap(),
+            Err(crate::core::agent::interaction::AskError::Cancelled)
+        ));
+    }
+
+    #[test]
+    fn on_done_does_not_queue_goal_eval_while_planning() {
+        use crate::core::agent::plan::RunMode;
+        let mut app = test_app();
+        app.goal = Some(crate::core::agent::goal::GoalState::new("cond"));
+        app.run_mode = RunMode::Plan;
+        app.status = Status::Running;
+        app.apply(StreamEvent::Token {
+            text: "planning".into(),
+        });
+        app.on_done("stop".into(), None);
+        assert!(
+            !app.goal_eval_pending,
+            "plan mode pauses the goal loop; no auto-continue"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -2080,9 +2080,74 @@ fn tool_activity(name: &str, args: &serde_json::Value) -> String {
         "await_subagent" => format!("Awaiting subagent: {}", subagent_name_from_run_id(s("run_id"))),
         "create_subagent" => format!("Creating subagent: {}", s("name")),
         "list_subagents" => "Listing subagents".to_string(),
+        "web_search" => {
+            let q = s("query");
+            if q.is_empty() {
+                "Searching the web".to_string()
+            } else {
+                format!("Searching the web: {}", truncate(q, COMMAND_LABEL_MAX))
+            }
+        }
+        "web_fetch" => {
+            let u = s("url");
+            if u.is_empty() {
+                "Fetching a page".to_string()
+            } else {
+                format!("Fetching: {}", truncate(u, COMMAND_LABEL_MAX))
+            }
+        }
+        "ask" => "Asking a question".to_string(),
+        "todo" => format!("{} {}", todo_op_verb(args, false), todo_target_label(args)),
         // Skill/memory tools already produce active labels ("Updating memory: X").
         _ => describe_tool_call(name, args),
     }
+}
+
+/// Present/past-tense verb for a `todo` tool call, keyed on its `op` argument.
+fn todo_op_verb(args: &serde_json::Value, past: bool) -> &'static str {
+    match (args.get("op").and_then(|v| v.as_str()).unwrap_or(""), past) {
+        ("init", false) => "Planning",
+        ("init", true) => "Planned",
+        ("start", false) => "Starting",
+        ("start", true) => "Started",
+        ("done", false) => "Completing",
+        ("done", true) => "Completed",
+        ("drop", false) => "Abandoning",
+        ("drop", true) => "Abandoned",
+        ("rm", false) => "Removing",
+        ("rm", true) => "Removed",
+        ("append", false) => "Adding",
+        ("append", true) => "Added",
+        ("view", false) => "Checking",
+        ("view", true) => "Checked",
+        (_, false) => "Updating",
+        (_, true) => "Updated",
+    }
+}
+
+/// Concise subject for a `todo` tool call's verb: the named task/phase, an
+/// item count for `append`, or "todos" as a generic fallback.
+fn todo_target_label(args: &serde_json::Value) -> String {
+    if let Some(task) = args.get("task").and_then(|v| v.as_str()) {
+        return format!("task: {}", truncate(task, COMMAND_LABEL_MAX));
+    }
+    if let Some(phase) = args.get("phase").and_then(|v| v.as_str()) {
+        if let Some(items) = args.get("items").and_then(|v| v.as_array()) {
+            if !items.is_empty() {
+                let n = items.len();
+                return format!("{n} task{} to {phase}", if n == 1 { "" } else { "s" });
+            }
+        }
+        return format!("phase: {phase}");
+    }
+    if let Some(list) = args.get("list").and_then(|v| v.as_array()) {
+        let n = list.len();
+        return format!("{n} phase{}", if n == 1 { "" } else { "s" });
+    }
+    if args.get("all").and_then(|v| v.as_bool()) == Some(true) {
+        return "all tasks".to_string();
+    }
+    "todos".to_string()
 }
 
 /// Detailed one-line label for a subagent's own tool call, shown in the live
@@ -2139,6 +2204,24 @@ fn tool_finished(name: &str, args: &serde_json::Value) -> String {
         "await_subagent" => format!("Subagent {} returned", subagent_name_from_run_id(s("run_id"))),
         "create_subagent" => format!("Created subagent: {}", s("name")),
         "list_subagents" => "Listed subagents".to_string(),
+        "web_search" => {
+            let q = s("query");
+            if q.is_empty() {
+                "Searched the web".to_string()
+            } else {
+                format!("Searched the web: {}", truncate(q, COMMAND_LABEL_MAX))
+            }
+        }
+        "web_fetch" => {
+            let u = s("url");
+            if u.is_empty() {
+                "Fetched a page".to_string()
+            } else {
+                format!("Fetched: {}", truncate(u, COMMAND_LABEL_MAX))
+            }
+        }
+        "ask" => "Asked a question".to_string(),
+        "todo" => format!("{} {}", todo_op_verb(args, true), todo_target_label(args)),
         _ => describe_tool_call(name, args),
     }
 }
@@ -6272,6 +6355,64 @@ mod tests {
             "Read main.rs"
         );
         assert_eq!(tool_finished("list", &json!({})), "Listed files");
+    }
+
+    /// `web_search`/`web_fetch`/`ask`/`todo` used to fall through to the raw
+    /// `"{name} {args}"` dump (no `tool_activity`/`tool_finished` match arm),
+    /// so a session mixing them with grep/read looked visually inconsistent
+    /// (friendly labels next to raw JSON blobs). Every builtin the model can
+    /// call now gets a concise label like the rest.
+    #[test]
+    fn every_builtin_gets_a_friendly_label_not_a_raw_json_dump() {
+        assert_eq!(
+            tool_activity("web_search", &json!({ "query": "rust async runtime" })),
+            "Searching the web: rust async runtime"
+        );
+        assert_eq!(
+            tool_finished("web_search", &json!({ "query": "rust async runtime" })),
+            "Searched the web: rust async runtime"
+        );
+        assert_eq!(
+            tool_activity("web_fetch", &json!({ "url": "https://example.com" })),
+            "Fetching: https://example.com"
+        );
+        assert_eq!(
+            tool_finished("web_fetch", &json!({ "url": "https://example.com" })),
+            "Fetched: https://example.com"
+        );
+        assert_eq!(tool_activity("ask", &json!({ "questions": [] })), "Asking a question");
+        assert_eq!(tool_finished("ask", &json!({ "questions": [] })), "Asked a question");
+    }
+
+    #[test]
+    fn todo_tool_label_names_the_op_and_target() {
+        assert_eq!(
+            tool_activity("todo", &json!({ "op": "start", "task": "write tests" })),
+            "Starting task: write tests"
+        );
+        assert_eq!(
+            tool_finished("todo", &json!({ "op": "done", "task": "write tests" })),
+            "Completed task: write tests"
+        );
+        assert_eq!(
+            tool_activity("todo", &json!({ "op": "drop", "all": true })),
+            "Abandoning all tasks"
+        );
+        assert_eq!(
+            tool_activity(
+                "todo",
+                &json!({ "op": "append", "phase": "Build", "items": ["a", "b"] })
+            ),
+            "Adding 2 tasks to Build"
+        );
+        assert_eq!(
+            tool_activity(
+                "todo",
+                &json!({ "op": "init", "list": [{ "phase": "Research", "items": ["a"] }] })
+            ),
+            "Planning 1 phase"
+        );
+        assert_eq!(tool_activity("todo", &json!({ "op": "view" })), "Checking todos");
     }
 
     fn line_text(line: &ratatui::text::Line) -> String {

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -410,6 +410,10 @@ struct App {
     /// Set after a turn finishes while a goal is active: the chat loop runs the
     /// evaluator off the render loop, then auto-continues or returns control.
     goal_eval_pending: bool,
+    /// Read-only plan mode. `Plan` blocks mutation-capable tools at the core
+    /// dispatcher (advisory prompt is defense in depth only). Persisted with
+    /// the thread so it survives restart/resume.
+    run_mode: crate::core::agent::plan::RunMode,
     /// Orchestration handle for out-of-run model calls (the `/compact` command).
     /// `None` in unit tests, set by `run` for the live session.
     args: Option<Arc<OrchestrationArgs>>,
@@ -621,6 +625,7 @@ impl App {
             model,
             goal: None,
             goal_eval_pending: false,
+            run_mode: crate::core::agent::plan::RunMode::Normal,
             args: None,
             max_turns,
             context_window,
@@ -1180,6 +1185,12 @@ impl App {
         if let Some(max) = self.max_tokens {
             body["max_tokens"] = serde_json::json!(max);
         }
+        // Live plan-mode toggle: the backend reads this per turn and falls back
+        // to the session default when absent. Only forwarded in Plan so normal
+        // turns keep an unchanged body.
+        if self.run_mode == crate::core::agent::plan::RunMode::Plan {
+            body["run_mode"] = serde_json::to_value(self.run_mode).unwrap_or(serde_json::Value::Null);
+        }
         body
     }
 
@@ -1203,9 +1214,10 @@ impl App {
     /// per-turn checkpoints, so `/resume` can restore and rewind. `None` when
     /// snapshots are inactive (keeps a plain `{}` metadata block).
     fn thread_metadata(&self) -> Option<serde_json::Value> {
-        // Persist metadata when either snapshots or a goal are present; a goal
+        // Persist metadata when snapshots, a goal, or plan mode are present; each
         // must survive restart/resume even in a non-git project (no snapshots).
-        if self.base_snapshot.is_none() && self.goal.is_none() {
+        let planning = self.run_mode == crate::core::agent::plan::RunMode::Plan;
+        if self.base_snapshot.is_none() && self.goal.is_none() && !planning {
             return None;
         }
         let mut meta = serde_json::Map::new();
@@ -1217,6 +1229,13 @@ impl App {
             meta.insert(
                 "goal".to_string(),
                 serde_json::to_value(goal).unwrap_or(serde_json::Value::Null),
+            );
+        }
+        // Only persisted in Plan (Normal is the default; keeps old threads clean).
+        if planning {
+            meta.insert(
+                "run_mode".to_string(),
+                serde_json::to_value(self.run_mode).unwrap_or(serde_json::Value::Null),
             );
         }
         Some(serde_json::Value::Object(meta))
@@ -1595,8 +1614,11 @@ impl App {
         // A turn just completed under an active goal: count it and queue an
         // evaluation. The chat loop runs the (stateless) evaluator off the
         // render loop, then auto-continues or hands control back.
+        // Plan mode pauses the goal loop: never auto-continue a goal while
+        // planning (spec: entering plan pauses an active goal).
+        let planning = self.run_mode == crate::core::agent::plan::RunMode::Plan;
         if let Some(goal) = self.goal.as_mut() {
-            if goal.is_active() {
+            if goal.is_active() && !planning {
                 goal.turns = goal.turns.saturating_add(1);
                 // Only evaluate on a normal completion; an early/no-answer finish
                 // is surfaced above and the user decides what to do next.
@@ -2778,12 +2800,55 @@ async fn resolve_front_ask(
     let Some(ask) = app.ask_queue.pop_front() else {
         return;
     };
+    // Reserved plan-review ask: a single question with the exact id drives the
+    // mode transition. Capture the chosen label before `answers` is moved into
+    // the outcome. Skipped on cancel so a cancelled review never changes mode.
+    let plan_choice = (!cancelled
+        && ask.request.questions.len() == 1
+        && ask.request.questions[0].id == crate::core::agent::plan::PLAN_REVIEW_QUESTION_ID)
+        .then(|| ask.answers.first().and_then(|a| a.selected.first().cloned()))
+        .flatten();
     let outcome = if cancelled {
         Err(crate::core::agent::interaction::AskError::Cancelled)
     } else {
         Ok(ask.answers)
     };
+    // Always respond so the model's in-flight turn completes normally.
     let _ = crate::core::agent::interaction::respond(registry, &ask.request_id, outcome).await;
+    if let Some(label) = plan_choice {
+        apply_plan_review(app, &label);
+    }
+}
+
+/// Drive the plan-mode transition from a `plan_review` answer. The model has
+/// already staged todos via `todo(init)` earlier in the same turn; here we only
+/// flip the mode (and, for Execute, queue the continuation turn). Persists so
+/// the mode survives resume.
+fn apply_plan_review(app: &mut App, label: &str) {
+    use crate::core::agent::plan::{self, RunMode};
+    match label {
+        plan::EXECUTE_PLAN_LABEL => {
+            // Atomic handoff: refuse to leave Plan unless the plan was actually
+            // staged (spec: failed todo init keeps the agent in Plan intact).
+            if app.todos.is_empty() {
+                app.note("cannot execute: no plan staged (todo init first); staying in plan mode");
+                return;
+            }
+            app.run_mode = RunMode::Normal;
+            app.persist();
+            app.note("▶ executing plan (normal mode)");
+            // Enqueues while the ask turn is still running; on_done dequeues it,
+            // starting execution only after the mode switch has committed.
+            app.submit_user("Proceed with the plan.".to_string());
+        }
+        plan::KEEP_PLANNING_LABEL => app.note("continuing to plan (read only)"),
+        plan::EXIT_PLAN_LABEL => {
+            app.run_mode = RunMode::Normal;
+            app.persist();
+            app.note("exited plan mode (no execution)");
+        }
+        other => app.note(&format!("unknown plan review choice: {other}")),
+    }
 }
 
 /// Handle keys owned by the front interactive question. Returns false only for
@@ -3221,6 +3286,11 @@ const SLASH_COMMANDS: &[SlashCommand] = &[
         description: "Keep working until a condition is met (bare: status)",
     },
     SlashCommand {
+        name: "/plan",
+        hint: "[exit]",
+        description: "Enter read-only plan mode (bare) or /plan exit to leave",
+    },
+    SlashCommand {
         name: "/threads",
         hint: "",
         description: "List saved threads for this project",
@@ -3343,6 +3413,7 @@ async fn run_command(app: &mut App, line: &str) {
         "mcp" => open_mcp_picker(app),
         "config" => open_config_screen(app),
         "goal" => goal_command(app, arg),
+        "plan" => plan_command(app, arg),
         "cancel" => cancel_command(app, arg),
         "quit" | "exit" => app.should_quit = true,
         other => app.note(&format!("unknown command '/{other}' (try /help)")),
@@ -3400,6 +3471,42 @@ fn goal_command(app: &mut App, arg: &str) {
         }
         "" => show_goal_status(app),
         condition => set_goal(app, condition),
+    }
+}
+
+/// `/plan` dispatcher: bare enters read-only plan mode, `/plan exit` leaves it.
+/// Only settable while idle so it never races the live tool set of a running
+/// turn (spec). Enforcement is at the core dispatcher; this just flips the
+/// per-turn flag forwarded in `App::body()` and persists it.
+fn plan_command(app: &mut App, arg: &str) {
+    use crate::core::agent::plan::RunMode;
+    if app.status != Status::Idle {
+        app.note("plan mode is only settable while idle");
+        return;
+    }
+    match arg.trim() {
+        "exit" => {
+            if app.run_mode == RunMode::Plan {
+                app.run_mode = RunMode::Normal;
+                app.persist();
+                app.note("exited plan mode (normal execution)");
+            } else {
+                app.note("not in plan mode");
+            }
+        }
+        "" => {
+            if app.run_mode == RunMode::Plan {
+                app.note("already in plan mode (/plan exit to leave)");
+                return;
+            }
+            app.run_mode = RunMode::Plan;
+            app.persist();
+            app.note("◈ PLAN · read only — investigate, then propose a plan for review");
+            if app.goal.is_some() {
+                app.note("active goal paused while planning; it resumes on exit");
+            }
+        }
+        other => app.note(&format!("usage: /plan [exit]  (got '{other}')")),
     }
 }
 
@@ -3743,6 +3850,24 @@ fn restore_goal(app: &mut App, metadata: Option<&serde_json::Value>) {
     }
 }
 
+/// Reload the persisted `RunMode` for a resumed thread. Defaults to `Normal` on
+/// absence/malformed metadata. Resume restores the mode only; the run stays at
+/// `Status::Idle` (set by the resume path), so a saved plan never auto-executes.
+fn restore_run_mode(app: &mut App, metadata: Option<&serde_json::Value>) {
+    use crate::core::agent::plan::RunMode;
+    app.run_mode = RunMode::Normal;
+    let Some(meta) = metadata else { return };
+    if let Some(mode) = meta
+        .get("run_mode")
+        .and_then(|v| serde_json::from_value::<RunMode>(v.clone()).ok())
+    {
+        app.run_mode = mode;
+        if mode == RunMode::Plan {
+            app.note("resumed in plan mode (read only); /plan exit to leave");
+        }
+    }
+}
+
 /// Open the double-Esc rewind picker listing the conversation's user messages.
 fn open_rewind_picker(app: &mut App) {
     let mut items = Vec::new();
@@ -3920,6 +4045,7 @@ fn load_thread(app: &mut App, thread: &serde_json::Value) {
     app.message_queue.clear();
     restore_snapshots(app, thread.get("metadata"));
     restore_goal(app, thread.get("metadata"));
+    restore_run_mode(app, thread.get("metadata"));
 
     // Adopt the thread's model so continuation stays coherent.
     if let Some(model) = thread
@@ -4758,6 +4884,14 @@ fn header(app: &App) -> Paragraph<'static> {
             GoalStatus::Achieved => ("  ◎ /goal done".to_string(), Style::new().green()),
         };
         spans.push(Span::styled(label, gstyle));
+    }
+    // Plan-mode badge: `PLAN · read only`. Only shown in Plan mode; normal mode
+    // keeps its existing layout unchanged (spec).
+    if app.run_mode == crate::core::agent::plan::RunMode::Plan {
+        spans.push(Span::styled(
+            "  PLAN · read only",
+            Style::new().magenta().bold(),
+        ));
     }
     spans.push(Span::raw("  "));
     spans.push(Span::styled(format!("[{status}]"), style));

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -553,6 +553,9 @@ struct App {
     /// Messages queued while a run is in progress, dequeued automatically
     /// when the current turn finishes.
     message_queue: std::collections::VecDeque<String>,
+    /// Canonical session todo list projection, kept in sync via
+    /// `StreamEvent::TodoUpdate`. Empty = no todos declared this session.
+    todos: crate::core::agent::todo::TodoList,
 }
 
 /// Braille throbber frames for in-progress rows (e.g. awaiting a subagent).
@@ -675,6 +678,7 @@ impl App {
             run_started: None,
             mouse_capture: true,
             message_queue: std::collections::VecDeque::new(),
+            todos: crate::core::agent::todo::TodoList::default(),
         }
     }
 
@@ -1502,6 +1506,9 @@ impl App {
             StreamEvent::MessagesUpdated { messages } => {
                 self.history = messages;
                 self.persist();
+            }
+            StreamEvent::TodoUpdate { list } => {
+                self.todos = list;
             }
         }
     }
@@ -2452,6 +2459,8 @@ pub async fn run(
     } = session;
     let ask_requests = crate::core::agent::interaction::new_registry();
     args.ask_requests = Some(ask_requests.clone());
+    let todo_registry = crate::core::agent::todo::new_registry();
+    args.todo_registry = Some(todo_registry.clone());
     let args = Arc::new(args);
 
     enable_raw_mode().map_err(|e| e.to_string())?;

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -21,7 +21,10 @@ use ratatui::crossterm::{
         MouseEvent, MouseEventKind,
     },
     execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    terminal::{
+        disable_raw_mode, enable_raw_mode, BeginSynchronizedUpdate, EndSynchronizedUpdate,
+        EnterAlternateScreen, LeaveAlternateScreen,
+    },
 };
 use ratatui::prelude::*;
 use ratatui::widgets::{Block, Borders, Paragraph, Wrap};
@@ -2770,9 +2773,16 @@ async fn chat_loop<B: Backend>(
             }
         }
 
-        terminal
-            .draw(|f| draw(f, app))
-            .map_err(|e| e.to_string())?;
+        // Wrap the repaint in synchronized-output (`\x1b[?2026h/l`) so the
+        // terminal buffers the whole frame and flips it atomically, eliminating
+        // tearing. Written straight to stdout (not the generic `Backend`) for the
+        // same reason mouse-capture toggles are: `chat_loop` is generic over B
+        // for TestBackend, which isn't `io::Write`. ratatui already diffs the
+        // buffer and emits ANSI only for changed cells.
+        let _ = execute!(io::stdout(), BeginSynchronizedUpdate);
+        let draw_result = terminal.draw(|f| draw(f, app)).map_err(|e| e.to_string());
+        let _ = execute!(io::stdout(), EndSynchronizedUpdate);
+        draw_result?;
 
         tokio::select! {
             _ = ticker.tick() => {

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -4802,20 +4802,22 @@ fn draw(f: &mut Frame, app: &mut App) {
     let todo_lines = (app.picker.is_none() && !app.todos.is_empty()).then(|| todo_hud(app));
     let todo_h = todo_lines.as_ref().map_or(0, |l| l.len() as u16);
     let show_todo = todo_h > 0;
-    // Persistent chrome (header, todos, path, footer hints) is grouped at the
-    // top so the bottom of the screen is just the input box; only the
-    // scrolling transcript and the input grow/shrink with content.
+    // Header/path/footer chrome stays pinned top and bottom; the todo HUD
+    // sits directly above the input box instead -- the last thing in view
+    // right before where the user types, not competing with the header for
+    // attention. Kept out of the layout entirely when there are no todos (or
+    // an overlay is open) so that case renders exactly as before.
     let (todo_area, chunks) = if show_todo {
         let raw = Layout::vertical([
-            Constraint::Length(1),        // 0: header
-            Constraint::Length(todo_h),   // 1: todo HUD
-            Constraint::Length(1),        // 2: path line
-            Constraint::Length(1),        // 3: footer
-            Constraint::Min(1),           // 4: body
-            Constraint::Length(input_h),  // 5: input
+            Constraint::Length(1),       // 0: header
+            Constraint::Length(1),       // 1: path line
+            Constraint::Length(1),       // 2: footer
+            Constraint::Min(1),          // 3: body
+            Constraint::Length(todo_h),  // 4: todo HUD
+            Constraint::Length(input_h), // 5: input
         ])
         .split(f.area());
-        (Some(raw[1]), [raw[0], raw[4], raw[5], raw[2], raw[3]])
+        (Some(raw[4]), [raw[0], raw[3], raw[5], raw[1], raw[2]])
     } else {
         let raw = Layout::vertical([
             Constraint::Length(1),       // 0: header
@@ -4829,11 +4831,6 @@ fn draw(f: &mut Frame, app: &mut App) {
     };
 
     f.render_widget(header(app), chunks[0]);
-    if let Some(area) = todo_area {
-        // `show_todo` (and thus `todo_area`) is only `Some` when `todo_lines`
-        // was built above.
-        f.render_widget(Paragraph::new(todo_lines.unwrap()), area);
-    }
 
     // Top/bottom borders only, so wrapping uses the full width; the two border
     // rows reduce the vertical viewport. Cache the width so flushed tables wrap.
@@ -5040,6 +5037,10 @@ fn draw(f: &mut Frame, app: &mut App) {
     } else {
         0
     };
+    if let Some(area) = todo_area {
+        // `todo_area` is only `Some` when `todo_lines` was built above.
+        f.render_widget(Paragraph::new(todo_lines.unwrap()), area);
+    }
     f.render_widget(input_box(app).scroll((input_scroll, 0)), chunks[2]);
     f.render_widget(path_line(app), chunks[3]);
     f.render_widget(footer(app), chunks[4]);

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -4685,31 +4685,31 @@ fn draw(f: &mut Frame, app: &mut App) {
     let todo_lines = (app.picker.is_none() && !app.todos.is_empty()).then(|| todo_hud(app));
     let todo_h = todo_lines.as_ref().map_or(0, |l| l.len() as u16);
     let show_todo = todo_h > 0;
-    let raw = if show_todo {
-        Layout::vertical([
-            Constraint::Length(1), // header
-            Constraint::Length(todo_h), // todo HUD
-            Constraint::Min(1),
-            Constraint::Length(input_h),
-            Constraint::Length(1), // path line
-            Constraint::Length(1), // footer
+    // Persistent chrome (header, todos, path, footer hints) is grouped at the
+    // top so the bottom of the screen is just the input box; only the
+    // scrolling transcript and the input grow/shrink with content.
+    let (todo_area, chunks) = if show_todo {
+        let raw = Layout::vertical([
+            Constraint::Length(1),        // 0: header
+            Constraint::Length(todo_h),   // 1: todo HUD
+            Constraint::Length(1),        // 2: path line
+            Constraint::Length(1),        // 3: footer
+            Constraint::Min(1),           // 4: body
+            Constraint::Length(input_h),  // 5: input
         ])
-        .split(f.area())
+        .split(f.area());
+        (Some(raw[1]), [raw[0], raw[4], raw[5], raw[2], raw[3]])
     } else {
-        Layout::vertical([
-            Constraint::Length(1),
-            Constraint::Min(1),
-            Constraint::Length(input_h),
-            Constraint::Length(1),
-            Constraint::Length(1),
+        let raw = Layout::vertical([
+            Constraint::Length(1),       // 0: header
+            Constraint::Length(1),       // 1: path line
+            Constraint::Length(1),       // 2: footer
+            Constraint::Min(1),          // 3: body
+            Constraint::Length(input_h), // 4: input
         ])
-        .split(f.area())
+        .split(f.area());
+        (None, [raw[0], raw[3], raw[4], raw[1], raw[2]])
     };
-    let todo_area = show_todo.then(|| raw[1]);
-    // Remap to a stable [header, body, input, path, footer] so the rest of draw
-    // is indifferent to whether the strip is present.
-    let base = if show_todo { 1 } else { 0 };
-    let chunks = [raw[0], raw[base + 1], raw[base + 2], raw[base + 3], raw[base + 4]];
 
     f.render_widget(header(app), chunks[0]);
     if let Some(area) = todo_area {

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -537,8 +537,14 @@ struct App {
     /// Rendered as a live throbber and cleared on the matching `ToolCall` (full
     /// args) or on the next `Step`, whichever comes first.
     starting: Vec<(String, String)>,
-    /// Monotonic frame counter advanced each render tick; drives the throbber.
+    /// Monotonic frame counter driving the throbber. Advanced by whole
+    /// `SPINNER_ADVANCE_MS` steps elapsed since `last_spinner_advance`, not once
+    /// per tick, so the animation runs at a fixed cadence and catches up after a
+    /// stalled loop instead of lagging.
     spinner_frame: usize,
+    /// Wall-clock baseline for the last spinner advance; moved forward by whole
+    /// frames only so leftover sub-frame time carries into the next tick.
+    last_spinner_advance: Instant,
     /// Transcript viewport rect from the last draw, for mapping mouse clicks
     /// to rows.
     transcript_rect: Rect,
@@ -578,6 +584,9 @@ struct App {
 
 /// Braille throbber frames for in-progress rows (e.g. awaiting a subagent).
 const SPINNER: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// Milliseconds per spinner frame, decoupled from the 50ms render tick.
+const SPINNER_ADVANCE_MS: u64 = 80;
 
 /// Live rolling view of an in-flight subagent's tool calls. The panel shows only
 /// the most recent [`SUBAGENT_WINDOW`] calls, but the full list is retained so
@@ -691,6 +700,7 @@ impl App {
             awaiting: Vec::new(),
             starting: Vec::new(),
             spinner_frame: 0,
+            last_spinner_advance: Instant::now(),
             transcript_rect: Rect::default(),
             last_scroll: 0,
             row_index: Vec::new(),
@@ -1116,6 +1126,19 @@ impl App {
     /// in the same input batch can't slip through as a second submit.
     /// When already running, the message is enqueued instead and auto-submitted
     /// when the current turn finishes.
+    /// Advance the spinner by however many whole `SPINNER_ADVANCE_MS` frames
+    /// have elapsed since the last advance (0 if under one frame, >1 on catch-up
+    /// after a stalled tick). The baseline moves forward by whole frames only so
+    /// leftover sub-frame milliseconds are not lost across ticks.
+    fn advance_spinner(&mut self, now: Instant) {
+        let elapsed = now.duration_since(self.last_spinner_advance).as_millis() as u64;
+        let frames = (elapsed / SPINNER_ADVANCE_MS) as usize;
+        if frames > 0 {
+            self.spinner_frame = self.spinner_frame.wrapping_add(frames);
+            self.last_spinner_advance += Duration::from_millis(frames as u64 * SPINNER_ADVANCE_MS);
+        }
+    }
+
     fn submit_user(&mut self, text: String) {
         // If a turn is already in progress, enqueue the message instead
         if self.status == Status::Running {
@@ -2735,8 +2758,9 @@ async fn chat_loop<B: Backend>(
 
         tokio::select! {
             _ = ticker.tick() => {
-                // Advance the frame counter always so the cursor blinks even when idle.
-                app.spinner_frame = app.spinner_frame.wrapping_add(1);
+                // Advance the throbber at its own fixed cadence, catching up
+                // whole frames if a tick stalled (a burst of deltas / slow term).
+                app.advance_spinner(Instant::now());
                 while event::poll(Duration::ZERO).unwrap_or(false) {
                     match event::read() {
                         Ok(Event::Key(key)) => {
@@ -5444,8 +5468,8 @@ fn footer(app: &App) -> Paragraph<'static> {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_user_message, clipboard_path, diff_lines, group_activity, group_detail_lines,
-        apply_resume, build_user_message, clipboard_path, diff_lines, group_activity, group_detail_lines,
+        apply_resume, build_user_message, clipboard_path, diff_lines, group_activity,
+        group_detail_lines,
         group_summary, handle_ask_key, handle_ask_mouse, handle_key, handle_mouse, image_mime,
         input_content_lines, is_table_separator, load_image_file, message_text,
         open_config_screen, parse_command, render_table, restore_goal, restore_run_mode,
@@ -5453,8 +5477,9 @@ mod tests {
         running_group_row, split_reasoning, subagent_activity, subagent_name_from_run_id,
         summarize_result, tool_activity, tool_finished, transcript_top_padding,
         user_content_parts, App, CurrentRun, Pending, PendingImage, PickerKind, ResumeTarget,
-        SnapshotJob, Status, DIFF_MAX_ROWS, SLASH_COMMANDS, SPINNER,
+        SnapshotJob, Status, DIFF_MAX_ROWS, SLASH_COMMANDS, SPINNER, SPINNER_ADVANCE_MS,
     };
+    use std::time::{Duration, Instant};
     use ratatui::crossterm::event::{
         KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
     };
@@ -5490,6 +5515,37 @@ mod tests {
             selected: 0,
             subagent: None,
         }
+    }
+
+    #[test]
+    fn spinner_advances_only_after_a_full_frame_elapses() {
+        let mut app = test_app();
+        let t0 = Instant::now();
+        app.last_spinner_advance = t0;
+        app.spinner_frame = 0;
+        // One 50ms tick is under the 80ms frame time: no advance.
+        app.advance_spinner(t0 + Duration::from_millis(50));
+        assert_eq!(app.spinner_frame, 0);
+        // A second tick brings cumulative elapsed to 100ms (>= 80): +1 frame.
+        app.advance_spinner(t0 + Duration::from_millis(100));
+        assert_eq!(app.spinner_frame, 1);
+        // Leftover 20ms carried forward: next advance is at 160ms, not 180ms.
+        app.advance_spinner(t0 + Duration::from_millis(150));
+        assert_eq!(app.spinner_frame, 1);
+        app.advance_spinner(t0 + Duration::from_millis(165));
+        assert_eq!(app.spinner_frame, 2);
+    }
+
+    #[test]
+    fn spinner_catches_up_multiple_frames_after_a_stall() {
+        let mut app = test_app();
+        let t0 = Instant::now();
+        app.last_spinner_advance = t0;
+        app.spinner_frame = 0;
+        // A 500ms stall == floor(500/80) = 6 frames caught up in one advance.
+        app.advance_spinner(t0 + Duration::from_millis(500));
+        assert_eq!(app.spinner_frame, (500 / SPINNER_ADVANCE_MS) as usize);
+        assert_eq!(app.spinner_frame, 6);
     }
 
     #[test]

--- a/src-tauri/src/core/server/proxy.rs
+++ b/src-tauri/src/core/server/proxy.rs
@@ -30,7 +30,8 @@ pub(crate) use crate::core::agent::r#loop::run_server_side_openai_orchestration;
 pub(crate) use crate::core::agent::upstream::{
     call_openai_chat_completions, collect_mcp_openai_tools, copy_optional_chat_params,
     execute_mcp_tool_calls, extract_choice_message, extract_tool_calls, load_assistant_config,
-    parse_openai_messages, resolve_upstream_for_model, set_system_prompt,
+    parse_openai_messages, repair_dangling_tool_calls, resolve_upstream_for_model,
+    set_system_prompt,
 };
 use crate::core::openai_schema::{
     http_status_indicates_api_key_retry, normalize_openai_tools_in_chat_body,
@@ -1213,6 +1214,13 @@ async fn proxy_request(
                     return Ok(error_response.body(full(e)).unwrap());
                 }
             };
+            // Self-heal a client-supplied conversation that has a tool_calls
+            // turn missing one of its results -- some providers (notably
+            // Anthropic) reject the entire request on a dangling tool_use.
+            let repaired = repair_dangling_tool_calls(&mut conversation_messages);
+            if repaired > 0 {
+                log::warn!("proxy: repaired {repaired} dangling tool call(s) with no prior result");
+            }
 
             // Load assistant config for system prompt + model hint when assistant_id is provided.
             let (assistant_instructions, assistant_model_hint) =


### PR DESCRIPTION
## Summary
- add read-only plan mode with explicit execution handoff
- add interactive structured `ask` and canonical session `todo` workflows to the agent TUI
- make the default agent prompt proactively use those workflows for substantive work

## Verification
- `cargo test --no-default-features --features cli --lib`
- `cargo build --release --no-default-features --features cli --bin jan`

## Notes
- Plan mode gates mutation-capable tools and preserves the session state through handoff.