### PR TITLE
feat(mcp): add per-server auto-approve toggle in settings

### DIFF
--- a/web-app/src/hooks/__tests__/useToolApproval.test.ts
+++ b/web-app/src/hooks/__tests__/useToolApproval.test.ts
@@ -40,6 +40,8 @@ describe('useToolApproval', () => {
     expect(result.current.allowAllMCPPermissions).toBe(false)
     expect(typeof result.current.approveToolForThread).toBe('function')
     expect(typeof result.current.approveServer).toBe('function')
+    expect(typeof result.current.revokeServer).toBe('function')
+    expect(typeof result.current.isServerApproved).toBe('function')
     expect(typeof result.current.approveToolEverywhere).toBe('function')
     expect(typeof result.current.isToolApproved).toBe('function')
     expect(typeof result.current.setAllowAllMCPPermissions).toBe('function')
@@ -191,6 +193,38 @@ describe('useToolApproval', () => {
       })
 
       expect(result.current.approvedServers).toEqual(['github'])
+    })
+  })
+
+  describe('revokeServer', () => {
+    it('un-trusts a server so its tools prompt again', () => {
+      const { result } = renderHook(() => useToolApproval())
+
+      act(() => {
+        result.current.approveServer('github')
+      })
+      expect(result.current.isServerApproved('github')).toBe(true)
+
+      act(() => {
+        result.current.revokeServer('github')
+      })
+
+      expect(result.current.isServerApproved('github')).toBe(false)
+      expect(
+        result.current.isToolApproved('thread-1', 'create_issue', 'github')
+      ).toBe(false)
+    })
+
+    it('leaves other approved servers intact', () => {
+      const { result } = renderHook(() => useToolApproval())
+
+      act(() => {
+        result.current.approveServer('github')
+        result.current.approveServer('filesystem')
+        result.current.revokeServer('github')
+      })
+
+      expect(result.current.approvedServers).toEqual(['filesystem'])
     })
   })
 

--- a/web-app/src/hooks/useToolApproval.ts
+++ b/web-app/src/hooks/useToolApproval.ts
@@ -14,6 +14,8 @@ type ToolApprovalState = {
 
   approveToolForThread: (threadId: string, toolName: string) => void
   approveServer: (serverName: string) => void
+  revokeServer: (serverName: string) => void
+  isServerApproved: (serverName: string) => boolean
   approveToolEverywhere: (toolName: string) => void
   isToolApproved: (
     threadId: string,
@@ -49,6 +51,18 @@ export const useToolApproval = create<ToolApprovalState>()(
             ? state
             : { approvedServers: [...state.approvedServers, serverName] }
         )
+      },
+
+      revokeServer: (serverName: string) => {
+        set((state) => ({
+          approvedServers: state.approvedServers.filter(
+            (s) => s !== serverName
+          ),
+        }))
+      },
+
+      isServerApproved: (serverName: string) => {
+        return get().approvedServers.includes(serverName)
       },
 
       approveToolEverywhere: (toolName: string) => {

--- a/web-app/src/locales/en/mcp-servers.json
+++ b/web-app/src/locales/en/mcp-servers.json
@@ -49,6 +49,7 @@
   "findMore": "Find more MCP servers at",
   "allowPermissions": "Allow All MCP Tool Permissions",
   "allowPermissionsDesc": "When enabled, all MCP tool calls will be automatically approved without showing permission dialogs. This setting applies globally to all conversations, including new chats.",
+  "autoApproveServer": "Auto-approve this server's tools",
   "noServers": "No MCP servers found",
   "args": "Args",
   "env": "Env",

--- a/web-app/src/routes/settings/__tests__/mcp-servers.error.test.tsx
+++ b/web-app/src/routes/settings/__tests__/mcp-servers.error.test.tsx
@@ -106,6 +106,9 @@ vi.mock('@/hooks/useToolApproval', () => ({
   useToolApproval: () => ({
     allowAllMCPPermissions: true,
     setAllowAllMCPPermissions: vi.fn(),
+    isServerApproved: () => false,
+    approveServer: vi.fn(),
+    revokeServer: vi.fn(),
   }),
 }))
 

--- a/web-app/src/routes/settings/mcp-servers.tsx
+++ b/web-app/src/routes/settings/mcp-servers.tsx
@@ -109,8 +109,13 @@ function MCPServersDesktop() {
     setSettings,
     updateSettings,
   } = useMCPServers()
-  const { allowAllMCPPermissions, setAllowAllMCPPermissions } =
-    useToolApproval()
+  const {
+    allowAllMCPPermissions,
+    setAllowAllMCPPermissions,
+    isServerApproved,
+    approveServer,
+    revokeServer,
+  } = useToolApproval()
 
   const [open, setOpen] = useState(false)
   const [editingKey, setEditingKey] = useState<string | null>(null)
@@ -700,6 +705,17 @@ function MCPServersDesktop() {
                               )}
                             </>
                           )}
+                          <div className="flex items-center gap-2 mt-2">
+                            <Switch
+                              checked={isServerApproved(key)}
+                              onCheckedChange={(checked) =>
+                                checked
+                                  ? approveServer(key)
+                                  : revokeServer(key)
+                              }
+                            />
+                            <span>{t('mcp-servers:autoApproveServer')}</span>
+                          </div>
                         </div>
                       }
                       actions={


### PR DESCRIPTION
## Problem

#8572 added per-server trust (`approvedServers` + `approveServer`, auto-approving a trusted server's tools), but it can only be granted through the runtime "allow always" prompt. There is no way to pre-approve a server before its first tool call, see which servers are trusted, or turn that trust back off (`approveServer` has no counterpart).

This is the Settings-side gap from #8449 ("auto-allow a trusted subset of tools"), on top of the mechanism #8572 already merged.

## Changes

- `useToolApproval`: add `revokeServer` and `isServerApproved`, mirroring the existing `approveServer`.
- Settings: each server card gets an "auto-approve this server's tools" toggle bound to `approvedServers` (on = `approveServer`, off = `revokeServer`).
- The global "Allow All" switch is left as-is; this is purely additive.

## Tests

`useToolApproval`, `useToolApprovalRequests`, and `mcp-servers.error` suites pass (31). New cases cover `revokeServer` un-trusting a server and leaving others intact.

Addresses #8449
