### PR TITLE
feat(agent): add TUI reasoning effort control

### DIFF
--- a/src-tauri/src/core/agent/upstream.rs
+++ b/src-tauri/src/core/agent/upstream.rs
@@ -316,6 +316,7 @@ pub(crate) fn copy_optional_chat_params(
         "top_p",
         "top_k",
         "max_tokens",
+        "reasoning_effort",
         "stop_sequences",
         "stop",
         "frequency_penalty",
@@ -924,6 +925,16 @@ mod tests {
         mpsc::UnboundedReceiver<StreamEvent>,
     ) {
         mpsc::unbounded_channel()
+    }
+
+    #[test]
+    fn copies_reasoning_effort_to_the_upstream_request() {
+        let from = json!({ "reasoning_effort": "high" });
+        let mut into = serde_json::Map::new();
+
+        copy_optional_chat_params(&from, &mut into);
+
+        assert_eq!(into.get("reasoning_effort"), Some(&json!("high")));
     }
 
     /// A model served both by a Jan desktop API server (reachable over HTTP) and

--- a/src-tauri/src/core/cli/run_report.rs
+++ b/src-tauri/src/core/cli/run_report.rs
@@ -93,7 +93,10 @@ impl RunReport {
         RunResult {
             kind: "result",
             is_error,
-            result: super::tui::answer_without_reasoning(final_text.unwrap_or(&self.partial)),
+            result: super::tui::answer_without_reasoning(
+                model,
+                final_text.unwrap_or(&self.partial),
+            ),
             stop_reason: if is_error {
                 "error".to_string()
             } else {

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -962,11 +962,68 @@ impl PendingAsk {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ReasoningEffort {
+    Low,
+    Medium,
+    High,
+    XHigh,
+}
+
+impl ReasoningEffort {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::XHigh => "xhigh",
+        }
+    }
+
+    fn parse(value: &str) -> Option<Self> {
+        match value {
+            "low" => Some(Self::Low),
+            "medium" => Some(Self::Medium),
+            "high" => Some(Self::High),
+            "xhigh" => Some(Self::XHigh),
+            _ => None,
+        }
+    }
+
+    fn next(self) -> Self {
+        match self {
+            Self::Low => Self::Medium,
+            Self::Medium => Self::High,
+            Self::High => Self::XHigh,
+            Self::XHigh => Self::Low,
+        }
+    }
+}
+
+impl std::fmt::Display for ReasoningEffort {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// OpenAI models known to accept the `reasoning_effort` chat parameter. Model
+/// catalogs only expose IDs, not parameter capabilities, so keep this
+/// conservative rather than sending a rejected field to every provider.
+fn model_supports_reasoning_effort(model: &str) -> bool {
+    let model = model.rsplit('/').next().unwrap_or(model).to_ascii_lowercase();
+    model.starts_with("gpt-5")
+        || model.starts_with("o1")
+        || model.starts_with("o3")
+        || model.starts_with("o4")
+}
+
 struct App {
     model: String,
     /// Fast model for the `smol` role, used by `/goal` evaluation. Defaults to
     /// `model` when no smol model is configured.
     smol_model: String,
+    /// Reasoning depth requested for the next model turn.
+    reasoning_effort: ReasoningEffort,
     /// Active `/goal`, if any: the loop keeps firing turns until the evaluator
     /// judges the condition met. Persisted with the thread so it survives
     /// restart/resume. `None` = no goal.
@@ -1360,6 +1417,7 @@ impl App {
         Self {
             smol_model: model.clone(),
             model,
+            reasoning_effort: ReasoningEffort::Medium,
             goal: None,
             goal_eval_pending: false,
             run_mode: crate::core::agent::plan::RunMode::Normal,
@@ -2416,6 +2474,9 @@ impl App {
         if let Some(max) = self.max_tokens {
             body["max_tokens"] = serde_json::json!(max);
         }
+        if model_supports_reasoning_effort(&self.model) {
+            body["reasoning_effort"] = serde_json::json!(self.reasoning_effort.as_str());
+        }
         // Live plan-mode toggle: the backend reads this per turn and falls back
         // to the session default when absent. Only forwarded in Plan so normal
         // turns keep an unchanged body.
@@ -2589,10 +2650,35 @@ impl App {
     /// persists across sessions.
     fn set_model(&mut self, model: String) {
         self.model = model;
-        match super::cli_set_project_model(&self.agent_dir, &self.model) {
-            Ok(()) => self.note(&format!("model set to {}", self.model)),
-            Err(e) => self.note(&format!("model set to {} (not saved: {e})", self.model)),
+        let effort_unavailable = !model_supports_reasoning_effort(&self.model);
+        if effort_unavailable {
+            self.reasoning_effort = ReasoningEffort::Medium;
         }
+        let suffix = if effort_unavailable {
+            "; reasoning effort unavailable"
+        } else {
+            ""
+        };
+        match super::cli_set_project_model(&self.agent_dir, &self.model) {
+            Ok(()) => self.note(&format!("model set to {}{suffix}", self.model)),
+            Err(e) => self.note(&format!(
+                "model set to {}{suffix} (not saved: {e})",
+                self.model
+            )),
+        }
+    }
+
+    fn set_reasoning_effort(&mut self, effort: ReasoningEffort) {
+        if !model_supports_reasoning_effort(&self.model) {
+            self.note(&format!("reasoning effort unavailable for {}", self.model));
+            return;
+        }
+        self.reasoning_effort = effort;
+        self.note(&format!("reasoning effort: {effort}"));
+    }
+
+    fn cycle_reasoning_effort(&mut self) {
+        self.set_reasoning_effort(self.reasoning_effort.next());
     }
 
     /// Non-terminal stream events. `Done`/`Error` are handled by the loop since
@@ -5568,6 +5654,9 @@ async fn handle_key(
         KeyCode::Enter if key.modifiers.contains(KeyModifiers::ALT) => {
             app.input_insert('\n');
         }
+        KeyCode::F(4) => {
+            app.cycle_reasoning_effort();
+        }
         KeyCode::Char('j') if ctrl => {
             app.input_insert('\n');
         }
@@ -5715,6 +5804,11 @@ const SLASH_COMMANDS: &[SlashCommand] = &[
         description: "Switch model (bare: pick interactively)",
     },
     SlashCommand {
+        name: "/effort",
+        hint: "[low|medium|high|xhigh]",
+        description: "Set reasoning effort for supported models (bare: status)",
+    },
+    SlashCommand {
         name: "/mcp",
         hint: "",
         description: "Enable/disable MCP servers",
@@ -5764,6 +5858,7 @@ const KEY_BINDINGS: &[(&str, &str)] = &[
     ("PgUp/PgDn", "Scroll the transcript"),
     ("Ctrl-O", "Expand or collapse all tool calls"),
     ("Ctrl-V", "Paste an image from the clipboard"),
+    ("F4", "Cycle reasoning effort"),
     ("Drag", "Select text, copied on release (Alt+drag for a block)"),
     ("Ctrl-D", "Quit"),
 ];
@@ -5840,6 +5935,20 @@ async fn run_command(app: &mut App, line: &str) {
                 open_model_picker(app);
             } else {
                 app.set_model(arg.to_string());
+            }
+        }
+        "effort" => {
+            if arg.is_empty() {
+                let status = if model_supports_reasoning_effort(&app.model) {
+                    app.reasoning_effort.to_string()
+                } else {
+                    "unavailable".into()
+                };
+                app.note(&format!("reasoning effort: {status}"));
+            } else if let Some(effort) = ReasoningEffort::parse(arg) {
+                app.set_reasoning_effort(effort);
+            } else {
+                app.note("usage: /effort [low|medium|high|xhigh]");
             }
         }
         "mcp" => open_mcp_picker(app),
@@ -7229,6 +7338,9 @@ async fn load_thread(app: &mut App, thread: &serde_json::Value) {
     {
         app.model = model.to_string();
     }
+    if !model_supports_reasoning_effort(&app.model) {
+        app.reasoning_effort = ReasoningEffort::Medium;
+    }
 
     // The journal holds what was rendered (reasoning, tool rows, diffs); the
     // messages hold what the model is sent. Prefer the journal for the
@@ -8575,6 +8687,12 @@ fn header_spans(app: &App) -> Vec<Span<'static>> {
     } else {
         Span::styled(format!(" {}  ", app.model), Style::new().bold())
     }];
+    if model_supports_reasoning_effort(&app.model) {
+        spans.push(Span::styled(
+            format!(" effort {}  ", app.reasoning_effort),
+            Style::new().dim(),
+        ));
+    }
     // Wall-clock (local) segment, mirroring the reference status line's leading
     // HH:MM:SS. Shown only while a run is active: a clock that ticks once per
     // second repaints the screen every second, which clears the terminal's text
@@ -9171,7 +9289,7 @@ mod tests {
         tool_activity, tool_finished,
         transcript_top_padding, rewind_to,
         row_width, user_content_parts, App, CurrentRun, Pending, PendingImage, PickerKind,
-        ResumeTarget, RowKind,
+        ReasoningEffort, ResumeTarget, RowKind,
         SnapshotJob, Status, AGENT_SETTINGS, ALT_SCROLL_RESTORE, ALT_SCROLL_SAVE_OFF,
         COMMAND_LABEL_MAX, DIFF_ADD_BG, DIFF_DEL_BG, DIFF_MAX_ROWS, DIFF_PREVIEW_MAX_ROWS,
         KEY_BINDINGS, MOUSE_TRACK_ON, SLASH_COMMANDS, SPINNER,
@@ -9244,6 +9362,63 @@ mod tests {
             std::path::PathBuf::from("/tmp/repo"),
             None,
         )
+    }
+
+    #[test]
+    fn effort_defaults_to_medium_and_is_forwarded_for_reasoning_models() {
+        let mut app = test_app();
+        app.model = "gpt-5".into();
+
+        assert_eq!(app.reasoning_effort, ReasoningEffort::Medium);
+        assert_eq!(app.body()["reasoning_effort"], "medium");
+    }
+
+    #[test]
+    fn effort_is_omitted_for_models_without_reasoning_effort_support() {
+        let mut app = test_app();
+        app.model = "gpt-4o".into();
+
+        assert!(app.body().get("reasoning_effort").is_none());
+    }
+
+    #[tokio::test]
+    async fn effort_command_and_shortcut_update_supported_model() {
+        let mut app = test_app();
+        app.model = "gpt-5".into();
+
+        run_command(&mut app, "effort high").await;
+        assert_eq!(app.reasoning_effort, ReasoningEffort::High);
+
+        press(&mut app, KeyCode::F(4), KeyModifiers::NONE).await;
+        assert_eq!(app.reasoning_effort, ReasoningEffort::XHigh);
+    }
+
+    #[tokio::test]
+    async fn unsupported_model_switch_resets_effort_and_never_forwards_it() {
+        let mut app = test_app();
+        app.model = "gpt-5".into();
+        app.reasoning_effort = ReasoningEffort::High;
+        app.history.push(serde_json::json!({"role": "user", "content": "keep"}));
+
+        app.set_model("gpt-4o".into());
+        run_command(&mut app, "effort low").await;
+
+        assert_eq!(app.reasoning_effort, ReasoningEffort::Medium);
+        assert_eq!(app.history, vec![serde_json::json!({"role": "user", "content": "keep"})]);
+        assert!(app.body().get("reasoning_effort").is_none());
+        assert!(transcript_text(&app).contains("reasoning effort unavailable"));
+    }
+
+    #[test]
+    fn header_shows_effort_only_for_supported_models() {
+        let mut app = test_app();
+        app.model = "gpt-5".into();
+        let supported = render_rows(&mut app, 100, 12).join("\n");
+        assert!(supported.contains("effort medium"), "{supported}");
+
+        app.model = "gpt-4o".into();
+        let unsupported = render_rows(&mut app, 100, 12).join("\n");
+        assert!(!unsupported.contains("effort"), "{unsupported}");
     }
 
     /// Draw `app` into an off-screen terminal and return its rows as strings.

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -1006,12 +1006,13 @@ impl std::fmt::Display for ReasoningEffort {
     }
 }
 
-/// OpenAI models known to accept the `reasoning_effort` chat parameter. Model
-/// catalogs only expose IDs, not parameter capabilities, so keep this
-/// conservative rather than sending a rejected field to every provider.
+/// Models verified to accept the `reasoning_effort` chat parameter. Model
+/// catalogs only expose IDs, not parameter capabilities, so keep this list
+/// explicit rather than sending a rejected field to every provider.
 fn model_supports_reasoning_effort(model: &str) -> bool {
     let model = model.rsplit('/').next().unwrap_or(model).to_ascii_lowercase();
-    model.starts_with("gpt-5")
+    model == "tokamak-1-preview"
+        || model.starts_with("gpt-5")
         || model.starts_with("o1")
         || model.starts_with("o3")
         || model.starts_with("o4")
@@ -9372,6 +9373,17 @@ mod tests {
         assert_eq!(app.reasoning_effort, ReasoningEffort::Medium);
         assert_eq!(app.body()["reasoning_effort"], "medium");
     }
+
+    #[test]
+    fn effort_is_forwarded_and_displayed_for_tokamak_preview() {
+        let mut app = test_app();
+        app.model = "tokamak-1-preview".into();
+
+        assert_eq!(app.body()["reasoning_effort"], "medium");
+        let rendered = render_rows(&mut app, 100, 12).join("\n");
+        assert!(rendered.contains("effort medium"), "{rendered}");
+    }
+
 
     #[test]
     fn effort_is_omitted_for_models_without_reasoning_effort_support() {

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -1018,6 +1018,15 @@ fn model_supports_reasoning_effort(model: &str) -> bool {
         || model.starts_with("o4")
 }
 
+/// True when `model` is served by the native Tokamak provider. Tokamak keeps
+/// reasoning out-of-band (a separate channel on the wire) instead of embedding
+/// ` thinking` markers in the answer text, so the TUI must not re-parse the
+/// model's raw output for reasoning. Disable that tag-based parsing here and
+/// let the answer render as-is.
+pub(crate) fn is_native_tokamak(model: &str) -> bool {
+    model.rsplit('/').next().unwrap_or(model).starts_with("tokamak-")
+}
+
 struct App {
     model: String,
     /// Fast model for the `smol` role, used by `/goal` evaluation. Defaults to
@@ -1687,7 +1696,7 @@ impl App {
         self.thinking_since = None;
         // No-op (and, crucially, don't finalize the tool group) on an empty or
         // whitespace-only buffer, so silent consecutive tool calls keep folding.
-        if !assistant_has_content(&text) {
+        if !assistant_has_content(&self.model, &text) {
             return;
         }
         // Model prose ends the current run of tool calls.
@@ -1706,7 +1715,16 @@ impl App {
     /// whose full dimmed detail is retained for expansion.
     fn push_assistant_blocks(&mut self, text: &str) {
         let text = strip_system_xml_tags(text);
-        for (reasoning, seg) in split_reasoning(&text) {
+        // Native Tokamak carries reasoning out-of-band, so a ` thinking` tag in the
+        // answer text is literal content, not a marker: feed the text through as
+        // one plain segment instead of splitting it. Separating reasoning is the
+        // chat template's job, not the TUI's.
+        let segments = if is_native_tokamak(&self.model) {
+            vec![(false, text)]
+        } else {
+            split_reasoning(&text)
+        };
+        for (reasoning, seg) in segments {
             if seg.trim().is_empty() {
                 continue;
             }
@@ -1943,7 +1961,12 @@ impl App {
     /// stretch of a run that puts nothing on screen, so the header badge is the
     /// only place progress can show.
     fn is_thinking(&self) -> bool {
-        self.status != Status::Idle && !self.show_reasoning && thinking_open(&self.assistant_buf)
+        // Native Tokamak never streams reasoning as inline tags, so there is no
+        // `[thinking]` stretch to signal.
+        self.status != Status::Idle
+            && !self.show_reasoning
+            && !is_native_tokamak(&self.model)
+            && thinking_open(&self.assistant_buf)
     }
 
     /// Header status while a turn is running with reasoning folding on:
@@ -1952,7 +1975,7 @@ impl App {
     /// plain `[working]`) once the model is working again. `None` when no
     /// reasoning has happened recently this turn.
     fn reasoning_status(&self) -> Option<(String, Style)> {
-        if thinking_open(&self.assistant_buf) {
+        if !is_native_tokamak(&self.model) && thinking_open(&self.assistant_buf) {
             Some(("thinking".to_string(), Style::new().cyan().bold()))
         } else {
             // The summary is transient: it lasts only `THOUGHT_FOR_TTL` after the
@@ -2691,8 +2714,9 @@ impl App {
                 // Track the live thinking state so the header can fold reasoning
                 // to `[thinking]` / `[thought for Ns]`. Start the timer when a
                 //  block opens; close it (stashing the duration) once the block
-                // closes or the tool group proceeds.
-                let open = thinking_open(&self.assistant_buf);
+                // Native Tokamak keeps reasoning out-of-band, so ` thinking` tags
+                // are literal content: never time the header's fold state on them.
+                let open = !is_native_tokamak(&self.model) && thinking_open(&self.assistant_buf);
                 if open && self.thinking_since.is_none() {
                     self.thinking_since = Some(Instant::now());
                 } else if !open {
@@ -2705,7 +2729,7 @@ impl App {
                 // it lands above the streaming response. Reasoning tokens must
                 // not trigger this, or every call by a reasoning model splits
                 // into its own row.
-                if self.tool_group.is_some() && has_answer_text(&self.assistant_buf) {
+                if self.tool_group.is_some() && has_answer_text(&self.model, &self.assistant_buf) {
                     self.finalize_tool_group();
                 }
             }
@@ -2714,7 +2738,7 @@ impl App {
                 // has produced answer prose; a turn that only reasoned or only
                 // called tools keeps the group open so the next turn's calls
                 // keep folding into one summary row instead of a row per turn.
-                if has_answer_text(&self.assistant_buf) {
+                if has_answer_text(&self.model, &self.assistant_buf) {
                     self.flush_assistant();
                 }
                 self.starting.clear();
@@ -3093,7 +3117,7 @@ impl App {
         // `SubagentEnd`.
         self.close_live_subagents();
         let answer = self.take_answer();
-        let wire = answer_without_reasoning(&answer);
+        let wire = answer_without_reasoning(&self.model, &answer);
         if !wire.is_empty() {
             self.history
                 .push(serde_json::json!({ "role": "assistant", "content": wire }));
@@ -3136,7 +3160,7 @@ impl App {
         // truncated/filtered finish, or a "stop" that yielded no answer (an
         // empty/malformed upstream completion defaults to stop_reason=stop).
         let normal = matches!(stop_reason.as_str(), "stop" | "end_turn" | "stop_sequence");
-        let no_answer = !has_answer_text(&answer);
+        let no_answer = !has_answer_text(&self.model, &answer);
         if !normal || no_answer {
             let msg = if no_answer {
                 format!("finished with no answer (stop_reason={stop_reason})")
@@ -3331,7 +3355,8 @@ impl App {
         // preceding tool calls stay in the transcript, and record the partial
         // answer in history so the next turn and a later /resume both see it.
         self.abort_tool_rows();
-        let answer = answer_without_reasoning(&self.take_answer());
+        let raw = self.take_answer();
+        let answer = answer_without_reasoning(&self.model, &raw);
         if !answer.is_empty() {
             self.history
                 .push(serde_json::json!({ "role": "assistant", "content": answer }));
@@ -4189,7 +4214,12 @@ fn pluralize(noun: &str, n: usize) -> String {
 /// decide when a tool group closes: reasoning streamed between tool calls must
 /// not end the run (a reasoning model thinks before every call), only real
 /// answer text does.
-fn has_answer_text(buf: &str) -> bool {
+fn has_answer_text(model: &str, buf: &str) -> bool {
+    if is_native_tokamak(model) {
+        // Reasoning is out-of-band, so every token is answer prose: any content
+        // closes the tool group, same as non-reasoning models.
+        return !buf.trim().is_empty();
+    }
     split_reasoning(buf)
         .iter()
         .any(|(reasoning, seg)| !reasoning && !seg.trim().is_empty())
@@ -4198,7 +4228,12 @@ fn has_answer_text(buf: &str) -> bool {
 /// `text` with its reasoning removed, for the copy that goes into `history`.
 /// Reasoning is display-only and must never be resent to the model (see
 /// `SseAccumulator`); the display journal is what keeps it for a resume.
-pub(crate) fn answer_without_reasoning(text: &str) -> String {
+pub(crate) fn answer_without_reasoning(model: &str, text: &str) -> String {
+    if is_native_tokamak(model) {
+        // Reasoning is out-of-band: there is no ` thinking` tag to strip, and a
+        // literal one in the text is real content. Keep it verbatim.
+        return text.trim().to_string();
+    }
     split_reasoning(text)
         .into_iter()
         .filter_map(|(reasoning, seg)| (!reasoning).then_some(seg))
@@ -4318,7 +4353,10 @@ fn thinking_open(text: &str) -> bool {
 }
 
 /// True if `text` has any non-whitespace content in any reasoning/answer run.
-fn assistant_has_content(text: &str) -> bool {
+fn assistant_has_content(model: &str, text: &str) -> bool {
+    if is_native_tokamak(model) {
+        return !text.trim().is_empty();
+    }
     split_reasoning(text)
         .iter()
         .any(|(_, seg)| !seg.trim().is_empty())
@@ -7721,7 +7759,12 @@ fn draw(f: &mut Frame, app: &mut App) {
         }
     }
     if !app.assistant_buf.is_empty() {
-        let tail = live_assistant_lines(&app.assistant_buf, width, !app.show_reasoning);
+        let tail = live_assistant_lines(
+            &app.assistant_buf,
+            width,
+            !app.show_reasoning,
+            is_native_tokamak(&app.model),
+        );
         if !tail.is_empty() {
             // Mirror flush_assistant's `gap(Kind::Prose)` so the separator above
             // streaming prose is present live, not only once it's finalized.
@@ -7733,7 +7776,7 @@ fn draw(f: &mut Frame, app: &mut App) {
                 lines.push(Line::raw(""));
             }
             // Live tail: same renderer as finalized messages, so an open
-            // (unterminated) <think> block dims and grows during streaming.
+            // (unterminated)  thinking block dims and grows during streaming.
             lines.extend(tail);
         }
     }
@@ -9286,6 +9329,7 @@ mod tests {
         autoscroll_selection, selection_text, Selection, SelectionMode, COPY_NOTICE,
         run_command, starting_call_lines, unescape_partial_json_string,
         running_group_row, split_reasoning, strip_system_xml_tags, subagent_activity,
+        answer_without_reasoning, assistant_has_content, has_answer_text,
         subagent_name_from_run_id, summarize_result, tilde_path, tokens_per_second,
         tool_activity, tool_finished,
         transcript_top_padding, rewind_to,
@@ -10141,6 +10185,85 @@ mod tests {
     fn split_reasoning_handles_namespaced_and_unterminated_tags() {
         let segs = split_reasoning("<mm:think>reasoning tail");
         assert_eq!(segs, vec![(true, "reasoning tail".to_string())]);
+    }
+
+    #[test]
+    fn answer_without_reasoning_keeps_literal_tags_for_native_tokamak() {
+        let (o, c) = ('<', '>');
+        let text = format!("answer with {o}think{c}literal reasoning response{o}/think{c} tag");
+        // Non-native strips the tag; native keeps it verbatim.
+        assert_eq!(
+            answer_without_reasoning("gpt-5", &text),
+            "answer with  tag"
+        );
+        assert_eq!(
+            answer_without_reasoning("tokamak-1-preview", &text),
+            text.trim()
+        );
+    }
+
+    #[test]
+    fn has_answer_text_treats_native_tags_as_content() {
+        let (o, c) = ('<', '>');
+        // For a reasoning (non-native) model, a lone think block is not answer
+        // text, so it must not close a tool group.
+        let thinking_only = format!("{o}think{c}reasoning{o}/think{c}");
+        assert!(!has_answer_text("gpt-5", &thinking_only));
+        // Native Tokamak streams reasoning out-of-band: the tag is literal
+        // content, so even a tag-only buffer counts as answer prose.
+        assert!(has_answer_text("tokamak-1-preview", &thinking_only));
+        assert!(!has_answer_text("tokamak-1-preview", "   "));
+    }
+    #[test]
+    fn assistant_has_content_treats_native_tags_as_content() {
+        let (o, c) = ('<', '>');
+        let thinking_only = format!("{o}think{c}reasoning{o}/think{c}");
+        // Both paths count any non-whitespace content, including a literal
+        // think tag; the native branch just routes through the trimmed check.
+        assert!(assistant_has_content("gpt-5", &thinking_only));
+        assert!(assistant_has_content("tokamak-1-preview", &thinking_only));
+        assert!(!assistant_has_content("tokamak-1-preview", " "));
+    }
+    #[test]
+    fn token_stream_does_not_time_thinking_for_native_tokamak() {
+        let mut app = test_app();
+        app.model = "tokamak-1-preview".into();
+        let (o, c) = ('<', '>');
+        // An unterminated think tag is the state that would open a fold timer
+        // for a reasoning model; native must ignore it as literal content.
+        app.apply(StreamEvent::Token {
+            text: format!("{o}think{c}not reasoning"),
+        });
+        assert!(app.thinking_since.is_none(), "native tags must not set thinking_since");
+    }
+
+    #[test]
+    fn token_stream_times_thinking_for_reasoning_models() {
+        let mut app = test_app();
+        app.model = "gpt-5".into();
+        let (o, c) = ('<', '>');
+        app.apply(StreamEvent::Token {
+            text: format!("{o}think{c}reasoning"),
+        });
+        assert!(app.thinking_since.is_some(), "reasoning model opens a think window");
+    }
+
+    #[test]
+    fn push_assistant_blocks_renders_native_tag_as_prose() {
+        let (o, c) = ('<', '>');
+        let tagged = format!("{o}think{c}reasoning{o}/think{c}answer");
+        let mut native = test_app();
+        native.model = "tokamak-1-preview".into();
+        native.push_assistant_blocks(&tagged);
+        // The literal tag is content: nothing is folded into a reasoning block,
+        // and the whole buffer renders as one markdown prose row.
+        assert!(native.reasoning_blocks.is_empty(), "native tag must not fold");
+        assert!(!native.transcript.is_empty(), "tag must render as prose");
+
+        let mut reasoning = test_app();
+        reasoning.model = "gpt-5".into();
+        reasoning.push_assistant_blocks(&tagged);
+        assert_eq!(reasoning.reasoning_blocks.len(), 1, "non-native tag folds to a block");
     }
 
     #[test]

--- a/src-tauri/src/core/cli/tui/markdown.rs
+++ b/src-tauri/src/core/cli/tui/markdown.rs
@@ -6,8 +6,13 @@ use ratatui::prelude::*;
 
 /// Render assistant text to styled lines: reasoning dimmed, answer prose passed
 /// through markdown formatting. `width` bounds table wrapping.
-pub(super) fn format_assistant_lines(text: &str, width: u16) -> Vec<Line<'static>> {
+pub(super) fn format_assistant_lines(text: &str, width: u16, native: bool) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
+    // Native Tokamak never annotates reasoning with inline tags, so a ` thinking`
+    // tag is literal content: skip the split and format the whole text as prose.
+    if native {
+        return format_markdown_lines(text, width);
+    }
     for (reasoning, seg) in super::split_reasoning(text) {
         if reasoning {
             lines.extend(reasoning_detail_lines(&seg));
@@ -24,9 +29,14 @@ pub(super) fn format_assistant_lines(text: &str, width: u16) -> Vec<Line<'static
 /// `[thinking]` header state; once the tag closes (or prose begins) the rest
 /// renders as usual. When folding is off this is identical to
 /// `format_assistant_lines`, so the existing live-tail tests hold.
-pub(super) fn live_assistant_lines(text: &str, width: u16, fold_reasoning: bool) -> Vec<Line<'static>> {
-    if !fold_reasoning {
-        return format_assistant_lines(text, width);
+pub(super) fn live_assistant_lines(
+    text: &str,
+    width: u16,
+    fold_reasoning: bool,
+    native: bool,
+) -> Vec<Line<'static>> {
+    if !fold_reasoning || native {
+        return format_assistant_lines(text, width, native);
     }
     let mut lines = Vec::new();
     for (reasoning, seg) in super::split_reasoning(text) {


### PR DESCRIPTION
## Summary
- Agent TUI sessions default to medium reasoning effort and offer /effort plus F4 controls for supported models.
- Unsupported models omit the parameter and reset incompatible session state without changing conversation history.

## Verification
- `cargo test --no-default-features --features cli` - 773 passed.
- `cargo build --release --no-default-features --features cli --bin jan` - passed.
- Rebuilt TUI smoke test - gpt-5 header showed `effort medium`; `/effort high` reported the selected level.