### PR TITLE
fix(agent): omit tool choice for DeepSeek v4 thinking

### DIFF
--- a/build-tui.sh
+++ b/build-tui.sh
@@ -41,8 +41,10 @@ build() {
     fi
 
     echo "==> Installing to $INSTALL_DIR/$BIN_NAME ..."
-    cp "$artifact" "$INSTALL_DIR/$BIN_NAME"
-    chmod +x "$INSTALL_DIR/$BIN_NAME"
+    local install_tmp
+    install_tmp="$(mktemp "$INSTALL_DIR/.${BIN_NAME}.XXXXXX")"
+    install -m 755 "$artifact" "$install_tmp"
+    mv -f "$install_tmp" "$INSTALL_DIR/$BIN_NAME"
 
     echo "==> Done: $INSTALL_DIR/$BIN_NAME"
     echo "    Make sure $INSTALL_DIR is in your PATH."

--- a/scripts/test-build-tui-install.sh
+++ b/scripts/test-build-tui-install.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+original_home="$HOME"
+test_home="$(mktemp -d)"
+trap 'rm -rf "$test_home"' EXIT
+
+export HOME="$test_home"
+export CARGO_HOME="${CARGO_HOME:-$original_home/.cargo}"
+export RUSTUP_HOME="${RUSTUP_HOME:-$original_home/.rustup}"
+
+"$repo_root/build-tui.sh" debug
+"$repo_root/build-tui.sh" debug
+
+python3 - "$HOME/.local/bin/jan" <<'PY'
+import subprocess
+import sys
+
+result = subprocess.run([sys.argv[1], "--version"], capture_output=True, check=True, text=True, timeout=5)
+assert result.stdout.startswith("jan "), result.stdout
+PY

--- a/src-tauri/src/core/agent/context.rs
+++ b/src-tauri/src/core/agent/context.rs
@@ -17,7 +17,7 @@ running commands, editing code, and writing new files.";
 
 /// Always-on behavioral guidelines. Kept short and model-facing.
 const GUIDELINES: &str =
-    "# Guidelines\n\n- Be concise in your responses.\n- Show file paths clearly when working with files.\n\
+    "# Guidelines\n\n- Be concise in your responses.\n- Reply in the same language as the user's most recent message unless they ask for another language.\n- Show file paths clearly when working with files.\n\
 - Reach for `todo` only when work genuinely needs tracking: several independent steps, or a task long enough that you or the user would otherwise lose the thread. When you do keep it current as tasks start, finish, or are abandoned. Most requests do not need one -- greetings, questions, single-file edits, and anything you can finish in a step or two are better done directly, and a plan for small work is noise the user has to read past.\n\
 - Call `ask` when the user's answer would materially change scope, behavior, or an irreversible action and it cannot be safely inferred from the request or project context. Ask concise, decision-ready questions; otherwise make the reasonable choice and proceed.\n\
 - Tool output is complete and verbatim. Trust it. Do not re-run a command to check for hidden or \
@@ -316,6 +316,14 @@ mod tests {
         let with_base = build_system_prompt(Some("base"), &root, false).expect("prompt");
         assert!(with_base.starts_with("base"));
         assert!(with_base.contains("Skills and Project Memory"));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn default_guidelines_match_the_user_language() {
+        let root = scratch_project("language");
+        let out = build_system_prompt(None, &root, false).expect("prompt");
+        assert!(out.contains("same language as the user's most recent message"));
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -1477,6 +1477,26 @@ fn requires_implicit_tool_choice(model_id: &str) -> bool {
     model_id.starts_with("deepseek-v4-")
 }
 
+/// Tokamak preview models ignore `role: "tool"` content. Their compatibility
+/// endpoint expects tool output as the next user message instead.
+fn requires_user_tool_results(model_id: &str) -> bool {
+    model_id == "tokamak-1-preview"
+}
+
+fn tool_result_message(model_id: &str, id: &str, content: &str) -> serde_json::Value {
+    if requires_user_tool_results(model_id) {
+        serde_json::json!({
+            "role": "user",
+            "content": format!(
+                "A tool returned:\n{content}\n\nContinue from this result. \
+                 Call another tool only if the next step requires it."
+            ),
+        })
+    } else {
+        serde_json::json!({ "role": "tool", "tool_call_id": id, "content": content })
+    }
+}
+
 
 /// Build one OpenAI chat-completion request from the current conversation.
 fn build_completion_request(
@@ -1767,31 +1787,23 @@ async fn run_turn_cycle(
             });
         }
 
-        // Record the assistant's tool-call turn using the standard OpenAI
-        // protocol: attach the `tool_calls` array here, and (below) feed each
-        // result back as a `role: "tool"` message carrying its `tool_call_id`.
-        //
-        // A prior workaround delivered tool results as `role: "user"` because
-        // some served models (observed with `tokamak-1-preview`) didn't attend
-        // to `role: "tool"` messages with large content. That is now fixed
-        // server-side: the tokamak-1-preview facade rewrites role:tool -> user
-        // for the specific model that needs it (scoped, content preserved), so
-        // the agent can speak standard OpenAI tool protocol on the wire again.
-        // See janhq/jan-internal#238.
-        if let Some(choice_message) = extract_choice_message(&completion) {
-            let assistant_content = choice_message
-                .get("content")
-                .cloned()
-                .unwrap_or(serde_json::Value::Null);
+        let assistant_content = extract_choice_message(&completion)
+            .and_then(|message| message.get("content"))
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        if requires_user_tool_results(model_id) {
             conversation_messages.push(serde_json::json!({
                 "role": "assistant",
-                "content": assistant_content,
-                "tool_calls": tool_calls.clone()
+                "content": if assistant_content.is_null() {
+                    serde_json::json!("(calling tools)")
+                } else {
+                    assistant_content
+                },
             }));
         } else {
             conversation_messages.push(serde_json::json!({
                 "role": "assistant",
-                "content": serde_json::Value::Null,
+                "content": assistant_content,
                 "tool_calls": tool_calls.clone()
             }));
         }
@@ -1813,11 +1825,7 @@ async fn run_turn_cycle(
                     is_error: true,
                     diff: None,
                 });
-                conversation_messages.push(serde_json::json!({
-                    "role": "tool",
-                    "tool_call_id": id,
-                    "content": content
-                }));
+                conversation_messages.push(tool_result_message(model_id, &id, &content));
             }
             turn += 1;
             continue;
