### PR TITLE
fix(agent): don't treat user@host as an @path reference

### DIFF
--- a/src-tauri/src/core/cli/path_refs.rs
+++ b/src-tauri/src/core/cli/path_refs.rs
@@ -11,6 +11,8 @@
 //! * Images are noted inline as `(image: image/mime)` markers.
 //! * Missing/unreadable items surface as inline error notices.
 //! * `@http://` / `@https://` / `@file://` prefixed tokens are skipped.
+//! * `user@host`, emails and bare IPv4 tokens are not references and pass
+//!   through untouched.
 //! * Once resolved, the `@path` tokens are removed from the text so the model
 //!   sees the content directly via the injected block, not raw `@` tokens.
 
@@ -18,13 +20,51 @@ use std::io::Read;
 use std::path::{Path, PathBuf};
 use once_cell::sync::Lazy;
 
-/// Regex matching `@path` references.
-/// The path stops at whitespace or common punctuation.
+/// Regex scanning `@token` candidates in text; `ref_matches` applies the
+/// reference rules (boundary, URL, IPv4) on top of this token scan.
 static REFERENCE_RE: Lazy<regex::Regex> = Lazy::new(|| {
     // Using a raw string with hash delimiters avoids escaping quotes and backticks.
     // The negated character class excludes tokens that would make bad paths.
     regex::Regex::new(r###"@([^\s,;:!?'"`\[\](){}<>)\)]+)"###).unwrap()
 });
+
+/// True when `at_idx` in `text` is the start of a reference token: the `@` is
+/// at the start of the text, or the char immediately before it is not a word
+/// character (ASCII letter/digit/underscore). This keeps `user@host` and
+/// `foo@bar.com` from being read as `@path` references while `@path`,
+/// `(@path)` and text in scripts without spaces still resolve.
+/// Non-ASCII letters (e.g. `看@path`) deliberately count as boundaries so CJK
+/// text can reference files without a preceding space.
+fn is_ref_start(text: &str, at_idx: usize) -> bool {
+    match text[..at_idx].chars().next_back() {
+        None => true,
+        Some(c) => !(c.is_ascii_alphanumeric() || c == '_'),
+    }
+}
+
+/// True for tokens shaped like an IPv4 address (`1.2.3.4`), which are never
+/// file paths. A trailing period (sentence punctuation) is ignored.
+fn is_ipv4_like(raw: &str) -> bool {
+    let raw = raw.trim_end_matches('.');
+    let octets: Vec<&str> = raw.split('.').collect();
+    octets.len() == 4
+        && octets
+            .iter()
+            .all(|o| !o.is_empty() && o.len() <= 3 && o.bytes().all(|b| b.is_ascii_digit()))
+}
+
+/// Iterate over `@token` spans in `text` that qualify as file references: the
+/// `@` must start a token (not be glued to a preceding word char) and the
+/// token must look like a path (not an `http`/`file://` URL or bare IPv4).
+fn ref_matches(text: &str) -> impl Iterator<Item = regex::Match<'_>> {
+    REFERENCE_RE.find_iter(text).filter(|m| {
+        let raw = &text[m.start() + 1..m.end()];
+        is_ref_start(text, m.start())
+            && !raw.starts_with("http")
+            && !raw.starts_with("file://")
+            && !is_ipv4_like(raw)
+    })
+}
 
 /// Maximum bytes we will read from a single file.
 const MAX_FILE_BYTES: u64 = 1024 * 1024;
@@ -37,20 +77,26 @@ const IMAGE_EXTS: &[&str] = &["jpg", "jpeg", "png", "gif", "webp", "bmp", "svg"]
 
 // ── Public API ───────────────────────────────────────────────────────────────
 
