### PR TITLE
fix(agent): expose Ask responses

### DIFF
--- a/src-tauri/src/core/agent/interaction.rs
+++ b/src-tauri/src/core/agent/interaction.rs
@@ -139,6 +139,23 @@ impl AskRequest {
         }
         Ok(())
     }
+
+    pub(crate) fn render_results(&self, results: &[QuestionResult]) -> String {
+        results
+            .iter()
+            .map(|result| {
+                let answer = result
+                    .custom_input
+                    .clone()
+                    .unwrap_or_else(|| result.selected.join(", "));
+                format!(
+                    "User response for {}: {answer}",
+                    serde_json::to_string(&result.id).expect("question ids serialize")
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
 }
 
 pub(crate) fn ask_tool_schema() -> Value {

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -453,9 +453,7 @@ impl CompositeToolInvoker {
         }
         match receiver.await {
             Ok(Ok(results)) => match request.validate_results(&results) {
-                Ok(()) => serde_json::to_string(&results).unwrap_or_else(|error| {
-                    format!("ERROR: could not encode ask response: {error}")
-                }),
+                Ok(()) => request.render_results(&results),
                 Err(error) => format!("ERROR: invalid ask response: {error}"),
             },
             Ok(Err(AskError::Cancelled)) | Err(_) => {
@@ -3104,7 +3102,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn ask_waits_for_and_returns_a_structured_response() {
+    async fn ask_waits_for_and_returns_model_readable_response() {
         let root = unique_project_root();
         let (tx, mut rx) = mpsc::unbounded_channel();
         let permissions: PermissionRegistry = Arc::new(Mutex::new(HashMap::new()));
@@ -3136,9 +3134,41 @@ mod tests {
         .unwrap();
 
         let out = task.await.unwrap();
-        let result: serde_json::Value = serde_json::from_str(&out[0].content).unwrap();
-        assert_eq!(result[0]["id"], "scope");
-        assert_eq!(result[0]["selected"][0], "Small");
+        assert_eq!(out[0].content, "User response for \"scope\": Small");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn ask_returns_custom_response_as_clear_model_text() {
+        let root = unique_project_root();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let permissions: PermissionRegistry = Arc::new(Mutex::new(HashMap::new()));
+        let asks = crate::core::agent::interaction::new_registry();
+        let mut invoker = build_prompting_invoker(root.clone(), tx, permissions);
+        invoker.ask_requests = Some(asks.clone());
+
+        let task = tokio::spawn(async move { invoker.invoke(&[ask_call()]).await.unwrap() });
+        let request_id = match rx.recv().await.unwrap() {
+            StreamEvent::AskRequest { request_id, .. } => request_id,
+            event => panic!("expected ask_request, got {event:?}"),
+        };
+        crate::core::agent::interaction::respond(
+            &asks,
+            &request_id,
+            Ok(vec![crate::core::agent::interaction::QuestionResult {
+                id: "scope".into(),
+                selected: Vec::new(),
+                custom_input: Some("CUSTOM-SENTINEL-4829".into()),
+            }]),
+        )
+        .await
+        .unwrap();
+
+        let out = task.await.unwrap();
+        assert_eq!(
+            out[0].content,
+            "User response for \"scope\": CUSTOM-SENTINEL-4829"
+        );
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -1495,10 +1495,16 @@ fn build_completion_request(
         "messages".to_string(),
         serde_json::Value::Array(conversation_messages.to_vec()),
     );
-    let tool_choice = match forced_tool_choice {
-        Some(name) => serde_json::json!({ "type": "function", "function": { "name": name } }),
-        None => serde_json::json!("auto"),
-    };
+    let tool_choice = forced_tool_choice
+        .filter(|name| {
+            openai_tools
+                .iter()
+                .any(|tool| tool["function"]["name"].as_str() == Some(*name))
+        })
+        .map_or_else(
+            || serde_json::json!("auto"),
+            |name| serde_json::json!({ "type": "function", "function": { "name": name } }),
+        );
     completion_map.insert("tool_choice".to_string(), tool_choice);
     if !openai_tools.is_empty() {
         completion_map.insert(
@@ -2161,7 +2167,7 @@ mod tests {
             &tx,
             &json!({}),
             "m",
-            &[],
+            &[crate::core::agent::todo::todo_tool_schema()],
             convo,
             8,
             &mut budget,
@@ -2184,6 +2190,27 @@ mod tests {
         assert_eq!(
             requests[1]["tool_choice"], "auto",
             "later turns must not keep forcing the same tool"
+        );
+    }
+
+    #[test]
+    fn forced_tool_choice_requires_an_advertised_tool() {
+        let messages = vec![user_message("build a flappy bird clone")];
+        let ask_only = vec![crate::core::agent::interaction::ask_tool_schema()];
+
+        let ask_request =
+            build_completion_request("m", &messages, &ask_only, &json!({}), Some("todo"));
+        assert_eq!(
+            ask_request["tool_choice"], "auto",
+            "a named tool_choice must not select a tool omitted from tools"
+        );
+
+        let todo = crate::core::agent::todo::todo_tool_schema();
+        let todo_request =
+            build_completion_request("m", &messages, &[todo], &json!({}), Some("todo"));
+        assert_eq!(
+            todo_request["tool_choice"],
+            json!({ "type": "function", "function": { "name": "todo" } })
         );
     }
 

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -2193,7 +2193,7 @@ mod tests {
 
     #[test]
     fn forced_tool_choice_requires_an_advertised_tool() {
-        let messages = vec![user_message("build a flappy bird clone")];
+        let messages = vec![json!({ "role": "user", "content": "build a flappy bird clone" })];
         let ask_only = vec![crate::core::agent::interaction::ask_tool_schema()];
 
         let ask_request =
@@ -3199,8 +3199,7 @@ mod tests {
         .unwrap();
 
         let out = task.await.unwrap();
-        let result: serde_json::Value = serde_json::from_str(&out[0].content).unwrap();
-        assert_eq!(result[0]["custom_input"], "custom answer");
+        assert_eq!(out[0].content, "User response for \"scope\": custom answer");
         let _ = std::fs::remove_dir_all(&root);
     }
 


### PR DESCRIPTION
## Summary

- only emit a named `tool_choice` when that function is in the request's final advertised `tools` array

## Why this check is necessary

A named `tool_choice` is not just a preference. It is a request-level constraint that tells an OpenAI-compatible upstream: "the next response must call this exact function."

That function must also appear in the same request's `tools` array. Otherwise the request is self-contradictory and the upstream rejects it before the model gets a chance to generate a response.

```json
{
  "tools": [
    { "type": "function", "function": { "name": "ask" } }
  ],
  "tool_choice": {
    "type": "function",
    "function": { "name": "todo" }
  }
}
```

The request exposes only `ask` but requires `todo`. `todo` cannot be called because it was never advertised.

## Request flow

```mermaid
sequenceDiagram
    participant Client
    participant Jan as Jan request builder
    participant Tools as Final tools array
    participant API as OpenAI-compatible upstream

    Client->>Jan: Request with a candidate forced tool: todo
    Jan->>Tools: Build and apply tool filtering
    Tools-->>Jan: Final advertised tools

    alt todo is present in final tools
        Jan->>API: tools include todo + named tool_choice: todo
        API-->>Jan: Valid request
    else todo is absent from final tools
        Jan->>API: tools omit todo + tool_choice: auto
        API-->>Jan: Valid request
    end
```

## Why the `if/else` happens at request construction

Jan may decide earlier that it wants to force a tool, but the tool list is finalized later. Between those steps, the request can remove a tool through an explicit `allowed_tools` list or policy-based filtering.

For example, a caller may restrict the request to:

```json
{ "allowed_tools": ["ask"] }
```

Even if `todo` was the candidate forced tool, it is not in the final `tools` array. Serializing a named `tool_choice: todo` would therefore create an invalid API request.

The request builder performs the final check immediately before it serializes `tool_choice`:

```text
forced tool is advertised -> send a named tool_choice
forced tool is not advertised -> send "auto"
```

`"auto"` is deliberate. It preserves a valid request and lets the model choose only from functions the request actually exposes. It does not silently re-add a disallowed tool.

## Verification

- `forced_tool_choice_requires_an_advertised_tool` covers both branches: an advertised `todo` remains a named choice; an absent `todo` falls back to `"auto"`.
