### PR TITLE
fix(ci): install Linux DBus build dependencies

### DIFF
--- a/.github/workflows/template-cli-build-linux-x64.yml
+++ b/.github/workflows/template-cli-build-linux-x64.yml
@@ -43,6 +43,16 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      - name: Install Linux native dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pkg-config libdbus-1-dev
+
+      - name: Verify DBus development package
+        run: |
+          pkg-config --exists dbus-1
+          echo "Found dbus-1 $(pkg-config --modversion dbus-1)"
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## Summary
- install pkg-config and libdbus-1-dev in the Linux CLI build job
- verify dbus-1 metadata before Cargo compilation

## Root cause
The Linux job failed in libdbus-sys because the Ubuntu runner lacked dbus-1.pc.

## Validation
- Ruby YAML parse passed
- git diff --check passed
- manually reviewed the workflow diff
- GitHub Actions CI will validate the Ubuntu build on this PR