@@ -1825,9 +1833,9 @@ async fn run_turn_cycle(
 
         let tool_results = tools.invoke(&tool_calls).await?;
 
-        // Standard OpenAI tool protocol: each result is a `role: "tool"` message
-        // carrying its `tool_call_id` (see note above the assistant push -- the
-        // tokamak-1-preview facade handles models that can't attend to it).
+        // Most providers use the OpenAI `role: "tool"` protocol. Tokamak
+        // preview models need a user-message compatibility path so they retain
+        // the tool result instead of receiving an empty `<tool_result>` block.
         let tool_names: HashMap<&str, &str> = tool_calls
             .iter()
             .filter_map(|tc| {
@@ -1865,11 +1873,7 @@ async fn run_turn_cycle(
                 is_error,
                 diff,
             });
-            conversation_messages.push(serde_json::json!({
-                "role": "tool",
-                "tool_call_id": id,
-                "content": content
-            }));
+            conversation_messages.push(tool_result_message(model_id, &id, &content));
         }
         if todo_touched_this_batch {
             mutations_since_todo_touch = 0;
@@ -2130,6 +2134,43 @@ mod tests {
             }
         }
         assert!(saw_tool_call && saw_tool_result);
+    }
+
+    #[tokio::test]
+    async fn tokamak_preview_receives_tool_results_as_user_messages() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let model = MockModel::new(vec![
+            tool_call_completion(),
+            json!({ "choices": [{ "message": { "content": "final answer" }, "finish_reason": "stop" }] }),
+        ]);
+        let tool = MockTool::default();
+        let mut budget = SessionBudget::new(None);
+
+        run_turn_cycle(
+            &tx,
+            &json!({}),
+            "tokamak-1-preview",
+            &[],
+            vec![user_message("ask something")],
+            8,
+            &mut budget,
+            &model,
+            &tool,
+            crate::core::agent::plan::RunMode::Normal,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let requests = model.requests.lock().unwrap();
+        let messages = requests[1]["messages"].as_array().unwrap();
+        assert_eq!(messages[messages.len() - 1]["role"], "user");
+        assert_eq!(
+            messages[messages.len() - 1]["content"],
+            "A tool returned:\nMOCK_RESULT\n\nContinue from this result. Call another tool only if the next step requires it."
+        );
+        assert!(messages[messages.len() - 2].get("tool_calls").is_none());
     }
 
     #[tokio::test]

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -1471,6 +1471,13 @@ async fn orchestrate_inner(
 /// overflowing request fails loudly instead of looping forever.
 const MAX_COMPACTION_ATTEMPTS: usize = 4;
 
+/// Direct DeepSeek v4 rejects every explicit `tool_choice` while thinking mode
+/// is enabled. Its implicit tool selection remains available when `tools` is sent.
+fn requires_implicit_tool_choice(model_id: &str) -> bool {
+    model_id.starts_with("deepseek-v4-")
+}
+
+
 /// Build one OpenAI chat-completion request from the current conversation.
 fn build_completion_request(
     model_id: &str,
@@ -1485,11 +1492,12 @@ fn build_completion_request(
         "messages".to_string(),
         serde_json::Value::Array(conversation_messages.to_vec()),
     );
-    let tool_choice = match forced_tool_choice {
-        Some(name) => serde_json::json!({ "type": "function", "function": { "name": name } }),
-        None => serde_json::json!("auto"),
-    };
-    completion_map.insert("tool_choice".to_string(), tool_choice);
+    if let Some(name) = forced_tool_choice.filter(|_| !requires_implicit_tool_choice(model_id)) {
+        completion_map.insert(
+            "tool_choice".to_string(),
+            serde_json::json!({ "type": "function", "function": { "name": name } }),
+        );
+    }
     if !openai_tools.is_empty() {
         completion_map.insert(
             "tools".to_string(),
@@ -2159,9 +2167,25 @@ mod tests {
             json!({ "type": "function", "function": { "name": "todo" } }),
             "the first turn's request must force the named tool"
         );
-        assert_eq!(
-            requests[1]["tool_choice"], "auto",
-            "later turns must not keep forcing the same tool"
+        assert!(
+            requests[1].get("tool_choice").is_none(),
+            "unforced turns must rely on the provider's implicit tool choice"
+        );
+    }
+
+    #[test]
+    fn deepseek_v4_uses_implicit_tool_choice_even_for_eager_todo() {
+        let request = build_completion_request(
+            "deepseek-v4-flash",
+            &[json!({ "role": "user", "content": "plan this work" })],
+            &[json!({ "type": "function", "function": { "name": "todo" } })],
+            &json!({}),
+            Some("todo"),
+        );
+
+        assert!(
+            request.get("tool_choice").is_none(),
+            "DeepSeek v4 thinking mode rejects every explicit tool_choice"
         );
     }
 

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -1654,6 +1654,10 @@ async fn run_turn_cycle(
     let mut mid_run_nudge_count: u32 = 0;
     // One-shot: asked the model to close out its todos before handing back.
     let mut closeout_nudged = false;
+    // Tokamak preview can otherwise repeat `ask` after receiving its answer as
+    // a compatibility user message. Hide only that tool for the immediately
+    // following completion, which requires the model to use the answer it has.
+    let mut suppress_ask_next_turn = false;
 
     while unlimited || turn < max_turns {
         let _ = events.send(StreamEvent::Step {
@@ -1668,10 +1672,23 @@ async fn run_turn_cycle(
             let mut keep_recent = crate::core::agent::compaction::DEFAULT_KEEP_RECENT;
             let mut attempts = 0usize;
             loop {
+                let filtered_tools = suppress_ask_next_turn.then(|| {
+                    openai_tools
+                        .iter()
+                        .filter(|tool| {
+                            tool.pointer("/function/name")
+                                .and_then(serde_json::Value::as_str)
+                                != Some("ask")
+                        })
+                        .cloned()
+                        .collect::<Vec<_>>()
+                });
+                let tools_for_request = filtered_tools.as_deref().unwrap_or(openai_tools);
+                suppress_ask_next_turn = false;
                 let request_value = build_completion_request(
                     model_id,
                     &conversation_messages,
-                    openai_tools,
+                    tools_for_request,
                     json_body,
                     (turn == 0).then_some(force_first_tool).flatten(),
                 );
@@ -1852,6 +1869,7 @@ async fn run_turn_cycle(
         // `todo` at all means the list was just reconciled, regardless of
         // what else ran alongside it.
         let mut todo_touched_this_batch = false;
+        let mut completed_ask = false;
         for outcome in tool_results {
             let ToolOutcome { id, content, diff } = outcome;
             // A `bash` call that exits non-zero isn't prefixed "ERROR" (that
@@ -1864,6 +1882,8 @@ async fn run_turn_cycle(
             let name = tool_names.get(id.as_str()).copied().unwrap_or("");
             if name == "todo" {
                 todo_touched_this_batch = true;
+            } else if name == "ask" && !is_error {
+                completed_ask = true;
             } else if !is_error && matches!(name, "bash" | "write" | "edit") {
                 mutations_since_todo_touch += 1;
             }
@@ -1874,6 +1894,9 @@ async fn run_turn_cycle(
                 diff,
             });
             conversation_messages.push(tool_result_message(model_id, &id, &content));
+        }
+        if completed_ask {
+            suppress_ask_next_turn = true;
         }
         if todo_touched_this_batch {
             mutations_since_todo_touch = 0;
@@ -2083,6 +2106,22 @@ mod tests {
         })
     }
 
+    fn named_tool_call_completion(name: &str) -> serde_json::Value {
+        json!({
+            "choices": [{
+                "message": {
+                    "content": serde_json::Value::Null,
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "type": "function",
+                        "function": { "name": name, "arguments": "{}" }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        })
+    }
+
     #[tokio::test]
     async fn turn_cycle_executes_tool_then_returns_final() {
         let (tx, mut rx) = mpsc::unbounded_channel();
@@ -2171,6 +2210,39 @@ mod tests {
             "A tool returned:\nMOCK_RESULT\n\nContinue from this result. Call another tool only if the next step requires it."
         );
         assert!(messages[messages.len() - 2].get("tool_calls").is_none());
+    }
+
+    #[tokio::test]
+    async fn tokamak_preview_cannot_immediately_repeat_ask() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let model = MockModel::new(vec![
+            named_tool_call_completion("ask"),
+            json!({ "choices": [{ "message": { "content": "final answer" }, "finish_reason": "stop" }] }),
+        ]);
+        let tool = MockTool::default();
+        let mut budget = SessionBudget::new(None);
+        let ask_tool = json!({ "type": "function", "function": { "name": "ask" } });
+
+        run_turn_cycle(
+            &tx,
+            &json!({}),
+            "tokamak-1-preview",
+            &[ask_tool],
+            vec![user_message("ask something")],
+            8,
+            &mut budget,
+            &model,
+            &tool,
+            crate::core::agent::plan::RunMode::Normal,
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let requests = model.requests.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(requests[1].get("tools").is_none());
     }
 
     #[tokio::test]

--- a/src-tauri/src/core/cli/mod.rs
+++ b/src-tauri/src/core/cli/mod.rs
@@ -11,6 +11,7 @@ pub mod tokamak;
 mod tui;
 pub mod updater;
 
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -23,6 +24,13 @@ use crate::core::threads::{
         get_thread_metadata_path,
     },
 };
+
+pub(crate) const PERSISTED_ASK_RESULT_TYPE: &str = "jan.ask_result";
+const RESUMED_ASK_RESULT_OPEN: &str = "<jan_ask_result>\n";
+
+pub(crate) fn resumed_ask_result_context(content: &str) -> String {
+    format!("{RESUMED_ASK_RESULT_OPEN}{content}\n</jan_ask_result>")
+}
 
 // ── Thread operations ──────────────────────────────────────────────────────
 
@@ -228,17 +236,40 @@ pub fn cli_save_thread(
     let now_ms = now.as_millis() as i64;
     let now_secs = now.as_secs_f64();
 
+    let ask_call_ids: HashSet<&str> = history
+        .iter()
+        .flat_map(|message| {
+            message
+                .get("tool_calls")
+                .and_then(serde_json::Value::as_array)
+                .into_iter()
+                .flatten()
+        })
+        .filter(|call| {
+            call.get("function")
+                .and_then(|function| function.get("name"))
+                .and_then(serde_json::Value::as_str)
+                == Some("ask")
+        })
+        .filter_map(|call| call.get("id").and_then(serde_json::Value::as_str))
+        .collect();
     let messages: Vec<serde_json::Value> = history
         .iter()
-        .filter_map(|m| {
-            let role = m.get("role").and_then(|v| v.as_str())?;
-            let content = openai_content_text(m.get("content"));
+        .filter_map(|message| {
+            let role = message.get("role").and_then(serde_json::Value::as_str)?;
+            let content = openai_content_text(message.get("content"));
+            let is_ask_result = (role == "tool"
+                && message
+                    .get("tool_call_id")
+                    .and_then(serde_json::Value::as_str)
+                    .is_some_and(|id| ask_call_ids.contains(id)))
+                || (role == "assistant" && content.starts_with(RESUMED_ASK_RESULT_OPEN));
             Some(serde_json::json!({
                 "id": uuid::Uuid::new_v4().to_string(),
                 "object": "thread.message",
                 "thread_id": id,
-                "role": role,
-                "type": "text",
+                "role": if is_ask_result { "tool" } else { role },
+                "type": if is_ask_result { PERSISTED_ASK_RESULT_TYPE } else { "text" },
                 "status": "ready",
                 "created_at": now_ms,
                 "completed_at": now_ms,

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -6231,8 +6231,7 @@ async fn apply_resume(app: &mut App, target: &ResumeTarget) {
 }
 
 /// Replace the live session with a saved thread's state: history, transcript,
-/// snapshots, goal, and model. Only user/assistant text is replayed (tool calls
-/// are not persisted as messages).
+/// snapshots, goal, and model. Ask answers are restored as hidden model context.
 async fn load_thread(app: &mut App, thread: &serde_json::Value) {
     let full_id = thread.get("id").and_then(|v| v.as_str()).unwrap_or_default();
 
@@ -6280,8 +6279,20 @@ async fn load_thread(app: &mut App, thread: &serde_json::Value) {
 
     let mut count = 0;
     for msg in &messages {
-        let role = msg.get("role").and_then(|v| v.as_str()).unwrap_or("");
         let text = message_text(msg);
+        if msg.get("type").and_then(|value| value.as_str())
+            == Some(super::PERSISTED_ASK_RESULT_TYPE)
+        {
+            if !text.is_empty() {
+                app.history.push(serde_json::json!({
+                    "role": "assistant",
+                    "content": super::resumed_ask_result_context(&text),
+                }));
+            }
+            continue;
+        }
+
+        let role = msg.get("role").and_then(|v| v.as_str()).unwrap_or("");
         if text.is_empty() || !matches!(role, "user" | "assistant") {
             continue;
         }
@@ -11839,6 +11850,42 @@ mod tests {
                 .unwrap();
         assert_eq!(same, id);
         assert_eq!(super::super::list_threads_in(&app.agent_dir).unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn apply_resume_retains_an_ask_custom_answer_for_the_next_turn() {
+        let mut app = test_app();
+        let history = vec![
+            json!({ "role": "user", "content": "Ask me for a password." }),
+            json!({
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [{
+                    "id": "ask-password",
+                    "type": "function",
+                    "function": { "name": "ask", "arguments": "{}" }
+                }]
+            }),
+            json!({
+                "role": "tool",
+                "tool_call_id": "ask-password",
+                "content": r#"[{"id":"password","selected":[],"custom_input":"ember-7392"}]"#
+            }),
+            json!({ "role": "assistant", "content": "RECEIVED." }),
+        ];
+        let id =
+            super::super::cli_save_thread(&app.agent_dir, None, "saved-model", &history, None)
+                .unwrap();
+
+        let mut fresh = test_app();
+        fresh.agent_dir = app.agent_dir.clone();
+        apply_resume(&mut fresh, &ResumeTarget::Id(id)).await;
+
+        assert!(fresh.history.iter().any(|message| {
+            message.get("content").and_then(|value| value.as_str()).is_some_and(|content| {
+                content.contains("ember-7392") && content.contains("ask")
+            })
+        }));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Omit explicit `tool_choice` for direct `deepseek-v4-*` requests while retaining `tools`.
- Keep forced eager TODO selection for models that support it.

## Reason
DeepSeek V4 rejects explicit `tool_choice` when thinking mode is active. Omitting it preserves implicit tool selection. [Official DeepSeek tool-calling docs](https://api-docs.deepseek.com/guides/tool_calls/#thinking-mode) document tool use in thinking mode.

## Tests
- `cargo test --no-default-features --features cli --lib force_first_tool`
- `cargo test --no-default-features --features cli --lib deepseek_v4_uses_implicit_tool_choice_even_for_eager_todo`
