### PR TITLE
fix(utils): honor NO_PROXY/no_proxy env var in should_bypass_proxy

### DIFF
--- a/src-tauri/utils/src/network.rs
+++ b/src-tauri/utils/src/network.rs
@@ -101,8 +101,36 @@ pub fn validate_proxy_config(config: &ProxyConfig) -> Result<(), String> {
     Ok(())
 }
 
+/// Reads the `NO_PROXY` / `no_proxy` environment variable and parses it into a
+/// list of comma-separated host patterns (the same format the in-app `no_proxy`
+/// setting uses). Returns an empty list when the variable is unset.
+fn no_proxy_from_env() -> Vec<String> {
+    let mut entries: Vec<String> = Vec::new();
+    // Prefer the uppercase variant, falling back to lowercase. This mirrors how
+    // reqwest and most tooling read the environment on case-sensitive systems.
+    let raw = std::env::var("NO_PROXY")
+        .or_else(|_| std::env::var("no_proxy"))
+        .unwrap_or_default();
+
+    for entry in raw.split(',') {
+        let entry = entry.trim().to_string();
+        if !entry.is_empty() && !entries.contains(&entry) {
+            entries.push(entry);
+        }
+    }
+    entries
+}
+
 /// Checks if URL should bypass proxy based on no_proxy patterns (supports wildcards)
 pub fn should_bypass_proxy(url: &str, no_proxy: &[String]) -> bool {
+    // Merge the app-supplied no_proxy list with the NO_PROXY/no_proxy
+    // environment variables. Without this, Jan ignores a user-configured
+    // `no_proxy` env var and keeps routing matching hosts through the proxy
+    // (Fixes #8565).
+    let mut entries = no_proxy.to_vec();
+    entries.extend(no_proxy_from_env());
+    let no_proxy = entries.as_slice();
+
     if no_proxy.is_empty() {
         return false;
     }

--- a/src-tauri/utils/tests/no_proxy_env.rs
+++ b/src-tauri/utils/tests/no_proxy_env.rs
@@ -1,0 +1,86 @@
+//! Regression tests for https://github.com/janhq/jan/issues/8565
+//!
+//! `should_bypass_proxy` only consulted the app-supplied `no_proxy` list and
+//! completely ignored the `NO_PROXY` / `no_proxy` environment variables. A
+//! user behind a corporate proxy who lists an inner-network host in `NO_PROXY`
+//! therefore still got that host routed through the proxy ("connection
+//! failed"). These tests pin the env-var behavior.
+
+use jan_utils::network::should_bypass_proxy;
+
+// Rust runs tests in the same binary concurrently, and environment variables
+// are process-global. Every test that touches NO_PROXY/no_proxy takes this
+// lock so a concurrent test cannot observe another test's env value.
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// RAII guard that removes the env var when dropped, keeping the test process
+/// clean for any other test in the same binary.
+struct EnvGuard(&'static str);
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        std::env::set_var(key, value);
+        EnvGuard(key)
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        std::env::remove_var(self.0);
+    }
+}
+
+#[test]
+fn no_proxy_env_var_bypasses_matching_host() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let _guard = EnvGuard::set("NO_PROXY", "internal.corp.example");
+
+    // Empty app-supplied list: without the env merge this must bypass anyway,
+    // because the host is exempted via the environment.
+    assert!(should_bypass_proxy(
+        "http://internal.corp.example:8080/v1",
+        &[]
+    ));
+}
+
+#[test]
+fn no_proxy_env_var_wildcard_bypasses_matching_host() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let _guard = EnvGuard::set("NO_PROXY", "*.corp.example");
+
+    assert!(should_bypass_proxy(
+        "https://api.corp.example/v1/chat/completions",
+        &[]
+    ));
+    // A host outside the wildcard must still go through the proxy.
+    assert!(!should_bypass_proxy("https://api.public.example/v1", &[]));
+}
+
+#[test]
+fn lowercase_no_proxy_env_var_is_also_honored() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let _guard = EnvGuard::set("no_proxy", "localhost,127.0.0.1");
+
+    assert!(should_bypass_proxy("http://localhost:3000", &[]));
+    assert!(should_bypass_proxy("https://127.0.0.1:3928", &[]));
+    // Hosts not listed are unaffected.
+    assert!(!should_bypass_proxy("http://other.com/path", &[]));
+}
+
+#[test]
+fn app_no_proxy_list_and_env_var_are_merged() {
+    let _lock = ENV_LOCK.lock().unwrap();
+    let _guard = EnvGuard::set("NO_PROXY", "internal.corp.example");
+    let app_list = vec!["*.example.com".to_string()];
+
+    // A host exempted only via the environment still bypasses the proxy.
+    assert!(should_bypass_proxy(
+        "http://internal.corp.example/v1",
+        &app_list
+    ));
+    // A host exempted only via the app list still bypasses the proxy.
+    assert!(should_bypass_proxy(
+        "http://sub.example.com/path",
+        &app_list
+    ));
+}


### PR DESCRIPTION
Fixes #8565

## Problem

When running behind a corporate proxy, Jan's `should_bypass_proxy` helper only consulted the `no_proxy` list stored in app settings. The `NO_PROXY` / `no_proxy` environment variables were never read, so hosts listed there (inner-network endpoints, or localhost/127.0.0.1 for llama.cpp) were still routed through the proxy and failed with "the connection failed" / 403 responses.

## Fix

`should_bypass_proxy` in `src-tauri/utils/src/network.rs` now merges the `NO_PROXY` / `no_proxy` environment variables with the app-supplied `no_proxy` list before matching, using the same comma-separated wildcard format as the in-app setting (uppercase `NO_PROXY` preferred, falling back to `no_proxy`).

This covers every path that already consults `should_bypass_proxy` (currently the downloads/llamacpp-backend proxy wiring). The OpenAI-compatible local server in `src-tauri/src/core/server/proxy.rs` builds its `reqwest` client without an explicit proxy and continues to rely on reqwest's native system-proxy/env handling; wiring the app-settings proxy into that client (and reusing this env merge there) is a follow-up worth doing separately.

## Verification

- New integration test `src-tauri/utils/tests/no_proxy_env.rs` reproduces the bug: it sets `NO_PROXY`/`no_proxy` and asserts matching hosts bypass the proxy. It fails against the current code and passes with the fix.
- `cargo test` in `src-tauri/utils` passes, including the pre-existing tests.

## Notes

Prior attempt: none found in open PRs referencing this issue.