### PR TITLE
feat(tui): animate the running input placeholder

### DIFF
--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -1895,6 +1895,13 @@ impl App {
         self.todo_ok_this_turn = false;
     }
 
+    /// Current throbber frame. `spinner_frame` is advanced on a fixed cadence
+    /// by the render loop, so every animated row in a frame shows the same
+    /// glyph and they turn together instead of drifting apart.
+    fn spinner(&self) -> &'static str {
+        SPINNER[self.spinner_frame % SPINNER.len()]
+    }
+
     /// Flush the current turn and return its text as the final assistant answer.
     fn take_answer(&mut self) -> String {
         let answer = self.assistant_buf.trim().to_string();
@@ -5523,7 +5530,7 @@ fn draw(f: &mut Frame, app: &mut App) {
         if !last_blank {
             lines.push(Line::raw(""));
         }
-        let frame = SPINNER[app.spinner_frame % SPINNER.len()];
+        let frame = app.spinner();
         lines.extend(subagent_panel_lines(
             &mut app.subagents,
             app.context_window,
@@ -5560,7 +5567,7 @@ fn draw(f: &mut Frame, app: &mut App) {
         }
     }
     for (_, _, name) in &app.awaiting {
-        let frame = SPINNER[app.spinner_frame % SPINNER.len()];
+        let frame = app.spinner();
         lines.push(tool_row(
             frame,
             Style::new().cyan(),
@@ -5571,7 +5578,7 @@ fn draw(f: &mut Frame, app: &mut App) {
     // In-progress tool calls whose arguments are still streaming: a throbber
     // trails the prose until the full call (with args) arrives and renders its
     // own row.
-    let frame = SPINNER[app.spinner_frame % SPINNER.len()];
+    let frame = app.spinner();
     for call in &mut app.starting {
         lines.extend(starting_call_lines(call, frame));
     }
@@ -6519,15 +6526,26 @@ fn input_box(app: &App) -> Paragraph<'static> {
     } else if app.status == Status::Running && app.input.is_empty() {
         // Show queue status when running with empty input
         if app.message_queue.is_empty() {
-            Paragraph::new(Line::styled(
-                "working… (Esc to cancel, type to queue next message)",
-                Style::new().dim().italic(),
-            ))
+            // The spinner carries the motion; the rest of the row is static so
+            // the text stays readable rather than shifting under the eye.
+            Paragraph::new(Line::from(vec![
+                Span::styled(format!("{} ", app.spinner()), Style::new().cyan()),
+                Span::styled(
+                    "working… (Esc to cancel, type to queue next message)",
+                    Style::new().dim().italic(),
+                ),
+            ]))
             .block(block)
         } else {
             let n = app.message_queue.len();
-            let msg = format!("⏳ Queued ({n}) — Esc to cancel, type to add more");
-            Paragraph::new(Line::styled(msg, Style::new().yellow())).block(block)
+            Paragraph::new(Line::from(vec![
+                Span::styled(format!("{} ", app.spinner()), Style::new().yellow()),
+                Span::styled(
+                    format!("⏳ Queued ({n}) — Esc to cancel, type to add more"),
+                    Style::new().yellow(),
+                ),
+            ]))
+            .block(block)
         }
     } else if app.input.is_empty() {
         // Same `› ` arrow as the typing view, then a fixed (non-blinking)
@@ -9514,6 +9532,49 @@ mod tests {
         assert!(out.contains("Task 1 agent"), "{out}");
         assert!(out.contains("starting…"), "{out}");
         assert!(!out.contains('%'), "no share before the first response: {out}");
+    }
+
+    /// The running placeholder is the row a user stares at during a long turn.
+    /// A static "working…" reads as a hung UI, so it animates on the same
+    /// cadence as every other throbber.
+    #[test]
+    fn working_placeholder_animates() {
+        let mut app = test_app();
+        app.submit_user("go".into());
+        assert_eq!(app.status, Status::Running);
+
+        let frame_of = |app: &mut App| {
+            render_rows(app, 80, 12)
+                .into_iter()
+                .find(|r| r.contains("working…"))
+                .expect("running placeholder present")
+        };
+
+        app.spinner_frame = 0;
+        let first = frame_of(&mut app);
+        assert!(first.contains(SPINNER[0]), "expected frame 0 glyph: {first:?}");
+
+        app.spinner_frame = 3;
+        let later = frame_of(&mut app);
+        assert!(later.contains(SPINNER[3]), "expected frame 3 glyph: {later:?}");
+        assert_ne!(first, later, "row must change as the frame advances");
+
+        // The wording itself does not move, only the glyph.
+        assert!(later.contains("(Esc to cancel, type to queue next message)"), "{later:?}");
+    }
+
+    /// A queued-message row is still a running row, so it animates too.
+    #[test]
+    fn queued_placeholder_animates() {
+        let mut app = test_app();
+        app.submit_user("go".into());
+        app.message_queue.push_back("next".into());
+        app.spinner_frame = 5;
+        let row = render_rows(&mut app, 80, 12)
+            .into_iter()
+            .find(|r| r.contains("Queued"))
+            .expect("queued row present");
+        assert!(row.contains(SPINNER[5]), "expected frame 5 glyph: {row:?}");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The input dock's running row was the one live-status line in the TUI with no motion:

```
working… (Esc to cancel, type to queue next message)
```

During a long turn it is also the row the user is most likely to be staring at, so a static `working…` reads as a hung UI rather than a busy one — every *other* in-progress row in the frame is animating while this one sits still.

## Change

```
⠋ working… (Esc to cancel, type to queue next message)
⠙ working… (Esc to cancel, type to queue next message)
⠹ working… (Esc to cancel, type to queue next message)
```

Driven by the existing shared `spinner_frame`, not a new timer — so this row turns in lockstep with every other throbber instead of drifting against them. Only the glyph moves; the wording stays put so it remains readable.

Two small things beyond the literal fix:

- **The queued variant animates too** (`⏳ Queued (1) — Esc to cancel, type to add more`). It is equally a running row; animating only one would move the dead-looking row one state over rather than fix it.
- **`App::spinner()`** — the `SPINNER[frame % SPINNER.len()]` lookup was already copy-pasted at three call sites. This would have been a fourth, so it is one accessor now.

## Tests

**202 TUI tests pass**, clippy clean.

Two new: the glyph tracks `spinner_frame`, the rendered row actually *changes* as the frame advances (not just that a glyph is present), and the wording does not move. Plus the same for the queued row.
