### PR TITLE
fix(web-app): let the custom Jinja chat template textarea grow/resize

### DIFF
--- a/web-app/src/containers/dynamicControllerSetting/TextareaControl.tsx
+++ b/web-app/src/containers/dynamicControllerSetting/TextareaControl.tsx
@@ -24,7 +24,7 @@ export function TextareaControl({
       value={value}
       onChange={(e) => onChange(e.target.value)}
       rows={rows}
-      className={cn('w-full resize-none')}
+      className={cn('w-full max-h-[420px] resize-y overflow-y-auto')}
       spellCheck={spellCheckChatInput}
       data-gramm={spellCheckChatInput}
       data-gramm_editor={spellCheckChatInput}

--- a/web-app/src/containers/dynamicControllerSetting/__tests__/TextareaControl.test.tsx
+++ b/web-app/src/containers/dynamicControllerSetting/__tests__/TextareaControl.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { TextareaControl } from '../TextareaControl'
+
+describe('TextareaControl', () => {
+  it('does not disable manual resize, so long content (e.g. Jinja templates) can be expanded into view', () => {
+    render(
+      <TextareaControl
+        value="{% for message in messages %}...{% endfor %}"
+        onChange={vi.fn()}
+      />
+    )
+
+    const textarea = screen.getByRole('textbox')
+    // `resize-none` combined with a fixed row count truncates long
+    // custom Jinja chat templates on webviews that don't support
+    // `field-sizing: content` (see issue #8672). The control must allow
+    // the user to grow the box instead of hard-locking its size.
+    expect(textarea).not.toHaveClass('resize-none')
+    expect(textarea).toHaveClass('resize-y')
+  })
+
+  it('caps growth with a scrollable max height instead of growing unbounded', () => {
+    render(<TextareaControl value="long template" onChange={vi.fn()} />)
+
+    const textarea = screen.getByRole('textbox')
+    expect(textarea).toHaveClass('max-h-[420px]')
+    expect(textarea).toHaveClass('overflow-y-auto')
+  })
+
+  it('respects a custom rows value passed by the caller', () => {
+    render(<TextareaControl value="" onChange={vi.fn()} rows={10} />)
+
+    const textarea = screen.getByRole('textbox')
+    expect(textarea).toHaveAttribute('rows', '10')
+  })
+})

--- a/web-app/src/lib/predefined.ts
+++ b/web-app/src/lib/predefined.ts
@@ -132,6 +132,7 @@ export const modelSettings = {
         'e.g., {% for message in messages %}...{% endfor %} (default is read from GGUF)',
       type: 'text',
       textAlign: 'right',
+      rows: 10,
     },
   },
   cpu_moe: {


### PR DESCRIPTION
## Describe Your Changes

- The "Custom Jinja Chat template" textarea (Model Settings) relies solely on Tailwind's `field-sizing-content` utility to auto-grow with input. That CSS property isn't supported on every webview Tauri ships on (e.g. WebKit-based ones), and where it falls back the box stayed locked at a fixed `rows=4` with `resize-none`, so longer custom Jinja templates appeared cut off with no way to see or edit the rest.
- `TextareaControl` now allows manual vertical resize (`resize-y`) with a bounded, scrollable max height (`max-h-[420px] overflow-y-auto`) as a fallback that works regardless of `field-sizing-content` support, instead of hard-locking the box size.
- The `chat_template` setting now defaults to `rows: 10` instead of 4, since Jinja templates are typically multi-line.
- Added a unit test (`TextareaControl.test.tsx`) that fails against the previous `resize-none`/no-max-height classes and passes with the fix.

## Fixes Issues

- Closes #8672

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed