### PR TITLE
fix(server): accept custom-scheme origins (e.g. app://obsidian.md) in CORS trusted hosts

### DIFF
--- a/src-tauri/utils/src/http.rs
+++ b/src-tauri/utils/src/http.rs
@@ -15,6 +15,11 @@ pub fn is_cors_header(header_name: &str) -> bool {
     header_lower.starts_with("access-control-")
 }
 
+/// Strips a leading scheme (e.g. "app://", "http://") from a host/origin value.
+fn strip_scheme(value: &str) -> &str {
+    value.split("://").nth(1).unwrap_or(value)
+}
+
 /// Validates if host is in trusted hosts list
 pub fn is_valid_host(host: &str, trusted_hosts: &[Vec<String>]) -> bool {
     if trusted_hosts.iter().any(|hosts| hosts.contains(&"*".to_string())) {
@@ -59,6 +64,9 @@ pub fn is_valid_host(host: &str, trusted_hosts: &[Vec<String>]) -> bool {
     }
 
     trusted_hosts.iter().flatten().any(|valid| {
+        // Users may list a scheme-qualified origin (e.g. "app://obsidian.md")
+        // in Trusted Hosts. Normalize both sides so the bare host matches.
+        let valid = strip_scheme(valid);
         let host_lower = host.to_lowercase();
         let valid_lower = valid.to_lowercase();
 

--- a/src-tauri/utils/tests/cors_origin.rs
+++ b/src-tauri/utils/tests/cors_origin.rs
@@ -1,0 +1,18 @@
+use jan_utils::{extract_host_from_origin, is_valid_host};
+
+// Issue #8608: a custom Electron scheme origin (e.g. app://obsidian.md) must
+// be accepted when the user lists the scheme-qualified origin in Trusted
+// Hosts. The CORS preflight path extracts "obsidian.md" from the origin and
+// compares it against the user's "app://obsidian.md" entry, so the trusted
+// value must be normalized by stripping its scheme.
+#[test]
+fn custom_scheme_origin_in_trusted_hosts_is_accepted() {
+    let trusted = vec![vec!["app://obsidian.md".to_string()]];
+    let origin_host = extract_host_from_origin("app://obsidian.md");
+    assert_eq!(origin_host, "obsidian.md");
+    assert!(is_valid_host(&origin_host, &trusted));
+    // A port-bearing host for the same origin must also match.
+    assert!(is_valid_host("obsidian.md:1337", &trusted));
+    // Untrusted custom-scheme origins are still rejected.
+    assert!(!is_valid_host("evil.com", &trusted));
+}


### PR DESCRIPTION
This fixes #8608.

## Problem

Obsidian community plugins call Jan's Local API Server from a custom Electron scheme origin (`app://obsidian.md`) instead of a standard `http://`/`https://` origin. The CORS preflight handler in the Rust backend (`src-tauri/src/core/server/proxy.rs`) validates the `Origin` header by extracting its host and comparing it against the user's Trusted Hosts via `jan_utils::is_valid_host`.

When the user adds `app://obsidian.md` to Trusted Hosts, the extracted host (`obsidian.md`) never matches the scheme-qualified entry (`app://obsidian.md`), so the preflight response omits `Access-Control-Allow-Origin` and the browser blocks the POST. The attached `app.log` shows exactly this:

```
CORS preflight: Host is 'localhost:1337', trusted hosts: [["http://127.0.0.1:1337/v1", "http://localhost:3000", "app://obsidian.md"]]
CORS preflight: Origin 'app://obsidian.md' is not trusted, not reflecting origin
CORS preflight response: host_trusted=true, origin='app://obsidian.md'
```

## Fix

`jan_utils::is_valid_host` (in `src-tauri/utils/src/http.rs`) now normalizes each Trusted Hosts entry by stripping a leading scheme (`app://`, `http://`, `https://`, ...) before comparing against the extracted origin host. A scheme-qualified entry like `app://obsidian.md` now correctly matches the origin host `obsidian.md`, while untrusted custom-scheme origins remain rejected.

## Test

Adds an integration test in `src-tauri/utils/tests/cors_origin.rs` that reproduces the preflight origin check for a custom scheme. The test fails on the current code (`is_valid_host("obsidian.md", [["app://obsidian.md"]])` returns false) and passes with the fix.