### PR TITLE
ci(agent-nightly): add sha256 checksums, fix macOS notarization

### DIFF
--- a/.github/workflows/jan-tauri-build-agent-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-agent-nightly.yaml
@@ -73,13 +73,16 @@ jobs:
             "pub_date": "$PUB_DATE",
             "platforms": {
               "linux-x86_64": {
-                "url": "https://delta.jan.ai/agent-nightly/${{ needs.build-linux-x64.outputs.FILE_NAME }}"
+                "url": "https://delta.jan.ai/agent-nightly/${{ needs.build-linux-x64.outputs.FILE_NAME }}",
+                "sha256": "${{ needs.build-linux-x64.outputs.SHA256 }}"
               },
               "darwin-universal": {
-                "url": "https://delta.jan.ai/agent-nightly/${{ needs.build-macos.outputs.FILE_NAME }}"
+                "url": "https://delta.jan.ai/agent-nightly/${{ needs.build-macos.outputs.FILE_NAME }}",
+                "sha256": "${{ needs.build-macos.outputs.SHA256 }}"
               },
               "windows-x86_64": {
-                "url": "https://delta.jan.ai/agent-nightly/${{ needs.build-windows-x64.outputs.FILE_NAME }}"
+                "url": "https://delta.jan.ai/agent-nightly/${{ needs.build-windows-x64.outputs.FILE_NAME }}",
+                "sha256": "${{ needs.build-windows-x64.outputs.SHA256 }}"
               }
             }
           }

--- a/.github/workflows/template-cli-build-linux-x64.yml
+++ b/.github/workflows/template-cli-build-linux-x64.yml
@@ -28,12 +28,15 @@ on:
     outputs:
       FILE_NAME:
         value: ${{ jobs.build-linux-x64.outputs.FILE_NAME }}
+      SHA256:
+        value: ${{ jobs.build-linux-x64.outputs.SHA256 }}
 
 jobs:
   build-linux-x64:
     runs-on: ubuntu-22.04
     outputs:
       FILE_NAME: ${{ steps.package.outputs.FILE_NAME }}
