### PR TITLE
fix(projects): use project assistant for new chats

### DIFF
--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -108,6 +108,7 @@ type ChatInputProps = {
   model?: ThreadModel
   initialMessage?: boolean
   projectId?: string
+  projectAssistantId?: string
   onSubmit?: (
     text: string,
     files?: Array<{ type: string; mediaType: string; url: string }>
@@ -138,6 +139,7 @@ const ChatInput = memo(function ChatInput({
   className,
   initialMessage,
   projectId,
+  projectAssistantId,
   onSubmit,
   onStop,
   chatStatus,
@@ -232,12 +234,12 @@ const ChatInput = memo(function ChatInput({
   })
   const [selectedAssistantId, setSelectedAssistantId] = useState<
     string | undefined
-  >(loading ? undefined : currentAssistant?.id || '')
+  >(loading ? undefined : projectAssistantId || currentAssistant?.id || '')
 
   useEffect(() => {
-    setSelectedAssistantId(currentAssistant?.id || '')
+    setSelectedAssistantId(projectAssistantId || currentAssistant?.id || '')
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loading])
+  }, [loading, projectAssistantId])
 
   // Jan Browser Extension hook
   const {

--- a/web-app/src/containers/__tests__/ChatInput.test.tsx
+++ b/web-app/src/containers/__tests__/ChatInput.test.tsx
@@ -96,9 +96,12 @@ vi.mock('@/hooks/useTokensCount', () => ({
 vi.mock('@/hooks/useAssistant', () => ({
   useAssistant: () => ({
     loading: false,
-    currentAssistant: { id: 'a1', avatar: '' },
+    currentAssistant: { id: 'a1', name: 'Global assistant', avatar: '' },
     setCurrentAssistant: vi.fn(),
-    assistants: [{ id: 'a1', avatar: '' }],
+    assistants: [
+      { id: 'a1', name: 'Global assistant', avatar: '' },
+      { id: 'a2', name: 'Project assistant', avatar: '' },
+    ],
   }),
 }))
 
@@ -336,6 +339,14 @@ describe('ChatInput', () => {
     expect(ta).toHaveAttribute('placeholder', 'common:placeholder.chatInput')
     // send button is present
     expect(document.querySelector('[data-test-id="send-message-button"]')).toBeTruthy()
+  })
+
+  it('shows the project assistant for a new conversation', () => {
+    renderInput({ projectId: 'project-1', projectAssistantId: 'a2' })
+
+    expect(
+      screen.getByRole('button', { name: 'Switch assistant' })
+    ).toHaveTextContent('Project assistant')
   })
 
   it('disables the send button when prompt is empty', () => {

--- a/web-app/src/routes/project/$projectId.tsx
+++ b/web-app/src/routes/project/$projectId.tsx
@@ -130,6 +130,7 @@ function ProjectPageContent() {
               showSpeedToken={false}
               initialMessage={true}
               projectId={projectId}
+              projectAssistantId={project.assistantId}
             />
           </div>
 


### PR DESCRIPTION
## Summary
- initialize the new-project chat assistant from the project's assigned assistant
- preserve the global assistant as the fallback for non-project chats
- cover the visible assistant selection regression

Fixes #8644

## Verification
- `yarn test:web --run src/containers/__tests__/ChatInput.test.tsx`
- `yarn build:web`