### PR TITLE
feat(agent): stop obstructing the agent state dir when the bash sandbox is off

### DIFF
--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/commands.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/commands.rs
@@ -299,6 +299,7 @@ pub async fn execute_tool(
         Some(&scratch),
         &ToolPermissions::default(),
         &SessionGrants::default(),
+        true,
     ) {
         Decision::Allow => {}
         Decision::HardDeny(gate::DenyReason::Hidden) => {

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/gate.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/gate.rs
@@ -136,20 +136,25 @@ pub fn resolve_decision(
     scratch: Option<&Path>,
     perms: &ToolPermissions,
     grants: &SessionGrants,
+    hide_jan: bool,
 ) -> Decision {
     if perms.is_denied(tool.name) {
         return Decision::HardDeny(DenyReason::Policy);
     }
-    // Nothing under .jan is reachable: skills/memory only through their
-    // dedicated tools, config, threads and the dir listing not at all. Checked
-    // ahead of allow rules so an allowed tool name cannot bypass it.
-    let hits_hidden = tool.path_args.iter().any(|key| {
-        args.get(key)
-            .and_then(|v| v.as_str())
-            .map(|p| is_hidden_jan_path(project_root, p))
-            .unwrap_or(false)
-    });
-    let exec_hits_hidden = tool.capability == Capability::Exec
+    // Nothing under .jan is reachable while hidden: skills/memory only through
+    // their dedicated tools, config, threads and the dir listing not at all.
+    // Checked ahead of allow rules so an allowed tool name cannot bypass it.
+    // The whole check is skipped when not hiding, so an unconfined CLI run can
+    // read and edit its own `.jan` like any other project state.
+    let hits_hidden = hide_jan
+        && tool.path_args.iter().any(|key| {
+            args.get(key)
+                .and_then(|v| v.as_str())
+                .map(|p| is_hidden_jan_path(project_root, p))
+                .unwrap_or(false)
+        });
+    let exec_hits_hidden = hide_jan
+        && tool.capability == Capability::Exec
         && args
             .get("command")
             .and_then(|v| v.as_str())
@@ -266,6 +271,7 @@ mod tests {
             None,
             &perms,
             &grants,
+            true,
         );
         assert_eq!(d, Decision::Allow);
         let _ = std::fs::remove_dir_all(&root);
@@ -283,6 +289,7 @@ mod tests {
             None,
             &perms,
             &grants,
+            true,
         );
         assert_eq!(d, Decision::Prompt(PromptKind::ReadEscape));
         let _ = std::fs::remove_dir_all(&root);
@@ -301,6 +308,7 @@ mod tests {
                 None,
                 &perms,
                 &grants,
+                true,
             );
             assert_eq!(d, Decision::Allow, "{tool} should be auto-allowed");
         }
@@ -320,6 +328,7 @@ mod tests {
             None,
             &perms,
             &grants,
+            true,
         );
         assert_eq!(
             d,
@@ -345,6 +354,7 @@ mod tests {
                 None,
                 &perms,
                 &grants,
+                true,
             );
             assert_eq!(
                 d,
@@ -360,6 +370,7 @@ mod tests {
             None,
             &perms,
             &grants,
+            true,
         );
         assert_eq!(d, Decision::HardDeny(DenyReason::Hidden));
         // The instructions file is an ordinary project file at the root.
@@ -371,8 +382,49 @@ mod tests {
             None,
             &perms,
             &grants,
+            true,
         );
         assert_eq!(d, Decision::Allow);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn hidden_jan_is_reachable_when_not_hiding() {
+        let root = unique_root();
+        std::fs::create_dir_all(root.join(".jan/agent")).unwrap();
+        std::fs::write(root.join(".jan/agent/agent.toml"), b"[tools]\n").unwrap();
+        let perms = ToolPermissions::allow_all();
+        let grants = SessionGrants::default();
+        // With hiding off, paths and commands under `.jan` take the ordinary
+        // capability path instead of the hard deny (here an in-project read
+        // allows; the write prompts like any in-project write).
+        for tool in ["read", "ls", "find", "grep", "write", "edit"] {
+            let d = resolve_decision(
+                lookup(tool).unwrap(),
+                &json!({ "path": ".jan/agent/agent.toml" }),
+                &root,
+                None,
+                &perms,
+                &grants,
+                false,
+            );
+            assert_ne!(
+                d,
+                Decision::HardDeny(DenyReason::Hidden),
+                "{tool} must not hard-deny .jan when not hiding"
+            );
+        }
+        // bash referencing it is a normal exec prompt, not a hidden deny.
+        let d = resolve_decision(
+            lookup("bash").unwrap(),
+            &json!({"command": "cat .jan/agent/agent.toml"}),
+            &root,
+            None,
+            &perms,
+            &grants,
+            false,
+        );
+        assert_ne!(d, Decision::HardDeny(DenyReason::Hidden));
         let _ = std::fs::remove_dir_all(&root);
     }
 
@@ -388,6 +440,7 @@ mod tests {
             None,
             &perms,
             &grants,
+            true,
         );
         assert_eq!(d, Decision::Prompt(PromptKind::Write));
         let _ = std::fs::remove_dir_all(&root);
@@ -405,6 +458,7 @@ mod tests {
             None,
             &perms,
             &grants,
+            true,
         );
         assert_eq!(d, Decision::Prompt(PromptKind::Exec));
         let _ = std::fs::remove_dir_all(&root);
@@ -422,6 +476,7 @@ mod tests {
             None,
             &perms,
             &grants,
+            true,
         );
         assert_eq!(d, Decision::Allow);
         let _ = std::fs::remove_dir_all(&root);
@@ -451,6 +506,7 @@ mod tests {
             None,
             &perms,
             &grants,
+            true,
         );
         assert_eq!(d, Decision::Allow);
 
@@ -462,6 +518,7 @@ mod tests {
             None,
             &perms,
             &grants,
+            true,
         );
         assert_eq!(d, Decision::Prompt(PromptKind::Exec));
         let _ = std::fs::remove_dir_all(&root);
@@ -487,6 +544,7 @@ mod tests {
                 None,
                 &perms,
                 &grants,
+                true,
             );
             assert_eq!(d, Decision::Prompt(PromptKind::Exec), "must reprompt: {cmd}");
         }
@@ -508,6 +566,7 @@ mod tests {
                 None,
                 &perms,
                 &grants,
+                true,
             );
             assert_eq!(d, Decision::Allow, "should be covered: {cmd}");
         }
@@ -529,6 +588,7 @@ mod tests {
             None,
             &perms,
             &grants,
+            true,
         );
         assert_eq!(d, Decision::Allow);
 
@@ -540,6 +600,7 @@ mod tests {
             None,
             &perms,
             &grants,
+            true,
         );
         assert_eq!(d, Decision::Prompt(PromptKind::Exec));
         let _ = std::fs::remove_dir_all(&root);
@@ -566,6 +627,7 @@ mod tests {
                     None,
                     &perms,
                     &grants,
+                    true,
                 );
                 assert_eq!(
                     d,
@@ -590,6 +652,7 @@ mod tests {
                 None,
                 &perms,
                 &grants,
+                true,
             );
             assert_eq!(d, Decision::Allow, "{name} should auto-allow");
         }
@@ -602,6 +665,7 @@ mod tests {
             None,
             &denied,
             &grants,
+            true,
         );
         assert_eq!(d, Decision::HardDeny(DenyReason::Policy));
         let _ = std::fs::remove_dir_all(&root);
@@ -619,6 +683,7 @@ mod tests {
             None,
             &perms,
             &grants,
+            true,
         );
         assert_eq!(d, Decision::HardDeny(DenyReason::Policy));
         let _ = std::fs::remove_dir_all(&root);
@@ -636,6 +701,7 @@ mod tests {
             None,
             &perms,
             &grants,
+            true,
         );
         assert_eq!(d, Decision::Allow);
         let _ = std::fs::remove_dir_all(&root);
@@ -654,6 +720,7 @@ mod tests {
             None,
             &perms,
             &grants,
+            true,
         );
         assert_eq!(d, Decision::Allow);
         let _ = std::fs::remove_dir_all(&root);
@@ -672,6 +739,7 @@ mod tests {
             None,
             &perms,
             &grants,
+            true,
         );
         assert_eq!(d, Decision::Allow);
         let _ = std::fs::remove_dir_all(&root);
@@ -689,6 +757,7 @@ mod tests {
             None,
             &perms,
             &grants,
+            true,
         );
         assert_eq!(d, Decision::Prompt(PromptKind::Write));
         let _ = std::fs::remove_dir_all(&root);
@@ -708,6 +777,7 @@ mod tests {
                 None,
                 &perms,
                 &grants,
+                true,
             );
             assert_eq!(d, Decision::Prompt(PromptKind::WriteEscape), "{}", path);
         }
@@ -727,6 +797,7 @@ mod tests {
             None,
             &perms,
             &grants,
+            true,
         );
         assert_eq!(d, Decision::Allow);
         let _ = std::fs::remove_dir_all(&root);
@@ -744,6 +815,7 @@ mod tests {
             None,
             &perms,
             &grants,
+            true,
         );
         assert_eq!(d, Decision::Prompt(PromptKind::ReadEscape));
         let _ = std::fs::remove_dir_all(&root);

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/handlers.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/handlers.rs
@@ -130,12 +130,12 @@ pub async fn execute_builtin(
     let scratch = ctx.scratch_root;
     match tool.name {
         "read" => read(args, project_root, scratch).await,
-        "ls" => ls(args, project_root, scratch).await,
+        "ls" => ls(args, project_root, scratch, ctx.sandbox).await,
         "write" => write(args, project_root, scratch, ctx.confine_writes).await,
         "edit" => edit(args, project_root, scratch, ctx.confine_writes).await,
         "bash" => bash(args, ctx).await,
-        "find" => find(args, project_root, scratch).await,
-        "grep" => grep(args, project_root, scratch).await,
+        "find" => find(args, project_root, scratch, ctx.sandbox).await,
+        "grep" => grep(args, project_root, scratch, ctx.sandbox).await,
         // Memory and skills live in the store root, not the sandbox: they must
         // outlive the conversation the filesystem tools are scoped to.
         "memory_list" => memory_list(ctx.store_root).await,
@@ -496,7 +496,7 @@ async fn read(args: &serde_json::Value, root: &Path, scratch: Option<&Path>) -> 
     )
 }
 
-async fn ls(args: &serde_json::Value, root: &Path, scratch: Option<&Path>) -> String {
+async fn ls(args: &serde_json::Value, root: &Path, scratch: Option<&Path>, hide_jan: bool) -> String {
     let path = arg_str(args, "path").unwrap_or(".");
     let limit = arg_u64(args, "limit")
         .map(|v| v as usize)
@@ -515,8 +515,9 @@ async fn ls(args: &serde_json::Value, root: &Path, scratch: Option<&Path>) -> St
         match entries.next_entry().await {
             Ok(Some(entry)) => {
                 // Hidden state is omitted, not reported-then-denied: an entry the
-                // agent can never open is only an invitation to try.
-                if is_hidden_jan_path(root, &entry.path().to_string_lossy()) {
+                // agent can never open is only an invitation to try. Skipped when
+                // not hiding, so an unconfined CLI run sees its own `.jan`.
+                if hide_jan && is_hidden_jan_path(root, &entry.path().to_string_lossy()) {
                     continue;
                 }
                 let mut name = entry.file_name().to_string_lossy().into_owned();
@@ -654,8 +655,14 @@ async fn bash(args: &serde_json::Value, ctx: &ToolContext<'_>) -> String {
     }
 
     let mut policy = jail::Policy::new(root, ctx.allow_network)
-        .with_home_readonly(ctx.home_readonly)
-        .with_hide_root(&root.join(crate::tools::sandbox::JAN_DIR));
+        .with_home_readonly(ctx.home_readonly);
+    // While the shell is sandboxed, hide the project's own `.jan` state directory
+    // from it (see [`Policy::with_hide_root`]). When the shell runs unconfined the
+    // hide is both pointless (there is no OS mount to layer it on) and wrong
+    // (the agent should see its own state), so it is only applied when sandboxed.
+    if ctx.sandbox {
+        policy = policy.with_hide_root(&root.join(crate::tools::sandbox::JAN_DIR));
+    }
     if let Some(mask) = ctx.mask_root {
         policy = policy.with_mask_root(mask);
     }
@@ -1038,7 +1045,7 @@ fn remove_spill_file(path: &Path) {
     let _ = std::fs::remove_file(path);
 }
 
-async fn find(args: &serde_json::Value, root: &Path, scratch: Option<&Path>) -> String {
+async fn find(args: &serde_json::Value, root: &Path, scratch: Option<&Path>, hide_jan: bool) -> String {
     let pattern = arg_str(args, "pattern").map(String::from);
     let path = arg_str(args, "path").unwrap_or(".").to_string();
     let limit = arg_u64(args, "limit")
@@ -1073,7 +1080,7 @@ async fn find(args: &serde_json::Value, root: &Path, scratch: Option<&Path>) -> 
             if entry.file_type().map(|t| t.is_dir()).unwrap_or(true) {
                 continue;
             }
-            if is_hidden_jan_path(&root_owned, &entry.path().to_string_lossy()) {
+            if hide_jan && is_hidden_jan_path(&root_owned, &entry.path().to_string_lossy()) {
                 continue;
             }
             let rel = rel_to(&base, entry.path());
@@ -1094,7 +1101,7 @@ async fn find(args: &serde_json::Value, root: &Path, scratch: Option<&Path>) -> 
     res.unwrap_or_else(|e| format!("ERROR: {e}"))
 }
 
-async fn grep(args: &serde_json::Value, root: &Path, scratch: Option<&Path>) -> String {
+async fn grep(args: &serde_json::Value, root: &Path, scratch: Option<&Path>, hide_jan: bool) -> String {
     let pattern = arg_str(args, "pattern").map(String::from);
     let path = arg_str(args, "path").unwrap_or(".").to_string();
     let glob_filter = arg_str(args, "glob").map(String::from);
@@ -1209,7 +1216,7 @@ async fn grep(args: &serde_json::Value, root: &Path, scratch: Option<&Path>) -> 
                 {
                     continue;
                 }
-                if is_hidden_jan_path(&root_owned, &entry.path().to_string_lossy()) {
+                if hide_jan && is_hidden_jan_path(&root_owned, &entry.path().to_string_lossy()) {
                     continue;
                 }
                 if !search_file(entry.path(), &base) {
@@ -2080,6 +2087,7 @@ mod tests {
             Some(&scratch),
             &crate::permissions::ToolPermissions::default(),
             &crate::tools::gate::SessionGrants::default(),
+            true,
         );
         assert_eq!(
             d,
@@ -2107,6 +2115,7 @@ mod tests {
             Some(&scratch),
             &crate::permissions::ToolPermissions::default(),
             &crate::tools::gate::SessionGrants::default(),
+            true,
         );
         assert_eq!(
             d,
@@ -2153,6 +2162,22 @@ mod tests {
         assert!(out.contains("src.rs"), "unexpected: {out}");
         assert!(out.contains("JAN.md"), "unexpected: {out}");
         assert!(!out.contains(".jan/"), "must not list the agent state dir: {out}");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// When the shell is unconfined (CLI with --no-sandbox) the `.jan` directory
+    /// is ordinary project state and is listed, not hidden.
+    #[tokio::test]
+    async fn ls_lists_the_jan_dir_when_unconfined() {
+        let root = unique_root();
+        std::fs::create_dir_all(root.join(".jan/agent")).unwrap();
+        std::fs::write(root.join(".jan/agent/agent.toml"), b"[tools]\n").unwrap();
+        std::fs::write(root.join("src.rs"), b"x").unwrap();
+        let store = crate::workspace::project_store(&root);
+        let ctx = ToolContext::new(&root, &store, &[]).with_sandbox(false);
+        let out = super::execute_builtin(lookup("ls").unwrap(), &json!({}), &ctx).await;
+        assert!(out.contains("src.rs"), "unexpected: {out}");
+        assert!(out.contains(".jan/"), "must list .jan when unconfined: {out}");
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -800,10 +800,11 @@ impl ToolInvoker for CompositeToolInvoker {
                 Some(self.scratch_root.as_path()),
                 &self.permissions,
                 &snapshot,
+                self.sandbox,
             );
             // Auto-approval suppresses every prompt (sandbox escape, write, exec) but
-            // still honors HardDeny, so the hidden `.jan` invariant and explicit
-            // agent.toml denies hold.
+            // still honors HardDeny, so the hidden `.jan` invariant (while the shell
+            // is sandboxed) and explicit agent.toml denies hold.
             let decision = match decision {
                 Decision::Prompt(_) if self.auto_approve => Decision::Allow,
                 other => other,


### PR DESCRIPTION
## Describe Your Changes
When the shell runs unconfined (CLI with --no-sandbox or sandbox = false), hiding the agent's own state directory is both pointless (there is no OS mount to layer the hide on) and wrong (the agent should see the project state it works with). Tie the hiding to the sandbox flag across all four enforcement points:

- gate: resolve_decision takes hide_jan; the hidden-path and command hard-denies only run while hiding.
- handlers: ls/find/grep skip the is_hidden_jan_path filter when not hiding; bash only applies with_hide_root while sandboxed.
- Desktop (commands.rs) stays hidden: it passes true. The CLI (loop.rs) passes self.sandbox, so the state dir becomes reachable when unconfined.

Tests: gate no longer hard-denies the state dir when not hiding; ls lists it when unconfined.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
