### PR TITLE
fix(cli): report nightly build version in --version

### DIFF
--- a/src-tauri/src/bin/jan.rs
+++ b/src-tauri/src/bin/jan.rs
@@ -37,8 +37,7 @@ Models are served by remote providers configured in ~/.jan/config.toml\n\
   jan cli agent run \"fix the failing test\"               # run the agent non-interactively\n  \
   jan cli models list                                    # show every configured provider model\n  \
   jan cli threads list                                   # list saved conversation threads\n  \
-  jan update                                             # install the latest build of this channel",
-    version
+  jan update                                             # install the latest build of this channel"
 )]
 struct Cli {
     #[command(subcommand)]
@@ -365,6 +364,7 @@ async fn main() {
     // Inject the logo at runtime so we can use ANSI styling.
     let logo = make_logo();
     let matches = Cli::command()
+        .version(app_lib::core::cli::updater::build_version())
         .before_help(logo.clone())
         .before_long_help(logo)
         .get_matches();

--- a/src-tauri/src/core/cli/updater.rs
+++ b/src-tauri/src/core/cli/updater.rs
@@ -53,7 +53,11 @@ fn update_channel() -> Option<&'static str> {
     option_env!("JAN_CLI_UPDATE_CHANNEL")
 }
 
-fn build_version() -> &'static str {
+/// The version this binary reports: the nightly build version embedded by CI
+/// (`JAN_CLI_BUILD_VERSION`) when present, otherwise `Cargo.toml`'s pinned
+/// version. Also used for `--version`, since Cargo.toml's version alone
+/// can't distinguish nightly builds cut from the same release.
+pub fn build_version() -> &'static str {
     option_env!("JAN_CLI_BUILD_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"))
 }
 


### PR DESCRIPTION
## Describe Your Changes

jan --version used clap's default, which resolves to Cargo.toml's pinned CARGO_PKG_VERSION at compile time. Nightly CI builds embed the real nightly version via JAN_CLI_BUILD_VERSION, but that was only ever read by updater.rs's internal build_version() for the self-update check, not by --version itself.

Make build_version() pub and wire it into the clap Command's version at runtime, so nightly builds report their actual version.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
