### PR TITLE
fix(hub): avoid duplicate org in "View on HuggingFace" URL

### DIFF
--- a/web-app/src/containers/DownloadButton.tsx
+++ b/web-app/src/containers/DownloadButton.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from '@/i18n'
 import {
   extractModelName,
   extractQuantLabel,
+  getHuggingFaceUrl,
   selectDefaultQuant,
 } from '@/lib/models'
 import { toast } from 'sonner'
@@ -105,7 +106,7 @@ export function DownloadButtonPlaceholder({
     return (
       <div className="flex items-center gap-2">
         <a
-          href={`https://huggingface.co/${model.developer ? `${model.developer}/` : ''}${model.model_name}`}
+          href={getHuggingFaceUrl(model)}
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/web-app/src/lib/__tests__/huggingface-url.test.ts
+++ b/web-app/src/lib/__tests__/huggingface-url.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { getHuggingFaceUrl } from '../models'
+
+describe('getHuggingFaceUrl', () => {
+  // Regression test for #8634: pasting a full HuggingFace URL into the hub
+  // stores the repo as model_name = 'meta-llama/Llama-3.1-8B' with
+  // developer = 'meta-llama' (see convertHfRepoToCatalogModel). The org must
+  // NOT be prepended a second time, otherwise the "View on HuggingFace" link
+  // becomes https://huggingface.co/meta-llama/meta-llama/Llama-3.1-8B -> 404.
+  it('does not duplicate the org when model_name already contains it (#8634)', () => {
+    const model = {
+      model_name: 'meta-llama/Llama-3.1-8B',
+      developer: 'meta-llama',
+    }
+
+    expect(getHuggingFaceUrl(model)).toBe(
+      'https://huggingface.co/meta-llama/Llama-3.1-8B'
+    )
+  })
+
+  it('prepends the developer when model_name is a bare model name', () => {
+    expect(
+      getHuggingFaceUrl({ model_name: 'tinyllama', developer: 'cortexso' })
+    ).toBe('https://huggingface.co/cortexso/tinyllama')
+  })
+
+  it('keeps the bare name when neither org nor developer is available', () => {
+    expect(getHuggingFaceUrl({ model_name: 'tinyllama' })).toBe(
+      'https://huggingface.co/tinyllama'
+    )
+  })
+})

--- a/web-app/src/lib/models.ts
+++ b/web-app/src/lib/models.ts
@@ -91,6 +91,26 @@ export const extractModelRepo = (model?: string) => {
   return model?.replace('https://huggingface.co/', '')
 }
 
+/**
+ * Build the canonical Hugging Face repo URL for a catalog model.
+ *
+ * `model_name` may already carry the org prefix — e.g. a repo pasted into the
+ * hub as `https://huggingface.co/meta-llama/Llama-3.1-8B` is stored with
+ * `model_name: 'meta-llama/Llama-3.1-8B'` and `developer: 'meta-llama'`
+ * (see convertHfRepoToCatalogModel). The developer must only be prepended when
+ * the org is missing, otherwise the "View on HuggingFace" link becomes
+ * `meta-llama/meta-llama/Llama-3.1-8B` and 404s (#8634).
+ */
+export const getHuggingFaceUrl = (model: {
+  model_name: string
+  developer?: string
+}): string => {
+  if (model.model_name.includes('/')) {
+    return `https://huggingface.co/${model.model_name}`
+  }
+  return `https://huggingface.co/${model.developer ? `${model.developer}/` : ''}${model.model_name}`
+}
+
 export const selectDefaultQuant = <T extends { model_id: string }>(
   quants: T[] | undefined,
   preferred: readonly string[]


### PR DESCRIPTION
Fixes #8634

## Problem

When a full Hugging Face repo URL is pasted into the Hub search field (e.g. `https://huggingface.co/meta-llama/Llama-3.1-8B`), the search flow calls `convertHfRepoToCatalogModel`, which stores the repo with `model_name = "meta-llama/Llama-3.1-8B"` (the full repo id, org included) and `developer = "meta-llama"` (the org).

The "View on HuggingFace" button in `DownloadButton.tsx` always prepended the developer to `model_name`, so the link became `https://huggingface.co/meta-llama/meta-llama/Llama-3.1-8B` — the org is doubled and the page 404s.

## Fix

Extract the URL construction into a small, pure helper `getHuggingFaceUrl(model)` in `web-app/src/lib/models.ts` and use it in `DownloadButton.tsx`. The helper only prepends `developer` when `model_name` does not already contain an org segment, so:

- `{ model_name: 'meta-llama/Llama-3.1-8B', developer: 'meta-llama' }` -> `https://huggingface.co/meta-llama/Llama-3.1-8B` (bug fixed)
- `{ model_name: 'tinyllama', developer: 'cortexso' }` -> `https://huggingface.co/cortexso/tinyllama` (existing catalog links unchanged)

## Verification

Added a regression test `web-app/src/lib/__tests__/huggingface-url.test.ts`.

- RED: on the current `main`, the test fails (the helper does not exist and the old code produced the doubled URL).
- GREEN: with the fix applied, the test passes.

Ran with: `yarn workspace @janhq/web-app test src/lib/__tests__/huggingface-url.test.ts`.

## Honest scope note

The other symptom in the issue (no download button for `meta-llama/Llama-3.1-8B`) is separate: that repo has no GGUF files, so `convertHfRepoToCatalogModel` produces zero quants and the UI falls back to the "View on HuggingFace" link. This PR fixes the broken link itself; the download-option behaviour is driven by repo contents and is unchanged.

Note: there are two other open PRs from this author in this repo covering unrelated subsystems (#8627 CORS trusted hosts, #8633 NO_PROXY env var); this change is independent of both.