### PR TITLE
feat(agent-cli): auto-approve by default, add --safe for the permission gate

### DIFF
--- a/docs/src/pages/docs/agent/cli.mdx
+++ b/docs/src/pages/docs/agent/cli.mdx
@@ -37,7 +37,7 @@ jan <COMMAND>
 | `--max-turns <N>` | Turns per message, clamped to 1-400 |
 | `--image <PATH>` | Attach an image to the first message. Repeatable |
 | `--plan` | Start in read-only plan mode |
-| `--yolo` | Disable the sandbox and auto-approve every tool call |
+| `--safe` | Ask for approval before writes, shell commands, and MCP tool calls |
 | `--resume [ID]` | Resume the most recent session, or one whose id starts with `ID` |
 | `-c`, `--continue` | Resume the most recent session |
 | `--provider <ID>` | Target a specific provider for this run |
@@ -50,12 +50,14 @@ jan --task "fix the failing test"       # with a first message
 jan -c                                  # resume the latest session
 jan --resume 3f7a91c2                   # resume by id prefix
 jan --plan                              # read-only
-jan --yolo                              # no prompts (see the warning below)
+jan --safe                              # ask before writes and shell commands
 ```
 
-<Callout type="warning">
-`--yolo` gives the agent unrestricted shell access. Use it only in a container, VM, or scratch
-checkout.
+<Callout type="info">
+Tool calls are auto-approved by default. Shell commands still run inside the OS sandbox
+(bubblewrap, Seatbelt, or AppContainer), confined to the project directory, and the hard denies
+never lift: `.jan/agent/` internals, anything in `[tools] deny`, and everything plan mode blocks.
+`--safe` adds the interactive approval prompt on top of that.
 </Callout>
 
 ## `jan cli agent`
@@ -70,7 +72,7 @@ Run to completion, or until the turn/token budget is spent.
 jan cli agent run "fix the failing test in tests/auth"
 jan cli agent run --project ~/code/app "update the changelog"
 jan cli agent run --model gpt-4o --max-turns 20 "add unit tests for the parser"
-jan cli agent run --yolo "run the migration"
+jan cli agent run --safe "run the migration"   # approve each step
 ```
 
 | Flag | Description |
@@ -78,7 +80,7 @@ jan cli agent run --yolo "run the migration"
 | `--project <PATH>` | Project root. Defaults to `.` |
 | `--model <ID>` | Model id, overriding `[agent].model` |
 | `--max-turns <N>` | Turns, overriding `[agent].max_turns`. Clamped to 1-400 |
-| `--yolo` | Disable the sandbox and auto-approve every tool call |
+| `--safe` | Ask for approval before writes, shell commands, and MCP tool calls |
 | `--resume[=ID]` | Resume the most recent session, or one by id |
 | `-c`, `--continue` | Resume the most recent session |
 | `--provider`, `--api-key` | Credential overrides for this run |
@@ -202,9 +204,9 @@ jan cli agent run \
   --project . \
   --provider anthropic \
   --max-turns 30 \
-  --yolo \
   "update the changelog for the current release"
 ```
 
-`--yolo` is appropriate here for the same reason it usually isn't: a CI runner is a disposable
-environment, and there's nobody at a keyboard to answer a prompt.
+No flag is needed: tool calls are auto-approved by default, which is what a CI runner wants since
+there's nobody at a keyboard to answer a prompt. Do not pass `--safe` here. With no TTY on stdin
+there is no way to answer, so every prompt is denied and the run stalls out on its first write.

--- a/docs/src/pages/docs/agent/console.mdx
+++ b/docs/src/pages/docs/agent/console.mdx
@@ -62,7 +62,8 @@ Type while it's working and your message queues rather than being dropped - see
 
 ## Approving work
 
-Reads are free. Writes and shell commands stop and ask:
+Writes and shell commands are auto-approved. Start the console with `jan --safe` and they stop to
+ask instead:
 
 ```
  write src/cli.rs
@@ -84,6 +85,6 @@ as you type.
 <DocCards>
   <DocCard title="Slash commands" href="/docs/agent/slash-commands" icon={<Command size={20} />}>Every command, grouped by what it's for.</DocCard>
   <DocCard title="Keybindings" href="/docs/agent/keybindings" icon={<Keyboard size={20} />}>Shortcuts for input, scrolling, and approval prompts.</DocCard>
