### PR TITLE
fix(tui,agent): stop finished todo lists lingering, and stop planning trivial work

### DIFF
--- a/src-tauri/src/core/agent/context.rs
+++ b/src-tauri/src/core/agent/context.rs
@@ -18,7 +18,7 @@ running commands, editing code, and writing new files.";
 /// Always-on behavioral guidelines. Kept short and model-facing.
 const GUIDELINES: &str =
     "# Guidelines\n\n- Be concise in your responses.\n- Show file paths clearly when working with files.\n\
-- For substantive work with multiple steps or repository changes, call `todo` to initialize a concise plan before beginning, then keep it current as tasks start, finish, or are abandoned. Do not create todos for greetings, simple questions, or one-step requests.\n\
+- Reach for `todo` only when work genuinely needs tracking: several independent steps, or a task long enough that you or the user would otherwise lose the thread. When you do keep it current as tasks start, finish, or are abandoned. Most requests do not need one -- greetings, questions, single-file edits, and anything you can finish in a step or two are better done directly, and a plan for small work is noise the user has to read past.\n\
 - Call `ask` when the user's answer would materially change scope, behavior, or an irreversible action and it cannot be safely inferred from the request or project context. Ask concise, decision-ready questions; otherwise make the reasonable choice and proceed.\n\
 - Tool output is complete and verbatim. Trust it. Do not re-run a command to check for hidden or \
 missing output: when output is cut it always carries an explicit `[output truncated ...]` notice, so \
@@ -332,8 +332,8 @@ mod tests {
         assert!(out.starts_with("You are Jan, an AI coding agent."));
         assert!(out.contains("# Guidelines"));
         assert!(out.contains("Be concise"));
-        assert!(out.contains("call `todo` to initialize a concise plan"));
-        assert!(out.contains("Do not create todos for greetings"));
+        assert!(out.contains("Reach for `todo` only when work genuinely needs tracking"));
+        assert!(out.contains("Most requests do not need one"));
         assert!(out.contains("Call `ask` when the user's answer would materially change"));
         assert!(out.contains("Tool output is complete and verbatim"));
         assert!(out.contains("Do not re-run a command to check"));

--- a/src-tauri/src/core/agent/todo.rs
+++ b/src-tauri/src/core/agent/todo.rs
@@ -67,6 +67,17 @@ impl TodoList {
         self.phases.iter().all(|p| p.tasks.is_empty())
     }
 
