### PR TITLE
fix(agent): regenerate once when the upstream rejects an incomplete tool call

### DIFF
--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -3225,6 +3225,112 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn ask_result_content_reaches_the_outgoing_request() {
+        let root = unique_project_root();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let permissions: PermissionRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let asks = crate::core::agent::interaction::new_registry();
+        let mut invoker = build_prompting_invoker(root.clone(), tx.clone(), permissions);
+        invoker.ask_requests = Some(asks.clone());
+        let invoker = Arc::new(invoker);
+
+        // Script: the model first calls `ask`, then finishes with plain text.
+        let model = Arc::new(MockModel::new(vec![
+            json!({
+                "choices": [{
+                    "message": {
+                        "content": serde_json::Value::Null,
+                        "tool_calls": [{
+                            "id": "call_ask1",
+                            "type": "function",
+                            "function": {
+                                "name": "ask",
+                                "arguments": serde_json::to_string(&json!({
+                                    "questions": [{
+                                        "id": "scope",
+                                        "question": "Which scope?",
+                                        "options": [{"label": "Small"}, {"label": "Large"}]
+                                    }]
+                                })).unwrap()
+                            }
+                        }]
+                    },
+                    "finish_reason": "tool_calls"
+                }]
+            }),
+            json!({ "choices": [{ "message": { "content": "final answer" }, "finish_reason": "stop" }] }),
+        ]));
+        let mut budget = SessionBudget::new(None);
+        let convo = vec![json!({ "role": "user", "content": "use the ask tool" })];
+
+        let task = tokio::spawn({
+            let tx = tx.clone();
+            let model = model.clone();
+            let invoker = invoker.clone();
+            async move {
+                run_turn_cycle(
+                    &tx,
+                    &json!({}),
+                    "m",
+                    &[crate::core::agent::interaction::ask_tool_schema()],
+                    convo,
+                    0,
+                    &mut budget,
+                    model.as_ref(),
+                    invoker.as_ref(),
+                    crate::core::agent::plan::RunMode::Normal,
+                    None,
+                    None,
+                )
+                .await
+            }
+        });
+
+        // Answer the ask the way the TUI does: a user selection on the question.
+        let request_id = loop {
+            match rx.recv().await.unwrap() {
+                StreamEvent::AskRequest { request_id, .. } => break request_id,
+                _ => continue,
+            }
+        };
+        crate::core::agent::interaction::respond(
+            &asks,
+            &request_id,
+            Ok(vec![crate::core::agent::interaction::QuestionResult {
+                id: "scope".into(),
+                selected: vec!["Small".into()],
+                custom_input: None,
+            }]),
+        )
+        .await
+        .unwrap();
+
+        let result = task.await.unwrap();
+        assert!(result.is_ok(), "cycle failed: {result:?}");
+
+        // The request after the ask MUST carry the tool result with content.
+        let requests = model.requests.lock().unwrap();
+        assert!(
+            requests.len() >= 2,
+            "expected two outgoing requests, got {}",
+            requests.len()
+        );
+        let second = &requests[1];
+        let tool_msg = second["messages"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|m| m.get("role").and_then(|r| r.as_str()) == Some("tool"))
+            .expect("tool result message present in second request");
+        let content = tool_msg["content"].as_str().expect("content is a string");
+        assert!(
+            content.contains("Small"),
+            "ask result content missing from outgoing request: {content}"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
     async fn todo_unavailable_without_an_attached_session() {
         let root = unique_project_root();
         let (tx, _rx) = mpsc::unbounded_channel();

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -1639,6 +1639,11 @@ async fn run_turn_cycle(
         let completion = {
             let mut keep_recent = crate::core::agent::compaction::DEFAULT_KEEP_RECENT;
             let mut attempts = 0usize;
+            // Regenerate once when the upstream rejects the model's tool call
+            // as incomplete (the facade's DSML guard). The truncated call
+            // never executed, so the request has no side effects and retrying
+            // is safe; the regenerated call usually completes (observed live).
+            let mut tool_call_regenerated = false;
             loop {
                 let request_value = build_completion_request(
                     model_id,
@@ -1649,6 +1654,15 @@ async fn run_turn_cycle(
                 );
                 match model.invoke(&request_value, events).await {
                     Ok(c) => break c,
+                    Err(e)
+                        if crate::core::agent::upstream::is_incomplete_tool_call_error(&e)
+                            && !tool_call_regenerated =>
+                    {
+                        log::info!(
+                            "agent: upstream rejected an incomplete tool call; regenerating once"
+                        );
+                        tool_call_regenerated = true;
+                    }
                     Err(e)
                         if crate::core::agent::upstream::is_context_overflow_error(&e)
                             && attempts < MAX_COMPACTION_ATTEMPTS =>
@@ -2569,6 +2583,96 @@ mod tests {
                 .pop_front()
                 .unwrap_or_else(|| Err("mock exhausted".to_string()))
         }
+    }
+
+    #[tokio::test]
+    async fn turn_cycle_regenerates_once_on_incomplete_tool_call() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        // First invoke: the facade's DSML guard rejects the truncated tool
+        // call. Second: a complete tool call. Third: the final answer.
+        let model = ResultQueueModel {
+            results: StdMutex::new(
+                vec![
+                    Err("Upstream stream error: upstream_error: upstream emitted an incomplete DSML tool call".to_string()),
+                    Ok(mutating_tool_call_completion("call_1", "bash")),
+                    Ok(json!({ "choices": [{ "message": { "content": "final answer" }, "finish_reason": "stop" }] })),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+        };
+        let tool = MockTool::default();
+        let mut budget = SessionBudget::new(None);
+        let convo = vec![json!({ "role": "user", "content": "run it" })];
+
+        let result = run_turn_cycle(
+            &tx,
+            &json!({}),
+            "m",
+            &[],
+            convo,
+            0,
+            &mut budget,
+            &model,
+            &tool,
+            crate::core::agent::plan::RunMode::Normal,
+            None,
+            None,
+        )
+        .await;
+
+        assert!(result.is_ok(), "cycle failed: {result:?}");
+        // The regenerated tool call executed exactly once (MockTool echoes).
+        assert_eq!(tool.calls.lock().unwrap().len(), 1);
+        assert_eq!(
+            model.results.lock().unwrap().len(),
+            0,
+            "the queue must be fully consumed (exactly one retry)"
+        );
+    }
+
+    #[tokio::test]
+    async fn turn_cycle_gives_up_after_one_incomplete_tool_call_retry() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        // The upstream keeps rejecting: exactly two invokes (original + one
+        // retry), then the run surfaces the error.
+        let model = ResultQueueModel {
+            results: StdMutex::new(
+                vec![
+                    Err("Upstream stream error: upstream_error: upstream emitted an incomplete DSML tool call".to_string()),
+                    Err("Upstream stream error: upstream_error: upstream emitted an incomplete DSML tool call".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+        };
+        let tool = MockTool::default();
+        let mut budget = SessionBudget::new(None);
+        let convo = vec![json!({ "role": "user", "content": "run it" })];
+
+        let result = run_turn_cycle(
+            &tx,
+            &json!({}),
+            "m",
+            &[],
+            convo,
+            0,
+            &mut budget,
+            &model,
+            &tool,
+            crate::core::agent::plan::RunMode::Normal,
+            None,
+            None,
+        )
+        .await;
+
+        assert!(result.is_err(), "persistent rejection must fail the run");
+        assert_eq!(
+            model.results.lock().unwrap().len(),
+            0,
+            "queue consumed exactly twice, then the run stopped"
+        );
+        assert!(tool.calls.lock().unwrap().is_empty(), "no tool ran");
     }
 
     #[tokio::test]

--- a/src-tauri/src/core/agent/upstream.rs
+++ b/src-tauri/src/core/agent/upstream.rs
@@ -554,6 +554,14 @@ pub(crate) fn is_context_overflow_error(err: &str) -> bool {
     err.contains(CONTEXT_OVERFLOW_MARKER)
 }
 
+/// True when the upstream rejected the model's tool call as incomplete (the
+/// facade's DSML guard: "upstream emitted an incomplete DSML tool call"). The
+/// truncated call never executed, so the request has no side effects and the
+/// loop can safely regenerate it once instead of killing the run.
+pub(crate) fn is_incomplete_tool_call_error(err: &str) -> bool {
+    err.contains("incomplete") && err.contains("tool call")
+}
+
 pub(crate) async fn stream_openai_chat_completions(
     client: &Client,
     upstream_url: &str,


### PR DESCRIPTION
## What

The facade's DSML guard rejects tool calls whose arguments were truncated mid-stream (the ds4/vLLM truncation issue). Previously the agent loop surfaced that as a terminal `Upstream stream error: ... incomplete DSML tool call` and **killed the run** — even though the truncated call never executed, so no tool ran and no side effects existed.

**Fix:** retry the same request once when the upstream reports an incomplete tool call. The regenerated call usually completes (observed live: the ask prompt fired on the second attempt). Bounded to a single regeneration — a persistently rejecting upstream still fails the run.

Also pins the ask delivery contract with a full-loop regression test: model calls `ask` -> the TUI-side registry answers -> the next outgoing request must carry the tool result with that content.

## Why now

Live reproduction: with `tokamak-1-preview`, asking the model to use the `ask` tool repeatedly hit `upstream emitted an incomplete DSML tool call`, terminating the turn before the question ever rendered. The ask tool itself is verified working end-to-end (capture -> registry -> request), so the actionable jan-side fix is making the run survive the upstream's flaky tool-call generation.

## Verification

- New: `turn_cycle_regenerates_once_on_incomplete_tool_call` (first invoke rejected, second completes, tool executes once)
- New: `turn_cycle_gives_up_after_one_incomplete_tool_call_retry` (persistent rejection fails the run after exactly one retry)
- New: `ask_result_content_reaches_the_outgoing_request` (full-loop ask delivery contract)
- Library suite: 662 passed (cli config); desktop `cargo check` clean