### PR TITLE
ci(cli): install libdbus-1-dev for linux CLI build

### DIFF
--- a/.github/workflows/template-cli-build-linux-x64.yml
+++ b/.github/workflows/template-cli-build-linux-x64.yml
@@ -53,14 +53,6 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      - name: Build CLI binary
-        env:
-          JAN_CLI_UPDATE_CHANNEL: ${{ inputs.channel }}
-          JAN_CLI_BUILD_VERSION: ${{ inputs.new_version }}
-        run: |
-          cd src-tauri
-          cargo build --no-default-features --features cli --bin jan --release
-
       - name: Assert no GUI crates
         run: |
           cd src-tauri
@@ -73,6 +65,14 @@ jobs:
             echo "GUI crate leaked into the CLI dependency graph" >&2
             exit 1
           fi
+
+      - name: Build CLI binary
+        env:
+          JAN_CLI_UPDATE_CHANNEL: ${{ inputs.channel }}
+          JAN_CLI_BUILD_VERSION: ${{ inputs.new_version }}
+        run: |
+          cd src-tauri
+          cargo build --no-default-features --features cli --bin jan --release
 
       - name: Strip binary
         run: strip src-tauri/target/release/jan

--- a/.github/workflows/template-cli-build-linux-x64.yml
+++ b/.github/workflows/template-cli-build-linux-x64.yml
@@ -45,6 +45,11 @@ jobs:
         with:
           toolchain: stable
 
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev pkg-config
+
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
## Describe Your Changes

- keyring (via dbus-secret-service) links against real libdbus on Linux,
which the CLI-only runner never installs, so libdbus-sys's build script
fails with a pkg-config error. Install libdbus-1-dev + pkg-config before
the build step.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
