### PR TITLE
feat(agent): add built-in Jan self-knowledge skill

### DIFF
--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/default_jan_skill.md
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/default_jan_skill.md
@@ -1,18 +1,18 @@
 ---
 name: jan
-description: Use when onboarding users to Jan or explaining where to customize Jan Agent, CLI, desktop, project settings, and skills.
+description: Use when onboarding users to Jan Agent or explaining where to customize models, providers, project settings, and skills.
 ---
-# Jan
+# Jan Agent
 
-Use this for Jan onboarding and customization, not user projects or Jan development.
+Use this to onboard users to Jan Agent and customize their workspace.
 
 ## Start
 
-- Run `jan --version`, `jan --help`, then relevant subcommand help.
-- Treat UI and command details as version-specific: inspect the current app or official Jan docs.
-- Do not infer update behavior for source builds; inspect installed help or official docs.
+- Read [Jan Docs](https://jan.ai/docs) and [Jan releases](https://github.com/janhq/jan/releases).
+- Check installed CLI behavior with `jan --version`, `jan --help`, then relevant subcommand help.
+- Use the docs for current UI, update, and source-build guidance.
 
 ## Customize
 
-- Desktop: use Settings. Project Agent: inspect `.jan/agent/agent.toml` before changing models, providers, permissions, or budgets.
-- Manage project skills with `skill_list`, `skill_read`, and `skill_write`, not undocumented paths.
+- Desktop: use Settings. Project Agent: inspect `.jan/agent/agent.toml` for models, providers, permissions, and budgets.
+- Manage project skills with `skill_list`, `skill_read`, and `skill_write`.

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/default_jan_skill.md
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/default_jan_skill.md
@@ -1,18 +1,28 @@
 ---
 name: jan
-description: Use when onboarding users to Jan Agent or explaining where to customize models, providers, project settings, and skills.
+description: Use when onboarding users to Jan Agent or explaining project and global configuration, skills, memory, providers, and MCP servers.
 ---
 # Jan Agent
 
-Use this to onboard users to Jan Agent and customize their workspace.
+Run `jan` in a folder. That CWD is the project root; `--project DIR` selects another root.
 
-## Start
+## Project state
 
-- Read [Jan Docs](https://jan.ai/docs) and [Jan releases](https://github.com/janhq/jan/releases).
-- Check installed CLI behavior with `jan --version`, `jan --help`, then relevant subcommand help.
-- Use the docs for current UI, update, and source-build guidance.
+`<project>/.jan/agent/` is created on first use:
 
-## Customize
+- `agent.toml`: model, provider override, budget, tools, and skills.
+- `AGENT.md`: always-on project instructions.
+- `skills/<name>/SKILL.md` or `skills/<name>.md`: reusable procedures.
+- `memory/`: durable project facts. `threads/`: saved sessions. `subagents/`: reusable agents.
 
-- Desktop: use Settings. Project Agent: inspect `.jan/agent/agent.toml` for models, providers, permissions, and budgets.
-- Manage project skills with `skill_list`, `skill_read`, and `skill_write`.
+Run `jan cli agent status --project .` to scaffold it. Commit `agent.toml`, `AGENT.md`, `skills/`, and `subagents/`; gitignore `threads/`.
+
+## Global state
+
+- `~/.jan/config.toml`: provider configuration and credentials.
+- `<JAN_DATA_FOLDER>/mcp_config.json`: MCP servers. Desktop: **Settings → MCP Servers**.
+- `<JAN_DATA_FOLDER>/agent-workspace/`: Desktop-global `skills/`, `memory/`, and `threads/`. `JAN_DATA_FOLDER` or the Desktop data-folder setting selects the root.
+
+## References
+
+[Project config](https://jan.ai/docs/agent/project-config) · [Skills](https://jan.ai/docs/agent/skills) · [MCP servers](https://jan.ai/docs/desktop/integrations/mcp-servers)

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/default_jan_skill.md
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/default_jan_skill.md
@@ -3,19 +3,23 @@ name: jan
 description: Use when onboarding users to Jan Agent or explaining project and global configuration, skills, memory, providers, and MCP servers.
 ---
 # Jan Agent
+When enabled, Jan lists this skill's name and purpose. The model loads its body with `skill_read`
+only when the task needs it.
+
 
 Run `jan` in a folder. That CWD is the project root; `--project DIR` selects another root.
 
 ## Project files
 
-Jan creates this tree on first use:
+Jan reads non-empty `JAN.md` files from the project root and its ancestors. The nearest file wins.
+Jan creates this separate state tree on first use:
 
 ```text
 <project>/
+|-- JAN.md                 # always-loaded project instructions
 `-- .jan/
     `-- agent/
         |-- agent.toml       # model, provider, budget, tools, skills
-        |-- AGENT.md         # always-loaded project instructions
         |-- skills/
         |   `-- <name>/
         |       `-- SKILL.md # procedure, plus optional scripts/templates
@@ -25,9 +29,8 @@ Jan creates this tree on first use:
 ```
 
 `agent.toml` has `[agent]`, `[provider]`, `[budget]`, `[tools]`, and `[skills]` sections.
-`AGENT.md` is the default `instructions_file`. A simple skill can instead be
-`skills/<name>.md`. Commit `agent.toml`, `AGENT.md`, `skills/`, and `subagents/`;
-gitignore `threads/`. Run `jan cli agent status --project .` to scaffold the tree.
+A simple skill can be `skills/<name>.md`. Commit `JAN.md`, `agent.toml`, `skills/`, and
+`subagents/`; gitignore `threads/`. Run `jan cli agent status --project .` to scaffold the tree.
 
 ## User-global files
 

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/default_jan_skill.md
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/default_jan_skill.md
@@ -1,0 +1,18 @@
+---
+name: jan
+description: Use when onboarding users to Jan or explaining where to customize Jan Agent, CLI, desktop, project settings, and skills.
+---
+# Jan
+
+Use this for Jan onboarding and customization, not user projects or Jan development.
+
+## Start
+
+- Run `jan --version`, `jan --help`, then relevant subcommand help.
+- Treat UI and command details as version-specific: inspect the current app or official Jan docs.
+- Do not infer update behavior for source builds; inspect installed help or official docs.
+
+## Customize
+
+- Desktop: use Settings. Project Agent: inspect `.jan/agent/agent.toml` before changing models, providers, permissions, or budgets.
+- Manage project skills with `skill_list`, `skill_read`, and `skill_write`, not undocumented paths.

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/default_jan_skill.md
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/default_jan_skill.md
@@ -6,23 +6,60 @@ description: Use when onboarding users to Jan Agent or explaining project and gl
 
 Run `jan` in a folder. That CWD is the project root; `--project DIR` selects another root.
 
-## Project state
+## Project files
 
-`<project>/.jan/agent/` is created on first use:
+Jan creates this tree on first use:
 
-- `agent.toml`: model, provider override, budget, tools, and skills.
-- `AGENT.md`: always-on project instructions.
-- `skills/<name>/SKILL.md` or `skills/<name>.md`: reusable procedures.
-- `memory/`: durable project facts. `threads/`: saved sessions. `subagents/`: reusable agents.
+```text
+<project>/
+`-- .jan/
+    `-- agent/
+        |-- agent.toml       # model, provider, budget, tools, skills
+        |-- AGENT.md         # always-loaded project instructions
+        |-- skills/
+        |   `-- <name>/
+        |       `-- SKILL.md # procedure, plus optional scripts/templates
+        |-- memory/          # durable project facts
+        |-- threads/         # saved conversations
+        `-- subagents/       # reusable agent definitions
+```
 
-Run `jan cli agent status --project .` to scaffold it. Commit `agent.toml`, `AGENT.md`, `skills/`, and `subagents/`; gitignore `threads/`.
+`agent.toml` has `[agent]`, `[provider]`, `[budget]`, `[tools]`, and `[skills]` sections.
+`AGENT.md` is the default `instructions_file`. A simple skill can instead be
+`skills/<name>.md`. Commit `agent.toml`, `AGENT.md`, `skills/`, and `subagents/`;
+gitignore `threads/`. Run `jan cli agent status --project .` to scaffold the tree.
 
-## Global state
+## User-global files
 
-- `~/.jan/config.toml`: provider configuration and credentials.
-- `<JAN_DATA_FOLDER>/mcp_config.json`: MCP servers. Desktop: **Settings > MCP Servers**.
-- `<JAN_DATA_FOLDER>/agent-workspace/`: Desktop-global `skills/`, `memory/`, and `threads/`. `JAN_DATA_FOLDER` or the Desktop data-folder setting selects the root.
+`~/.jan/` is separate from a project's `.jan/`:
 
-## References
+```text
+~/.jan/
+`-- config.toml              # CLI provider configuration and credentials
+```
 
-[Project config](https://jan.ai/docs/agent/project-config) | [Skills](https://jan.ai/docs/agent/skills) | [MCP servers](https://jan.ai/docs/desktop/integrations/mcp-servers)
+Jan Desktop stores its settings and shared MCP configuration under the platform support folder:
+
+```text
+<support-folder>/Jan/
+|-- settings.json             # Desktop settings, including an optional data_folder
+`-- data/                     # default JAN_DATA_FOLDER
+    |-- mcp_config.json       # shared MCP server definitions
+    `-- agent-workspace/      # Desktop-global agent store
+        |-- skills/
+        |-- memory/
+        `-- threads/
+```
+
+Default `<support-folder>`:
+
+```text
+macOS:   ~/Library/Application Support
+Linux:   $XDG_DATA_HOME, or ~/.local/share
+Windows: %APPDATA%
+```
+
+`JAN_DATA_FOLDER` overrides the `data/` location. Otherwise Jan uses
+`settings.json`'s `data_folder`, then `<support-folder>/Jan/data`.
+Add MCP servers in Desktop at `Settings > MCP Servers`; Jan writes
+`<JAN_DATA_FOLDER>/mcp_config.json`.

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/default_jan_skill.md
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/default_jan_skill.md
@@ -20,9 +20,9 @@ Run `jan cli agent status --project .` to scaffold it. Commit `agent.toml`, `AGE
 ## Global state
 
 - `~/.jan/config.toml`: provider configuration and credentials.
-- `<JAN_DATA_FOLDER>/mcp_config.json`: MCP servers. Desktop: **Settings → MCP Servers**.
+- `<JAN_DATA_FOLDER>/mcp_config.json`: MCP servers. Desktop: **Settings > MCP Servers**.
 - `<JAN_DATA_FOLDER>/agent-workspace/`: Desktop-global `skills/`, `memory/`, and `threads/`. `JAN_DATA_FOLDER` or the Desktop data-folder setting selects the root.
 
 ## References
 
-[Project config](https://jan.ai/docs/agent/project-config) · [Skills](https://jan.ai/docs/agent/skills) · [MCP servers](https://jan.ai/docs/desktop/integrations/mcp-servers)
+[Project config](https://jan.ai/docs/agent/project-config) | [Skills](https://jan.ai/docs/agent/skills) | [MCP servers](https://jan.ai/docs/desktop/integrations/mcp-servers)

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/skills.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/skills.rs
@@ -421,7 +421,7 @@ mod tests {
                 .unwrap()
                 .as_nanos()
         ));
-        assert!(read_body(&root, "jan").unwrap().contains("## Start"));
+        assert!(!read_body(&root, "jan").unwrap().trim().is_empty());
         assert!(read_body(&root, "../jan").is_err());
 
         write(

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/skills.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/skills.rs
@@ -19,6 +19,13 @@ use crate::workspace::{store_dir, workspace_filename};
 
 const KIND: &str = "skills";
 
+const DEFAULT_JAN_SKILL_NAME: &str = "jan";
+const DEFAULT_JAN_SKILL: &str = include_str!("default_jan_skill.md");
+
+fn is_default_jan_skill(name: &str) -> bool {
+    safe_stem(name).ok().as_deref() == Some(DEFAULT_JAN_SKILL_NAME)
+}
+
 /// `<store_root>/skills`.
 pub fn skills_dir(store: &Path) -> PathBuf {
     store_dir(store, KIND)
@@ -201,6 +208,14 @@ fn describe(parsed: &ParsedSkill) -> String {
         .unwrap_or_else(|| first_line(&parsed.body))
 }
 
+fn default_jan_skill_meta() -> SkillMeta {
+    let parsed = parse(DEFAULT_JAN_SKILL);
+    SkillMeta {
+        name: DEFAULT_JAN_SKILL_NAME.to_string(),
+        description: describe(&parsed),
+    }
+}
+
 /// Metadata for every discovered skill (name + description) — for the UI list.
 /// Keeps empty stubs so the user can see and edit them.
 pub fn list_meta(store: &Path) -> Vec<SkillMeta> {
@@ -218,14 +233,14 @@ pub fn list_meta(store: &Path) -> Vec<SkillMeta> {
 
 /// Skills worth advertising in the system prompt: name + description, skipping
 /// skills with neither a description nor a body. This is the progressive-
-/// disclosure catalog — the model calls `skill_read` to load a body on demand.
+/// disclosure catalog - the model calls `skill_read` to load a body on demand.
 ///
 /// `enabled` is a whitelist of skill names; an empty list means "all skills"
 /// (backward-compatible with the agent.toml scaffold, which ships `enabled = []`).
 pub fn catalog(store: &Path, enabled: &[String]) -> Vec<SkillMeta> {
     let allow: Option<std::collections::HashSet<&str>> =
         (!enabled.is_empty()).then(|| enabled.iter().map(String::as_str).collect());
-    discover(store)
+    let mut skills = discover(store)
         .into_iter()
         .filter_map(|e| {
             if let Some(allow) = &allow {
@@ -243,7 +258,16 @@ pub fn catalog(store: &Path, enabled: &[String]) -> Vec<SkillMeta> {
                 description,
             })
         })
-        .collect()
+        .collect::<Vec<_>>();
+    if is_enabled(enabled, DEFAULT_JAN_SKILL_NAME)
+        && !skills
+            .iter()
+            .any(|skill| skill.name == DEFAULT_JAN_SKILL_NAME)
+    {
+        skills.push(default_jan_skill_meta());
+    }
+    skills.sort_by(|a, b| a.name.cmp(&b.name));
+    skills
 }
 
 /// Raw SKILL.md text (frontmatter included) for the editor.
@@ -252,10 +276,16 @@ pub fn read_raw(store: &Path, name: &str) -> Result<String, String> {
     std::fs::read_to_string(&entry.file).map_err(|e| format!("ERROR: {e}"))
 }
 
-/// A skill's markdown body with the frontmatter fence stripped — what the
+/// A skill's markdown body with the frontmatter fence stripped - what the
 /// `skill_read` tool hands the model when it loads a skill on demand.
 pub fn read_body(store: &Path, name: &str) -> Result<String, String> {
-    Ok(parse(&read_raw(store, name)?).body)
+    match resolve(store, name) {
+        Ok(entry) => std::fs::read_to_string(&entry.file)
+            .map(|content| parse(&content).body)
+            .map_err(|e| format!("ERROR: {e}")),
+        Err(_) if is_default_jan_skill(name) => Ok(parse(DEFAULT_JAN_SKILL).body),
+        Err(error) => Err(error),
+    }
 }
 
 /// Create or overwrite a skill. Existing skills are written in place (preserving
@@ -369,13 +399,46 @@ mod tests {
         write(&root, "a", "body a").unwrap();
         write(&root, "b", "body b").unwrap();
 
-        // Empty whitelist = all skills.
-        assert_eq!(catalog(&root, &[]).len(), 2);
+        // Empty whitelist = all project skills plus the built-in Jan skill.
+        assert_eq!(catalog(&root, &[]).len(), 3);
 
-        // Non-empty whitelist restricts to the listed names.
+        // Non-empty whitelist restricts every skill, including the default.
         let only_a = catalog(&root, &["a".to_string()]);
         assert_eq!(only_a.len(), 1);
         assert_eq!(only_a[0].name, "a");
+        let only_jan = catalog(&root, &["jan".to_string()]);
+        assert_eq!(only_jan.len(), 1);
+        assert_eq!(only_jan[0].name, "jan");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn default_jan_skill_is_safe_to_read_and_project_skills_override_it() {
+        let root = std::env::temp_dir().join(format!(
+            "jan_default_skill_{}",
+            std::time::SystemTime::UNIX_EPOCH
+                .elapsed()
+                .unwrap()
+                .as_nanos()
+        ));
+        assert!(read_body(&root, "jan").unwrap().contains("## Start"));
+        assert!(read_body(&root, "../jan").is_err());
+
+        write(
+            &root,
+            "jan",
+            "---\ndescription: Custom Jan guidance\n---\ncustom body",
+        )
+        .unwrap();
+        assert_eq!(read_body(&root, "jan").unwrap(), "custom body");
+        assert_eq!(
+            catalog(&root, &[])
+                .into_iter()
+                .find(|skill| skill.name == "jan")
+                .unwrap()
+                .description,
+            "Custom Jan guidance"
+        );
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/handlers.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/handlers.rs
@@ -2190,7 +2190,11 @@ mod tests {
         let root = unique_root();
 
         let list = execute_builtin(lookup("skill_list").unwrap(), &json!({}), &root).await;
-        assert!(list.contains("jan — Use when"), "unexpected list: {list}");
+        assert!(
+            list.lines()
+                .any(|line| line == "jan" || line.starts_with("jan — ")),
+            "unexpected list: {list}"
+        );
 
         let body = execute_builtin(
             lookup("skill_read").unwrap(),
@@ -2198,15 +2202,7 @@ mod tests {
             &root,
         )
         .await;
-        assert!(body.starts_with("# Jan"), "unexpected body: {body}");
-        assert!(body.contains("## Start"), "unexpected body: {body}");
-        assert!(body.contains("## Customize"), "unexpected body: {body}");
-        assert!(body.contains("`jan --help`"), "unexpected body: {body}");
-        assert!(body.contains("source builds"), "unexpected body: {body}");
-        assert!(
-            body.split_whitespace().count() <= 100,
-            "default skill should stay concise: {body}"
-        );
+        assert!(!body.trim().is_empty(), "unexpected body: {body}");
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/handlers.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/handlers.rs
@@ -2186,6 +2186,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn built_in_jan_skill_is_available_without_project_skills() {
+        let root = unique_root();
+
+        let list = execute_builtin(lookup("skill_list").unwrap(), &json!({}), &root).await;
+        assert!(list.contains("jan — Use when"), "unexpected list: {list}");
+
+        let body = execute_builtin(
+            lookup("skill_read").unwrap(),
+            &json!({"name": "jan"}),
+            &root,
+        )
+        .await;
+        assert!(body.starts_with("# Jan"), "unexpected body: {body}");
+        assert!(body.contains("## Start"), "unexpected body: {body}");
+        assert!(body.contains("## Customize"), "unexpected body: {body}");
+        assert!(body.contains("`jan --help`"), "unexpected body: {body}");
+        assert!(body.contains("source builds"), "unexpected body: {body}");
+        assert!(
+            body.split_whitespace().count() <= 100,
+            "default skill should stay concise: {body}"
+        );
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
     async fn skill_tools_hide_disabled_skills() {
         let root = unique_root();
         execute_builtin(

--- a/src-tauri/src/core/agent/context.rs
+++ b/src-tauri/src/core/agent/context.rs
@@ -237,9 +237,11 @@ mod tests {
     }
 
     #[test]
-    fn no_skills_dir_yields_none() {
+    fn built_in_jan_skill_is_advertised_without_project_skills() {
         let root = scratch_project("nodir");
-        assert!(load_skills(&root).is_none());
+        let block = load_skills(&root).expect("built-in skills block");
+        assert!(block.contains("## Skill: jan"));
+        assert!(block.contains("Use when"));
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/src-tauri/src/core/agent/context.rs
+++ b/src-tauri/src/core/agent/context.rs
@@ -241,7 +241,6 @@ mod tests {
         let root = scratch_project("nodir");
         let block = load_skills(&root).expect("built-in skills block");
         assert!(block.contains("## Skill: jan"));
-        assert!(block.contains("Use when"));
         let _ = std::fs::remove_dir_all(&root);
     }
 


### PR DESCRIPTION
## Summary
- Jan Agent now has a built-in `jan` skill for concise onboarding and customization guidance; previously no shipped skill was discoverable without project setup.
- Project-authored `jan` skills can override the default, and existing enabled-skill restrictions remain in effect.

Fixes #8659

## Verification
- `cargo test --no-default-features built_in_jan_skill_is_available_without_project_skills` - 1 passed.
- `cargo test --no-default-features --features cli --lib built_in_jan_skill_is_advertised_without_project_skills` - 1 passed.