### PR TITLE
fix(llamacpp): trim context-shifted chat history

### DIFF
--- a/web-app/src/lib/__tests__/custom-chat-transport-prefix-stability.test.ts
+++ b/web-app/src/lib/__tests__/custom-chat-transport-prefix-stability.test.ts
@@ -9,6 +9,9 @@ const h = vi.hoisted(() => ({
   disabledTools: [] as string[],
   servers: ['srv'] as string[],
   getRelevantTools: vi.fn(),
+  getModelProps: vi.fn(),
+  assistantParameters: null as Record<string, unknown> | null,
+  providerId: 'openai',
   serviceHub: null as unknown,
 }))
 
@@ -43,7 +46,12 @@ vi.mock('ai', async () => {
   }
 })
 
-const provider = { provider: 'openai', api_key: 'k', models: [] }
+const provider = {
+  provider: 'openai',
+  api_key: 'k',
+  models: [],
+  settings: [] as Array<{ key: string; controller_props: { value: boolean } }>,
+}
 const selectedModel = { id: 'gpt', capabilities: ['tools'] }
 
 vi.mock('@/hooks/useServiceHub', () => ({
@@ -58,13 +66,19 @@ vi.mock('@/hooks/useModelProvider', () => ({
   useModelProvider: {
     getState: () => ({
       selectedModel,
-      selectedProvider: 'openai',
+      selectedProvider: h.providerId,
       getProviderByName: () => provider,
     }),
   },
 }))
 vi.mock('@/hooks/useAssistant', () => ({
-  useAssistant: { getState: () => ({ currentAssistant: null }) },
+  useAssistant: {
+    getState: () => ({
+      currentAssistant: h.assistantParameters
+        ? { parameters: h.assistantParameters }
+        : null,
+    }),
+  },
 }))
 vi.mock('@/hooks/useThreads', () => ({
   useThreads: { getState: () => ({ threads: {} }) },
@@ -91,11 +105,12 @@ vi.mock('@/hooks/useAppState', () => ({
   },
 }))
 vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn(async () => []) }))
-vi.mock('@/lib/extension', () => ({
-  ExtensionManager: { getInstance: () => ({ get: () => null }) },
+vi.mock('@janhq/tauri-plugin-llamacpp-api', () => ({
+  getLoadedModels: vi.fn(async () => ['llama-local']),
+  unloadLlamaModel: vi.fn(),
 }))
 vi.mock('@/lib/llamacppRouterProps', () => ({
-  getLlamacppExtension: () => null,
+  getLlamacppExtension: () => ({ getModelProps: h.getModelProps }),
 }))
 vi.mock('@/lib/mcp-orchestrator', () => ({
   mcpOrchestrator: { getRelevantTools: h.getRelevantTools },
@@ -144,6 +159,13 @@ describe('CustomChatTransport prompt-prefix stability across turns', () => {
     streamTextCalls.length = 0
     h.disabledTools = []
     h.servers = ['srv']
+    h.providerId = 'openai'
+    h.assistantParameters = null
+    h.getModelProps.mockReset()
+    provider.provider = 'openai'
+    provider.settings = []
+    selectedModel.id = 'gpt'
+    selectedModel.capabilities = ['tools']
     h.getRelevantTools.mockReset()
     h.getRelevantTools.mockResolvedValue([
       { name: 'tool_a', description: 'a', inputSchema: {}, server: 'srv' },
@@ -185,6 +207,32 @@ describe('CustomChatTransport prompt-prefix stability across turns', () => {
     ).toBe(JSON.stringify(firstMessages))
   })
 
+  it('trims history to the loaded llama.cpp context window before streaming', async () => {
+    h.providerId = 'llamacpp'
+    h.getModelProps.mockResolvedValue({ nCtx: 4096 })
+    provider.provider = 'llamacpp'
+    provider.settings = [
+      { key: 'ctx_shift', controller_props: { value: true } },
+    ]
+    selectedModel.id = 'llama-local'
+
+    const transport = new CustomChatTransport('you are jan', 'thread-1')
+    await drain(
+      await send(transport, [
+        user('u1', `old-user ${'context '.repeat(1_200)}`),
+        assistant('a1', `old-assistant ${'context '.repeat(1_200)}`),
+        user('u2', `latest-user ${'context '.repeat(1_200)}`),
+      ])
+    )
+
+    const requestMessages = streamTextCalls[0].messages as unknown[]
+    const serialized = JSON.stringify(requestMessages)
+    expect(h.getModelProps).toHaveBeenCalledWith('llama-local')
+    expect(requestMessages).toHaveLength(1)
+    expect(serialized).not.toContain('old-user')
+    expect(serialized).toContain('latest-user')
+  })
+
   it('keeps the prefix stable when the third turn extends the second', async () => {
     const transport = new CustomChatTransport('you are jan', 'thread-1')
 
@@ -206,6 +254,30 @@ describe('CustomChatTransport prompt-prefix stability across turns', () => {
       JSON.stringify(thirdMessages.slice(0, secondMessages.length))
     ).toBe(JSON.stringify(secondMessages))
   })
+
+  it('keeps the configured limit when llama.cpp context shift is disabled', async () => {
+    h.providerId = 'llamacpp'
+    h.getModelProps.mockResolvedValue({ nCtx: 4096 })
+    h.assistantParameters = {
+      max_context_tokens: 12_000,
+      max_output_tokens: 2048,
+    }
+    provider.provider = 'llamacpp'
+    selectedModel.id = 'llama-local'
+
+    const transport = new CustomChatTransport('you are jan', 'thread-1')
+    await drain(
+      await send(transport, [
+        user('u1', `first-user ${'context '.repeat(1_200)}`),
+        assistant('a1', `first-assistant ${'context '.repeat(1_200)}`),
+        user('u2', `latest-user ${'context '.repeat(1_200)}`),
+      ])
+    )
+
+    const requestMessages = streamTextCalls[0].messages as unknown[]
+    expect(h.getModelProps).not.toHaveBeenCalled()
+    expect(requestMessages).toHaveLength(3)
+  })
 })
 
 describe('CustomChatTransport assistant completion (continuation prefill)', () => {
@@ -213,6 +285,13 @@ describe('CustomChatTransport assistant completion (continuation prefill)', () =
     streamTextCalls.length = 0
     h.disabledTools = []
     h.servers = ['srv']
+    h.providerId = 'openai'
+    h.assistantParameters = null
+    h.getModelProps.mockReset()
+    provider.provider = 'openai'
+    provider.settings = []
+    selectedModel.id = 'gpt'
+    selectedModel.capabilities = ['tools']
     h.getRelevantTools.mockReset()
     h.getRelevantTools.mockResolvedValue([
       { name: 'tool_a', description: 'a', inputSchema: {}, server: 'srv' },

--- a/web-app/src/lib/__tests__/custom-chat-transport.test.ts
+++ b/web-app/src/lib/__tests__/custom-chat-transport.test.ts
@@ -4,6 +4,7 @@ import type { UIMessage } from '@ai-sdk/react'
 import {
   buildLlamacppReasoningParams,
   coalesceMessagesForAlternation,
+  effectiveContextWindow,
   hasGenuineUserQuery,
   extractContextInfoFromError,
   normalizeToolInputSchema,
@@ -29,6 +30,14 @@ const assistantMsg = (
     role: 'assistant',
     parts,
   }) as UIMessage
+
+describe('effectiveContextWindow', () => {
+  it('uses the live llama.cpp context only when context shift is enabled', () => {
+    expect(effectiveContextWindow(0, 12_288, true)).toBe(12_288)
+    expect(effectiveContextWindow(8_192, 12_288, false)).toBe(8_192)
+  })
+})
+
 
 describe('normalizeToolInputSchema', () => {
   it('adds empty properties for object schemas without properties', () => {

--- a/web-app/src/lib/custom-chat-transport.ts
+++ b/web-app/src/lib/custom-chat-transport.ts
@@ -195,6 +195,19 @@ async function resolveThinkingBudgetTokens(
   return tokensForThinkingBudgetLevel(rawLevel, contextSize || 8192)
 }
 
+export function effectiveContextWindow(
+  configuredContextTokens: number,
+  liveContextTokens: number | undefined,
+  contextShiftEnabled: boolean
+): number {
+  return contextShiftEnabled &&
+    typeof liveContextTokens === 'number' &&
+    liveContextTokens > 0
+    ? liveContextTokens
+    : configuredContextTokens
+}
+
+
 /**
  * Coerce a schema-node slot into a valid sub-schema. Some tool generators
  * emit shorthand like `{ "properties": { "foo": "string" } }` instead of
@@ -1266,15 +1279,36 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
       return isNaN(n) ? undefined : n
     })()
 
-    const maxContextTokens = (() => {
+    const configuredContextTokens = (() => {
       const raw = inferenceParams.max_context_tokens
       return typeof raw === 'number' ? raw : (Number(raw) || 0)
     })()
+    const contextShiftEnabled =
+      providerId === 'llamacpp' &&
+      provider.settings?.some(
+        (setting) =>
+          setting.key === 'ctx_shift' &&
+          setting.controller_props?.value === true
+      ) === true
+    let liveContextTokens: number | undefined
+    if (contextShiftEnabled) {
+      try {
+        liveContextTokens = (
+          await getLlamacppExtension()?.getModelProps?.(modelId)
+        )?.nCtx
+      } catch {
+        // The router has not loaded the model yet. Preserve the configured limit.
+      }
+    }
+    const maxContextTokens = effectiveContextWindow(
+      configuredContextTokens,
+      liveContextTokens,
+      contextShiftEnabled
+    )
     const autoCompact =
       inferenceParams.auto_compact === true ||
       inferenceParams.auto_compact === 'true'
 
-    // Auto-trim or auto-compact conversation history when max_context_tokens is configured
     let effectiveMessages = messagesToConvert
     if (maxContextTokens > 0) {
       const contextConfig: ContextManagerConfig = {
@@ -1283,11 +1317,12 @@ export class CustomChatTransport implements ChatTransport<UIMessage> {
         autoCompact: !!autoCompact,
       }
 
+      // Context Shift only shifts llama.cpp's KV cache after generation starts.
+      // Keep the submitted chat history under the live router context window first.
       const systemPromptTokens = effectiveSystem
         ? estimateTokens(effectiveSystem) + 4
         : 0
-
-      if (autoCompact && this.model) {
+      if (autoCompact && !contextShiftEnabled && this.model) {
         const compactResult = await compactMessages(
           messagesToConvert,
           contextConfig,


### PR DESCRIPTION
## Summary
- Chats with a llama.cpp model and Context Shift enabled now keep running past the context window instead of hard-stopping on an HTTP 400: Jan trims submitted history to the loaded model's live context window, because llama.cpp's request admission rejects an oversized prompt before its generation-time Context Shift can evict old tokens.
- With Context Shift disabled, the existing manual context-limit trimming is preserved, and summary-based auto-compaction is skipped while shifting so the constrained model is not asked to summarize first.

Fixes #8610

## Verification
- `yarn vitest run web-app/src/lib/__tests__/custom-chat-transport.test.ts web-app/src/lib/__tests__/custom-chat-transport-prefix-stability.test.ts web-app/src/lib/__tests__/context-manager.test.ts` - 87 passed
- `llama-server` b9967 (`bb7049f71`), Qwen3-0.6B-Q8_0.gguf, `--ctx-size 8192 --context-shift` - untrimmed 11,888-token chat returned HTTP 400 `exceed_context_size_error` (n_prompt_tokens 11888, n_ctx 8192); same chat trimmed via `nCtx - 2048 - systemTokens` returned HTTP 200
- `GET /props` on the kv-unified server (n_slots 4, n_ctx_slot 8192) - `default_generation_settings.n_ctx` is 8192, the per-slot admission threshold, not the 32768 total KV
- `llama-server` b9967, `--ctx-size 1024 --context-shift` - untrimmed 2,617-token chat returned HTTP 400; retaining the latest message returned HTTP 200 (297 prompt tokens); a 1,100-token completion produced the server log `slot context shift` during generation
- `yarn build:web` - passed
- Not run: packaged native Jan desktop build (no full Xcode on host)
