### PR TITLE
feat: add Apiário Dev as a native provider

### DIFF
--- a/web-app/src/constants/__tests__/providers.test.ts
+++ b/web-app/src/constants/__tests__/providers.test.ts
@@ -12,7 +12,7 @@ describe('Apiário Provider Configuration', () => {
     expect(apiarioProvider?.base_url).toBe('https://api.apiario.dev/v1')
     expect(apiarioProvider?.api_key).toBe('')
     expect(apiarioProvider?.explore_models_url).toBe(
-      'https://docs.apiario.dev/models'
+      'https://apiario.dev/modelos'
     )
   })
 

--- a/web-app/src/constants/__tests__/providers.test.ts
+++ b/web-app/src/constants/__tests__/providers.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+
+describe('Apiário Provider Configuration', () => {
+  it('should be present in predefinedProviders', async () => {
+    const { predefinedProviders } = await import('@/constants/providers')
+    const apiarioProvider = predefinedProviders.find(
+      (p) => p.provider === 'apiario'
+    )
+
+    expect(apiarioProvider).toBeDefined()
+    expect(apiarioProvider?.active).toBe(true)
+    expect(apiarioProvider?.base_url).toBe('https://api.apiario.dev/v1')
+    expect(apiarioProvider?.api_key).toBe('')
+    expect(apiarioProvider?.explore_models_url).toBe(
+      'https://docs.apiario.dev/models'
+    )
+  })
+
+  it('should have correct settings structure', async () => {
+    const { predefinedProviders } = await import('@/constants/providers')
+    const apiarioProvider = predefinedProviders.find(
+      (p) => p.provider === 'apiario'
+    )
+
+    expect(apiarioProvider?.settings).toBeDefined()
+    expect(Array.isArray(apiarioProvider?.settings)).toBe(true)
+
+    const apiKeySetting = apiarioProvider?.settings.find(
+      (s) => s.key === 'api-key'
+    )
+    expect(apiKeySetting).toBeDefined()
+    expect(apiKeySetting?.title).toBe('API Key')
+    expect(apiKeySetting?.controller_type).toBe('input')
+    expect(typeof apiKeySetting?.description).toBe('string')
+    expect(apiKeySetting?.description).toContain('apiario.dev')
+  })
+
+  it('should have OpenAI-compatible api_type (undefined = default openai)', async () => {
+    const { predefinedProviders } = await import('@/constants/providers')
+    const apiarioProvider = predefinedProviders.find(
+      (p) => p.provider === 'apiario'
+    )
+
+    expect(apiarioProvider?.api_type).toBeUndefined()
+  })
+})

--- a/web-app/src/constants/providers.ts
+++ b/web-app/src/constants/providers.ts
@@ -403,7 +403,7 @@ export const predefinedProviders = [
     active: true,
     api_key: '',
     base_url: 'https://api.apiario.dev/v1',
-    explore_models_url: 'https://docs.apiario.dev/models',
+    explore_models_url: 'https://apiario.dev/modelos',
     provider: 'apiario',
     settings: [
       {

--- a/web-app/src/constants/providers.ts
+++ b/web-app/src/constants/providers.ts
@@ -399,4 +399,27 @@ export const predefinedProviders = [
     ],
     models: [],
   },
+  {
+    active: true,
+    api_key: '',
+    base_url: 'https://api.apiario.dev/v1',
+    explore_models_url: 'https://docs.apiario.dev/models',
+    provider: 'apiario',
+    settings: [
+      {
+        key: 'api-key',
+        title: 'API Key',
+        description:
+          'The Apiário API uses API keys for authentication. Visit [apiario.dev](https://apiario.dev) to get your API key.',
+        controller_type: 'input',
+        controller_props: {
+          placeholder: 'Insert API Key',
+          value: '',
+          type: 'password',
+          input_actions: ['unobscure', 'copy'],
+        },
+      },
+    ],
+    models: [],
+  },
 ]


### PR DESCRIPTION
This PR adds [Apiário Dev](https://apiario.dev/) as a native provider in Jan's predefined providers list. Apiário is an AI gateway that provides access to 25+ models from providers like Anthropic, DeepSeek, OpenAI, Maritaca, Moonshot, and others through a single OpenAI-compatible endpoint.

Changes

web-app/src/constants/providers.ts — Added apiario entry to the predefinedProviders array (23 lines)
web-app/src/constants/__tests__/providers.test.ts — Added validation tests for the new provider configuration (49 lines)

Why Apiário?

OpenAI-compatible — works with Jan's existing RemoteOAIEngine, no new engine needed
25+ models — includes Claude, GPT, DeepSeek, Sabiá, Kimi, and more
Single API key — access multiple model providers through one endpoint
api_type is undefined (defaults to 'openai') since the Apiário API follows the OpenAI format

Testing

 - Unit tests pass (3/3) — validates provider structure, settings, and API type
 - API endpoint verified — GET /v1/models returns models in OpenAI-compatible format
 - All existing tests remain green