### PR TITLE
fix(i18n): complete Traditional Chinese chat and assistant copy

### DIFF
--- a/web-app/src/locales/zh-TW/assistants.json
+++ b/web-app/src/locales/zh-TW/assistants.json
@@ -31,5 +31,11 @@
   "personality": "個性",
   "capabilities": "能力",
   "instructionsDateHint": "提示：使用 {{current_date}} 插入今天的日期。",
-  "maxToolSteps": "最大工具步驟"
+  "maxToolSteps": "最大工具步驟",
+  "setAsDefault": "設為預設助理",
+  "isDefault": "預設",
+  "defaultAssistantSection": "預設助理",
+  "defaultAssistantDesc": "開始新聊天時使用",
+  "allAssistants": "所有助理",
+  "lastUsed": "上次使用"
 }

--- a/web-app/src/locales/zh-TW/chat.json
+++ b/web-app/src/locales/zh-TW/chat.json
@@ -9,5 +9,25 @@
   "clearHistory": "清除歷史記錄",
   "temporaryChat": "臨時聊天",
   "temporaryChatDescription": "開始一個不會儲存到聊天歷史記錄的臨時對話。",
-  "done": "Done"
+  "embeddings": {
+    "title": "正在準備您的文件",
+    "description": "正在為附件建立索引，以便搜尋及引用。大型文件可能需要一些時間。"
+  },
+  "actions": {
+    "regenerate": "重新產生回覆",
+    "continue": "繼續產生"
+  },
+  "done": "完成",
+  "webSources": "{{count}} 個來源",
+  "reasoning": {
+    "label": "推理中…",
+    "thinking": "思考中",
+    "usingTool": "正在使用 {{tool}}…",
+    "showFullTimeline": "顯示完整時間軸",
+    "showCurrentStep": "僅顯示目前步驟",
+    "thoughtForAWhile": "思考了幾秒鐘",
+    "thoughtFor": "思考了 {{duration}}",
+    "workedForAWhile": "處理了幾秒鐘",
+    "workedFor": "處理了 {{duration}}"
+  }
 }


### PR DESCRIPTION
## Describe Your Changes

- Complete all 20 missing Traditional Chinese locale keys in the chat and assistant namespaces.
- Remove the remaining English `Done` fallback from the Traditional Chinese chat UI.
- Cover document indexing, response actions, web sources, reasoning timelines, and default-assistant controls while preserving all i18next placeholders.

## Screenshots

![Traditional Chinese assistant settings](https://raw.githubusercontent.com/nrps9909/jan/refs/heads/codex/pr-assets-8631/.github/pr-assets/jan-assistant-zhtw.png)

## Fixes Issues

- N/A — direct localization gap fix.

## Validation

- `yarn lint`
- `yarn test:web` — 255 files and 3,220 tests passed on the CI Node 20 runtime
- `yarn build:web`
- Prettier 3.6.2 check on both modified JSON files
- JSON parsing, English/zh-TW key parity, and placeholder parity checks

## Self Checklist

- [x] No code comments needed for a locale-only change
- [x] No documentation changes needed for a locale-only change
- [x] No follow-up refactoring identified

AI assistance disclosure: Codex was used to trace missing locale keys, compare the English source and UI context, verify placeholder and key parity, run the listed validation, and help draft this description. I reviewed the final translations and rendered screenshot.