### PR TITLE
ci(cli): embed update channel/version in nightly builds, run Tue/Thu

### DIFF
--- a/.github/workflows/jan-tauri-build-agent-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-agent-nightly.yaml
@@ -2,7 +2,7 @@ name: Jan Agent CLI - Nightly Build
 
 on:
   schedule:
-    - cron: '0 10 * * *' # 10 AM UTC daily
+    - cron: '0 10 * * 2,4' # 10 AM UTC Tuesday and Thursday
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/template-cli-build-linux-x64.yml
+++ b/.github/workflows/template-cli-build-linux-x64.yml
@@ -49,6 +49,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build CLI binary
+        env:
+          JAN_CLI_UPDATE_CHANNEL: ${{ inputs.channel }}
+          JAN_CLI_BUILD_VERSION: ${{ inputs.new_version }}
         run: |
           cd src-tauri
           cargo build --features cli --bin jan --release

--- a/.github/workflows/template-cli-build-macos.yml
+++ b/.github/workflows/template-cli-build-macos.yml
@@ -61,11 +61,17 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build CLI binary (x86_64)
+        env:
+          JAN_CLI_UPDATE_CHANNEL: ${{ inputs.channel }}
+          JAN_CLI_BUILD_VERSION: ${{ inputs.new_version }}
         run: |
           cd src-tauri
           cargo build --features cli --bin jan --release --target x86_64-apple-darwin
 
       - name: Build CLI binary (aarch64)
+        env:
+          JAN_CLI_UPDATE_CHANNEL: ${{ inputs.channel }}
+          JAN_CLI_BUILD_VERSION: ${{ inputs.new_version }}
         run: |
           cd src-tauri
           cargo build --features cli --bin jan --release --target aarch64-apple-darwin

--- a/.github/workflows/template-cli-build-windows-x64.yml
+++ b/.github/workflows/template-cli-build-windows-x64.yml
@@ -49,6 +49,9 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Build CLI binary
+        env:
+          JAN_CLI_UPDATE_CHANNEL: ${{ inputs.channel }}
+          JAN_CLI_BUILD_VERSION: ${{ inputs.new_version }}
         run: |
           cd src-tauri
           cargo build --features cli --bin jan --release


### PR DESCRIPTION
## Describe Your Changes

- Sets JAN_CLI_UPDATE_CHANNEL/JAN_CLI_BUILD_VERSION during the cargo build step so the jan CLI's startup update check can compare against the published channel manifest. Also moves the agent nightly schedule from daily to Tuesday and Thursday.


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