-  <DocCard title="Run modes" href="/docs/agent/run-modes" icon={<GitBranch size={20} />}>Normal, read-only plan mode, and YOLO.</DocCard>
+  <DocCard title="Run modes" href="/docs/agent/run-modes" icon={<GitBranch size={20} />}>Auto-approval, safe mode, and read-only plan mode.</DocCard>
   <DocCard title="Sessions" href="/docs/agent/sessions" icon={<Layers size={20} />}>Resuming, rewinding, and queueing.</DocCard>
 </DocCards>

--- a/docs/src/pages/docs/agent/index.mdx
+++ b/docs/src/pages/docs/agent/index.mdx
@@ -116,15 +116,15 @@ Desktop's [local API server](/docs/desktop/api-server), with `jan config set --b
 
 ## Staying in control
 
-The agent never edits a file or runs a command without asking, unless you tell it otherwise. Reads
-are free; writes and shell commands prompt. You can approve a single call, approve that kind of call
-for the rest of the session, or deny it.
+The agent edits files and runs commands without stopping to ask, but a shell command runs inside an
+OS sandbox confined to the project directory, and `.jan/agent/` internals and anything in
+`[tools] deny` are refused outright.
 
 Two ways to change that:
 
 - **Plan mode** (`jan --plan`) makes the session read-only. The agent investigates and proposes, but
   cannot change anything.
-- **YOLO mode** (`jan --yolo`) disables the sandbox and auto-approves everything. Fast, and only
-  appropriate in a throwaway environment such as a container or a scratch checkout.
+- **Safe mode** (`jan --safe`) asks before every write and shell command, instead of auto-approving
+  them inside the sandbox.
 
 See [Tools & permissions](/docs/agent/permissions) for the full picture.

--- a/docs/src/pages/docs/agent/permissions.mdx
+++ b/docs/src/pages/docs/agent/permissions.mdx
@@ -68,7 +68,7 @@ allow_write = []
 
 | `default` | Effect |
 | --- | --- |
-| `read-only` | The default. MCP tools and built-in reads available; built-in writes and exec still prompt |
+| `read-only` | The default. MCP tools and built-in reads available; built-in writes and exec go through the gate |
 | `deny` | Locks down all MCP tools. Anything in `allow` is still exposed |
 | `allow` | Exposes everything not in `deny` |
 
@@ -76,22 +76,22 @@ allow_write = []
 
 ## Network access
 
-A `bash` command runs inside an OS sandbox, and by default it has **no network**. An explicitly
-approved command cannot `curl`, `git fetch`, or install a package unless networking is switched on
-for that surface. Where the toggle lives depends on how the agent runs:
+A `bash` command runs inside an OS sandbox. Whether that sandbox has network access depends on the
+surface, and the two defaults differ:
 
 | Surface | How to set network access | Default |
 | --- | --- | --- |
 | Desktop chat agent | The chat-screen tools toggle (`agent_tools`). Per session, in the UI | Off |
 | `jan cli` code-screen agent | `[tools].allow_network` in `.jan/agent/agent.toml` | On |
 
-The two are deliberately independent: the desktop chat agent is ephemeral and never prompts, so it
-stays offline unless you opt in; the CLI runs in your own terminal where every exec is already
-gated behind a prompt, so a coding agent that cannot `curl` or `git fetch` would be largely useless.
+The split is deliberate. The desktop chat agent is ephemeral, so it stays offline unless you opt in.
+The CLI is a coding agent in your own project, where one that cannot `curl`, `git fetch`, or install
+a package would be largely useless.
+
 ```toml
-# Re-enable networking for a CLI agent
+# Take a CLI agent offline
 [tools]
-allow_network = true
+allow_network = false
 ```
 
 ## Subagents
