### PR TITLE
ci: run the Rust check gate on PRs into dev

### DIFF
--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -1,0 +1,108 @@
+name: Rust Check
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - dev
+
+concurrency:
+  group: rust-check-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # The desktop and CLI feature sets are mutually exclusive configs of the same
+  # crate, so neither one alone proves the other compiles.
+  app:
+    name: app (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: desktop
+            features: test-tauri
+            targets: --all-targets
+            tauri: true
+          # --all-targets matters here: modules like core::agent::global_config
+          # are #[cfg(feature = "cli")], so their tests exist in no other config
+          # and --lib --bins would leave them unlinted.
+          - name: cli
+            features: cli
+            targets: --all-targets
+            tauri: false
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+          key: ${{ matrix.name }}
+
+      - name: Install Tauri dependencies
+        if: matrix.tauri
+        run: |
+          sudo apt update
+          sudo apt install -y libglib2.0-dev libatk1.0-dev libpango1.0-dev libgtk-3-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev librsvg2-dev
+
+      - name: Create Tauri resource stubs
+        if: matrix.tauri
+        run: ./scripts/stub-tauri-resources.sh
+
+      - name: cargo check
+        run: |
+          cargo check --locked --manifest-path src-tauri/Cargo.toml \
+            --no-default-features --features ${{ matrix.features }} ${{ matrix.targets }}
+
+      - name: cargo clippy
+        run: |
+          cargo clippy --locked --manifest-path src-tauri/Cargo.toml \
+            --no-default-features --features ${{ matrix.features }} ${{ matrix.targets }} \
+            -- -D warnings
+
+  # Each plugin and src-tauri/utils is its own workspace, so checking the app
+  # crate compiles them as path dependencies but never lints them. No --locked
+  # here: Cargo.lock is gitignored and only some of these crates commit one.
+  crates:
+    name: ${{ matrix.crate }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # tauri-plugin-mlx is Apple-Silicon-only and is a macOS target
+        # dependency, not part of any Linux build.
+        crate:
+          - plugins/tauri-plugin-agent-tools
+          - plugins/tauri-plugin-hardware
+          - plugins/tauri-plugin-llamacpp
+          - plugins/tauri-plugin-rag
+          - plugins/tauri-plugin-vector-db
+          - plugins/tauri-plugin-websearch
+          - utils
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri/${{ matrix.crate }}
+
+      - name: Install Tauri dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y libglib2.0-dev libatk1.0-dev libpango1.0-dev libgtk-3-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev librsvg2-dev
+
+      - name: cargo check
+        run: cargo check --manifest-path src-tauri/${{ matrix.crate }}/Cargo.toml --all-targets
+
+      - name: cargo clippy
+        run: cargo clippy --manifest-path src-tauri/${{ matrix.crate }}/Cargo.toml --all-targets -- -D warnings

--- a/scripts/rust-coverage.sh
+++ b/scripts/rust-coverage.sh
@@ -3,21 +3,7 @@
 # Outputs: rust-lcov.info in the current directory.
 set -euo pipefail
 
-# Tauri build script validates resources, externalBin, and icons exist.
-# Create stubs so the build succeeds in CI where these aren't present.
-TRIPLE=$(rustc -vV | awk '/^host:/ { print $2 }')
-mkdir -p src-tauri/resources/bin src-tauri/resources/pre-install src-tauri/icons
-[ -f src-tauri/resources/LICENSE ] || touch src-tauri/resources/LICENSE
-[ -f src-tauri/resources/bin/jan ] || touch src-tauri/resources/bin/jan
-[ "$(ls -A src-tauri/resources/pre-install 2>/dev/null)" ] || touch src-tauri/resources/pre-install/.gitkeep
-for bin in uv bun; do
-  stub="src-tauri/resources/bin/${bin}-${TRIPLE}"
-  [ -f "$stub" ] || touch "$stub"
-done
-# Icons are gitignored; generate_context!() requires them at compile time
-for icon in 32x32.png 128x128.png 128x128@2x.png icon.icns icon.ico; do
-  [ -f "src-tauri/icons/$icon" ] || cp src-tauri/icons/icon.png "src-tauri/icons/$icon"
-done
+"$(dirname "$0")/stub-tauri-resources.sh"
 
 cargo llvm-cov clean --workspace --manifest-path src-tauri/Cargo.toml
 cargo llvm-cov --no-report --manifest-path src-tauri/Cargo.toml --no-default-features --features test-tauri -- --test-threads=1

--- a/scripts/stub-tauri-resources.sh
+++ b/scripts/stub-tauri-resources.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# The Tauri build script validates resources, externalBin, icons and
+# frontendDist exist. Create stubs so a compile-only run succeeds in CI, where
+# none of them are built.
+set -euo pipefail
+
+TRIPLE=$(rustc -vV | awk '/^host:/ { print $2 }')
+mkdir -p src-tauri/resources/bin src-tauri/resources/pre-install src-tauri/icons web-app/dist
+[ -f src-tauri/resources/LICENSE ] || touch src-tauri/resources/LICENSE
+# The bundled CLI is `jan-cli` on some branches and `jan` on others; the Tauri
+# config only asks for one, and stubbing the other costs nothing.
+for cli in jan jan-cli; do
+  [ -f "src-tauri/resources/bin/$cli" ] || touch "src-tauri/resources/bin/$cli"
+done
+[ -f web-app/dist/index.html ] || touch web-app/dist/index.html
+[ "$(ls -A src-tauri/resources/pre-install 2>/dev/null)" ] || touch src-tauri/resources/pre-install/.gitkeep
+for bin in uv bun; do
+  stub="src-tauri/resources/bin/${bin}-${TRIPLE}"
+  [ -f "$stub" ] || touch "$stub"
+done
+# Icons are gitignored; generate_context!() requires them at compile time
+for icon in 32x32.png 128x128.png 128x128@2x.png icon.icns icon.ico; do
+  [ -f "src-tauri/icons/$icon" ] || cp src-tauri/icons/icon.png "src-tauri/icons/$icon"
+done


### PR DESCRIPTION
## Describe Your Changes
The workflow landed on main (#8649), but `pull_request` resolves workflow files from the merge ref -- head merged into base. A dev-based branch merged into dev contains no rust-check.yml, so nothing was selected and the gate never fired. Putting it on dev is what makes it apply.

Ports rust-check.yml (with the CLI config linting --all-targets) and scripts/stub-tauri-resources.sh, and drops rust-coverage.sh's inline copy of the stub logic in favour of the shared script.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