+/// Index of the last `@` in `text` that starts a reference token, if any.
+/// Uses the same rules as `ref_matches`; a trailing bare `@` (empty query)
+/// still counts so the TUI hint popup can open with an empty search.
+pub fn last_ref_start(text: &str) -> Option<usize> {
+    if let Some(idx) = text.len().checked_sub(1) {
+        if text.ends_with('@') && is_ref_start(text, idx) {
+            return Some(idx);
+        }
+    }
+    ref_matches(text).map(|m| m.start()).last()
+}
+
 /// Parse `@path` references from `text`.
 ///
 /// Returns the raw path strings in order of appearance (deduplicated).
 pub fn parse_references(text: &str) -> Vec<String> {
     let mut seen = std::collections::HashSet::new();
     let mut refs = Vec::new();
-    for cap in REFERENCE_RE.captures_iter(text) {
-        let raw = cap[1].trim();
-        if raw.is_empty()
-            || raw.starts_with("http")
-            || raw.starts_with("file://")
-        {
-            continue;
-        }
+    for m in ref_matches(text) {
+        let raw = &text[m.start() + 1..m.end()];
         if seen.insert(raw.to_string()) {
             refs.push(raw.to_string());
         }
@@ -60,10 +106,17 @@ pub fn parse_references(text: &str) -> Vec<String> {
 
 /// Remove all `@path` references from `text` and normalise whitespace.
 pub fn strip_references(text: &str) -> String {
-    let cleaned = REFERENCE_RE.replace_all(text, "");
-    let mut result = String::with_capacity(cleaned.len());
+    let mut kept = String::with_capacity(text.len());
+    let mut last = 0;
+    for m in ref_matches(text) {
+        kept.push_str(&text[last..m.start()]);
+        last = m.end();
+    }
+    kept.push_str(&text[last..]);
+
+    let mut result = String::with_capacity(kept.len());
     let mut prev_space = false;
-    for ch in cleaned.chars() {
+    for ch in kept.chars() {
         if ch.is_whitespace() {
             if !prev_space {
                 result.push(' ');
@@ -321,5 +374,87 @@ mod tests {
         let (clean, block) = resolve_references("plain text", &dir);
         assert_eq!(clean, "plain text");
         assert!(block.is_empty());
+    }
+
+    #[test]
+    fn test_ssh_address_not_a_reference() {
+        // Regression: `ssh username@44.50.0.89` must survive verbatim.
+        let text = "please use bash to ssh username@44.50.0.89";
+        assert!(parse_references(text).is_empty());
+
+        let text = "please use bash to ssh alandao@44.50.0.89";
+        assert!(parse_references(text).is_empty());
+
+        let dir = std::env::temp_dir().join("path_ref_test_ssh");
+        let (clean, block) = resolve_references(text, &dir);
+        assert_eq!(clean, text);
+        assert!(block.is_empty());
+    }
+
+    #[test]
+    fn test_email_not_a_reference() {
+        let refs = parse_references("mail me at foo@bar.com please");
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn test_bare_ip_after_space_not_a_reference() {
+        let refs = parse_references("use bash to ssh @44.50.0.89 now");
+        assert!(refs.is_empty());
+
+        // Sentence-final trailing period must not turn it into a path either.
+        let refs = parse_references("please ping @44.50.0.89.");
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn test_reference_with_rest_of_query_survives() {
+        // The reference resolves, and the rest of the query stays intact.
+        let refs = parse_references("use @README.md to check the build steps");
+        assert_eq!(refs, vec!["README.md"]);
+
+        let dir = std::env::temp_dir().join("path_ref_test_rest");
+        let _ = std::fs::create_dir_all(&dir);
+        std::fs::write(dir.join("README.md"), b"build steps here").unwrap();
+        let (clean, block) = resolve_references("use @README.md to check the build steps", &dir);
+        assert_eq!(clean, "use to check the build steps");
+        assert!(block.contains("build steps here"));
+    }
+
+    #[test]
+    fn test_reference_with_hyphen() {
+        let refs = parse_references("diff @my-file.txt against main");
+        assert_eq!(refs, vec!["my-file.txt"]);
+    }
+
+    #[test]
+    fn test_reference_still_parsed_with_boundaries() {
+        let refs = parse_references("open @src/main.ts and (@README.md) and 看@docs/guide.md");
+        assert_eq!(refs, vec!["src/main.ts", "README.md", "docs/guide.md"]);
+    }
+
+    #[test]
+    fn test_strip_keeps_ssh_address() {
+        let cleaned = strip_references("see @src/main.ts and ssh user@44.50.0.89");
+        assert_eq!(cleaned, "see and ssh user@44.50.0.89");
+    }
+
+    #[test]
+    fn test_last_ref_start() {
+        assert_eq!(last_ref_start("ssh user@44.50.0.89"), None);
+        assert_eq!(last_ref_start("mail foo@bar.com"), None);
+        assert_eq!(last_ref_start("ping @44.50.0.89 now"), None);
+        assert_eq!(
+            last_ref_start("check @src/main.ts and ssh user@host"),
+            Some("check ".len())
+        );
+        assert_eq!(last_ref_start("see (@README.md)"), Some("see (".len()));
+        // Last of several qualifying references wins.
+        assert_eq!(last_ref_start("check @a and @b"), Some("check @a and ".len()));
+        // A bare trailing `@` is still a hint trigger (empty query).
+        assert_eq!(last_ref_start("@"), Some(0));
+        assert_eq!(last_ref_start("check @"), Some(6));
+        // But a mid-word `@` never is, even at the end.
+        assert_eq!(last_ref_start("ssh user@"), None);
     }
 }

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -1151,10 +1151,11 @@ impl App {
 
     /// Extract the current `@query` from the input buffer, if any.
     /// Returns `None` when the cursor is not inside or immediately after
-    /// a `@`-prefixed token (no space since the `@`).
+    /// a `@`-prefixed token (no space since the `@`), or when the `@` does
+    /// not start a token (e.g. `user@host` is not a file reference).
     fn path_hint_query(&self) -> Option<String> {
         let before = &self.input[..self.cursor];
-        let at_idx = before.rfind('@')?;
+        let at_idx = path_refs::last_ref_start(before)?;
         let after_at = &before[at_idx + 1..];
         if after_at.contains(' ') {
             return None; // space after @ means the token ended
@@ -1197,7 +1198,7 @@ impl App {
         let sel = self.path_hint_selected.min(self.path_hints.len() - 1);
         let selected = &self.path_hints[sel];
         let before = &self.input[..self.cursor];
-        let at_idx = match before.rfind('@') {
+        let at_idx = match path_refs::last_ref_start(before) {
             Some(i) => i,
             None => return,
         };

--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -107,7 +107,7 @@ import {
   resolvePathReference,
   formatPathReferenceText,
   searchFiles,
-  REFERENCE_PATTERN,
+  stripPromptReferences,
   type FilePickerEntry as FileEntry,
 } from '@/lib/path-references'
 import { FilePickerPopover } from '@/components/FilePickerPopover'
@@ -243,9 +243,11 @@ const ChatInput = memo(function ChatInput({
 
       const cursorIdx = filePickerCursorPos.current ?? value.length
 
-      // Look backwards from current cursor to find the last word starting with @
+      // Look backwards from current cursor to find the last word starting with
+      // @ (the @ must not be glued to a preceding word char, so `user@host`
+      // never opens the picker)
       const beforeCursor = value.slice(0, cursorIdx)
-      const atMatch = beforeCursor.match(/@([\w.\/-]*)$/)
+      const atMatch = beforeCursor.match(/(?<![A-Za-z0-9_])@([\w.\/-]*)$/)
 
       if (atMatch) {
         const query = atMatch[1] ?? ''
@@ -287,7 +289,7 @@ const ChatInput = memo(function ChatInput({
       const afterCursor = prompt.slice(filePickerCursorPos.current)
 
       // Replace the `@query` with `path/to/file` (the resolved reference)
-      const textBefore = beforeCursor.replace(/@[\w.\/-]*$/, '')
+      const textBefore = beforeCursor.replace(/(?<![A-Za-z0-9_])@[\w.\/-]*$/, '')
       const refText = entry.path
       const newPrompt = textBefore + refText + afterCursor
 
@@ -339,7 +341,7 @@ const ChatInput = memo(function ChatInput({
 
       // Remove @ references from the prompt text (they'll be replaced by the
       // resolved contents above so the model sees the content directly)
-      const cleanText = text.replace(REFERENCE_PATTERN, '').replace(/\s+/g, ' ').trim()
+      const cleanText = stripPromptReferences(text)
 
       return { text: cleanText, resolvedContents }
     },

--- a/web-app/src/lib/__tests__/path-references.test.ts
+++ b/web-app/src/lib/__tests__/path-references.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  parsePromptForReferences,
+  stripPromptReferences,
+} from '../path-references'
+
+vi.mock('@janhq/core', () => ({
+  fs: {},
+}))
+
+describe('parsePromptForReferences', () => {
+  it('does not treat ssh/email addresses as references', () => {
+    expect(
+      parsePromptForReferences('please use bash to ssh username@44.50.0.89')
+    ).toEqual([])
+    expect(
+      parsePromptForReferences('please use bash to ssh alandao@44.50.0.89')
+    ).toEqual([])
+    expect(parsePromptForReferences('mail me at foo@bar.com please')).toEqual(
+      []
+    )
+  })
+
+  it('does not treat bare IPv4 as a reference, even with a trailing period', () => {
+    expect(parsePromptForReferences('use bash to ssh @44.50.0.89 now')).toEqual(
+      []
+    )
+    expect(parsePromptForReferences('please ping @44.50.0.89.')).toEqual([])
+  })
+
+  it('parses references and keeps the rest of the query', () => {
+    expect(
+      parsePromptForReferences('use @README.md to check the build steps')
+    ).toEqual(['README.md'])
+    expect(parsePromptForReferences('diff @my-file.txt against main')).toEqual(
+      ['my-file.txt']
+    )
+    expect(
+      parsePromptForReferences('open @src/main.ts and (@README.md)')
+    ).toEqual(['src/main.ts', 'README.md'])
+  })
+})
+
+describe('stripPromptReferences', () => {
+  it('strips references but keeps ssh/email addresses', () => {
+    expect(
+      stripPromptReferences('see @src/main.ts and ssh user@44.50.0.89')
+    ).toBe('see and ssh user@44.50.0.89')
+  })
+
+  it('keeps non-reference text intact', () => {
+    expect(stripPromptReferences('no refs here')).toBe('no refs here')
+    expect(stripPromptReferences('ssh username@44.50.0.89')).toBe(
+      'ssh username@44.50.0.89'
+    )
+  })
+})

--- a/web-app/src/lib/path-references.ts
+++ b/web-app/src/lib/path-references.ts
@@ -15,8 +15,12 @@ export type { FilePickerEntry }
 
 // ── Exports ──────────────────────────────────────────────────────────────────
 
-/** Regex matching @path references in text. */
-export const REFERENCE_PATTERN = /@([^\s,;:!?'"`)\]}>]+)/g
+/**
+ * Regex scanning `@token` candidates in text. The `@` must not be glued to a
+ * preceding word char, so `user@host` and `foo@bar.com` are not references;
+ * `isReferenceToken` applies the remaining rules (URL, IPv4) on top.
+ */
+export const REFERENCE_PATTERN = /(?<![A-Za-z0-9_])@([^\s,;:!?'"`)\]}>]+)/g
 
 /** Maximum bytes we'll read from a single file. */
 const MAX_FILE_BYTES = 1 * 1024 * 1024
@@ -35,6 +39,29 @@ const CODE_EXTS = new Set([
   'html', 'sh', 'bash', 'zsh', 'sql', 'graphql',
 ])
 
+/** True for tokens shaped like an IPv4 address (`1.2.3.4`), which are never
+ *  file paths. A trailing period (sentence punctuation) is ignored. */
+function isIpv4Like(raw: string): boolean {
+  const trimmed = raw.replace(/\.+$/, '')
+  const octets = trimmed.split('.')
+  return (
+    octets.length === 4 &&
+    octets.every((o) => o.length > 0 && o.length <= 3 && /^\d+$/.test(o))
+  )
+}
+
+/** True when a captured token qualifies as a file reference. */
+function isReferenceToken(raw: string): boolean {
+  return (
+    raw.length > 0 &&
+    !raw.startsWith('http://') &&
+    !raw.startsWith('https://') &&
+    !raw.startsWith('file://') &&
+    !raw.includes('@') &&
+    !isIpv4Like(raw)
+  )
+}
+
 // ── Parsing references from text ─────────────────────────────────────────────
 
 /**
@@ -46,23 +73,25 @@ export function parsePromptForReferences(text: string): string[] {
   const refs: string[] = []
   let match: RegExpExecArray | null
   while ((match = REFERENCE_PATTERN.exec(text)) !== null) {
-    const raw = match[1].trim()
-    // Skip obvious non-paths
-    if (
-      !raw ||
-      raw.startsWith('http://') ||
-      raw.startsWith('https://') ||
-      raw.startsWith('file://') ||
-      raw.includes('@') ||
-      raw === ''
-    )
-      continue
+    const raw = match[1]
+    if (!isReferenceToken(raw)) continue
     if (!seen.has(raw)) {
       seen.add(raw)
       refs.push(raw)
     }
   }
   return refs
+}
+
+/**
+ * Remove qualified @path references from `text`, leaving non-reference `@`
+ * tokens (ssh/email addresses, bare IPs) intact, and normalise whitespace.
+ */
+export function stripPromptReferences(text: string): string {
+  const cleaned = text.replace(REFERENCE_PATTERN, (match, raw: string) =>
+    isReferenceToken(raw) ? '' : match
+  )
+  return cleaned.replace(/\s+/g, ' ').trim()
 }
 
 /**


### PR DESCRIPTION
## Describe Your Changes

`@path` file references were parsed from any `@token`, so a prompt like `please use bash to ssh username@44.50.0.89` was read as a reference to `44.50.0.89`, stripped to `ssh username`, and the model got a `[44.50.0.89: cannot access: ...]` notice. Same for emails (`foo@bar.com`) and any `user@host` text, in the TUI submit path and the headless task path.

Fix in `path_refs.rs`:
- `@` only starts a reference when it is not glued to a preceding word character: `@path`, `(@path)`, `看@path` still resolve; `user@host`, `foo@bar.com` pass through verbatim.
- Bare IPv4 tokens (`@1.2.3.4`, including a sentence-final trailing period) are skipped as never-paths.
- Shared `ref_matches` iterator so parse, strip, and resolve agree on what a reference is.
- New `last_ref_start` helper uses the same rules; the TUI @-hint popup (`path_hint_query`) and Tab-accept use it, so typing an ssh/email address no longer triggers or mis-replaces the file picker. A trailing bare `@` still opens the picker with an empty query.

Web-app parity (second commit): the same bug class existed in the agent chat input - `web-app/src/lib/path-references.ts` stripped `@44.50.0.89` at send in agent mode. `REFERENCE_PATTERN` now requires a token boundary (lookbehind), IPv4 tokens are skipped, and the new `stripPromptReferences` replaces the inline strip in `ChatInput.tsx`; the picker trigger and accept-replace regexes are boundary-guarded too.

Tests: 13 `path_refs.rs` tests (7 new regressions: exact ssh repro, email, bare IP + trailing period, reference-with-rest-of-query, hyphenated file, boundary cases, strip behavior, last_ref_start incl. bare-`@`) and 5 new web `path-references.test.ts` tests.

## Fixes Issues

- Closes https://github.com/janhq/jan-internal/issues/319

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

## Notes

- Verification: `cargo test --no-default-features --features cli` - 332 cli module tests pass (13 path_refs). Web: `vitest path-references.test.ts` - 5/5 pass.
- Behavior side-effect worth knowing: `strip_references` previously removed every `@token` including URL-prefixed ones; it now removes only qualified references, so mixed input like `see @http://x and @a` keeps `@http://x` in the cleaned text (consistent with `parse_references`).
- Pre-existing on this branch, untouched: 4 failing `ChatInput.test.tsx` tests (fail identically at base) and 9 `tsc -b` errors (dead imports in ChatInput, `ref.rawPath` on a string, missing `@janhq/tauri-plugin-websearch-api` module). Suggest a separate cleanup PR.
