### PR TITLE
fix(agent-cli): support aarch64 linux in install script

### DIFF
--- a/scripts/install-jan-agent.sh
+++ b/scripts/install-jan-agent.sh
@@ -56,9 +56,17 @@ detect_platform() {
   arch="$(uname -m)"
   case "$os" in
     Linux)
-      [ "$arch" = "x86_64" ] || die "no published build for Linux $arch; use --source"
-      PLATFORM_KEY="linux-x86_64"
-      ARCHIVE_SLUG="linux-x86_64"
+      case "$arch" in
+        x86_64)
+          PLATFORM_KEY="linux-x86_64"
+          ARCHIVE_SLUG="linux-x86_64"
+          ;;
+        aarch64)
+          PLATFORM_KEY="linux-aarch64"
+          ARCHIVE_SLUG="linux-aarch64"
+          ;;
+        *) die "no published build for Linux $arch; use --source" ;;
+      esac
       ARCHIVE_EXT="tar.gz"
       ;;
     Darwin)


### PR DESCRIPTION
## Describe Your Changes
The installer previously refused to install a published build on Linux aarch64. Now that the agent CLI ships a linux-aarch64 nightly, resolve aarch64 to that build instead of bailing with the --source fallback.

Depends on #8682

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