+    /// True while any task is still pending or in progress.
+    ///
+    /// Distinct from `is_empty`, which only asks whether tasks exist at all: a
+    /// fully completed list is non-empty but has no open work left.
+    pub fn has_open(&self) -> bool {
+        self.phases
+            .iter()
+            .flat_map(|p| &p.tasks)
+            .any(|t| matches!(t.status, TodoStatus::Pending | TodoStatus::InProgress))
+    }
+
     pub fn done_total(&self) -> (usize, usize) {
         let mut done = 0;
         let mut total = 0;

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -583,6 +583,12 @@ struct App {
     scrollback: u16,
     /// Set when the user submits a message; the loop spawns a run next tick.
     want_start: bool,
+    /// Runs started since the todo list last had open work. The list is the
+    /// model's own scratchpad, so a finished one lingers until it declares a
+    /// new plan -- which may never happen. This counts down a grace period
+    /// instead of clearing the moment the last task closes, so a model that is
+    /// still mid-flow (about to append, or reopening a task) keeps its list.
+    runs_since_todos_closed: u32,
     /// Transcript viewport width in cells, refreshed each `draw`; tables wrap to
     /// it. 0 until the first draw (callers fall back to a default).
     view_width: u16,
@@ -802,6 +808,7 @@ impl App {
             update_installing: false,
             scrollback: 0,
             want_start: false,
+            runs_since_todos_closed: 0,
             view_width: 0,
             last_kind: Kind::None,
             should_quit: false,
@@ -3370,6 +3377,7 @@ async fn chat_loop<B: Backend>(
             let base_ready = app.repo_root.is_none() || app.base_snapshot.is_some();
             if mcp_ready && base_ready {
                 app.want_start = false;
+                age_closed_todos(app).await;
                 current = Some(spawn_run(args, app.body()));
             } else if !loading_noted && !mcp_ready {
                 // The base snapshot gates silently; only the MCP connect notes.
@@ -4302,10 +4310,15 @@ async fn run_command(app: &mut App, line: &str) {
         }
         "clear" => {
             app.reset_session();
+            // reset_session only drops the projection; the registry is the
+            // model's copy and would otherwise survive the clear and reappear
+            // on its next todo op.
+            clear_todos(app).await;
             app.note("conversation cleared");
         }
         "new" => {
             app.reset_session();
+            clear_todos(app).await;
             app.note("started a new session");
         }
         "compact" => compact_command(app).await,
@@ -4484,6 +4497,48 @@ async fn apply_todo_mutation(
     app.todos = list;
     app.persist();
     Ok(())
+}
+
+/// Runs allowed to start with a fully closed-out todo list before it is
+/// dropped. One is too eager -- a model often closes the last task and then
+/// appends follow-up work in the next run, and clearing between the two would
+/// destroy a list it is still using.
+const TODO_KEEP_CLOSED_RUNS: u32 = 2;
+
+/// Clear the canonical todo list and the TUI projection together.
+///
+/// The registry is the model's source of truth; clearing only the projection
+/// leaves the model appending to a list the user believes is gone, and the next
+/// `TodoUpdate` resurrects it on screen.
+async fn clear_todos(app: &mut App) {
+    if let Some(args) = app.args.clone() {
+        if let Some(registry) = args.todo_registry.as_ref() {
+            *registry.lock().await = crate::core::agent::todo::TodoList::default();
+        }
+    }
+    app.todos = crate::core::agent::todo::TodoList::default();
+    app.last_todo_reminder = None;
+    app.runs_since_todos_closed = 0;
+}
+
+/// Age a finished todo list, dropping it once it has survived
+/// `TODO_KEEP_CLOSED_RUNS` runs without the model reopening or extending it.
+///
+/// Without this the widget is sticky: `is_empty` means "no tasks exist", and a
+/// completed task is still a task, so a finished plan renders forever and only
+/// a fresh `todo init` ever replaces it. Users end up reading a plan that
+/// belongs to work they finished several tasks ago.
+async fn age_closed_todos(app: &mut App) {
+    if app.todos.is_empty() || app.todos.open_summary().is_some() {
+        // Nothing to age, or the model still has open work.
+        app.runs_since_todos_closed = 0;
+        return;
+    }
+    app.runs_since_todos_closed += 1;
+    if app.runs_since_todos_closed > TODO_KEEP_CLOSED_RUNS {
+        clear_todos(app).await;
+        app.persist();
+    }
 }
 
 /// Build the `/todo` editor rows: one per task, in phase/task order, prefixed by
@@ -6662,7 +6717,8 @@ fn footer(app: &App) -> Paragraph<'static> {
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_resume, assistant_is_awaiting_user_answer, build_user_message, clipboard_path,
+        age_closed_todos, apply_resume, assistant_is_awaiting_user_answer, build_user_message,
+        clipboard_path,
         diff_lines, group_activity, group_detail_lines, group_summary, handle_ask_key,
         handle_ask_mouse, handle_key, handle_mouse, image_mime, input_content_lines,
         compact_tokens, finish_login, finish_update_install, load_image_file, message_text,
@@ -9691,6 +9747,92 @@ mod tests {
         // A new turn starts the count over rather than accumulating forever.
         app.submit_user("again".into());
         assert_eq!(app.turn_output_tokens, 0);
+    }
+
+    fn todo_item(content: &str) -> crate::core::agent::todo::TodoItem {
+        crate::core::agent::todo::TodoItem {
+            content: content.to_string(),
+            status: crate::core::agent::todo::TodoStatus::Pending,
+        }
+    }
+
+    /// A finished todo list is sticky: `is_empty` means "no tasks exist", and a
+    /// completed task is still a task, so the widget renders a plan the user
+    /// finished long ago until the model happens to declare a new one.
+    #[tokio::test]
+    async fn finished_todos_clear_after_a_grace_period() {
+        let mut app = test_app();
+        app.todos
+            .init(vec![crate::core::agent::todo::TodoPhase {
+                name: String::new(),
+                tasks: vec![
+                    todo_item("write the parser"),
+                ],
+            }])
+            .unwrap();
+        assert!(!app.todos.is_empty());
+
+        // Open work is never aged away, however many runs go by.
+        for _ in 0..5 {
+            age_closed_todos(&mut app).await;
+        }
+        assert!(!app.todos.is_empty(), "open work must survive");
+
+        app.todos
+            .done(crate::core::agent::todo::Target::All)
+            .unwrap();
+        assert!(app.todos.open_summary().is_none(), "all work closed out");
+
+        // The finished list survives the grace period, so a model that closes
+        // its last task and then appends follow-up work keeps its list.
+        for i in 1..=super::TODO_KEEP_CLOSED_RUNS {
+            age_closed_todos(&mut app).await;
+            assert!(!app.todos.is_empty(), "cleared too eagerly at run {i}");
+        }
+
+        // One run past the grace period and it goes.
+        age_closed_todos(&mut app).await;
+        assert!(app.todos.is_empty(), "finished list should have been dropped");
+    }
+
+    /// Reopening work resets the grace period, so a list in active use is never
+    /// aged out from under the model.
+    #[tokio::test]
+    async fn reopened_todos_reset_the_grace_period() {
+        let mut app = test_app();
+        app.todos
+            .init(vec![crate::core::agent::todo::TodoPhase {
+                name: String::new(),
+                tasks: vec![todo_item("a")],
+            }])
+            .unwrap();
+        app.todos
+            .done(crate::core::agent::todo::Target::All)
+            .unwrap();
+
+        age_closed_todos(&mut app).await;
+        assert_eq!(app.runs_since_todos_closed, 1);
+
+        // The model declares new work before the grace period expires.
+        app.todos
+            .init(vec![crate::core::agent::todo::TodoPhase {
+                name: String::new(),
+                tasks: vec![todo_item("b")],
+            }])
+            .unwrap();
+        age_closed_todos(&mut app).await;
+        assert_eq!(app.runs_since_todos_closed, 0, "counter must reset");
+        assert!(!app.todos.is_empty(), "new work must not be aged out");
+    }
+
+    /// An empty list never accumulates grace, so the counter can't drift.
+    #[tokio::test]
+    async fn empty_todos_do_not_accumulate_grace() {
+        let mut app = test_app();
+        for _ in 0..5 {
+            age_closed_todos(&mut app).await;
+        }
+        assert_eq!(app.runs_since_todos_closed, 0);
     }
 
     #[test]

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -4310,9 +4310,6 @@ async fn run_command(app: &mut App, line: &str) {
         }
         "clear" => {
             app.reset_session();
-            // reset_session only drops the projection; the registry is the
-            // model's copy and would otherwise survive the clear and reappear
-            // on its next todo op.
             clear_todos(app).await;
             app.note("conversation cleared");
         }
@@ -4507,16 +4504,17 @@ const TODO_KEEP_CLOSED_RUNS: u32 = 2;
 
 /// Clear the canonical todo list and the TUI projection together.
 ///
-/// The registry is the model's source of truth; clearing only the projection
-/// leaves the model appending to a list the user believes is gone, and the next
-/// `TodoUpdate` resurrects it on screen.
+/// Goes through `apply_todo_mutation` so the registry -- the model's source of
+/// truth -- is cleared too. Dropping only the projection would leave the model
+/// appending to a list the user believes is gone, and the next `TodoUpdate`
+/// would resurrect it on screen.
 async fn clear_todos(app: &mut App) {
-    if let Some(args) = app.args.clone() {
-        if let Some(registry) = args.todo_registry.as_ref() {
-            *registry.lock().await = crate::core::agent::todo::TodoList::default();
-        }
-    }
-    app.todos = crate::core::agent::todo::TodoList::default();
+    // `Target::All` clears unconditionally; the Result exists for the
+    // unknown-task and unknown-phase targets.
+    let _ = apply_todo_mutation(app, |list| {
+        list.rm(crate::core::agent::todo::Target::All)
+    })
+    .await;
     app.last_todo_reminder = None;
     app.runs_since_todos_closed = 0;
 }
@@ -4529,7 +4527,7 @@ async fn clear_todos(app: &mut App) {
 /// a fresh `todo init` ever replaces it. Users end up reading a plan that
 /// belongs to work they finished several tasks ago.
 async fn age_closed_todos(app: &mut App) {
-    if app.todos.is_empty() || app.todos.open_summary().is_some() {
+    if app.todos.is_empty() || app.todos.has_open() {
         // Nothing to age, or the model still has open work.
         app.runs_since_todos_closed = 0;
         return;
@@ -9756,9 +9754,6 @@ mod tests {
         }
     }
 
-    /// A finished todo list is sticky: `is_empty` means "no tasks exist", and a
-    /// completed task is still a task, so the widget renders a plan the user
-    /// finished long ago until the model happens to declare a new one.
     #[tokio::test]
     async fn finished_todos_clear_after_a_grace_period() {
         let mut app = test_app();
@@ -9783,8 +9778,7 @@ mod tests {
             .unwrap();
         assert!(app.todos.open_summary().is_none(), "all work closed out");
 
-        // The finished list survives the grace period, so a model that closes
-        // its last task and then appends follow-up work keeps its list.
+        // Survives every run up to the cutoff.
         for i in 1..=super::TODO_KEEP_CLOSED_RUNS {
             age_closed_todos(&mut app).await;
             assert!(!app.todos.is_empty(), "cleared too eagerly at run {i}");
@@ -9813,7 +9807,6 @@ mod tests {
         age_closed_todos(&mut app).await;
         assert_eq!(app.runs_since_todos_closed, 1);
 
-        // The model declares new work before the grace period expires.
         app.todos
             .init(vec![crate::core::agent::todo::TodoPhase {
                 name: String::new(),


### PR DESCRIPTION
## Problem

Reported in Slack: the todo widget is sticky. A task finishes, and the plan stays on screen through every later turn - *"xong task rồi mà các turn tiếp theo không xoá; chỉ khi nào có todo mới mới override"* - leaving you reading a finished plan while doing unrelated work.

Two separate causes.

### 1. A finished list is never dropped

The widget renders on one condition:

```rust
let todo_lines = (app.picker.is_none() && !app.todos.is_empty()).then(|| todo_hud(app));
```

and `is_empty` means **no tasks exist**, not **no work remains**:

```rust
pub fn is_empty(&self) -> bool { self.phases.iter().all(|p| p.tasks.is_empty()) }
```

A completed task is still a task, so the list never becomes empty. `app.todos` was cleared only by `/new`, `/clear`, or resume - never by finishing - so the only thing that replaced a done plan was the model declaring a new one with `todo init`. A model that simply stops using todos left the old plan up indefinitely.

### 2. The model plans work that needs no plan

```
For substantive work with multiple steps or repository changes, call `todo` to
initialize a concise plan before beginning...
```

"or repository changes" covers essentially every edit, and "call `todo` ... before beginning" reads as an instruction rather than a judgement call. So one-line fixes got a plan longer than the work.

## Changes

**Age out a finished list.** Each run that starts with no open work counts against a grace period; past it the list is dropped. The grace matters - a model often closes its last task and appends follow-up work on the next run, and clearing immediately would destroy a list still in use. Any reopened or newly declared work resets the counter, so a list in active use is never aged out from under the model.

Grace is `TODO_KEEP_CLOSED_RUNS = 2`, per the suggestion in the thread.

**Clear through the registry, not just the projection.** The registry is the model's source of truth. Dropping only the TUI copy leaves the model appending to a list the user believes is gone, and the next `TodoUpdate` puts it straight back on screen.

That also fixes a bug found on the way: **`/new` and `/clear` cleared the projection alone**, so old todos could resurrect on the model's next todo op.

**Raise the bar in the prompt.** Now: reach for `todo` only when work genuinely needs tracking - several independent steps, or long enough to lose the thread - and *most requests do not need one*, naming the cases that kept triggering it.

Ageing out a finished list bounds how long a stale plan is visible. Not creating one for a two-step task is what stops it appearing at all.

## Verification

Rendered real frames rather than only asserting state:

```
Todos   /todo                    →    (gone)
 └─ ☑ write the parser
```

**676 lib tests pass** (264 TUI), clippy clean on the touched code.

Three new tests: open work never ages out however many runs pass; a finished list survives exactly the grace period and is then dropped; reopened work resets the counter. The prompt assertions were updated to the new wording rather than deleted.

## Note

The `[budget]`-style knob here is one constant. If 2 runs reads as too eager or too patient in real use, `TODO_KEEP_CLOSED_RUNS` in `tui.rs` is the single place to change it.