+      SHA256: ${{ steps.package.outputs.SHA256 }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -84,6 +87,7 @@ jobs:
           FILE_NAME="jan-agent-linux-x86_64-$VERSION.tar.gz"
           tar czf "$FILE_NAME" -C src-tauri/target/release jan
           echo "FILE_NAME=$FILE_NAME" >> "$GITHUB_OUTPUT"
+          echo "SHA256=$(sha256sum "$FILE_NAME" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
       - name: Upload to S3
         run: |

--- a/.github/workflows/template-cli-build-macos.yml
+++ b/.github/workflows/template-cli-build-macos.yml
@@ -112,7 +112,10 @@ jobs:
         continue-on-error: true
         run: |
           if [ -n "${{ secrets.CODE_SIGN_P12_BASE64 }}" ]; then
-            codesign --force --sign "Developer ID Application" universal/jan --timestamp
+            # --options runtime is required: notarization rejects binaries
+            # without the hardened runtime enabled.
+            codesign --force --sign "Developer ID Application" universal/jan \
+              --options runtime --timestamp
           else
             echo "No signing cert configured; skipping code sign."
           fi
@@ -130,10 +133,11 @@ jobs:
         continue-on-error: true
         run: |
           if [ -n "${{ secrets.NOTARY_ISSUER }}" ]; then
-            # notarytool rejects .tar.gz outright (zip/pkg/dmg only), so zip the
-            # binary just for submission; the distributed artifact stays the tarball.
+            # notarytool rejects .tar.gz outright (zip/pkg/dmg only), so submit a
+            # zip; the distributed artifact stays the tarball. ditto is Apple's
+            # documented way to package a command line tool for notarization.
             NOTARIZE_ZIP="jan-agent-darwin-universal-notarize.zip"
-            zip -j "$NOTARIZE_ZIP" universal/jan
+            ditto -c -k universal/jan "$NOTARIZE_ZIP"
             xcrun notarytool submit "$NOTARIZE_ZIP" \
               --key /tmp/notary-key.p8 \
               --key-id "${{ secrets.NOTARY_KEY_ID }}" \

--- a/.github/workflows/template-cli-build-macos.yml
+++ b/.github/workflows/template-cli-build-macos.yml
@@ -39,12 +39,15 @@ on:
     outputs:
       FILE_NAME:
         value: ${{ jobs.build-macos.outputs.FILE_NAME }}
+      SHA256:
+        value: ${{ jobs.build-macos.outputs.SHA256 }}
 
 jobs:
   build-macos:
     runs-on: macos-latest
     outputs:
       FILE_NAME: ${{ steps.package.outputs.FILE_NAME }}
+      SHA256: ${{ steps.package.outputs.SHA256 }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -121,12 +124,17 @@ jobs:
           FILE_NAME="jan-agent-darwin-universal-$VERSION.tar.gz"
           tar czf "$FILE_NAME" -C universal jan
           echo "FILE_NAME=$FILE_NAME" >> "$GITHUB_OUTPUT"
+          echo "SHA256=$(shasum -a 256 "$FILE_NAME" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
       - name: Notarize (if configured)
         continue-on-error: true
         run: |
           if [ -n "${{ secrets.NOTARY_ISSUER }}" ]; then
-            xcrun notarytool submit "${{ steps.package.outputs.FILE_NAME }}" \
+            # notarytool rejects .tar.gz outright (zip/pkg/dmg only), so zip the
+            # binary just for submission; the distributed artifact stays the tarball.
+            NOTARIZE_ZIP="jan-agent-darwin-universal-notarize.zip"
+            zip -j "$NOTARIZE_ZIP" universal/jan
+            xcrun notarytool submit "$NOTARIZE_ZIP" \
               --key /tmp/notary-key.p8 \
               --key-id "${{ secrets.NOTARY_KEY_ID }}" \
               --issuer "${{ secrets.NOTARY_ISSUER }}" \

--- a/.github/workflows/template-cli-build-windows-x64.yml
+++ b/.github/workflows/template-cli-build-windows-x64.yml
@@ -28,12 +28,15 @@ on:
     outputs:
       FILE_NAME:
         value: ${{ jobs.build-windows-x64.outputs.FILE_NAME }}
+      SHA256:
+        value: ${{ jobs.build-windows-x64.outputs.SHA256 }}
 
 jobs:
   build-windows-x64:
     runs-on: windows-latest
     outputs:
       FILE_NAME: ${{ steps.package.outputs.FILE_NAME }}
+      SHA256: ${{ steps.package.outputs.SHA256 }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -64,6 +67,7 @@ jobs:
           FILE_NAME="jan-agent-windows-x86_64-$VERSION.zip"
           7z a "$FILE_NAME" ./src-tauri/target/release/jan.exe
           echo "FILE_NAME=$FILE_NAME" >> "$GITHUB_OUTPUT"
+          echo "SHA256=$(sha256sum "$FILE_NAME" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
       - name: Upload to S3
         shell: bash


### PR DESCRIPTION
## Summary
- **Checksums**: add a `SHA256` output to each platform build template, threaded into the nightly `manifest.json`. Verified the field name and platform keys match what `updater.rs` on `goal/general-agent` actually reads (`sha256`, `linux-x86_64` / `darwin-universal` / `windows-x86_64`), and that it hashes the same archive we upload.
- **macOS notarization**: `notarytool` rejects `.tar.gz` outright (zip/pkg/dmg only), so submit a zip built with `ditto`; the distributed artifact stays the tarball.
- **Hardened runtime**: added `--options runtime` to `codesign`. Notarization also rejects binaries without it, so the zip change alone would have swapped the "must be a zip archive" error for an `Invalid` verdict.

## Note
A notarization ticket can't be stapled to a bare binary (stapling only supports .app/.dmg/.pkg) — Gatekeeper verifies these via an online cdhash lookup instead, which is the normal path for CLI tools.

## Test plan
- [ ] Trigger the nightly workflow; all three platform builds succeed
- [ ] `manifest.json` has a valid `sha256` per platform
- [ ] macOS notarization returns `Accepted` (no "must be a zip archive", no hardened-runtime rejection)
- [ ] `jan update` verifies the checksum and installs