### PR TITLE
fix(agent-tui): route ask paste to custom editor, accept repeated keys

### DIFF
--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -3077,6 +3077,38 @@ mod tests {
         let _ = std::fs::remove_dir_all(&root);
     }
 
+    #[tokio::test]
+    async fn ask_returns_custom_response_at_invoker_boundary() {
+        let root = unique_project_root();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let permissions: PermissionRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let asks = crate::core::agent::interaction::new_registry();
+        let mut invoker = build_prompting_invoker(root.clone(), tx, permissions);
+        invoker.ask_requests = Some(asks.clone());
+
+        let task = tokio::spawn(async move { invoker.invoke(&[ask_call()]).await.unwrap() });
+        let request_id = match rx.recv().await.unwrap() {
+            StreamEvent::AskRequest { request_id, .. } => request_id,
+            event => panic!("expected ask_request, got {event:?}"),
+        };
+        crate::core::agent::interaction::respond(
+            &asks,
+            &request_id,
+            Ok(vec![crate::core::agent::interaction::QuestionResult {
+                id: "scope".into(),
+                selected: Vec::new(),
+                custom_input: Some("custom answer".into()),
+            }]),
+        )
+        .await
+        .unwrap();
+
+        let out = task.await.unwrap();
+        let result: serde_json::Value = serde_json::from_str(&out[0].content).unwrap();
+        assert_eq!(result[0]["custom_input"], "custom answer");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
     fn todo_call(id: &str, args: serde_json::Value) -> serde_json::Value {
         json!({
             "id": id,

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -3739,16 +3739,19 @@ async fn chat_loop<B: Backend>(
                                 };
                             }
                         }
-                        Ok(Event::Paste(text)) => match app.login.as_mut() {
-                            // A pasted API key belongs to the login field, not
-                            // the input box (where it would be echoed).
-                            Some(prompt) => prompt.paste(&text),
-                            None => {
+                        Ok(Event::Paste(text)) => {
+                            if let Some(prompt) = app.login.as_mut() {
+                                // A pasted API key belongs to the login field,
+                                // not the chat composer (where it would echo).
+                                prompt.paste(&text);
+                            } else if !app.ask_queue.is_empty() {
+                                handle_ask_paste(app, &text);
+                            } else {
                                 for c in text.chars() {
                                     app.input_insert(c);
                                 }
                             }
-                        },
+                        }
                         // `handle_ask_mouse` mutates app state, so it stays in the
                         // arm body rather than a match guard that hides the effect.
                         #[allow(clippy::collapsible_match)]
@@ -3997,7 +4000,7 @@ async fn handle_ask_key(
     if app.ask_queue.is_empty() {
         return false;
     }
-    if key.kind != KeyEventKind::Press {
+    if key.kind == KeyEventKind::Release {
         return true;
     }
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
@@ -4041,6 +4044,15 @@ async fn handle_ask_key(
         resolve_front_ask(app, registry, false).await;
     }
     true
+}
+
+/// Route bracketed paste to the active custom answer instead of the chat composer.
+fn handle_ask_paste(app: &mut App, text: &str) {
+    if let Some(ask) = app.ask_queue.front_mut() {
+        if ask.editing_custom {
+            ask.custom_input.push_str(text);
+        }
+    }
 }
 
 async fn handle_ask_mouse(
@@ -7568,6 +7580,7 @@ mod tests {
         clipboard_path,
         diff_lines, group_activity, group_detail_lines, group_summary, handle_ask_key,
         handle_ask_mouse, handle_key, handle_mouse, image_mime, input_content_lines,
+        handle_ask_paste,
         compact_tokens, finish_login, finish_update_install, load_image_file, message_text,
         note_update, open_config_screen,
         parse_command, partial_json_field, restore_goal, restore_run_mode, restore_todos,
@@ -7583,7 +7596,7 @@ mod tests {
     };
     use std::time::{Duration, Instant};
     use ratatui::crossterm::event::{
-        KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
+        KeyCode, KeyEvent, KeyEventKind, KeyModifiers, MouseButton, MouseEvent, MouseEventKind,
     };
     use ratatui::layout::Rect;
     use ratatui::{style::Modifier, text::Line};
@@ -7950,6 +7963,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ask_keyboard_accepts_repeated_key_events() {
+        let mut app = test_app();
+        let registry = crate::core::agent::interaction::new_registry();
+        let (request_id, receiver) = crate::core::agent::interaction::register(&registry).await;
+        app.apply(StreamEvent::AskRequest {
+            request_id,
+            request: ask_request(false, false),
+        });
+
+        let mut key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+        key.kind = KeyEventKind::Repeat;
+        assert!(handle_ask_key(&mut app, key, &registry).await);
+
+        let answers = receiver.await.unwrap().unwrap();
+        assert_eq!(answers[0].selected, vec!["Small"]);
+        assert!(app.ask_queue.is_empty());
+    }
+
+    #[tokio::test]
     async fn ask_keyboard_handles_multi_select_and_cancellation() {
         let mut app = test_app();
         let registry = crate::core::agent::interaction::new_registry();
@@ -8025,6 +8057,34 @@ mod tests {
         );
         let answers = receiver.await.unwrap().unwrap();
         assert_eq!(answers[0].custom_input.as_deref(), Some("custom answer"));
+        assert!(app.ask_queue.is_empty());
+    }
+
+    #[tokio::test]
+    async fn ask_paste_routes_to_custom_editor() {
+        let mut app = test_app();
+        let registry = crate::core::agent::interaction::new_registry();
+        let (request_id, receiver) = crate::core::agent::interaction::register(&registry).await;
+        app.apply(StreamEvent::AskRequest {
+            request_id,
+            request: ask_request(false, false),
+        });
+
+        press_ask(&mut app, &registry, KeyCode::Down).await;
+        press_ask(&mut app, &registry, KeyCode::Down).await;
+        press_ask(&mut app, &registry, KeyCode::Enter).await;
+        assert!(app.ask_queue.front().unwrap().editing_custom);
+
+        handle_ask_paste(&mut app, "pasted answer");
+        assert_eq!(
+            app.ask_queue.front().unwrap().custom_input,
+            "pasted answer"
+        );
+        assert!(app.input.is_empty(), "paste leaked into chat composer");
+
+        press_ask(&mut app, &registry, KeyCode::Enter).await;
+        let answers = receiver.await.unwrap().unwrap();
+        assert_eq!(answers[0].custom_input.as_deref(), Some("pasted answer"));
         assert!(app.ask_queue.is_empty());
     }
 


### PR DESCRIPTION
## Describe Your Changes

Bracketed paste while an `ask` prompt is open went to the chat composer, so a pasted custom answer never reached the ask responder and the model saw `ERROR [ask_cancelled]`. This routes paste into the active custom-answer field; paste during option selection is dropped so it cannot leak into the next chat message.

Repeated key events (keyboard auto-repeat) were previously rejected by the ask key handler, so holding Enter did nothing. The handler now ignores only key-release events.

## Changes

- Route `Event::Paste` to the front ask's custom editor when one is open (`handle_ask_paste`)
- Accept `KeyEventKind::Repeat` in `handle_ask_key`; ignore only `Release`
- Tests drive the real handlers end to end:
  - repeated Enter selects and submits an option
  - paste lands in the custom field and leaves the chat composer untouched
  - a custom answer is received at the agent invoker boundary

## Verification

- CLI lib tests: 633 passed (incl. 19 ask_*)
- Tauri lib tests: 509 passed (incl. 10 ask_*)
- Release CLI build passes; `--max-turns` absent from help (per #8617)
- `git diff --check` clean; PR contains only the two source files

## Fixes Issues

- Closes # (none; bug reported while testing #8617)