@@ -100,11 +100,12 @@ A [subagent's](/docs/agent/subagents) tools are narrowed, never widened. For a s
 allowlist further restricts its own; for a one-off it is its toolset. Either way a subagent reaches
 a subset of what the parent could, so delegation can't be used to escape this policy.
 
-## Turning it off
+## Turning the prompts on
 
-[YOLO mode](/docs/agent/run-modes#yolo-mode) disables the sandbox and auto-approves everything.
+Approval prompts are opt-in: by default every call above is auto-approved. Start the session with
+`jan --safe` to be asked instead. See [run modes](/docs/agent/run-modes).
 
-<Callout type="warning">
-That means unrestricted shell access to the machine. Appropriate in a container, a VM, or CI - not
-in your home directory.
+<Callout type="info">
+Auto-approval only removes the prompt. The OS sandbox around shell commands, the `.jan/agent/`
+restriction, and `[tools] deny` all still apply.
 </Callout>

--- a/docs/src/pages/docs/agent/run-modes.mdx
+++ b/docs/src/pages/docs/agent/run-modes.mdx
@@ -1,7 +1,7 @@
 ---
 title: Run Modes
-description: Normal, plan, and YOLO - how much freedom the agent has in a session.
-keywords: [Jan, Jan Agent, plan mode, yolo, read-only, sandbox, run modes]
+description: Default, safe, and plan - how much freedom the agent has in a session.
+keywords: [Jan, Jan Agent, plan mode, safe mode, read-only, sandbox, run modes]
 ---
 
 import { Callout } from 'nextra/components'
@@ -13,13 +13,33 @@ without you.
 
 | Mode | Reads | Writes and commands | Start with |
 | --- | --- | --- | --- |
-| Normal | Free | Prompt for approval | `jan` |
+| Default | Free | Auto-approved, inside the sandbox | `jan` |
+| Safe | Free | Prompt for approval | `jan --safe` |
 | Plan | Free | Blocked | `jan --plan` |
-| YOLO | Free | Auto-approved, sandbox off | `jan --yolo` |
 
-## Normal
+## Default
 
-The default. The agent reads freely and stops to ask before anything that changes your machine:
+The agent works without stopping to ask. That is not the same as unrestricted: shell commands run
+inside an OS sandbox (bubblewrap on Linux, Seatbelt on macOS, AppContainer on Windows) confined to
+the project directory, and if no sandbox can be established the `bash` tool refuses to run at all.
+
+Some things are denied outright and no mode lifts them:
+
+- `.jan/agent/` internals, so the agent cannot rewrite its own permissions
+- anything listed in `[tools] deny` in `agent.toml`
+- every write and command while plan mode is on
+
+Auto-approval is the right default in a disposable environment and in CI, where nobody is at a
+keyboard to answer a prompt. On a machine where the project directory holds work you cannot
+recreate, start with `--safe`.
+
+## Safe mode
+
+```bash
+jan --safe
+```
+
+The agent reads freely and stops to ask before anything that changes your machine:
 
 ```
  write src/cli.rs
@@ -29,6 +49,11 @@ The default. The agent reads freely and stops to ask before anything that change
 ```
 
 `a` lasts for the session only. Details in [Tool permissions](/docs/agent/permissions).
+
+<Callout type="warning">
+Do not pass `--safe` to a headless run with no TTY on stdin, such as CI. There is no way to answer
+the prompt, so it is denied and the run stalls on its first write.
+</Callout>
 
 ## Plan mode
 
@@ -49,31 +74,8 @@ The header shows a `PLAN` badge while it's active, so you always know where you 
 Use it to audit an unfamiliar codebase, or to agree on an approach before letting anything change.
 Todos staged during plan mode carry over when you exit, so the plan becomes the work list.
 
-## YOLO mode
-
-No sandbox, no prompts. Every tool call is auto-approved.
-
-```bash
-jan --yolo
-```
-
-The console prints a warning on start:
-
-```
-WARNING: --yolo disables the sandbox. The agent can read, write, and run any
-command without asking for approval.
-```
-
-<Callout type="warning">
-This grants unrestricted shell access to the machine you run it on. Use it in a container, a VM, or
-a scratch checkout you don't mind losing - not in your home directory.
-</Callout>
-
-It is the right choice in CI, where there is no one to answer a prompt and the environment is
-disposable. See [running in CI](/docs/agent/cli#using-it-in-ci).
-
 ## Switching
 
-Plan mode toggles at any time with `/plan` and `/plan exit`. Normal and YOLO are decided at launch -
-YOLO cannot be turned on mid-session, which is deliberate: a session you started cautiously stays
+Plan mode toggles at any time with `/plan` and `/plan exit`. Whether prompts are on is decided at
+launch: `--safe` cannot be turned on or off mid-session, so a session you started cautiously stays
 cautious.

--- a/src-tauri/src/bin/jan.rs
+++ b/src-tauri/src/bin/jan.rs
@@ -30,7 +30,7 @@ Models are served by remote providers configured in ~/.jan/config.toml\n\
 (see `jan config set`), a project's agent.toml, or the Jan desktop app.",
     after_help = "Examples:\n  \
   jan                                                    # open the interactive agent console (TUI)\n  \
-  jan --yolo                                             # TUI with every tool call auto-approved\n  \
+  jan --safe                                             # TUI that asks before writes and commands\n  \
   jan --task \"fix the failing test\"                      # seed the TUI with a first message\n  \
   jan -c                                                 # resume the most recent session\n  \
   jan --resume 3f7a91c2                                  # resume a session by id (or id prefix)\n  \
@@ -59,10 +59,10 @@ struct Cli {
     images: Vec<String>,
     #[command(flatten)]
     providers: ProviderArgs,
-    /// Disable the sandbox and auto-approve every tool call in the default agent
-    /// TUI (no prompts). Ignored when a subcommand is given.
+    /// Prompt for approval before writes, shell commands, and MCP tool calls in
+    /// the default agent TUI. Ignored when a subcommand is given.
     #[arg(long)]
-    yolo: bool,
+    safe: bool,
     #[command(flatten)]
     resume: ResumeArgs,
     /// Start the default agent TUI in read-only plan mode (same as /plan).
@@ -207,9 +207,9 @@ enum AgentCommands {
         /// Max turns (overrides [agent].max_turns; clamped 1..=400)
         #[arg(long)]
         max_turns: Option<u32>,
-        /// Disable the sandbox and auto-approve every tool call (no prompts)
+        /// Prompt for approval before writes, shell commands, and MCP tool calls
         #[arg(long)]
-        yolo: bool,
+        safe: bool,
         #[command(flatten)]
         providers: ProviderArgs,
         #[command(flatten)]
@@ -225,9 +225,9 @@ enum AgentCommands {
         /// Model ID (overrides [agent].model in agent.toml)
         #[arg(long)]
         model: Option<String>,
-        /// Disable the sandbox and auto-approve every tool call (no prompts)
+        /// Prompt for approval before writes, shell commands, and MCP tool calls
         #[arg(long)]
-        yolo: bool,
+        safe: bool,
         #[command(flatten)]
         providers: ProviderArgs,
     },
@@ -388,7 +388,7 @@ async fn main() {
             cli.max_turns,
             cli.images,
             overrides,
-            cli.yolo,
+            !cli.safe,
             cli.plan,
             cli.resume.into_target(),
         )
@@ -475,7 +475,7 @@ async fn handle_agent(cmd: AgentCommands) {
             task,
             model,
             max_turns,
-            yolo,
+            safe,
             providers,
             resume,
         } => {
@@ -485,7 +485,7 @@ async fn handle_agent(cmd: AgentCommands) {
                 model,
                 max_turns,
                 providers.into_overrides(),
-                yolo,
+                !safe,
                 resume.into_target(),
             )
             .await
@@ -494,9 +494,9 @@ async fn handle_agent(cmd: AgentCommands) {
             project,
             task,
             model,
-            yolo,
+            safe,
             providers,
-        } => cli_agent_step(&project, &task, model, providers.into_overrides(), yolo).await,
+        } => cli_agent_step(&project, &task, model, providers.into_overrides(), !safe).await,
         AgentCommands::Status { project, providers } => {
             match cli_agent_status(&project, &providers.into_overrides()) {
                 Ok(status) => {
@@ -632,17 +632,25 @@ async fn handle_models(cmd: ModelsCommands) {
 mod tests {
     use super::*;
 
-    // `--plan` is a per-invocation startup toggle mirroring `--yolo`; it must
+    // `--plan` is a per-invocation startup toggle mirroring `--safe`; it must
     // parse on the top-level `jan` command and default off.
     #[test]
     fn top_level_plan_flag_parses() {
         let cli = Cli::parse_from(["jan", "--plan"]);
         assert!(cli.plan);
-        assert!(!cli.yolo);
+        assert!(!cli.safe);
         assert!(cli.command.is_none());
 
         let cli = Cli::parse_from(["jan"]);
         assert!(!cli.plan);
+    }
+
+    // Permission prompts are opt-in: auto-approval inside the OS sandbox is the
+    // default, and `--safe` is what turns the gate back on.
+    #[test]
+    fn safe_flag_parses_and_defaults_off() {
+        assert!(!Cli::parse_from(["jan"]).safe);
+        assert!(Cli::parse_from(["jan", "--safe"]).safe);
     }
 
     #[test]

--- a/src-tauri/src/core/agent/commands.rs
+++ b/src-tauri/src/core/agent/commands.rs
@@ -72,7 +72,7 @@ fn build_orchestration_args<R: Runtime>(
         system_prompt_override: None,
         subagents_enabled: true,
         max_parallel_subagents: crate::core::agent::subagent::DEFAULT_MAX_PARALLEL_SUBAGENTS,
-        yolo: false,
+        auto_approve: false,
         run_mode: crate::core::agent::plan::RunMode::Normal,
     }
 }

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -81,14 +81,16 @@ pub(crate) struct OrchestrationArgs {
     /// (`[agent].max_parallel_subagents` in agent.toml, default 10). Snapshot
     /// taken at run start: a mid-run config edit affects the *next* run only.
     pub max_parallel_subagents: u32,
-    /// `--yolo`: disable the sandbox/permission gate and auto-allow every tool
-    /// call (built-in reads/writes/exec and MCP) without prompting. Inherited by
-    /// dispatched subagents via the cloned parent args.
-    pub yolo: bool,
+    /// Auto-allow every tool call that would otherwise prompt (built-in
+    /// reads/writes/exec and MCP). The CLI default, since the OS jail in the
+    /// tools plugin confines exec regardless; `--safe` turns it off. Desktop
+    /// leaves it false. `HardDeny` still stands. Inherited by dispatched
+    /// subagents via the cloned parent args.
+    pub auto_approve: bool,
     /// Read-only plan mode. When `Plan`, mutation-capable tools (write/edit/bash,
     /// memory_write/skill_write, MCP, subagent dispatch) are neither advertised
     /// nor executable: the dispatcher hard-denies them with `plan_mode_read_only`,
-    /// stronger than `--yolo`'s prompt suppression (yolo cannot override this).
+    /// stronger than auto-approval's prompt suppression (it cannot override this).
     pub run_mode: crate::core::agent::plan::RunMode,
 }
 
@@ -212,22 +214,21 @@ struct CompositeToolInvoker {
     todo_registry: Option<crate::core::agent::todo::TodoRegistry>,
     grants: std::sync::Mutex<tauri_plugin_agent_tools::tools::gate::SessionGrants>,
     subagents: Option<SubagentContext>,
-    yolo: bool,
+    auto_approve: bool,
     run_mode: crate::core::agent::plan::RunMode,
 }
 
 /// Default for the sandboxed shell's network namespace, used when
 /// `[tools].allow_network` is unset.
 ///
-/// The CLI agent runs in the user's own terminal against their own project, and
-/// every exec is already gated behind an interactive prompt, so the network is
-/// not what confines it -- the user is. Before the shell was sandboxed at all it
-/// ran fully unconfined, and a coding agent that cannot `curl`, `git fetch`, or
-/// install a package is largely useless, so the sandbox keeps the network and
-/// relies on the prompt.
+/// The CLI agent runs against the user's own project, where what confines it is
+/// the workspace the sandbox pins it to, not the network namespace. Before the
+/// shell was sandboxed at all it ran fully unconfined, and a coding agent that
+/// cannot `curl`, `git fetch`, or install a package is largely useless, so the
+/// network stays on. `--safe` adds a prompt on top; it does not change this.
 ///
-/// The desktop chat sandbox makes the opposite trade: it is ephemeral, has no
-/// prompt, and opts in per call from a user setting (`commands.rs`).
+/// The desktop chat sandbox makes the opposite trade: it is ephemeral, cannot
+/// prompt at all, and opts in per call from a user setting (`commands.rs`).
 #[cfg(feature = "cli")]
 const DEFAULT_ALLOW_NETWORK: bool = true;
 #[cfg(not(feature = "cli"))]
@@ -633,7 +634,7 @@ impl ToolInvoker for CompositeToolInvoker {
                 let id = tc.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string();
                 // Plan mode blocks subagent dispatch (a subagent could mutate).
                 // They are not advertised in Plan; this is defense in depth
-                // against a stale tool schema. `--yolo` cannot override.
+                // against a stale tool schema. Auto-approval cannot override.
                 if self.run_mode == crate::core::agent::plan::RunMode::Plan {
                     out.push(ToolOutcome::plain(id, plan_mode_read_only_msg(name)));
                     continue;
@@ -652,7 +653,7 @@ impl ToolInvoker for CompositeToolInvoker {
                 let id = tc.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string();
                 // Plan mode blocks all MCP tools: their capability is arbitrary
                 // and unknowable, so they are never advertised in Plan and are
-                // hard-denied here as defense in depth. `--yolo` cannot override.
+                // hard-denied here as defense in depth. Auto-approval cannot override.
                 if self.run_mode == crate::core::agent::plan::RunMode::Plan {
                     out.push(ToolOutcome::plain(id, plan_mode_read_only_msg(name)));
                     continue;
@@ -665,7 +666,7 @@ impl ToolInvoker for CompositeToolInvoker {
                     ));
                     continue;
                 }
-                if self.yolo || self.grants.lock().unwrap().covers_mcp(name) {
+                if self.auto_approve || self.grants.lock().unwrap().covers_mcp(name) {
                     mcp_calls.push(tc.clone());
                     continue;
                 }
@@ -695,7 +696,7 @@ impl ToolInvoker for CompositeToolInvoker {
                 .unwrap_or(serde_json::Value::Object(Default::default()));
             let tool = lookup(name).expect("is_builtin implies lookup");
             // Plan mode: mutation-capable builtins (Write/Exec) are hard-denied
-            // BEFORE the normal gate, without a permission prompt, and `--yolo`
+            // BEFORE the normal gate, without a permission prompt, and auto-approval
             // cannot override this (unlike the normal prompt suppression below).
             // Read/Net/workspace-read tools fall through to the usual gate.
             if self.run_mode == crate::core::agent::plan::RunMode::Plan
@@ -712,11 +713,11 @@ impl ToolInvoker for CompositeToolInvoker {
                 &self.permissions,
                 &snapshot,
             );
-            // --yolo suppresses every prompt (sandbox escape, write, exec) but
+            // Auto-approval suppresses every prompt (sandbox escape, write, exec) but
             // still honors HardDeny, so the `.jan/agent` restricted-path invariant
             // and explicit agent.toml denies hold.
             let decision = match decision {
-                Decision::Prompt(_) if self.yolo => Decision::Allow,
+                Decision::Prompt(_) if self.auto_approve => Decision::Allow,
                 other => other,
             };
             // Read and Net tools are non-mutating and safe to run concurrently
@@ -872,7 +873,7 @@ pub(crate) async fn run_server_side_openai_orchestration(
         system_prompt_override: None,
         subagents_enabled: false,
         max_parallel_subagents: crate::core::agent::subagent::DEFAULT_MAX_PARALLEL_SUBAGENTS,
-        yolo: false,
+        auto_approve: false,
         run_mode: crate::core::agent::plan::RunMode::Normal,
     };
     run_orchestration_streamed(&tx, json_body, &args).await
@@ -1100,7 +1101,7 @@ async fn orchestrate_inner(
         system_prompt_override,
         subagents_enabled,
         max_parallel_subagents,
-        yolo,
+        auto_approve,
         run_mode,
     } = args;
 
@@ -1397,7 +1398,7 @@ async fn orchestrate_inner(
             todo_registry: todo_registry.clone(),
             grants: std::sync::Mutex::new(tauri_plugin_agent_tools::tools::gate::SessionGrants::default()),
             subagents,
-            yolo: *yolo,
+            auto_approve: *auto_approve,
             run_mode,
         };
         let result = run_turn_cycle(
@@ -2692,7 +2693,7 @@ mod tests {
             todo_registry: None,
             grants: std::sync::Mutex::new(SessionGrants::default()),
             subagents: None,
-            yolo: false,
+            auto_approve: false,
             run_mode: crate::core::agent::plan::RunMode::Normal,
         }
     }
@@ -2873,14 +2874,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn plan_mode_denies_write_even_with_yolo() {
+    async fn plan_mode_denies_write_even_with_auto_approve() {
         let root = unique_project_root();
         let (tx, _rx) = mpsc::unbounded_channel();
         let permissions: PermissionRegistry = Arc::new(Mutex::new(HashMap::new()));
         let mut invoker = build_prompting_invoker(root.clone(), tx, permissions);
         invoker.run_mode = crate::core::agent::plan::RunMode::Plan;
-        // --yolo must NOT override the plan-mode read-only gate.
-        invoker.yolo = true;
+        // Auto-approval must NOT override the plan-mode read-only gate.
+        invoker.auto_approve = true;
 
         let out = invoker.invoke(&[write_call()]).await.unwrap();
 
@@ -2901,7 +2902,7 @@ mod tests {
         let permissions: PermissionRegistry = Arc::new(Mutex::new(HashMap::new()));
         let mut invoker = build_prompting_invoker(root.clone(), tx, permissions);
         invoker.run_mode = crate::core::agent::plan::RunMode::Plan;
-        invoker.yolo = true;
+        invoker.auto_approve = true;
 
         // An unknown (non-builtin) name stands in for an MCP tool a stale schema
         // could still surface; it must be denied before any dispatch.
@@ -3191,12 +3192,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn yolo_writes_without_prompting() {
+    async fn auto_approve_writes_without_prompting() {
         let root = unique_project_root();
         let (tx, mut rx) = mpsc::unbounded_channel();
         let registry: PermissionRegistry = Arc::new(Mutex::new(HashMap::new()));
         let mut invoker = build_prompting_invoker(root.clone(), tx, registry);
-        invoker.yolo = true;
+        invoker.auto_approve = true;
 
         let out = invoker.invoke(&[write_call()]).await.unwrap();
 
@@ -3206,7 +3207,7 @@ mod tests {
         // No permission prompt should have been emitted.
         assert!(
             !matches!(rx.try_recv(), Ok(StreamEvent::PermissionRequest { .. })),
-            "yolo must not prompt for a write"
+            "auto_approve must not prompt for a write"
         );
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/src-tauri/src/core/agent/plan.rs
+++ b/src-tauri/src/core/agent/plan.rs
@@ -8,7 +8,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Persisted per-session run mode. `Normal` is the default (normal permission
-/// gate / `--yolo`); `Plan` is read-only by enforcement.
+/// gate / auto-approval); `Plan` is read-only by enforcement.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum RunMode {

--- a/src-tauri/src/core/agent/project.rs
+++ b/src-tauri/src/core/agent/project.rs
@@ -138,7 +138,8 @@ max_tokens = 200000
 
 [tools]
 # read-only | deny | allow. read-only (default) exposes MCP tools and built-in
-# reads; built-in writes/exec still prompt. deny locks down all MCP tools.
+# reads; built-in writes/exec go through the permission gate. deny locks down
+# all MCP tools.
 default = "read-only"
 # Exposed even under deny; deny-list wins over everything:
 allow = []
@@ -147,8 +148,8 @@ deny = []
 # allow_write = ["fs.write"]
 allow_write = []
 # Whether the sandboxed shell can reach the network. Unset follows the surface
-# running the agent: the CLI allows it (every exec is prompted first), the
-# desktop's throwaway chat sandbox does not.
+# running the agent: the CLI allows it, the desktop's throwaway chat sandbox
+# does not.
 # allow_network = true
 # Whether the sandboxed shell can read your home directory (for git/ssh
 # credential helpers and ~/.ssh/config). Unset follows the surface: the CLI

--- a/src-tauri/src/core/agent/subagent.rs
+++ b/src-tauri/src/core/agent/subagent.rs
@@ -1510,7 +1510,7 @@ mod tests {
             system_prompt_override: None,
             subagents_enabled: true,
             max_parallel_subagents: 1,
-            yolo: false,
+            auto_approve: false,
             run_mode: crate::core::agent::plan::RunMode::Normal,
         }
     }

--- a/src-tauri/src/core/cli/mod.rs
+++ b/src-tauri/src/core/cli/mod.rs
@@ -498,10 +498,10 @@ pub async fn cli_agent_run(
     model: Option<String>,
     max_turns: Option<u32>,
     overrides: ProviderOverrides,
-    yolo: bool,
+    auto_approve: bool,
     resume: Option<ResumeTarget>,
 ) -> Result<(), String> {
-    run_agent_loop(project, task, model, max_turns, overrides, yolo, resume).await
+    run_agent_loop(project, task, model, max_turns, overrides, auto_approve, resume).await
 }
 
 /// Single-turn run for debugging (`max_turns = 1`).
@@ -510,9 +510,9 @@ pub async fn cli_agent_step(
     task: &str,
     model: Option<String>,
     overrides: ProviderOverrides,
-    yolo: bool,
+    auto_approve: bool,
 ) -> Result<(), String> {
-    run_agent_loop(project, task, model, Some(1), overrides, yolo, None).await
+    run_agent_loop(project, task, model, Some(1), overrides, auto_approve, None).await
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -523,7 +523,7 @@ fn build_cli_orchestration_args(
     mcp_servers: crate::core::state::SharedMcpServers,
     mcp_settings: McpSettings,
     permission_requests: PermissionRegistry,
-    yolo: bool,
+    auto_approve: bool,
     plan: bool,
     max_parallel_subagents: u32,
 ) -> OrchestrationArgs {
@@ -541,7 +541,7 @@ fn build_cli_orchestration_args(
         system_prompt_override: None,
         subagents_enabled: true,
         max_parallel_subagents,
-        yolo,
+        auto_approve,
         run_mode: if plan {
             crate::core::agent::plan::RunMode::Plan
         } else {
@@ -626,7 +626,7 @@ fn prepare_agent_session(
     model_override: Option<String>,
     max_turns_override: Option<u32>,
     overrides: ProviderOverrides,
-    yolo: bool,
+    auto_approve: bool,
     plan: bool,
     require_model: bool,
 ) -> Result<AgentSession, String> {
@@ -637,12 +637,6 @@ fn prepare_agent_session(
     }
     let cfg = load_agent_config(&project_root)?;
     let permissions = permissions_from(&cfg);
-
-    if yolo {
-        eprintln!(
-            "WARNING: --yolo disables the sandbox. The agent can read, write, and run any command without asking for approval."
-        );
-    }
 
     // Resolution order: --model flag, then agent.toml [agent].model, then the
     // standalone global config (~/.jan/config.toml default_model / first provider
@@ -733,7 +727,7 @@ fn prepare_agent_session(
         mcp_servers.clone(),
         mcp_settings,
         permission_requests.clone(),
-        yolo,
+        auto_approve,
         plan,
         max_parallel_subagents,
     );
@@ -797,7 +791,7 @@ fn prepare_agent_run(
     model_override: Option<String>,
     max_turns_override: Option<u32>,
     overrides: ProviderOverrides,
-    yolo: bool,
+    auto_approve: bool,
     resume: Option<ResumeTarget>,
 ) -> Result<PreparedRun, String> {
     // Non-interactive runs (`agent run`/`step`) have no plan-review handoff, so
@@ -807,7 +801,7 @@ fn prepare_agent_run(
         model_override,
         max_turns_override,
         overrides,
-        yolo,
+        auto_approve,
         false,
         true,
     )?;
@@ -867,7 +861,7 @@ async fn run_agent_loop(
     model_override: Option<String>,
     max_turns_override: Option<u32>,
     overrides: ProviderOverrides,
-    yolo: bool,
+    auto_approve: bool,
     resume: Option<ResumeTarget>,
 ) -> Result<(), String> {
     let PreparedRun {
@@ -882,7 +876,7 @@ async fn run_agent_loop(
         model_override,
         max_turns_override,
         overrides,
-        yolo,
+        auto_approve,
         resume,
     )?;
 
@@ -950,7 +944,7 @@ pub async fn cli_agent_ui(
     max_turns: Option<u32>,
     images: Vec<String>,
     overrides: ProviderOverrides,
-    yolo: bool,
+    auto_approve: bool,
     plan: bool,
     resume: Option<ResumeTarget>,
 ) -> Result<(), String> {
@@ -964,7 +958,15 @@ pub async fn cli_agent_ui(
     // Fresh install with a terminal attached: launch with no model rather than
     // forcing sign-in here. The TUI shows a one-line notice and `/login` (or
     // `jan login`) picks a model up once the user is ready.
-    let session = prepare_agent_session(project, model, max_turns, overrides, yolo, plan, false)?;
+    let session = prepare_agent_session(
+        project,
+        model,
+        max_turns,
+        overrides,
+        auto_approve,
+        plan,
+        false,
+    )?;
     // TUI threads persist under the project's .jan/agent dir, separate from the
     // desktop store, so continuing here never mutates desktop threads.
     let agent_dir = agent_dir_for(&project_root);

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -3437,8 +3437,10 @@ pub async fn run(
     if app.model.is_empty() {
         app.note("not signed in — run /login to sign in to Tokamak, or `jan config set` to configure a provider manually");
     }
-    if args.yolo {
-        app.note("--yolo: sandbox disabled, all tool calls auto-approved without prompting");
+    if args.auto_approve {
+        app.note("tool calls are auto-approved inside the OS sandbox; start with --safe to be asked first");
+    } else {
+        app.note("--safe: writes, shell commands, and MCP tool calls need approval");
     }
     // A failed resume is not fatal: the note explains why and the blank session
     // the user already has stays usable.


### PR DESCRIPTION
## Describe Your Changes

The OS jail (bubblewrap/seatbelt/AppContainer) confines every shell command regardless of the permission gate, so prompting on each write and exec is no longer what contains the CLI agent. Flip the default: tool calls are auto-approved, and --safe turns the interactive gate back on.

- Remove --yolo from the bare TUI, `cli agent run`, and `cli agent step`; add --safe, inverted once at the arg boundary.
- Rename OrchestrationArgs.yolo to auto_approve. Desktop entry points keep it false, so desktop behavior is unchanged.
- Drop the --yolo stderr banner, which would now fire on every default run. The TUI notes the active mode on startup instead.
- HardDeny is untouched: .jan/agent/ internals, [tools] deny, and plan mode still refuse regardless of auto-approval.

Docs restructured around Default/Safe/Plan. The CI example drops the flag and warns that --safe with no TTY auto-denies and stalls on the first write.

Also correct two claims this invalidated, plus one that was already wrong: allow_network's rationale no longer cites the prompt, the generated agent.toml template says "go through the permission gate" rather than "still prompt", and permissions.mdx no longer says the sandboxed shell has no network by default (true on desktop, false on the CLI, where DEFAULT_ALLOW_NETWORK is true).

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
