### PR TITLE
fix: Init TUI branding, resume content, isolate system notes

### DIFF
--- a/src-tauri/src/bin/jan.rs
+++ b/src-tauri/src/bin/jan.rs
@@ -312,32 +312,11 @@ enum ModelsCommands {
 
 /// Build a left-aligned, bright-yellow ASCII logo for the help header.
 fn make_logo() -> String {
-    // "JAN" in ANSI Shadow block letters
-    let lines = [
-        r"     ██╗ █████╗ ███╗  ██╗",
-        r"     ██║██╔══██╗████╗ ██║",
-        r"     ██║███████║██╔██╗██║",
-        r"██   ██║██╔══██║██║╚████║",
-        r"╚█████╔╝██║  ██║██║ ╚███║",
-        r" ╚════╝ ╚═╝  ╚═╝╚═╝  ╚══╝",
-    ];
-
-    // Fixed left-aligned indent (2 spaces)
-    let indent = "  ";
-
     let yellow = Style::new().yellow().bold();
-
-    let mut out: Vec<String> = Vec::new();
-
-    // Add padding at top
-    out.push(String::new());
-    out.push(String::new());
-
-    // Logo lines
-    for l in &lines {
-        out.push(format!("{}{}", indent, yellow.apply_to(l)));
+    let mut out = vec![String::new(), String::new()];
+    for l in app_lib::core::cli::brand::LOGO {
+        out.push(format!("  {}", yellow.apply_to(l)));
     }
-
     out.join("\n")
 }
 

--- a/src-tauri/src/core/cli/brand.rs
+++ b/src-tauri/src/core/cli/brand.rs
@@ -1,0 +1,31 @@
+//! The `jan` wordmark, shared by `jan --help` and the TUI splash so the two
+//! can't drift.
+
+/// "JAN" in ANSI Shadow block letters. Each glyph cell is one terminal column,
+/// so `LOGO_WIDTH` is the rendered width.
+pub const LOGO: [&str; 6] = [
+    r"     ██╗ █████╗ ███╗  ██╗",
+    r"     ██║██╔══██╗████╗ ██║",
+    r"     ██║███████║██╔██╗██║",
+    r"██   ██║██╔══██║██║╚████║",
+    r"╚█████╔╝██║  ██║██║ ╚███║",
+    r" ╚════╝ ╚═╝  ╚═╝╚═╝  ╚══╝",
+];
+
+pub const LOGO_WIDTH: u16 = 25;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_logo_line_is_the_advertised_width() {
+        for line in LOGO {
+            assert_eq!(
+                line.chars().count(),
+                LOGO_WIDTH as usize,
+                "ragged logo line: {line}"
+            );
+        }
+    }
+}

--- a/src-tauri/src/core/cli/journal.rs
+++ b/src-tauri/src/core/cli/journal.rs
@@ -1,0 +1,286 @@
+//! Display journal: the transcript as it was shown, so `/resume` can restore
+//! reasoning, tool calls and their results.
+//!
+//! `messages.jsonl` is the wire conversation and cannot carry this: reasoning is
+//! deliberately kept out of it (never resent to the model), tool calls are
+//! flattened to text on save, and a `/compact` rewrites it. The journal is a
+//! separate append-only log of what the TUI rendered, in emission order, written
+//! off the render loop at each turn boundary and replayed through the same
+//! rendering path on resume.
+
+use std::path::{Path, PathBuf};
+
+/// One rendered transcript event. Only what a replay needs to rebuild rows:
+/// notes, turn receipts and permission prompts are transient by design.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum DisplayEntry {
+    User {
+        text: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        images: Vec<String>,
+    },
+    /// Assistant text exactly as streamed, `<think>` markers included, so the
+    /// replay folds reasoning the same way the live turn did.
+    Assistant { text: String },
+    ToolCall {
+        id: String,
+        name: String,
+        args: serde_json::Value,
+    },
+    ToolResult {
+        id: String,
+        content: String,
+        #[serde(default)]
+        is_error: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        diff: Option<String>,
+    },
+    /// A closed subagent's summary row (its call labels stay behind the row).
+    Subagent {
+        name: String,
+        #[serde(default)]
+        calls: Vec<String>,
+        /// False for a child closed with the run instead of by its own
+        /// `SubagentEnd`, which the row reports as `interrupted`.
+        #[serde(default = "default_true")]
+        finished: bool,
+    },
+}
+
+fn default_true() -> bool {
+    true
+}
+
+pub const JOURNAL_FILE: &str = "display.jsonl";
+
+pub fn journal_path(agent_dir: &Path, thread_id: &str) -> PathBuf {
+    crate::core::threads::utils::get_thread_dir(agent_dir, thread_id).join(JOURNAL_FILE)
+}
+
+/// Rewrite the whole journal. A rewind or `/clear` truncates the log, so an
+/// append-only writer would leave dropped turns on disk; the write goes to a
+/// sibling temp file and is renamed, so a crash mid-dump cannot leave a
+/// half-written journal in place of the last good one.
+pub fn write_journal(path: &Path, entries: &[DisplayEntry]) -> Result<(), String> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+    }
+    let mut body = String::new();
+    for entry in entries {
+        let line = serde_json::to_string(entry).map_err(|e| e.to_string())?;
+        body.push_str(&line);
+        body.push('\n');
+    }
+    let tmp = path.with_extension("jsonl.tmp");
+    std::fs::write(&tmp, body).map_err(|e| e.to_string())?;
+    std::fs::rename(&tmp, path).map_err(|e| e.to_string())
+}
+
+/// Read a journal, skipping any line that no longer parses (a truncated tail, or
+/// an entry written by a newer build) so a resume degrades instead of failing.
+pub fn read_journal(path: &Path) -> Vec<DisplayEntry> {
+    use std::io::BufRead;
+
+    let Ok(file) = std::fs::File::open(path) else {
+        return Vec::new();
+    };
+    std::io::BufReader::new(file)
+        .lines()
+        .map_while(Result::ok)
+        .filter(|l| !l.trim().is_empty())
+        .filter_map(|l| serde_json::from_str(&l).ok())
+        .collect()
+}
+
+/// Dumps journals on one background thread, so the render loop never pays for a
+/// long conversation's rewrite. One thread rather than one per dump because
+/// `persist` fires several times a turn: concurrent writers renaming the same
+/// path could land out of order and leave a stale journal as the final state.
+/// Failures are silent, like the rest of persistence -- a lost dump costs the
+/// resume its detail, which is not worth interrupting the session over.
+pub struct Writer {
+    tx: Option<std::sync::mpsc::Sender<(PathBuf, Vec<DisplayEntry>)>>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Writer {
+    pub fn new() -> Self {
+        let (tx, rx) = std::sync::mpsc::channel::<(PathBuf, Vec<DisplayEntry>)>();
+        let handle = std::thread::spawn(move || {
+            for (path, entries) in rx {
+                let _ = write_journal(&path, &entries);
+            }
+        });
+        Self {
+            tx: Some(tx),
+            handle: Some(handle),
+        }
+    }
+
+    pub fn dump(&self, path: PathBuf, entries: Vec<DisplayEntry>) {
+        if let Some(tx) = self.tx.as_ref() {
+            let _ = tx.send((path, entries));
+        }
+    }
+
+    /// Wait for every queued dump to land. Called on session exit (and by tests)
+    /// so the last turn is on disk before the process goes away.
+    pub fn join(&mut self) {
+        drop(self.tx.take());
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Default for Writer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Drop for Writer {
+    fn drop(&mut self) {
+        self.join();
+    }
+}
+
+/// Index just past the `target`-th (0-based) user entry's turn, i.e. the length
+/// the log keeps when a rewind drops that message and everything after it.
+pub fn truncate_at_user(entries: &[DisplayEntry], target: usize) -> usize {
+    let mut seen = 0;
+    for (i, e) in entries.iter().enumerate() {
+        if matches!(e, DisplayEntry::User { .. }) {
+            if seen == target {
+                return i;
+            }
+            seen += 1;
+        }
+    }
+    entries.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn user(text: &str) -> DisplayEntry {
+        DisplayEntry::User {
+            text: text.into(),
+            images: Vec::new(),
+        }
+    }
+
+    fn sample() -> Vec<DisplayEntry> {
+        vec![
+            user("do it"),
+            DisplayEntry::Assistant {
+                text: "<think>plan</think>".into(),
+            },
+            DisplayEntry::ToolCall {
+                id: "c1".into(),
+                name: "write".into(),
+                args: serde_json::json!({ "path": "a.txt" }),
+            },
+            DisplayEntry::ToolResult {
+                id: "c1".into(),
+                content: "ok".into(),
+                is_error: false,
+                diff: Some("@@ created file @@\n+    1 | x".into()),
+            },
+            DisplayEntry::Subagent {
+                name: "scout".into(),
+                calls: vec!["Read a.txt".into()],
+                finished: true,
+            },
+            DisplayEntry::Assistant {
+                text: "Done.".into(),
+            },
+        ]
+    }
+
+    fn tmp_dir() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "jan_journal_{}_{}",
+            std::process::id(),
+            uuid::Uuid::new_v4()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    fn round_trips_every_entry_kind() {
+        let path = tmp_dir().join(JOURNAL_FILE);
+        let entries = sample();
+        write_journal(&path, &entries).unwrap();
+        assert_eq!(read_journal(&path), entries);
+    }
+
+    #[test]
+    fn rewrite_replaces_a_truncated_log() {
+        let path = tmp_dir().join(JOURNAL_FILE);
+        write_journal(&path, &sample()).unwrap();
+        let kept = sample()[..2].to_vec();
+        write_journal(&path, &kept).unwrap();
+        assert_eq!(read_journal(&path), kept, "rewind must not leave a tail");
+        assert!(
+            !path.with_extension("jsonl.tmp").exists(),
+            "temp file is renamed, not left behind"
+        );
+    }
+
+    #[test]
+    fn read_skips_unparsable_lines() {
+        let path = tmp_dir().join(JOURNAL_FILE);
+        let good = serde_json::to_string(&user("hi")).unwrap();
+        std::fs::write(
+            &path,
+            format!("{good}\n{{\"kind\":\"from_the_future\"}}\n{{\"kind\":\"user\",\"te\n"),
+        )
+        .unwrap();
+        assert_eq!(read_journal(&path), vec![user("hi")]);
+    }
+
+    #[test]
+    fn read_of_a_missing_journal_is_empty() {
+        assert!(read_journal(&tmp_dir().join(JOURNAL_FILE)).is_empty());
+    }
+
+    #[test]
+    fn truncate_at_user_cuts_the_whole_turn() {
+        let mut entries = sample();
+        entries.push(user("second"));
+        entries.push(DisplayEntry::Assistant {
+            text: "more".into(),
+        });
+        assert_eq!(truncate_at_user(&entries, 0), 0);
+        assert_eq!(truncate_at_user(&entries, 1), 6, "cuts at the second user");
+        assert_eq!(
+            truncate_at_user(&entries, 9),
+            entries.len(),
+            "an out-of-range target keeps the log"
+        );
+    }
+
+    #[test]
+    fn writer_lands_dumps_in_order() {
+        let path = tmp_dir().join(JOURNAL_FILE);
+        let mut writer = Writer::new();
+        writer.dump(path.clone(), sample());
+        let last = sample()[..1].to_vec();
+        writer.dump(path.clone(), last.clone());
+        writer.join();
+        assert_eq!(read_journal(&path), last, "the newest dump must win");
+    }
+
+    #[test]
+    fn journal_sits_in_the_thread_dir() {
+        let base = tmp_dir();
+        assert_eq!(
+            journal_path(&base, "t1"),
+            base.join("threads").join("t1").join(JOURNAL_FILE)
+        );
+    }
+}

--- a/src-tauri/src/core/cli/mod.rs
+++ b/src-tauri/src/core/cli/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! This module is only compiled when the `cli` feature is enabled.
 
+pub mod journal;
 pub mod login;
 pub mod mcp;
 pub mod providers;
@@ -233,7 +234,7 @@ pub fn cli_save_thread(
         .filter_map(|m| {
             let role = m.get("role").and_then(|v| v.as_str())?;
             let content = openai_content_text(m.get("content"));
-            Some(serde_json::json!({
+            let mut record = serde_json::json!({
                 "id": uuid::Uuid::new_v4().to_string(),
                 "object": "thread.message",
                 "thread_id": id,
@@ -243,7 +244,16 @@ pub fn cli_save_thread(
                 "created_at": now_ms,
                 "completed_at": now_ms,
                 "content": [{ "type": "text", "text": { "value": content, "annotations": [] } }],
-            }))
+            });
+            // Carry the wire fields the text form cannot express, so a resumed
+            // conversation still shows the model the tools it ran. Extra keys on
+            // a `thread.message`; the desktop reads `role` and `content`.
+            for key in ["tool_calls", "tool_call_id"] {
+                if let Some(v) = m.get(key) {
+                    record[key] = v.clone();
+                }
+            }
+            Some(record)
         })
         .collect();
     write_messages_to_file(&messages, &get_messages_path(base, &id))?;
@@ -287,6 +297,82 @@ pub fn cli_save_thread(
 /// default in the model-resolution order). `agent_dir` is `<project>/.jan/agent`.
 pub fn cli_set_project_model(agent_dir: &std::path::Path, model: &str) -> Result<(), String> {
     set_model_in_agent_toml(&agent_dir.join("agent.toml"), model)
+}
+
+/// Stands in for a tool result that never reached disk, so the call it answers
+/// stays valid. Says what happened rather than inventing an outcome.
+const MISSING_TOOL_RESULT: &str =
+    "(result not saved: the session ended before this call's output was recorded)";
+
+/// Rebuild the wire conversation from persisted `thread.message` records: the
+/// user/assistant text plus the tool calls and results that text cannot express,
+/// so a resumed model sees the work it did instead of only its own answers.
+///
+/// Tool pairing is enforced, because an OpenAI-compatible upstream rejects a
+/// conversation where it is broken: a result whose call is gone is dropped, and a
+/// call whose result is missing (a crash between the two) gets the placeholder
+/// above. Roles the agent owns (`system`) and messages carrying neither text nor
+/// calls are left out.
+pub(crate) fn rebuild_wire_history(messages: &[serde_json::Value]) -> Vec<serde_json::Value> {
+    fn answer_open(out: &mut Vec<serde_json::Value>, open: &mut Vec<String>) {
+        for id in open.drain(..) {
+            out.push(serde_json::json!({
+                "role": "tool",
+                "tool_call_id": id,
+                "content": MISSING_TOOL_RESULT,
+            }));
+        }
+    }
+
+    let mut out: Vec<serde_json::Value> = Vec::new();
+    let mut open: Vec<String> = Vec::new();
+    for m in messages {
+        let role = m.get("role").and_then(|v| v.as_str()).unwrap_or_default();
+        let text = thread_message_text(m);
+        if role == "tool" {
+            let id = m
+                .get("tool_call_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            if let Some(pos) = open.iter().position(|open_id| open_id == id) {
+                open.remove(pos);
+                out.push(serde_json::json!({
+                    "role": "tool",
+                    "tool_call_id": id,
+                    "content": text,
+                }));
+            }
+            continue;
+        }
+        if !matches!(role, "user" | "assistant") {
+            continue;
+        }
+        // A new turn: whatever the previous assistant left unanswered is closed
+        // out first, so calls and results stay adjacent and paired.
+        answer_open(&mut out, &mut open);
+        let calls = m
+            .get("tool_calls")
+            .filter(|v| v.as_array().is_some_and(|a| !a.is_empty()));
+        if text.is_empty() && calls.is_none() {
+            continue;
+        }
+        let mut msg = serde_json::json!({ "role": role, "content": text });
+        if let Some(calls) = calls {
+            msg["tool_calls"] = calls.clone();
+            open = calls
+                .as_array()
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|c| c.get("id").and_then(|v| v.as_str()))
+                        .map(str::to_string)
+                        .collect()
+                })
+                .unwrap_or_default();
+        }
+        out.push(msg);
+    }
+    answer_open(&mut out, &mut open);
+    out
 }
 
 /// Text of a persisted `thread.message` (content parts carry `text.value`) or of
@@ -762,9 +848,9 @@ struct ResumedSession {
     history: Vec<serde_json::Value>,
 }
 
-/// Load a saved thread's user/assistant turns for continuation. Tool calls are
-/// not replayed (they are not persisted as messages), matching `/resume` in the
-/// TUI. Errors describe why nothing could be resumed; the caller starts fresh.
+/// Load a saved thread's conversation for continuation, tool calls and results
+/// included (see `rebuild_wire_history`), matching `/resume` in the TUI. Errors
+/// describe why nothing could be resumed; the caller starts fresh.
 fn load_resume_history(
     agent_dir: &std::path::Path,
     target: &ResumeTarget,
@@ -779,17 +865,7 @@ fn load_resume_history(
     if skipped > 0 {
         eprintln!("(skipped {skipped} unreadable message(s) in the resumed session)");
     }
-    let history = messages
-        .iter()
-        .filter_map(|m| {
-            let role = m.get("role").and_then(|v| v.as_str())?;
-            if !matches!(role, "user" | "assistant") {
-                return None;
-            }
-            let text = thread_message_text(m);
-            (!text.is_empty()).then(|| serde_json::json!({ "role": role, "content": text }))
-        })
-        .collect();
+    let history = rebuild_wire_history(&messages);
     Ok(ResumedSession { thread_id, history })
 }
 
@@ -1234,6 +1310,77 @@ mod tests {
                 .history,
             extended
         );
+    }
+
+    fn call(id: &str, name: &str) -> serde_json::Value {
+        serde_json::json!({
+            "id": id,
+            "type": "function",
+            "function": { "name": name, "arguments": "{\"path\":\"a.txt\"}" },
+        })
+    }
+
+    #[test]
+    fn tool_calls_and_results_survive_a_save_resume_cycle() {
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path();
+        let history = vec![
+            serde_json::json!({ "role": "user", "content": "do it" }),
+            serde_json::json!({ "role": "assistant", "content": "", "tool_calls": [call("c1", "write")] }),
+            serde_json::json!({ "role": "tool", "tool_call_id": "c1", "content": "wrote 1 line" }),
+            serde_json::json!({ "role": "assistant", "content": "Done." }),
+        ];
+        let id = cli_save_thread(base, None, "m", &history, None).unwrap();
+
+        let resumed = load_resume_history(base, &ResumeTarget::Latest).unwrap();
+        assert_eq!(resumed.thread_id, id);
+        assert_eq!(
+            resumed.history, history,
+            "the model must see the tools it ran, not just its own text"
+        );
+    }
+
+    #[test]
+    fn a_call_whose_result_was_never_saved_gets_one() {
+        // A crash between the call and its result leaves the pair broken, and an
+        // OpenAI-compatible upstream rejects an unanswered `tool_call_id`.
+        let messages = vec![
+            serde_json::json!({ "role": "assistant", "content": "", "tool_calls": [call("c1", "write"), call("c2", "read")] }),
+            serde_json::json!({ "role": "tool", "tool_call_id": "c1", "content": "ok" }),
+            serde_json::json!({ "role": "user", "content": "next" }),
+        ];
+        let out = rebuild_wire_history(&messages);
+        assert_eq!(out.len(), 4);
+        assert_eq!(out[2]["role"], "tool");
+        assert_eq!(out[2]["tool_call_id"], "c2");
+        assert!(
+            out[2]["content"].as_str().unwrap().contains("not saved"),
+            "the gap is stated, not invented: {}",
+            out[2]["content"]
+        );
+        assert_eq!(out[3]["role"], "user");
+    }
+
+    #[test]
+    fn an_orphan_tool_message_is_dropped() {
+        let messages = vec![
+            serde_json::json!({ "role": "tool", "tool_call_id": "gone", "content": "stale" }),
+            serde_json::json!({ "role": "user", "content": "hi" }),
+        ];
+        let out = rebuild_wire_history(&messages);
+        assert_eq!(out.len(), 1, "a result with no call would be rejected");
+        assert_eq!(out[0]["role"], "user");
+    }
+
+    #[test]
+    fn rebuild_drops_messages_that_carry_nothing() {
+        let messages = vec![
+            serde_json::json!({ "role": "assistant", "content": "" }),
+            serde_json::json!({ "role": "user", "content": "hi" }),
+            serde_json::json!({ "role": "system", "content": "ignored" }),
+        ];
+        let out = rebuild_wire_history(&messages);
+        assert_eq!(out, vec![serde_json::json!({ "role": "user", "content": "hi" })]);
     }
 
     #[test]

--- a/src-tauri/src/core/cli/mod.rs
+++ b/src-tauri/src/core/cli/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! This module is only compiled when the `cli` feature is enabled.
 
+pub mod brand;
 pub mod journal;
 pub mod login;
 pub mod mcp;

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -145,6 +145,41 @@ enum Kind {
     Meta,
 }
 
+/// Gutter glyph for a system line. A category with its own established glyph
+/// (`◎` for a goal) passes that instead, so the column always carries exactly
+/// one marker.
+const SYSTEM_GLYPH: &str = "•";
+
+/// Gutter glyph for goal-loop lines, matching the header's `◎ /goal` badge.
+const GOAL_GLYPH: &str = "◎";
+
+/// How loud a system line is. The only thing that varies between them, so it is
+/// a parameter rather than a colour picked at each of the ~90 call sites.
+#[derive(Copy, Clone, PartialEq)]
+enum Level {
+    /// A dim acknowledgement or status note.
+    Info,
+    /// Something the user should notice but that needs no action.
+    Warn,
+    /// A failed turn, tool or command.
+    Error,
+    /// Work that completed successfully.
+    Good,
+}
+
+impl Level {
+    /// `(gutter, body)` styles. The gutter always carries colour so the marker
+    /// is scannable down the left edge even when the body is dim.
+    fn styles(self) -> (Style, Style) {
+        match self {
+            Level::Info => (Style::new().light_blue(), Style::new().dim()),
+            Level::Warn => (Style::new().yellow(), Style::new().yellow()),
+            Level::Error => (Style::new().red().bold(), Style::new().red().bold()),
+            Level::Good => (Style::new().green(), Style::new().green().bold()),
+        }
+    }
+}
+
 /// Blocks that read as one run of activity and so need no blank between them.
 /// A turn alternating folded reasoning summaries with tool rows was spending a
 /// blank line on every switch, which is most of the turn.
@@ -1486,10 +1521,28 @@ impl App {
         self.last_kind = Kind::None;
     }
 
-    fn note(&mut self, text: &str) {
+    /// Append a line the *app* is saying, in its own gutter column. Every other
+    /// transcript class owns one (`› ` user, `│ ` tool, `┊ ` reasoning), so
+    /// without it a note is indistinguishable from model prose. `glyph` names the
+    /// category and `level` carries severity.
+    fn system_marked(&mut self, glyph: &str, level: Level, text: &str) {
         self.scrollback = 0;
         self.gap(Kind::Meta);
-        self.push(Line::styled(text.to_string(), Style::new().dim()));
+        let (gutter, body) = level.styles();
+        self.push(Line::from(vec![
+            Span::styled(format!("{glyph} "), gutter),
+            Span::styled(text.to_string(), body),
+        ]));
+    }
+
+    fn system(&mut self, level: Level, text: &str) {
+        self.system_marked(SYSTEM_GLYPH, level, text);
+    }
+
+    /// A dim informational note: the common case, and what every `/command`
+    /// acknowledgement and background result goes through.
+    fn note(&mut self, text: &str) {
+        self.system(Level::Info, text);
     }
 
     fn flush_assistant(&mut self) {
@@ -2131,11 +2184,7 @@ impl App {
     fn submit_reminder(&mut self, text: String) {
         self.history
             .push(serde_json::json!({ "role": "user", "content": text }));
-        self.gap(Kind::Meta);
-        self.push(Line::styled(
-            "◈ todo reminder — unfinished work, continuing".to_string(),
-            Style::new().dim(),
-        ));
+        self.note("todo reminder — unfinished work, continuing");
         self.begin_turn();
         self.want_start = true;
         self.persist();
@@ -2909,8 +2958,7 @@ impl App {
             } else {
                 format!("finished early (stop_reason={stop_reason})")
             };
-            self.gap(Kind::Meta);
-            self.push(Line::styled(msg, Style::new().yellow().bold()));
+            self.system(Level::Warn, &msg);
         }
         self.checkpoint_turn();
         // A turn just completed under an active goal: count it and queue an
@@ -2952,12 +3000,7 @@ impl App {
         } else {
             format!("{code}: {message}")
         };
-        self.gap(Kind::Meta);
-        self.push(Line::styled(
-            format!("error: {message}"),
-            Style::new().red().bold(),
-        ));
-        self.scrollback = 0;
+        self.system(Level::Error, &format!("error: {message}"));
         // An errored turn halts the goal loop; the user decides how to recover.
         self.goal_eval_pending = false;
         if let Some(goal) = self.goal.as_ref() {
@@ -3007,20 +3050,21 @@ impl App {
                     }
                     let turns = self.goal.as_ref().map(|g| g.turns).unwrap_or(0);
                     let elapsed = self.goal.as_ref().map(|g| g.elapsed_secs()).unwrap_or(0);
-                    self.gap(Kind::Meta);
-                    self.push(Line::styled(
-                        format!(
-                            "◎ goal achieved in {turns} turn(s), {}",
-                            fmt_duration(elapsed)
-                        ),
-                        Style::new().green().bold(),
-                    ));
+                    self.system_marked(
+                        GOAL_GLYPH,
+                        Level::Good,
+                        &format!("goal achieved in {turns} turn(s), {}", fmt_duration(elapsed)),
+                    );
                     self.push(Line::styled(format!("  {}", v.reason), Style::new().dim()));
                     self.persist();
                 } else {
                     // Goal unmet: surface the reason as guidance and start the
                     // next turn automatically, no user prompt needed.
-                    self.note(&format!("◎ goal not met: {} — continuing", v.reason));
+                    self.system_marked(
+                        GOAL_GLYPH,
+                        Level::Info,
+                        &format!("goal not met: {} — continuing", v.reason),
+                    );
                     let prompt =
                         crate::core::agent::goal::continuation_prompt(&goal.condition, &v.reason);
                     self.submit_user(prompt);
@@ -3057,8 +3101,7 @@ impl App {
         self.close_live_subagents();
         self.detail = "cancelled".to_string();
         self.scrollback = 0;
-        self.gap(Kind::Meta);
-        self.push(Line::styled("cancelled", Style::new().yellow()));
+        self.system(Level::Warn, "cancelled");
         // A cancel stops the goal loop mid-flight; the goal itself is kept so
         // the user can inspect it (/goal) or clear it (/goal clear).
         self.goal_eval_pending = false;
@@ -5053,10 +5096,7 @@ async fn handle_key(
             // already shows the call proceeded, so an "allowed" line is
             // pure noise once granted.
             if matches!(d, PermissionDecision::Deny) {
-                app.push(Line::styled(
-                    format!("• denied: {}", pending.summary()),
-                    Style::new().red(),
-                ));
+                app.system(Level::Error, &format!("denied: {}", pending.summary()));
             }
             if let Some(sender) = registry.lock().await.remove(&pending.request_id) {
                 let _ = sender.send(d);
@@ -5491,8 +5531,7 @@ async fn run_command(app: &mut App, line: &str) {
     let (name, arg) = parse_command(line);
     match name {
         "" | "help" | "?" => {
-            app.gap(Kind::Meta);
-            app.push(Line::styled("commands:".to_string(), Style::new().dim()));
+            app.note("commands:");
             for c in SLASH_COMMANDS {
                 let sig = if c.hint.is_empty() {
                     c.name.to_string()
@@ -5504,8 +5543,7 @@ async fn run_command(app: &mut App, line: &str) {
                     Style::new().dim(),
                 ));
             }
-            app.gap(Kind::Meta);
-            app.push(Line::styled("keys:".to_string(), Style::new().dim()));
+            app.note("keys:");
             for (keys, description) in KEY_BINDINGS {
                 app.push(Line::styled(
                     format!("  {keys:18} {description}"),
@@ -5531,11 +5569,7 @@ async fn run_command(app: &mut App, line: &str) {
             Ok(mut threads) => {
                 sort_threads_recent(&mut threads);
                 let base = app.agent_dir.clone();
-                app.gap(Kind::Meta);
-                app.push(Line::styled(
-                    format!("{} saved thread(s):", threads.len()),
-                    Style::new().dim(),
-                ));
+                app.note(&format!("{} saved thread(s):", threads.len()));
                 for t in &threads {
                     let id = t.get("id").and_then(|v| v.as_str()).unwrap_or("?");
                     let title =
@@ -5547,7 +5581,7 @@ async fn run_command(app: &mut App, line: &str) {
                     ]));
                 }
                 app.push(Line::styled(
-                    "resume with /resume".to_string(),
+                    "  resume with /resume".to_string(),
                     Style::new().dim(),
                 ));
             }
@@ -6241,11 +6275,7 @@ fn show_goal_status(app: &mut App) {
         GoalStatus::Active => "active",
         GoalStatus::Achieved => "achieved",
     };
-    app.gap(Kind::Meta);
-    app.push(Line::styled(
-        format!("◎ goal [{state}]"),
-        Style::new().cyan().bold(),
-    ));
+    app.system_marked(GOAL_GLYPH, Level::Info, &format!("goal [{state}]"));
     app.push(Line::styled(
         format!("  condition: {}", goal.condition),
         Style::new().dim(),
@@ -6412,11 +6442,7 @@ fn open_mcp_picker(app: &mut App) {
 /// just handed to the browser, so a headless or remote session can still be
 /// completed by hand.
 fn open_login_prompt(app: &mut App) {
-    app.gap(Kind::Meta);
-    app.push(Line::styled(
-        "sign in to Tokamak and create an API key:".to_string(),
-        Style::new().dim(),
-    ));
+    app.note("sign in to Tokamak and create an API key:");
     app.push(Line::styled(
         format!("  {}", super::tokamak::API_KEYS_URL),
         Style::new().cyan(),
@@ -8864,7 +8890,7 @@ mod tests {
     use ratatui::buffer::Buffer;
     use ratatui::layout::Rect;
     use ratatui::{
-        style::{Modifier, Style},
+        style::{Color, Modifier, Style},
         text::Line,
     };
     use crate::core::agent::events::{StreamEvent, Usage};
@@ -15611,6 +15637,79 @@ mod tests {
         }
         assert_eq!(super::hint_rows(pairs, 200).len(), 1, "one row when it fits");
     }
+    /// Spans of the last committed transcript row, as `(text, style)`.
+    fn last_row(app: &App) -> Vec<(String, Style)> {
+        app.transcript
+            .last()
+            .expect("a row")
+            .lines(80)
+            .remove(0)
+            .spans
+            .iter()
+            .map(|s| (s.content.to_string(), s.style))
+            .collect()
+    }
+
+    #[test]
+    fn every_transcript_class_owns_a_distinct_gutter() {
+        let mut app = test_app();
+
+        app.note("conversation cleared");
+        assert_eq!(last_row(&app)[0].0, "\u{2022} ", "system note");
+
+        app.push_user_line("do it", &[]);
+        assert_eq!(last_row(&app)[0].0, "\u{203a} ", "user message");
+
+        app.apply(StreamEvent::ToolCall {
+            id: "t1".into(),
+            name: "bash".into(),
+            args: json!({"command": "ls"}),
+        });
+        app.apply(StreamEvent::ToolResult {
+            id: "t1".into(),
+            content: "ok".into(),
+            is_error: false,
+            diff: None,
+        });
+        app.finalize_tool_group();
+        assert_eq!(last_row(&app)[0].0, "\u{2502} ", "tool row");
+
+        // Model prose is the one class with no gutter, which is what makes the
+        // others readable as "not the model".
+        app.assistant_buf = "Done.".into();
+        app.flush_assistant();
+        let prose = last_row(&app);
+        assert!(
+            !prose[0].0.starts_with('\u{2022}') && !prose[0].0.starts_with('\u{203a}'),
+            "prose took a gutter: {prose:?}"
+        );
+    }
+
+    #[test]
+    fn severity_colours_the_gutter_and_the_body() {
+        let mut app = test_app();
+
+        app.note("saved");
+        let info = last_row(&app);
+        assert_eq!(info[0].1.fg, Some(Color::LightBlue), "info gutter");
+        assert!(info[1].1.add_modifier.contains(Modifier::DIM), "info body");
+
+        app.system(super::Level::Warn, "finished early");
+        assert_eq!(last_row(&app)[0].1.fg, Some(Color::Yellow));
+
+        app.system(super::Level::Error, "denied: rm -rf /");
+        let err = last_row(&app);
+        assert_eq!(err[0].1.fg, Some(Color::Red));
+        assert!(err[1].1.add_modifier.contains(Modifier::BOLD), "{err:?}");
+
+        // A category with its own glyph keeps it, so the column never carries
+        // two markers.
+        app.system_marked(super::GOAL_GLYPH, super::Level::Good, "goal achieved");
+        let goal = last_row(&app);
+        assert_eq!(goal[0].0, "\u{25ce} ");
+        assert_eq!(goal[0].1.fg, Some(Color::Green));
+    }
+
 }
 
 

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -153,6 +153,11 @@ const SYSTEM_GLYPH: &str = "•";
 /// Gutter glyph for goal-loop lines, matching the header's `◎ /goal` badge.
 const GOAL_GLYPH: &str = "◎";
 
+/// Gutter for the body rows of a multi-line system block. Distinct from the tool
+/// rows' `│` and the reasoning rows' `┊`, so three stacked blocks stay tellable
+/// apart at a glance.
+const SYSTEM_CONT: &str = "┆";
+
 /// How loud a system line is. The only thing that varies between them, so it is
 /// a parameter rather than a colour picked at each of the ~90 call sites.
 #[derive(Copy, Clone, PartialEq)]
@@ -652,6 +657,17 @@ enum RowKind {
     /// The opening splash, re-laid out at the draw width (the wordmark is
     /// dropped and the hints re-packed on a terminal too narrow for them).
     Banner(Box<Banner>),
+    /// A line the app is saying: `glyph` in the gutter column, body wrapped at
+    /// the draw width, so the gutter owns the left edge of the whole row instead
+    /// of only its first line. `cont` is what a wrapped continuation puts in the
+    /// column: an edge glyph repeats, a marker glyph gives way to blanks (a
+    /// second `•` would read as a second note).
+    System {
+        glyph: &'static str,
+        cont: &'static str,
+        gutter: Style,
+        body: Vec<Span<'static>>,
+    },
     /// A tool call/summary row, re-truncated to `width - reserve`.
     Tool {
         tag: String,
@@ -702,6 +718,28 @@ impl Row {
             RowKind::Line(line) => vec![line.clone()],
             RowKind::Markdown(text) => format_markdown_lines(text, width),
             RowKind::Banner(banner) => banner_lines(banner, width),
+            RowKind::System {
+                glyph,
+                cont,
+                gutter,
+                body,
+            } => {
+                let lead = glyph.chars().count() + 1;
+                let max = width.saturating_sub(lead as u16).max(8) as usize;
+                markdown::wrap_spans_at_words(body.clone(), max)
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, spans)| {
+                        let mark = if i == 0 { *glyph } else { *cont };
+                        let mut row = vec![Span::styled(
+                            format!("{mark:<width$}", width = lead),
+                            *gutter,
+                        )];
+                        row.extend(spans);
+                        Line::from(row)
+                    })
+                    .collect()
+            }
             RowKind::Tool {
                 tag,
                 tag_style,
@@ -1489,7 +1527,6 @@ impl App {
         self.reminder_awaiting_progress = false;
     }
 
-    /// Append a dim single-line status note (command output, cancel, errors).
     /// Drop any selection, and with it a copy armed but not yet lifted out of a
     /// frame -- otherwise it would fire against whatever is selected next.
     fn clear_selection(&mut self) {
@@ -1525,14 +1562,16 @@ impl App {
     /// transcript class owns one (`› ` user, `│ ` tool, `┊ ` reasoning), so
     /// without it a note is indistinguishable from model prose. `glyph` names the
     /// category and `level` carries severity.
-    fn system_marked(&mut self, glyph: &str, level: Level, text: &str) {
+    fn system_marked(&mut self, glyph: &'static str, level: Level, text: &str) {
         self.scrollback = 0;
         self.gap(Kind::Meta);
         let (gutter, body) = level.styles();
-        self.push(Line::from(vec![
-            Span::styled(format!("{glyph} "), gutter),
-            Span::styled(text.to_string(), body),
-        ]));
+        self.push_row(RowKind::System {
+            glyph,
+            cont: " ",
+            gutter,
+            body: vec![Span::styled(text.to_string(), body)],
+        });
     }
 
     fn system(&mut self, level: Level, text: &str) {
@@ -1543,6 +1582,26 @@ impl App {
     /// acknowledgement and background result goes through.
     fn note(&mut self, text: &str) {
         self.system(Level::Info, text);
+    }
+
+    /// A body row of a multi-line system block (`/help`, `/threads`, a goal
+    /// status), under the header its `system*` call pushed. The gutter keeps
+    /// running so the block reads as one unit instead of leaving its body
+    /// unattributed, and the body starts in the header's column.
+    ///
+    /// Fixed dim styling rather than the header's `Level`: blocks are
+    /// informational -- a warning or an error is a single line.
+    fn system_detail(&mut self, body: Vec<Span<'static>>) {
+        self.push_row(RowKind::System {
+            glyph: SYSTEM_CONT,
+            cont: SYSTEM_CONT,
+            gutter: Style::new().dark_gray(),
+            body,
+        });
+    }
+
+    fn system_detail_text(&mut self, text: &str) {
+        self.system_detail(vec![Span::styled(text.to_string(), Style::new().dim())]);
     }
 
     fn flush_assistant(&mut self) {
@@ -3055,7 +3114,7 @@ impl App {
                         Level::Good,
                         &format!("goal achieved in {turns} turn(s), {}", fmt_duration(elapsed)),
                     );
-                    self.push(Line::styled(format!("  {}", v.reason), Style::new().dim()));
+                    self.system_detail_text(&v.reason);
                     self.persist();
                 } else {
                     // Goal unmet: surface the reason as guidance and start the
@@ -5538,17 +5597,11 @@ async fn run_command(app: &mut App, line: &str) {
                 } else {
                     format!("{} {}", c.name, c.hint)
                 };
-                app.push(Line::styled(
-                    format!("  {sig:18} {}", c.description),
-                    Style::new().dim(),
-                ));
+                app.system_detail_text(&format!("{sig:18} {}", c.description));
             }
             app.note("keys:");
             for (keys, description) in KEY_BINDINGS {
-                app.push(Line::styled(
-                    format!("  {keys:18} {description}"),
-                    Style::new().dim(),
-                ));
+                app.system_detail_text(&format!("{keys:18} {description}"));
             }
         }
         "clear" => {
@@ -5575,15 +5628,12 @@ async fn run_command(app: &mut App, line: &str) {
                     let title =
                         thread_display_name(&base, id, t.get("title").and_then(|v| v.as_str()));
                     let short: String = id.chars().take(8).collect();
-                    app.push(Line::from(vec![
-                        Span::styled(format!("  {short}  "), Style::new().cyan()),
+                    app.system_detail(vec![
+                        Span::styled(format!("{short}  "), Style::new().cyan()),
                         Span::raw(title),
-                    ]));
+                    ]);
                 }
-                app.push(Line::styled(
-                    "  resume with /resume".to_string(),
-                    Style::new().dim(),
-                ));
+                app.system_detail_text("resume with /resume");
             }
             Err(e) => app.note(&format!("failed to list threads: {e}")),
         },
@@ -6276,27 +6326,18 @@ fn show_goal_status(app: &mut App) {
         GoalStatus::Achieved => "achieved",
     };
     app.system_marked(GOAL_GLYPH, Level::Info, &format!("goal [{state}]"));
-    app.push(Line::styled(
-        format!("  condition: {}", goal.condition),
-        Style::new().dim(),
-    ));
-    app.push(Line::styled(
-        format!(
-            "  turns: {}   duration: {}",
-            goal.turns,
-            fmt_duration(goal.elapsed_secs())
-        ),
-        Style::new().dim(),
+    app.system_detail_text(&format!("condition: {}", goal.condition));
+    app.system_detail_text(&format!(
+        "turns: {}   duration: {}",
+        goal.turns,
+        fmt_duration(goal.elapsed_secs())
     ));
     let reason = if goal.last_reason.is_empty() {
         "(not evaluated yet)"
     } else {
         &goal.last_reason
     };
-    app.push(Line::styled(
-        format!("  evaluator: {reason}"),
-        Style::new().dim(),
-    ));
+    app.system_detail_text(&format!("evaluator: {reason}"));
 }
 
 /// Set a new goal from `condition` and immediately start a turn toward it (the
@@ -6443,15 +6484,15 @@ fn open_mcp_picker(app: &mut App) {
 /// completed by hand.
 fn open_login_prompt(app: &mut App) {
     app.note("sign in to Tokamak and create an API key:");
-    app.push(Line::styled(
-        format!("  {}", super::tokamak::API_KEYS_URL),
+    app.system_detail(vec![Span::styled(
+        super::tokamak::API_KEYS_URL,
         Style::new().cyan(),
-    ));
+    )]);
     let browser = match super::tokamak::open_api_keys_page() {
-        Ok(()) => "  opening that page in your browser".to_string(),
-        Err(e) => format!("  open that URL yourself ({e})"),
+        Ok(()) => "opening that page in your browser".to_string(),
+        Err(e) => format!("open that URL yourself ({e})"),
     };
-    app.push(Line::styled(browser, Style::new().dim()));
+    app.system_detail_text(&browser);
     app.login = Some(LoginPrompt::new());
 }
 
@@ -15708,6 +15749,72 @@ mod tests {
         let goal = last_row(&app);
         assert_eq!(goal[0].0, "\u{25ce} ");
         assert_eq!(goal[0].1.fg, Some(Color::Green));
+    }
+
+    #[tokio::test]
+    async fn probe_blocks() {
+        let mut app = test_app();
+        app.note("conversation cleared");
+        run_command(&mut app, "help").await;
+        for l in render_rows(&mut app, 84, 40) { println!("|{}", l.trim_end()); }
+    }
+
+    /// Every rendered line of the last row, as plain text.
+    fn last_row_lines(app: &App, width: u16) -> Vec<String> {
+        app.transcript
+            .last()
+            .expect("a row")
+            .lines(width)
+            .iter()
+            .map(|l| l.spans.iter().map(|s| s.content.to_string()).collect())
+            .collect()
+    }
+
+    #[test]
+    fn a_wrapped_note_indents_instead_of_repeating_its_marker() {
+        let mut app = test_app();
+        app.note("not signed in - run /login to sign in to Tokamak, or jan config set to configure a provider manually");
+
+        let lines = last_row_lines(&app, 60);
+        assert!(lines.len() > 1, "expected a wrap: {lines:?}");
+        assert!(lines[0].starts_with("\u{2022} "), "{lines:?}");
+        for line in &lines[1..] {
+            assert!(
+                line.starts_with("  ") && !line.starts_with('\u{2022}'),
+                "a continuation must not read as a second note: {line:?}"
+            );
+        }
+        // Wrapped at a space, not mid-word.
+        assert!(
+            lines.iter().all(|l| !l.ends_with("Tokam") && !l.ends_with("provi")),
+            "{lines:?}"
+        );
+        assert!(lines.iter().all(|l| l.chars().count() <= 60), "{lines:?}");
+    }
+
+    #[test]
+    fn a_wrapped_block_body_keeps_its_edge() {
+        let mut app = test_app();
+        app.note("commands:");
+        app.system_detail_text("/plan [exit|text]  Enter read-only plan mode, optionally seeding it with a message");
+
+        let lines = last_row_lines(&app, 50);
+        assert!(lines.len() > 1, "expected a wrap: {lines:?}");
+        for line in &lines {
+            assert!(
+                line.starts_with("\u{2506} "),
+                "the block's left edge breaks on a wrap: {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn system_rows_relay_out_on_a_resize() {
+        let mut app = test_app();
+        app.system_detail_text("a fairly long block body that has to wrap somewhere sensible");
+        let (wide, narrow) = (last_row_lines(&app, 90), last_row_lines(&app, 30));
+        assert_eq!(wide.len(), 1, "{wide:?}");
+        assert!(narrow.len() > 1, "{narrow:?}");
     }
 
 }

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -216,7 +216,7 @@ impl Pending {
         match &self.diff {
             Some(d) => diff_lines(
                 d,
-                (inner as usize).saturating_sub(4).max(1),
+                inner as usize,
                 DIFF_PREVIEW_MAX_ROWS,
                 "",
                 self.path.as_deref(),
@@ -573,7 +573,7 @@ impl Row {
                 if let Some(diff) = diff {
                     out.extend(diff_lines(
                         diff,
-                        max,
+                        width as usize,
                         DIFF_MAX_ROWS,
                         "│     ",
                         lang.as_deref(),
@@ -2931,17 +2931,19 @@ const DIFF_DEL_BG: Color = Color::Rgb(66, 26, 30);
 /// `+` rows on a green background and `-` rows on a red one across the whole row
 /// (so the change reads as a band), `@@` headers dim-cyan. Every row keeps its
 /// syntax highlighting, changed or not; only the background says what happened.
-/// Content is truncated to `max` and each row padded so the right border aligns.
+/// Content is truncated to what `width` leaves after the gutter and the frame,
+/// and each row padded so the right border aligns.
 /// Collapses to `max_rows` with a `(+N more)` tail before the closing rule.
 /// `gutter` indents the panel (tool-row alignment under a result; empty in the
 /// prompt).
 fn diff_lines(
     diff: &str,
-    max: usize,
+    width: usize,
     max_rows: usize,
     gutter: &'static str,
     lang: Option<&str>,
 ) -> Vec<Line<'static>> {
+    let max = panel_inner(width, gutter);
     let all: Vec<&str> = diff.lines().collect();
     let shown = all.len().min(max_rows);
     let truncated = all.len() > shown;
@@ -3001,7 +3003,7 @@ fn diff_lines(
             Style::new().dim(),
         ));
     }
-    boxed_panel(rows, max, gutter)
+    boxed_panel(rows, width, gutter)
 }
 
 /// Split a diff row into its leading marker and the code after it. A `@@` hunk
@@ -3021,20 +3023,28 @@ fn row_width(row: &Line<'_>) -> usize {
     row.spans.iter().map(|s| s.content.chars().count()).sum()
 }
 
+/// Content columns a panel of total `width` has left after its gutter and the
+/// four the frame spends (`│ ` and ` │`). Callers size their rows with this so
+/// the closing border lands inside the terminal instead of wrapping onto a line
+/// of its own.
+pub(super) fn panel_inner(width: usize, gutter: &str) -> usize {
+    width.saturating_sub(gutter.chars().count() + 4).max(1)
+}
+
 /// Frame styled rows in a light box, right-padded to the widest row (clamped to
-/// `max`). Rows carry their own spans so style can vary within a row (syntax
-/// highlighting); `gutter` prefixes every line to indent the panel. A row's
-/// line-level style is folded into its spans, since the framed line replaces it
-/// with the border's own style, and a row-level background also fills the
-/// interior padding so a highlighted row reads as a band from border to border
-/// rather than stopping at the end of its text.
-fn boxed_panel(rows: Vec<Line<'static>>, max: usize, gutter: &'static str) -> Vec<Line<'static>> {
+/// what `width` leaves for content). Rows carry their own spans so style can vary
+/// within a row (syntax highlighting); `gutter` prefixes every line to indent the
+/// panel. A row's line-level style is folded into its spans, since the framed
+/// line replaces it with the border's own style, and a row-level background also
+/// fills the interior padding so a highlighted row reads as a band from border to
+/// border rather than stopping at the end of its text.
+fn boxed_panel(rows: Vec<Line<'static>>, width: usize, gutter: &'static str) -> Vec<Line<'static>> {
     let inner = rows
         .iter()
         .map(row_width)
         .max()
         .unwrap_or(0)
-        .clamp(1, max.max(1));
+        .clamp(1, panel_inner(width, gutter));
     let border = Style::new().dark_gray();
     let mut out = Vec::with_capacity(rows.len() + 2);
     out.push(Line::from(vec![
@@ -3544,7 +3554,7 @@ fn group_detail_lines(group: &ToolGroup, width: u16) -> Vec<Line<'static>> {
                 ]));
             }
             if let Some(diff) = &call.diff {
-                for line in diff_lines(diff, max, DIFF_MAX_ROWS, cont_gutter, None) {
+                for line in diff_lines(diff, width as usize, DIFF_MAX_ROWS, cont_gutter, None) {
                     out.push(line);
                 }
             }
@@ -8530,7 +8540,8 @@ mod tests {
         subagent_name_from_run_id, summarize_result, tilde_path, tokens_per_second,
         tool_activity, tool_finished,
         transcript_top_padding, rewind_to,
-        user_content_parts, App, CurrentRun, Pending, PendingImage, PickerKind, ResumeTarget,
+        row_width, user_content_parts, App, CurrentRun, Pending, PendingImage, PickerKind,
+        ResumeTarget, RowKind,
         SnapshotJob, Status, AGENT_SETTINGS, ALT_SCROLL_RESTORE, ALT_SCROLL_SAVE_OFF,
         COMMAND_LABEL_MAX, DIFF_ADD_BG, DIFF_DEL_BG, DIFF_MAX_ROWS, DIFF_PREVIEW_MAX_ROWS,
         KEY_BINDINGS, MOUSE_TRACK_ON, SLASH_COMMANDS, SPINNER,
@@ -11416,6 +11427,51 @@ mod tests {
             "bottom: {}",
             line_text(out.last().unwrap())
         );
+    }
+
+    /// The panel is sized to the width it is drawn at: gutter, frame and content
+    /// together have to fit, or the closing border wraps onto a line of its own
+    /// and the box reads as double-spaced with no right edge.
+    #[test]
+    fn a_boxed_diff_fits_the_draw_width() {
+        let long = format!("+    1 | {}", "x".repeat(300));
+        for gutter in ["", "│   ", "│     ", "│       "] {
+            for width in [40usize, 80, 163] {
+                for line in diff_lines(&long, width, DIFF_MAX_ROWS, gutter, None) {
+                    assert!(
+                        row_width(&line) <= width,
+                        "gutter {:?} at width {width}: row is {} wide: {:?}",
+                        gutter,
+                        row_width(&line),
+                        line_text(&line)
+                    );
+                }
+            }
+        }
+    }
+
+    /// Same, through the row that actually renders in the transcript: the result
+    /// row owns both the gutter and the width, so its diff must fit unaided.
+    #[test]
+    fn a_result_row_diff_fits_the_draw_width() {
+        let row: Row = RowKind::Result {
+            tag: "✓",
+            tag_style: Style::new().green(),
+            content: Some("Wrote notes.md".into()),
+            diff: Some(format!("@@ created file @@\n+    1 | {}", "y".repeat(300))),
+            lang: None,
+        }
+        .into();
+        for width in [40u16, 80, 163] {
+            for line in row.lines(width) {
+                assert!(
+                    row_width(&line) <= width as usize,
+                    "width {width}: row is {} wide: {:?}",
+                    row_width(&line),
+                    line_text(&line)
+                );
+            }
+        }
     }
 
     fn plus_rows(n: usize) -> String {

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -39,6 +39,7 @@ use markdown::{
     format_markdown_lines, live_assistant_lines, reasoning_detail_lines, reasoning_summary_row,
 };
 
+use super::journal::{self, DisplayEntry};
 use super::{sort_threads_recent, AgentSession, ResumeTarget, SessionLimits};
 use crate::core::agent::events::{describe_tool_call, StreamEvent, Usage};
 use crate::core::agent::git;
@@ -826,6 +827,13 @@ struct App {
     /// not lines: width-dependent entries keep their source and re-render on
     /// resize (see `Row`).
     transcript: Vec<Row>,
+    /// What was rendered, in emission order, so a resumed session gets its
+    /// reasoning and tool calls back. `history` cannot serve this: reasoning is
+    /// kept out of it and tool calls are flattened away on save. Dumped off the
+    /// render loop by `persist`, replayed by `replay_display_log`.
+    display_log: Vec<DisplayEntry>,
+    /// Background journal writer, created on the first dump and joined on exit.
+    journal_writer: Option<journal::Writer>,
     /// In-progress assistant text for the current turn, flushed on the next
     /// step/tool/terminal event.
     assistant_buf: String,
@@ -1161,6 +1169,8 @@ impl App {
             history: Vec::new(),
             thread_id: None,
             transcript: Vec::new(),
+            display_log: Vec::new(),
+            journal_writer: None,
             assistant_buf: String::new(),
             tool_group: None,
             grouped_ids: std::collections::HashSet::new(),
@@ -1282,6 +1292,7 @@ impl App {
         self.base_requested = false;
         self.last_esc = None;
         self.transcript.clear();
+        self.display_log.clear();
         self.tool_group = None;
         self.grouped_ids.clear();
         self.starting.clear();
@@ -1349,6 +1360,12 @@ impl App {
         }
         // Model prose ends the current run of tool calls.
         self.finalize_tool_group();
+        // Journaled with its `<think>` markers intact: this is the only place the
+        // reasoning exists (it is kept out of `history` on purpose), and the
+        // replay folds it exactly as the live turn did.
+        self.display_log.push(DisplayEntry::Assistant {
+            text: text.clone(),
+        });
         self.push_assistant_blocks(&text);
     }
 
@@ -1478,6 +1495,11 @@ impl App {
     /// the row can expand back to it (like a tool group). `finished` separates a
     /// clean `SubagentEnd` from a child the run ended out from under.
     fn push_subagent_summary(&mut self, name: &str, calls: Vec<String>, finished: bool) {
+        self.display_log.push(DisplayEntry::Subagent {
+            name: name.to_string(),
+            calls: calls.clone(),
+            finished,
+        });
         let total = calls.len();
         let noun = if total == 1 { "call" } else { "calls" };
         let verb = if finished { "finished" } else { "interrupted" };
@@ -1937,6 +1959,12 @@ impl App {
         };
         self.history.push(build_user_message(&final_text, &images));
         self.push_user_line(&text, &names);
+        // The typed text, not `final_text`: `@path` expansions are context for
+        // the model, and the row never showed them.
+        self.display_log.push(DisplayEntry::User {
+            text: text.clone(),
+            images: names,
+        });
         self.begin_turn();
         // A fresh user turn is new context: allow the next boundary to remind
         // again even if the open work is unchanged (dedup is "twice in a row"),
@@ -2237,9 +2265,32 @@ impl App {
             &self.history,
             self.thread_metadata(),
         ) {
-            Ok(id) => self.thread_id = Some(id),
+            Ok(id) => {
+                self.thread_id = Some(id);
+                self.dump_display_log();
+            }
             Err(e) => self.detail = format!("save failed: {e}"),
         }
+    }
+
+    /// Hand the rendered transcript to the writer thread, so a turn boundary (or
+    /// a cancel) leaves a resumable journal without a frame paying for the write.
+    fn dump_display_log(&mut self) {
+        let Some(id) = self.thread_id.clone() else {
+            return;
+        };
+        let path = journal::journal_path(&self.agent_dir, &id);
+        self.journal_writer
+            .get_or_insert_with(journal::Writer::new)
+            .dump(path, self.display_log.clone());
+    }
+
+    /// Wait for queued journal dumps to reach disk (session exit, tests).
+    fn join_journal(&mut self) {
+        if let Some(writer) = self.journal_writer.as_mut() {
+            writer.join();
+        }
+        self.journal_writer = None;
     }
 
     /// Switch the active model and remember it in the project's agent.toml so it
@@ -2307,6 +2358,23 @@ impl App {
                 // The full call (with parsed args) supersedes its in-progress
                 // throbber.
                 self.starting.retain(|c| c.id != id);
+                // Commit buffered prose/reasoning before anything else: every
+                // branch below does it anyway (so the timeline stays in emission
+                // order), and doing it here keeps the journal in that order too
+                // -- text that preceded the call, then the call. `flush_assistant`
+                // no-ops on an empty buffer, so silent consecutive calls still
+                // fold into one group row.
+                self.flush_assistant();
+                // `await_subagent` renders a live throbber that its result
+                // clears, so journaling the call would replay a spinner nothing
+                // ever stops; its result row is journaled below either way.
+                if name != "await_subagent" {
+                    self.display_log.push(DisplayEntry::ToolCall {
+                        id: id.clone(),
+                        name: name.clone(),
+                        args: args.clone(),
+                    });
+                }
                 // Track todo activity this turn so the reminder policy can tell
                 // an engaged turn (mutated todos) from a stalled one.
                 if name == "todo" {
@@ -2316,11 +2384,6 @@ impl App {
                 // (advanced each render tick) instead of a static grouped row,
                 // cleared when its result arrives.
                 if name == "await_subagent" {
-                    // Commit any buffered reasoning/prose the model emitted
-                    // before awaiting so it folds to its summary row instead of
-                    // lingering fully expanded in the live tail behind the
-                    // throbber (matches the grouped-call path below).
-                    self.flush_assistant();
                     let run_id = args.get("run_id").and_then(|v| v.as_str()).unwrap_or("");
                     let sub = subagent_name_from_run_id(run_id).to_string();
                     self.awaiting.push((id, run_id.to_string(), sub));
@@ -2339,7 +2402,6 @@ impl App {
                     }
                     // Diff-producing tools render standalone (call row & panel).
                     self.finalize_tool_group();
-                    self.flush_assistant();
                     self.gap(Kind::Tool);
                     self.push_row(RowKind::Tool {
                         tag: "▸".to_string(),
@@ -2355,12 +2417,6 @@ impl App {
                         done,
                     });
                 } else {
-                    // Commit any buffered prose OR reasoning the model emitted
-                    // before this call so the timeline stays in emission order
-                    // (pre-tool thinking renders above the tool row, not stranded
-                    // in the live tail below it). `flush_assistant` no-ops on an
-                    // empty buffer, so truly silent consecutive calls still fold.
-                    self.flush_assistant();
                     self.push_grouped_call(&id, &name, label, done);
                 }
             }
@@ -2372,6 +2428,12 @@ impl App {
             } => {
                 // Clear the throbber for an awaited subagent once its result lands.
                 self.awaiting.retain(|(await_id, ..)| await_id != &id);
+                self.display_log.push(DisplayEntry::ToolResult {
+                    id: id.clone(),
+                    content: content.clone(),
+                    is_error,
+                    diff: diff.clone(),
+                });
                 let resolved = self.resolve_pending_row(&id, is_error);
                 // Any tool result means the model took some action since the last
                 // reminder fired; let a later stop remind again if work is still
@@ -2651,9 +2713,10 @@ impl App {
         // `SubagentEnd`.
         self.close_live_subagents();
         let answer = self.take_answer();
-        if !answer.is_empty() {
+        let wire = answer_without_reasoning(&answer);
+        if !wire.is_empty() {
             self.history
-                .push(serde_json::json!({ "role": "assistant", "content": answer.clone() }));
+                .push(serde_json::json!({ "role": "assistant", "content": wire }));
         }
         // A closing receipt for the turn: when, how much context went up, how
         // much came back, how long it took, how fast. Cheap to skim, and the
@@ -2834,7 +2897,7 @@ impl App {
         // preceding tool calls stay in the transcript, and record the partial
         // answer in history so the next turn and a later /resume both see it.
         self.abort_tool_rows();
-        let answer = self.take_answer();
+        let answer = answer_without_reasoning(&self.take_answer());
         if !answer.is_empty() {
             self.history
                 .push(serde_json::json!({ "role": "assistant", "content": answer }));
@@ -3669,6 +3732,18 @@ fn has_answer_text(buf: &str) -> bool {
         .any(|(reasoning, seg)| !reasoning && !seg.trim().is_empty())
 }
 
+/// `text` with its reasoning removed, for the copy that goes into `history`.
+/// Reasoning is display-only and must never be resent to the model (see
+/// `SseAccumulator`); the display journal is what keeps it for a resume.
+fn answer_without_reasoning(text: &str) -> String {
+    split_reasoning(text)
+        .into_iter()
+        .filter_map(|(reasoning, seg)| (!reasoning).then_some(seg))
+        .collect::<String>()
+        .trim()
+        .to_string()
+}
+
 /// A leading markdown list/blockquote marker (`> `, `- `, `1. `), stripped
 /// before checking whether a line reads as a question.
 fn markdown_prefix_re() -> &'static regex::Regex {
@@ -4065,6 +4140,10 @@ pub async fn run(
         &mcp_servers,
     )
     .await;
+
+    // The last turn's journal may still be queued on the writer thread; a
+    // process that exits now would lose it, and with it that turn's resume.
+    app.join_journal();
 
     let _ = disable_raw_mode();
     let _ = execute!(
@@ -6498,6 +6577,10 @@ fn rewind_to(app: &mut App, target: usize, restore_workspace: bool) {
     .0;
 
     app.history.truncate(cut);
+    // The journal is keyed by its own user entries, not by history indices: it
+    // holds rows (tool calls, reasoning) that history never had.
+    app.display_log
+        .truncate(journal::truncate_at_user(&app.display_log, target));
     app.checkpoints.retain(|c| c.user_index < target);
     rebuild_transcript(app);
     rebuild_recall(app);
@@ -6531,7 +6614,65 @@ fn rebuild_recall(app: &mut App) {
     }
 }
 
-/// Re-render the transcript from the current `history` after a rewind.
+/// Replay a display journal through the very paths that rendered it live, so a
+/// resumed or rewound transcript keeps its reasoning, tool rows and diff panels.
+/// The replayed events journal themselves again, so `entries` is reinstated as
+/// the log afterwards instead of whatever the replay appended.
+fn replay_display_log(app: &mut App, entries: Vec<DisplayEntry>) {
+    for entry in &entries {
+        match entry {
+            DisplayEntry::User { text, images } => {
+                app.finalize_tool_group();
+                app.push_user_line(text, images);
+            }
+            // Through `flush_assistant`, not `push_assistant_blocks`: the prose
+            // is also what closes the preceding run of grouped calls. Rendering
+            // the blocks directly leaves the group open, so every later call
+            // folds back into one row that is never committed -- the whole turn's
+            // tool calls then render as nothing at all.
+            DisplayEntry::Assistant { text } => {
+                app.assistant_buf = text.clone();
+                app.flush_assistant();
+            }
+            DisplayEntry::ToolCall { id, name, args } => app.apply(StreamEvent::ToolCall {
+                id: id.clone(),
+                name: name.clone(),
+                args: args.clone(),
+            }),
+            DisplayEntry::ToolResult {
+                id,
+                content,
+                is_error,
+                diff,
+            } => app.apply(StreamEvent::ToolResult {
+                id: id.clone(),
+                content: content.clone(),
+                is_error: *is_error,
+                diff: diff.clone(),
+            }),
+            DisplayEntry::Subagent {
+                name,
+                calls,
+                finished,
+            } => {
+                app.finalize_tool_group();
+                app.push_subagent_summary(name, calls.clone(), *finished);
+            }
+        }
+    }
+    // A replay is rendering, not work: the calls it re-renders must not stage
+    // files for the next checkpoint, leave a call awaiting a diff, or read as
+    // todo activity in the turn that follows.
+    app.finalize_tool_group();
+    app.turn_touched.clear();
+    app.diff_paths.clear();
+    app.todo_call_this_turn = false;
+    app.display_log = entries;
+}
+
+/// Re-render the transcript after a rewind: from the display journal when there
+/// is one (so the kept turns keep their reasoning and tool rows), else from the
+/// `history` the rewind left behind.
 fn rebuild_transcript(app: &mut App) {
     app.transcript.clear();
     app.tool_group = None;
@@ -6545,6 +6686,10 @@ fn rebuild_transcript(app: &mut App) {
     app.reveal = None;
     app.assistant_buf.clear();
     app.last_kind = Kind::None;
+    if !app.display_log.is_empty() {
+        let logged = std::mem::take(&mut app.display_log);
+        return replay_display_log(app, logged);
+    }
     let history = app.history.clone();
     for m in &history {
         let role = m.get("role").and_then(|v| v.as_str()).unwrap_or("");
@@ -6624,21 +6769,27 @@ async fn load_thread(app: &mut App, thread: &serde_json::Value) {
         app.model = model.to_string();
     }
 
-    let mut count = 0;
-    for msg in &messages {
-        let role = msg.get("role").and_then(|v| v.as_str()).unwrap_or("");
-        let text = message_text(msg);
-        if text.is_empty() || !matches!(role, "user" | "assistant") {
-            continue;
-        }
-        app.history
-            .push(serde_json::json!({ "role": role, "content": text }));
-        if role == "user" {
-            app.push_user_line(&text, &[]);
-        } else {
-            app.push_assistant_blocks(&text);
-        }
-        count += 1;
+    // The journal holds what was rendered (reasoning, tool rows, diffs); the
+    // messages hold what the model is sent. Prefer the journal for the
+    // transcript, and fall back to replaying the messages for a thread saved
+    // before journaling (or whose journal was lost).
+    let logged = journal::read_journal(&journal::journal_path(&app.agent_dir, full_id));
+    app.history = super::rebuild_wire_history(&messages);
+    let count = app
+        .history
+        .iter()
+        .filter(|m| {
+            matches!(
+                m.get("role").and_then(|v| v.as_str()),
+                Some("user" | "assistant")
+            )
+        })
+        .count();
+    app.display_log.clear();
+    if logged.is_empty() {
+        rebuild_transcript(app);
+    } else {
+        replay_display_log(app, logged);
     }
     // Recall follows the conversation, so the replaced session's lines go with
     // it and the resumed thread's come back.
@@ -8523,6 +8674,7 @@ fn footer_spans(app: &App) -> Vec<Span<'static>> {
 #[cfg(test)]
 mod tests {
     use super::SessionLimits;
+    use super::{journal, DisplayEntry};
     use super::{
         age_closed_todos, apply_resume, assistant_is_awaiting_user_answer, build_user_message,
         clipboard_path,
@@ -12527,6 +12679,226 @@ mod tests {
         assert_eq!(summarize_result("a    b\tc", 80), "a b c");
         // Truncates the head to max.
         assert_eq!(summarize_result("abcdefgh", 4), "abc…");
+    }
+
+    /// Run one turn that reasons, calls a diff-producing tool, and answers,
+    /// leaving it persisted (messages + journal) in `app.agent_dir`.
+    fn record_full_turn(app: &mut App) {
+        app.submit_user("do it".to_string());
+        app.apply(StreamEvent::Token {
+            text: "<think>my private reasoning</think>".into(),
+        });
+        app.apply(StreamEvent::ToolCall {
+            id: "c1".into(),
+            name: "write".into(),
+            args: json!({ "path": "a.txt", "content": "x" }),
+        });
+        app.apply(StreamEvent::ToolResult {
+            id: "c1".into(),
+            content: "wrote 1 line".into(),
+            is_error: false,
+            diff: Some("@@ created file @@\n+    1 | x".into()),
+        });
+        app.apply(StreamEvent::MessagesUpdated {
+            messages: vec![
+                json!({ "role": "user", "content": "do it" }),
+                json!({ "role": "assistant", "content": "", "tool_calls": [{
+                    "id": "c1",
+                    "type": "function",
+                    "function": { "name": "write", "arguments": "{\"path\":\"a.txt\"}" },
+                }]}),
+                json!({ "role": "tool", "tool_call_id": "c1", "content": "wrote 1 line" }),
+            ],
+        });
+        app.apply(StreamEvent::Token {
+            text: "Answer.".into(),
+        });
+        app.on_done("stop".into(), None);
+        app.join_journal();
+    }
+
+    #[tokio::test]
+    async fn resume_restores_reasoning_tool_rows_and_diffs() {
+        let mut app = test_app();
+        record_full_turn(&mut app);
+        let live: String = app
+            .transcript
+            .iter()
+            .map(row_text)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let mut fresh = test_app();
+        fresh.agent_dir = app.agent_dir.clone();
+        apply_resume(&mut fresh, &ResumeTarget::Latest).await;
+        let resumed: String = fresh
+            .transcript
+            .iter()
+            .map(row_text)
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert_eq!(fresh.reasoning_blocks.len(), 1, "folded reasoning is back");
+        assert!(resumed.contains("reasoning (1 line)"), "{resumed}");
+        assert!(resumed.contains("✓ Wrote a.txt"), "tool row: {resumed}");
+        assert!(
+            resumed.contains("@@ created file @@") && resumed.contains("+    1 | x"),
+            "diff panel: {resumed}"
+        );
+        assert!(resumed.contains("Answer."), "{resumed}");
+        // Every rendered row returns; the turn receipt (`↑ tokens ⏱ elapsed`) is
+        // deliberately transient, like notes and permission prompts.
+        assert!(
+            live.lines()
+                .filter(|l| !l.contains('⏱'))
+                .all(|l| resumed.contains(l.trim_end())),
+            "every live row must come back\nlive:\n{live}\nresumed:\n{resumed}"
+        );
+        // Expanding the restored reasoning row reveals its full detail, so the
+        // journal carried the text and not just the summary count.
+        fresh.toggle_regions();
+        let expanded = render_rows(&mut fresh, 60, 30).join("\n");
+        assert!(expanded.contains("my private reasoning"), "{expanded}");
+    }
+
+    /// The common shape: several grouped calls (bash, not the standalone
+    /// edit/write rows), each run separated by the model's prose. Live, the
+    /// prose is what closes each group; a replay must close them the same way or
+    /// every call folds into one row that is never committed.
+    #[tokio::test]
+    async fn resume_restores_grouped_tool_calls_between_prose() {
+        let mut app = test_app();
+        app.submit_user("check it".to_string());
+        for (i, cmd) in ["git status", "git log -1"].iter().enumerate() {
+            app.apply(StreamEvent::Token {
+                text: format!("<think>step {i}</think>"),
+            });
+            app.apply(StreamEvent::ToolCall {
+                id: format!("c{i}"),
+                name: "bash".into(),
+                args: json!({ "command": cmd }),
+            });
+            app.apply(StreamEvent::ToolResult {
+                id: format!("c{i}"),
+                content: "output".into(),
+                is_error: false,
+                diff: None,
+            });
+            app.apply(StreamEvent::Token {
+                text: format!("Ran {cmd}.\n"),
+            });
+        }
+        app.on_done("stop".into(), None);
+        app.join_journal();
+        let live: String = app
+            .transcript
+            .iter()
+            .map(row_text)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(live.contains("git status") && live.contains("git log -1"), "{live}");
+
+        let mut fresh = test_app();
+        fresh.agent_dir = app.agent_dir.clone();
+        apply_resume(&mut fresh, &ResumeTarget::Latest).await;
+        let resumed: String = fresh
+            .transcript
+            .iter()
+            .map(row_text)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            resumed.contains("git status") && resumed.contains("git log -1"),
+            "both grouped calls must come back as their own rows:\n{resumed}"
+        );
+        assert!(
+            fresh.tool_group.is_none(),
+            "no group may be left open after a replay"
+        );
+        assert_eq!(fresh.groups.len(), 2, "one closed group per run of calls");
+        // Expanding a restored group row still shows the call and its output.
+        fresh.toggle_regions();
+        let expanded = render_rows(&mut fresh, 80, 40).join("\n");
+        assert!(expanded.contains("output"), "{expanded}");
+    }
+
+    #[tokio::test]
+    async fn resume_restores_the_model_side_tool_calls() {
+        let mut app = test_app();
+        record_full_turn(&mut app);
+        assert!(
+            !serde_json::to_string(&app.history).unwrap().contains("<think>"),
+            "reasoning must not be resent to the model: {:?}",
+            app.history
+        );
+
+        let mut fresh = test_app();
+        fresh.agent_dir = app.agent_dir.clone();
+        apply_resume(&mut fresh, &ResumeTarget::Latest).await;
+
+        assert_eq!(fresh.history, app.history, "the wire conversation round-trips");
+        let called = fresh
+            .history
+            .iter()
+            .find(|m| m.get("tool_calls").is_some())
+            .expect("the call the model made is back");
+        assert_eq!(called["tool_calls"][0]["id"], "c1");
+        let result = fresh
+            .history
+            .iter()
+            .find(|m| m["role"] == "tool")
+            .expect("its result is back");
+        assert_eq!(result["tool_call_id"], "c1");
+        assert_eq!(result["content"], "wrote 1 line");
+    }
+
+    #[tokio::test]
+    async fn resume_falls_back_to_messages_without_a_journal() {
+        let mut app = test_app();
+        record_full_turn(&mut app);
+        let id = app.thread_id.clone().expect("saved");
+        std::fs::remove_file(journal::journal_path(&app.agent_dir, &id)).unwrap();
+
+        let mut fresh = test_app();
+        fresh.agent_dir = app.agent_dir.clone();
+        apply_resume(&mut fresh, &ResumeTarget::Latest).await;
+        let resumed: String = fresh
+            .transcript
+            .iter()
+            .map(row_text)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(resumed.contains("do it") && resumed.contains("Answer."), "{resumed}");
+        assert!(fresh.display_log.is_empty(), "nothing to journal from");
+    }
+
+    #[tokio::test]
+    async fn rewind_keeps_the_kept_turns_tool_rows() {
+        let mut app = test_app();
+        record_full_turn(&mut app);
+        app.submit_user("and again".to_string());
+        app.apply(StreamEvent::Token {
+            text: "Second answer.".into(),
+        });
+        app.on_done("stop".into(), None);
+
+        rewind_to(&mut app, 1, false);
+        let after: String = app
+            .transcript
+            .iter()
+            .map(row_text)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(after.contains("✓ Wrote a.txt"), "first turn keeps its rows: {after}");
+        assert!(after.contains("@@ created file @@"), "{after}");
+        assert!(!after.contains("Second answer."), "rewound turn is gone: {after}");
+        assert!(
+            !app.display_log
+                .iter()
+                .any(|e| matches!(e, DisplayEntry::User { text, .. } if text == "and again")),
+            "the journal is truncated with the conversation"
+        );
+        assert_eq!(app.input, "and again", "the rewound message returns to the input");
     }
 
     #[tokio::test]

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -39,6 +39,7 @@ use markdown::{
     format_markdown_lines, live_assistant_lines, reasoning_detail_lines, reasoning_summary_row,
 };
 
+use super::brand;
 use super::journal::{self, DisplayEntry};
 use super::{sort_threads_recent, AgentSession, ResumeTarget, SessionLimits};
 use crate::core::agent::events::{describe_tool_call, StreamEvent, Usage};
@@ -467,6 +468,131 @@ struct PendingToolRow {
     done: String,
 }
 
+/// What the session opens with: the `jan` wordmark plus the facts a first-time
+/// reader needs (which model, which project, how tool calls are approved) and
+/// the commands to go on with. Held as data rather than rendered lines so the
+/// row re-lays out at the draw width like every other width-dependent row.
+struct Banner {
+    version: &'static str,
+    model: String,
+    project: String,
+    branch: Option<String>,
+    /// How tool calls are approved this session (sandboxed, or `--safe`).
+    tools: String,
+    /// False when `--task` already seeded the first message, so the splash does
+    /// not invite one.
+    awaiting_first_message: bool,
+}
+
+/// Indent shared by every splash row, matching `jan --help`.
+const BANNER_INDENT: u16 = 2;
+
+/// Commands worth putting in front of a first-time reader. The full list is
+/// behind `/help` (see `SLASH_COMMANDS`).
+const BANNER_HINTS: &[(&str, &str)] = &[
+    ("/help", "commands"),
+    ("/model", "switch model"),
+    ("/resume", "reopen a session"),
+    ("Ctrl-D", "quit"),
+];
+
+fn banner_lines(banner: &Banner, width: u16) -> Vec<Line<'static>> {
+    let accent = Style::new().yellow().bold();
+    let label = Style::new().dark_gray();
+    let dim = Style::new().dim();
+    let indent = " ".repeat(BANNER_INDENT as usize);
+    let mut out: Vec<Line<'static>> = Vec::new();
+
+    // A clipped wordmark reads as breakage, so a narrow terminal gets the name
+    // as text instead.
+    if width >= brand::LOGO_WIDTH + BANNER_INDENT * 2 {
+        for art in brand::LOGO {
+            out.push(Line::styled(format!("{indent}{art}"), accent));
+        }
+        out.push(Line::raw(""));
+        out.push(Line::styled(
+            format!("{indent}interactive agent console · v{}", banner.version),
+            dim,
+        ));
+    } else {
+        out.push(Line::from(vec![
+            Span::styled(format!("{indent}jan"), accent),
+            Span::styled(format!(" v{}", banner.version), dim),
+        ]));
+    }
+    out.push(Line::raw(""));
+
+    let value_max = width.saturating_sub(BANNER_INDENT + 10).max(8) as usize;
+    let mut field = |name: &str, value: String| {
+        out.push(Line::from(vec![
+            Span::styled(format!("{indent}{name:<8}"), label),
+            Span::styled(truncate(&value, value_max), dim),
+        ]));
+    };
+    field("model", banner.model.clone());
+    // Repeated from the dock on purpose: the tools act on this directory, and a
+    // `jan` started in the wrong one is the mistake worth catching before the
+    // first message, not in a dim one-line footer.
+    let location = match &banner.branch {
+        Some(branch) => format!("{} ⎇ {branch}", banner.project),
+        None => banner.project.clone(),
+    };
+    field("project", location);
+    field("tools", banner.tools.clone());
+    out.push(Line::raw(""));
+
+    for row in hint_rows(BANNER_HINTS, width) {
+        out.push(row);
+    }
+    if banner.awaiting_first_message {
+        let long = "type a message to start";
+        let invite = if width as usize >= BANNER_INDENT as usize + long.len() {
+            long
+        } else {
+            "type a message"
+        };
+        out.push(Line::styled(format!("{indent}{invite}"), dim));
+    }
+    out
+}
+
+/// Pack `(key, label)` hints into as few indented rows as `width` allows, so a
+/// narrow terminal wraps between hints instead of mid-hint.
+fn hint_rows(pairs: &[(&str, &str)], width: u16) -> Vec<Line<'static>> {
+    let key_style = Style::new().cyan().bold();
+    // `hint_spans` opens with one space; the splash indents by two.
+    let row = |group: &[(&str, &str)]| {
+        let mut spans = vec![Span::raw(" ")];
+        spans.extend(hint_spans(key_style, group));
+        Line::from(spans)
+    };
+    let mut groups: Vec<Vec<(&str, &str)>> = Vec::new();
+    let mut group: Vec<(&str, &str)> = Vec::new();
+    for pair in pairs {
+        group.push(*pair);
+        if row_width(&row(&group)) > width as usize && group.len() > 1 {
+            group.pop();
+            groups.push(std::mem::take(&mut group));
+            group.push(*pair);
+        }
+    }
+    if !group.is_empty() {
+        groups.push(group);
+    }
+    groups
+        .into_iter()
+        .map(|group| {
+            let full = row(&group);
+            if row_width(&full) <= width as usize {
+                return full;
+            }
+            // A hint too wide even on its own keeps its key and drops the
+            // description; the key is the part the user has to type.
+            row(&group.iter().map(|(key, _)| (*key, "")).collect::<Vec<_>>())
+        })
+        .collect()
+}
+
 /// One committed transcript entry. Width-dependent entries keep their *source*
 /// rather than rendered lines, so a terminal resize re-lays them out at the new
 /// width instead of leaving tables, boxed diffs and truncated labels sized for
@@ -489,6 +615,9 @@ enum RowKind {
     Line(Line<'static>),
     /// Assistant prose, re-wrapped through markdown at the draw width.
     Markdown(String),
+    /// The opening splash, re-laid out at the draw width (the wordmark is
+    /// dropped and the hints re-packed on a terminal too narrow for them).
+    Banner(Box<Banner>),
     /// A tool call/summary row, re-truncated to `width - reserve`.
     Tool {
         tag: String,
@@ -538,6 +667,7 @@ impl Row {
         match &self.kind {
             RowKind::Line(line) => vec![line.clone()],
             RowKind::Markdown(text) => format_markdown_lines(text, width),
+            RowKind::Banner(banner) => banner_lines(banner, width),
             RowKind::Tool {
                 tag,
                 tag_style,
@@ -1338,6 +1468,25 @@ impl App {
         self.copied
             .filter(|(at, _)| at.elapsed() < COPY_NOTICE)
             .map(|(_, lines)| lines)
+    }
+
+    /// Open the session with the splash: the wordmark, this session's model,
+    /// project and approval mode, and where to go next.
+    fn push_banner(&mut self, tools: &str, awaiting_first_message: bool) {
+        let banner = Banner {
+            version: super::updater::build_version(),
+            model: if self.model.is_empty() {
+                "not signed in".to_string()
+            } else {
+                self.model.clone()
+            },
+            project: tilde_path(&self.project_root),
+            branch: self.git_branch.clone(),
+            tools: tools.to_string(),
+            awaiting_first_message,
+        };
+        self.gap(Kind::Meta);
+        self.push_row(RowKind::Banner(Box::new(banner)));
     }
 
     fn note(&mut self, text: &str) {
@@ -4104,13 +4253,19 @@ pub async fn run(
     // Adopt the session's startup run mode (e.g. `--plan`) so the header badge
     // shows immediately; a resumed thread overrides this via restore_run_mode.
     app.run_mode = args.run_mode;
+    let seeded = initial_task
+        .as_deref()
+        .is_some_and(|t| !t.trim().is_empty());
+    app.push_banner(
+        if args.auto_approve {
+            "auto-approved inside the OS sandbox (start with --safe to be asked first)"
+        } else {
+            "--safe: writes, shell commands and MCP tool calls need approval"
+        },
+        !seeded,
+    );
     if app.model.is_empty() {
         app.note("not signed in — run /login to sign in to Tokamak, or `jan config set` to configure a provider manually");
-    }
-    if args.auto_approve {
-        app.note("tool calls are auto-approved inside the OS sandbox; start with --safe to be asked first");
-    } else {
-        app.note("--safe: writes, shell commands, and MCP tool calls need approval");
     }
     // A failed resume is not fatal: the note explains why and the blank session
     // the user already has stays usable.
@@ -4209,9 +4364,10 @@ async fn chat_loop<B: Backend>(
         None;
     let mut compact_base = 0usize;
 
-    match initial_task {
-        Some(task) if !task.trim().is_empty() => app.submit_user(task.trim().to_string()),
-        _ => app.note("type a message to start, or /help for commands"),
+    // Nothing to say when there is no seed message: the splash already invites
+    // the first one (`Banner::awaiting_first_message`).
+    if let Some(task) = initial_task.filter(|t| !t.trim().is_empty()) {
+        app.submit_user(task.trim().to_string());
     }
 
     while !app.should_quit {
@@ -8644,9 +8800,9 @@ fn footer_spans(app: &App) -> Vec<Span<'static>> {
         }
         Status::Idle => {
             // Idle is the default state, so a cheat sheet here is permanent
-            // noise. Discovery is already covered without it: the transcript
-            // opens with "type a message to start, or /help for commands", and
-            // `/help` carries the full list (see `KEY_BINDINGS`). Keep only the
+            // noise. Discovery is already covered without it: the session opens
+            // with the splash (`Banner`, which names `/help`), and `/help`
+            // carries the full list (see `KEY_BINDINGS`). Keep only the
             // leading pad `hint_spans` emits, so a queue count or detail suffix
             // lands in the same column as the other states.
             let mut s = vec![Span::raw(" ")];
@@ -8676,7 +8832,7 @@ mod tests {
     use super::SessionLimits;
     use super::{journal, DisplayEntry};
     use super::{
-        age_closed_todos, apply_resume, assistant_is_awaiting_user_answer, build_user_message,
+        age_closed_todos, apply_resume, assistant_is_awaiting_user_answer, brand, build_user_message,
         clipboard_path,
         diff_lines, Row, group_activity, group_detail_lines, group_summary, handle_ask_key,
         handle_ask_mouse, handle_key, handle_mouse, image_mime, input_content_lines,
@@ -15350,6 +15506,89 @@ mod tests {
             goal.status = GoalStatus::Achieved;
         }
         assert!(app.body().get("goal_mode").is_none());
+    }
+
+    /// The splash row's rendered text at `width`, one string per line.
+    fn banner_text(app: &App, width: u16) -> Vec<String> {
+        app.transcript
+            .iter()
+            .flat_map(|row| row.lines(width))
+            .map(|l| l.spans.iter().map(|s| s.content.to_string()).collect())
+            .collect()
+    }
+
+    #[test]
+    fn banner_opens_with_the_wordmark_and_this_sessions_facts() {
+        let mut app = test_app();
+        app.model = "tokamak-1-preview".into();
+        app.git_branch = Some("fix/tui-panel-width".into());
+        app.push_banner("auto-approved inside the OS sandbox", true);
+
+        let text = banner_text(&app, 90);
+        let joined = text.join("\n");
+        assert!(
+            text.iter().any(|l| l.contains(brand::LOGO[0].trim())),
+            "the wordmark is missing:\n{joined}"
+        );
+        assert!(joined.contains("tokamak-1-preview"), "{joined}");
+        assert!(joined.contains("/tmp/repo"), "{joined}");
+        assert!(joined.contains("fix/tui-panel-width"), "{joined}");
+        assert!(joined.contains("auto-approved inside the OS sandbox"), "{joined}");
+        assert!(joined.contains("/help"), "{joined}");
+        assert!(joined.contains("type a message to start"), "{joined}");
+        assert!(
+            joined.contains(super::super::updater::build_version()),
+            "{joined}"
+        );
+    }
+
+    #[test]
+    fn a_seeded_session_is_not_invited_to_type() {
+        let mut app = test_app();
+        app.push_banner("--safe", false);
+        let joined = banner_text(&app, 90).join("\n");
+        assert!(!joined.contains("type a message to start"), "{joined}");
+        assert!(joined.contains("--safe"), "{joined}");
+    }
+
+    #[test]
+    fn a_narrow_terminal_gets_the_name_instead_of_a_clipped_wordmark() {
+        let mut app = test_app();
+        app.push_banner("--safe", true);
+
+        let wide = banner_text(&app, 90).join("\n");
+        assert!(wide.contains('█'), "{wide}");
+
+        // Same row, re-laid out: the source is data, not rendered lines.
+        let narrow = banner_text(&app, 24);
+        let joined = narrow.join("\n");
+        assert!(!joined.contains('█'), "{joined}");
+        assert!(joined.contains("jan"), "{joined}");
+        for line in &narrow {
+            assert!(
+                line.chars().count() <= 24,
+                "row overflows a 24-column terminal: {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn hints_wrap_between_pairs_never_mid_pair() {
+        let pairs = super::BANNER_HINTS;
+        let rows = super::hint_rows(pairs, 30);
+        assert!(rows.len() > 1, "narrow width must wrap");
+        for row in &rows {
+            assert!(row_width(row) <= 30 || row.spans.len() <= 3, "{row:?}");
+        }
+        let all: String = rows
+            .iter()
+            .flat_map(|r| r.spans.iter().map(|s| s.content.to_string()))
+            .collect();
+        for (key, label) in pairs {
+            assert!(all.contains(key), "dropped {key}");
+            assert!(all.contains(label), "dropped {label}");
+        }
+        assert_eq!(super::hint_rows(pairs, 200).len(), 1, "one row when it fits");
     }
 }
 

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -469,12 +469,11 @@ struct PendingToolRow {
 }
 
 /// What the session opens with: the `jan` wordmark plus the facts a first-time
-/// reader needs (which model, which project, how tool calls are approved) and
-/// the commands to go on with. Held as data rather than rendered lines so the
-/// row re-lays out at the draw width like every other width-dependent row.
+/// reader needs (which project, how tool calls are approved) and the commands to
+/// go on with. Held as data rather than rendered lines so the row re-lays out at
+/// the draw width like every other width-dependent row.
 struct Banner {
     version: &'static str,
-    model: String,
     project: String,
     branch: Option<String>,
     /// How tool calls are approved this session (sandboxed, or `--safe`).
@@ -529,10 +528,10 @@ fn banner_lines(banner: &Banner, width: u16) -> Vec<Line<'static>> {
             Span::styled(truncate(&value, value_max), dim),
         ]));
     };
-    field("model", banner.model.clone());
-    // Repeated from the dock on purpose: the tools act on this directory, and a
-    // `jan` started in the wrong one is the mistake worth catching before the
-    // first message, not in a dim one-line footer.
+    // No `model` row: the header leads with it, bold, two rows above. The
+    // location is a different case -- the dock's copy is dim and easy to miss,
+    // and the tools act on that directory, so a `jan` started in the wrong one
+    // is the mistake worth catching before the first message.
     let location = match &banner.branch {
         Some(branch) => format!("{} ⎇ {branch}", banner.project),
         None => banner.project.clone(),
@@ -1470,16 +1469,11 @@ impl App {
             .map(|(_, lines)| lines)
     }
 
-    /// Open the session with the splash: the wordmark, this session's model,
-    /// project and approval mode, and where to go next.
+    /// Open the session with the splash: the wordmark, this session's project
+    /// and approval mode, and where to go next.
     fn push_banner(&mut self, tools: &str, awaiting_first_message: bool) {
         let banner = Banner {
             version: super::updater::build_version(),
-            model: if self.model.is_empty() {
-                "not signed in".to_string()
-            } else {
-                self.model.clone()
-            },
             project: tilde_path(&self.project_root),
             branch: self.git_branch.clone(),
             tools: tools.to_string(),
@@ -1487,6 +1481,9 @@ impl App {
         };
         self.gap(Kind::Meta);
         self.push_row(RowKind::Banner(Box::new(banner)));
+        // Whatever follows -- a startup note, or the first message -- gets a
+        // blank line off the splash instead of butting against its last row.
+        self.last_kind = Kind::None;
     }
 
     fn note(&mut self, text: &str) {
@@ -8258,10 +8255,15 @@ fn header(app: &App) -> Paragraph<'static> {
         .run_started
         .map(|t| format!("  {}", format_elapsed(t.elapsed().as_secs())))
         .unwrap_or_default();
-    let mut spans = vec![
-        Span::styled(" jan agent ", Style::new().on_blue().white().bold()),
-        Span::raw(format!("  {}  ", app.model)),
-    ];
+    // No name chip: the splash names the app (see `Banner`), and the header's
+    // columns are better spent on state that changes. The model leads instead,
+    // bold so the row still has an anchor on the left; an unset model says so
+    // rather than opening the row with blanks.
+    let mut spans = vec![if app.model.is_empty() {
+        Span::styled(" no model  ", Style::new().red().bold())
+    } else {
+        Span::styled(format!(" {}  ", app.model), Style::new().bold())
+    }];
     // Wall-clock (local) segment, mirroring the reference status line's leading
     // HH:MM:SS. Shown only while a run is active: a clock that ticks once per
     // second repaints the screen every second, which clears the terminal's text
@@ -15530,7 +15532,9 @@ mod tests {
             text.iter().any(|l| l.contains(brand::LOGO[0].trim())),
             "the wordmark is missing:\n{joined}"
         );
-        assert!(joined.contains("tokamak-1-preview"), "{joined}");
+        // The model is the header's job, not the splash's (it would otherwise
+        // appear twice on the first screen).
+        assert!(!joined.contains("tokamak-1-preview"), "{joined}");
         assert!(joined.contains("/tmp/repo"), "{joined}");
         assert!(joined.contains("fix/tui-panel-width"), "{joined}");
         assert!(joined.contains("auto-approved inside the OS sandbox"), "{joined}");
@@ -15570,6 +15574,23 @@ mod tests {
                 "row overflows a 24-column terminal: {line:?}"
             );
         }
+    }
+
+    #[test]
+    fn header_leads_with_the_model_not_a_name_chip() {
+        let mut app = test_app();
+        app.model = "tokamak-1-preview".into();
+        let top = render_rows(&mut app, 60, 12).remove(0);
+        assert!(
+            top.starts_with(" tokamak-1-preview"),
+            "the name chip is back: {top:?}"
+        );
+        // The freed columns are what let the status survive a 60-column frame.
+        assert!(top.contains("[ready]"), "{top:?}");
+
+        app.model.clear();
+        let top = render_rows(&mut app, 60, 12).remove(0);
+        assert!(top.starts_with(" no model"), "{top:?}");
     }
 
     #[test]

--- a/src-tauri/src/core/cli/tui/markdown.rs
+++ b/src-tauri/src/core/cli/tui/markdown.rs
@@ -126,7 +126,8 @@ fn has_open_fence(text: &str) -> bool {
 /// language tag (when present) as a dim header row and the body
 /// syntax-highlighted. Long lines wrap rather than truncate: dropping the tail
 /// of a line of code loses the part that usually matters most.
-fn render_code_block(body: &[&str], lang: &str, max: usize, plain: bool) -> Vec<Line<'static>> {
+fn render_code_block(body: &[&str], lang: &str, width: usize, plain: bool) -> Vec<Line<'static>> {
+    let max = super::panel_inner(width, "");
     let mut rows: Vec<Line<'static>> = Vec::with_capacity(body.len() + 1);
     if !lang.is_empty() {
         rows.push(Line::styled(
@@ -146,7 +147,7 @@ fn render_code_block(body: &[&str], lang: &str, max: usize, plain: bool) -> Vec<
             rows.push(Line::from(chunk));
         }
     }
-    super::boxed_panel(rows, max, "")
+    super::boxed_panel(rows, width, "")
 }
 
 /// Break a styled row into chunks of at most `max` columns, splitting spans
@@ -530,9 +531,8 @@ impl Renderer {
             TagEnd::CodeBlock => {
                 if let Some(c) = self.code.take() {
                     let body: Vec<&str> = c.body.lines().collect();
-                    let max = (self.width as usize).saturating_sub(4);
                     let plain = self.plain_code_block == Some(self.code_blocks_seen);
-                    let panel = render_code_block(&body, &c.lang, max, plain);
+                    let panel = render_code_block(&body, &c.lang, self.width as usize, plain);
                     self.out.extend(panel);
                 }
             }

--- a/src-tauri/src/core/cli/tui/markdown.rs
+++ b/src-tauri/src/core/cli/tui/markdown.rs
@@ -186,6 +186,62 @@ fn wrap_spans(spans: Vec<Span<'static>>, max: usize) -> Vec<Vec<Span<'static>>> 
     out
 }
 
+/// Like `wrap_spans`, but breaking at a space where one is in reach so prose
+/// does not split mid-word. A token longer than `max` is still split hard, since
+/// there is nowhere else to break it. Used by the system rows, whose gutter has
+/// to line up under itself on every continuation.
+pub(super) fn wrap_spans_at_words(
+    spans: Vec<Span<'static>>,
+    max: usize,
+) -> Vec<Vec<Span<'static>>> {
+    let max = max.max(1);
+    // Per-character styles: the wrap points are character positions, and each
+    // span's style has to survive being cut at one.
+    let cells: Vec<(char, Style)> = spans
+        .iter()
+        .flat_map(|s| {
+            let style = s.style;
+            s.content.chars().map(move |c| (c, style))
+        })
+        .collect();
+    let mut out: Vec<Vec<Span<'static>>> = Vec::new();
+    let mut start = 0;
+    while start < cells.len() {
+        let mut end = (start + max).min(cells.len());
+        if end < cells.len() {
+            if let Some(space) = cells[start..end].iter().rposition(|(c, _)| *c == ' ') {
+                if space > 0 {
+                    end = start + space;
+                }
+            }
+        }
+        out.push(merge_cells(&cells[start..end]));
+        start = end;
+        // Swallow the break's spaces so a continuation does not open with them.
+        while matches!(cells.get(start), Some((' ', _))) {
+            start += 1;
+        }
+    }
+    if out.is_empty() {
+        out.push(Vec::new());
+    }
+    out
+}
+
+/// Re-collapse per-character cells into one span per run of equal style.
+fn merge_cells(cells: &[(char, Style)]) -> Vec<Span<'static>> {
+    let mut runs: Vec<(String, Style)> = Vec::new();
+    for (c, style) in cells {
+        match runs.last_mut() {
+            Some((text, run_style)) if run_style == style => text.push(*c),
+            _ => runs.push((c.to_string(), *style)),
+        }
+    }
+    runs.into_iter()
+        .map(|(text, style)| Span::styled(text, style))
+        .collect()
+}
+
 /// Heading ladder. Weight and hue carry the level -- no `#` markers and no
 /// filled background, so headings sit in the same palette as the rest of the
 /// transcript (cyan accent, `dark_gray` structure).
@@ -731,7 +787,8 @@ fn group_by_style(chars: &[(char, Style)]) -> Vec<(Style, String)> {
 
 #[cfg(test)]
 mod tests {
-    use super::{format_markdown_lines, render_table};
+    use super::{format_markdown_lines, render_table, wrap_spans_at_words};
+    use ratatui::prelude::*;
 
     fn line_text(line: &ratatui::text::Line) -> String {
         line.spans.iter().map(|s| s.content.as_ref()).collect()
@@ -1294,4 +1351,39 @@ mod tests {
             .iter()
             .all(|l| joined(std::slice::from_ref(l)).chars().count() <= 30));
     }
+    #[test]
+    fn wrap_at_words_breaks_on_spaces_and_keeps_styles() {
+        let spans = vec![
+            Span::styled("3f7a91c2  ", Style::new().cyan()),
+            Span::raw("fix the failing test in the parser"),
+        ];
+        let rows = wrap_spans_at_words(spans, 20);
+        let text: Vec<String> = rows
+            .iter()
+            .map(|r| r.iter().map(|s| s.content.to_string()).collect())
+            .collect();
+        assert!(rows.len() > 1, "{text:?}");
+        for row in &text {
+            assert!(row.chars().count() <= 20, "{text:?}");
+        }
+        // No word is cut, and nothing is lost.
+        let joined = text.join(" ");
+        assert!(joined.contains("failing"), "{text:?}");
+        assert!(joined.contains("parser"), "{text:?}");
+        // The lead span's style survives the split.
+        assert_eq!(rows[0][0].style.fg, Some(Color::Cyan));
+    }
+
+    #[test]
+    fn wrap_at_words_splits_a_token_longer_than_the_width() {
+        let long = "supercalifragilistic";
+        let rows = wrap_spans_at_words(vec![Span::raw(long)], 8);
+        assert_eq!(rows.len(), 3, "a token with no space must still fit");
+        let joined: String = rows
+            .iter()
+            .flat_map(|r| r.iter().map(|s| s.content.to_string()))
+            .collect();
+        assert_eq!(joined, long);
+    }
+
 }


### PR DESCRIPTION
## Describe Your Changes

Overhauls the `jan` terminal agent's presentation and resume path. The branch
tightens up the transcript and header, gives system/status lines their own
gutter and severity, opens on a splash instead of two dim status notes, sizes
boxed diff and code panels to the actual draw width, and makes `/resume`
restore the **whole** session - tool calls, their results and reasoning - not
just the user/assistant text.

The branch is based on `dev` at `5ff4102eb` (6 commits, ~1,626 insertions /
~196 deletions across 6 files, all under `src-tauri`, all `cli`-feature only;
no desktop/tauri-app code touched).

## What changed

### Boxed diff and code panels are sized to the draw width (`18f0d4565`)
`boxed_panel` spends `gutter + 4` columns on its frame, but the transcript
call sites reserved a flat `width - 8` while their gutters are 6 and 8 chars
wide. Every panel row came out 2-4 columns too wide, so the closing border
wrapped onto a line of its own: no right edge and a blank row after every
content line. `diff_lines`/`boxed_panel` now take the total draw width and
derive the content width through a shared `panel_inner`, removing the
duplicated `- 4` from the result row, the expanded group detail, the
permission preview and the markdown code block.

### `/resume` restores the whole session, not just its text (`798201a72`)
Previously `/resume` restored only user/assistant text: reasoning, tool calls,
their results and diff panels were gone, and the model came back unaware of
the work it had done. Two files now back a resume:

- `display.jsonl` (`core::cli::journal`) is the transcript as rendered, in
  emission order, dumped by a single background writer thread from `persist`
  - so every turn boundary and every cancel leaves a resumable journal without
  a frame paying for the write, and concurrent renames cannot land a stale one.
  `replay_display_log` feeds it back through the same functions that rendered
  it live, so there is no second renderer to drift. It cannot be folded into
  `messages.jsonl`: reasoning is deliberately never resent to the model, and
  `/compact` rewrites the wire history without touching what the user can see.
- `messages.jsonl` now carries `tool_calls`/`tool_call_id` through as extra
  keys on the `thread.message` record, and `rebuild_wire_history` reconstructs
  the conversation for both `/resume` and `jan cli agent run --resume`,
  enforcing tool pairing: an orphaned result is dropped, and a call whose
  result never reached disk gets an explicit placeholder rather than an
  invented outcome.

Also: `on_done`/`cancel_run` strip ` thinking` from the history they push
(reasoning is display-only, which the streaming layer always intended but the
TUI had been resending and persisting); rewind replays the journal so kept
turns keep their tool rows; and `apply(ToolCall)` flushes buffered prose once
at the top of the arm instead of per branch, removing a duplicated call and
keeping the journal in emission order.

### The TUI opens on a splash instead of two dim notes (`b1307d7ea`, `f11d44ba0`)
The first frame used to be an empty screen with two dim status lines that said
nothing about what `jan` is or how to drive it. It now opens with the same
wordmark `jan --help` prints, plus the facts a first-time reader needs - model,
project and branch, how tool calls are approved - and the commands to go on
with.

- The art lives in one place (`core::cli::brand::LOGO`), shared by the help
  header and the TUI, so the two wordmarks cannot drift.
- `RowKind::Banner` keeps the splash as data, so a resize re-lays it out rather
  than leaving it sized for the width it was committed at. A terminal too
  narrow for the wordmark gets the name as text; `hint_rows` wraps between
  hints; the invite shortens rather than wrapping.
- The header drops its name chip and leads with the model (bold), freeing the
  columns that previously pushed `ctx` and the status badge off a 60-column
  frame. An unset model reads `no model` in red rather than opening with blanks.

### System lines get their own gutter and severity (`83cb628ea`, `aef7b2186`)
Notes were dim text flush against the left margin, which is exactly how model
prose renders - "not signed in" read like something the model said. System
lines now own a two-column gutter (`• `, coloured by `Level`:
Info/Warn/Error/Good), with the body keeping its emphasis.

- `Level` replaces a colour picked by hand at each of ~90 sites; a category
  with an established glyph keeps it (`◎` for the goal loop, matching the
  header badge), so the column never carries two markers.
- A multi-line system block (e.g. `/help`, `/threads`) previously marked only
  its first line; its body rows now carry `┆`, giving the block one unbroken
  left edge - distinct from the tool rows' `│` and the reasoning rows' `┊`.
- System lines became width-aware (`RowKind::System` keeps the source and
  wraps at the draw width via `wrap_spans_at_words`), so a resize re-lays them
  out instead of soft-wrapping a continuation into column 0 with no gutter.

## Notes

- All changes are in the `cli` feature only (no desktop/`tauri-app` code), per
  the headless-CLI Tauri-free constraint.
- Build/verify with:
  `cargo build --no-default-features --features cli --bin jan` and
  `cargo test --no-default-features --features cli`.
- Branch is based on `dev` at `5ff4102eb` and rebases cleanly onto current
  `dev` (the TUI/journal work does not overlap the compaction work in
  `core::agent::compaction.rs`).


<img width="1237" height="855" alt="image" src="https://github.com/user-attachments/assets/5d092bcc-ec1a-43d2-a87d-174388c5b05d" />


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
