### PR TITLE
ci(cli): build with --no-default-features and guard against GUI crates

### DIFF
--- a/.github/workflows/template-cli-build-linux-x64.yml
+++ b/.github/workflows/template-cli-build-linux-x64.yml
@@ -54,7 +54,20 @@ jobs:
           JAN_CLI_BUILD_VERSION: ${{ inputs.new_version }}
         run: |
           cd src-tauri
-          cargo build --features cli --bin jan --release
+          cargo build --no-default-features --features cli --bin jan --release
+
+      - name: Assert no GUI crates
+        run: |
+          cd src-tauri
+          if cargo tree --no-default-features --features cli -i tauri >/dev/null 2>&1 || \
+             cargo tree --no-default-features --features cli -i gtk >/dev/null 2>&1 || \
+             cargo tree --no-default-features --features cli -i gdk >/dev/null 2>&1 || \
+             cargo tree --no-default-features --features cli -i muda >/dev/null 2>&1 || \
+             cargo tree --no-default-features --features cli -i wry >/dev/null 2>&1 || \
+             cargo tree --no-default-features --features cli -i webkit2gtk >/dev/null 2>&1; then
+            echo "GUI crate leaked into the CLI dependency graph" >&2
+            exit 1
+          fi
 
       - name: Strip binary
         run: strip src-tauri/target/release/jan

--- a/.github/workflows/template-cli-build-macos.yml
+++ b/.github/workflows/template-cli-build-macos.yml
@@ -66,7 +66,7 @@ jobs:
           JAN_CLI_BUILD_VERSION: ${{ inputs.new_version }}
         run: |
           cd src-tauri
-          cargo build --features cli --bin jan --release --target x86_64-apple-darwin
+          cargo build --no-default-features --features cli --bin jan --release --target x86_64-apple-darwin
 
       - name: Build CLI binary (aarch64)
         env:
@@ -74,7 +74,7 @@ jobs:
           JAN_CLI_BUILD_VERSION: ${{ inputs.new_version }}
         run: |
           cd src-tauri
-          cargo build --features cli --bin jan --release --target aarch64-apple-darwin
+          cargo build --no-default-features --features cli --bin jan --release --target aarch64-apple-darwin
 
       - name: Create universal binary
         run: |

--- a/.github/workflows/template-cli-build-windows-x64.yml
+++ b/.github/workflows/template-cli-build-windows-x64.yml
@@ -54,7 +54,7 @@ jobs:
           JAN_CLI_BUILD_VERSION: ${{ inputs.new_version }}
         run: |
           cd src-tauri
-          cargo build --features cli --bin jan --release
+          cargo build --no-default-features --features cli --bin jan --release
 
       - name: Package zip
         id: package


### PR DESCRIPTION
## Describe Your Changes

- Add missing --no-default-features to all three CLI build templates, and add a Linux CI check that fails if tauri/gtk/gdk/muda/wry/webkit2gtk ever leak back into the CLI dependency graph.


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
