### PR TITLE
fix(web-app): repair the type error breaking every build on goal/general-agent

### DIFF
--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -101,11 +101,9 @@ import JanBrowserExtensionDialog from '@/containers/dialogs/JanBrowserExtensionD
 import { useJanBrowserExtension } from '@/hooks/useJanBrowserExtension'
 import { useAgentMode } from '@/hooks/useAgentMode'
 import { useWebSearchConfig } from '@/hooks/useWebSearchConfig'
-import { usePathReferences } from '@/stores/path-references'
 import {
   parsePromptForReferences,
   resolvePathReference,
-  formatPathReferenceText,
   searchFiles,
   REFERENCE_PATTERN,
   type FilePickerEntry as FileEntry,
@@ -197,11 +195,6 @@ const ChatInput = memo(function ChatInput({
   const webSearchEnabled = useWebSearchConfig((s) => s.webSearchEnabled)
   const setWebSearchEnabled = useWebSearchConfig((s) => s.setWebSearchEnabled)
 
-  // ── @path file reference state ──────────────────────────────────────────
-  const pathRefs = usePathReferences((s) => s.references)
-  const setPathRefs = usePathReferences((s) => s.setReferences)
-  const clearPathRefs = usePathReferences((s) => s.clearReferences)
-
   const [filePickerOpen, setFilePickerOpen] = useState(false)
   const [filePickerQuery, setFilePickerQuery] = useState('')
   const [filePickerEntries, setFilePickerEntries] = useState<FileEntry[]>([])
@@ -218,7 +211,7 @@ const ChatInput = memo(function ChatInput({
     const loadWorkingDir = async () => {
       try {
         // Try to get project home directory
-        const { homeDir, documentDir } = await import('@tauri-apps/api/path')
+        const { homeDir } = await import('@tauri-apps/api/path')
         const home = await homeDir()
         setWorkingDir(home)
       } catch {
@@ -330,7 +323,7 @@ const ChatInput = memo(function ChatInput({
           }
         } else {
           parts.push(
-            `[File not found or too large: ${ref.rawPath}]`
+            `[File not found or too large: ${ref}]`
           )
         }
       }

--- a/web-app/src/lib/path-references.ts
+++ b/web-app/src/lib/path-references.ts
@@ -9,7 +9,7 @@
  *   as inline notices.
  */
 import { fs } from '@janhq/core'
-import type { PathReference, FilePickerEntry } from '@/types/path-reference'
+import type { FilePickerEntry } from '@/types/path-reference'
 
 export type { FilePickerEntry }
 


### PR DESCRIPTION
## Problem

`tsc -b` fails on `goal/general-agent`, so the `Build app` step fails on **every** PR into this branch before it compiles anything. It surfaced on the docs PR (#8455), which touches only `docs/`.

The branch runs no CI on push - only on PRs - so this sat unnoticed since `feat(agent): @path file references in chat input`.

```
src/containers/ChatInput.tsx(108,3): error TS6133: 'formatPathReferenceText' is declared but its value is never read.
src/containers/ChatInput.tsx(201,9): error TS6133: 'pathRefs' is declared but its value is never read.
src/containers/ChatInput.tsx(202,9): error TS6133: 'setPathRefs' is declared but its value is never read.
src/containers/ChatInput.tsx(203,9): error TS6133: 'clearPathRefs' is declared but its value is never read.
src/containers/ChatInput.tsx(221,26): error TS6133: 'documentDir' is declared but its value is never read.
src/containers/ChatInput.tsx(333,50): error TS2339: Property 'rawPath' does not exist on type 'string'.
src/lib/path-references.ts(12,15): error TS6196: 'PathReference' is declared but never used.
```

## The real bug

`parsePromptForReferences` returns `string[]` and `resolvePathReference` takes a `string`, so `ref` in the resolve loop is a **raw path**, not a `PathReference`:

```ts
const refs = parsePromptForReferences(text)      // string[]
for (const ref of refs) {
  const resolved = await resolvePathReference(ref, workingDir)
  ...
  parts.push(`[File not found or too large: ${ref.rawPath}]`)   // ← string has no .rawPath
}
```

Worth noting this isn't only a compile error: had it built, the not-found message would have read `[File not found or too large: undefined]`.

## The rest

Dead weight from the same refactor - away from store-held `PathReference` objects, toward parsing the prompt text directly. Each had exactly one occurrence in the file, its own declaration:

- `usePathReferences` import and its three selectors (`pathRefs`, `setPathRefs`, `clearPathRefs`)
- `formatPathReferenceText` import
- `documentDir` in a destructure that only uses `homeDir`
- `PathReference` type import in `path-references.ts`

The store itself is untouched, so re-wiring the chips UI later just means reading from it again.

## Verification

`tsc -b` over the full workspace, with `core` and the plugin API packages built first the way CI does it: **clean**, no errors.

Unblocks #8455 and any other PR into this branch.
