### PR TITLE
fix(server): don't panic on Cyrillic chat bodies

### DIFF
--- a/src-tauri/src/core/server/proxy.rs
+++ b/src-tauri/src/core/server/proxy.rs
@@ -296,7 +296,10 @@ pub(crate) fn transform_anthropic_to_openai(body: &serde_json::Value) -> Option<
 ///   wrapped: "x-anthropic-billing-header:\n   cc_version=…;\n<prompt>"
 pub(crate) fn strip_anthropic_billing_header(text: &str) -> &str {
     const KEY: &str = "x-anthropic-billing-header:";
-    if text.len() < KEY.len() || !text[..KEY.len()].eq_ignore_ascii_case(KEY) {
+    if !text
+        .get(..KEY.len())
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case(KEY))
+    {
         return text;
     }
     let first_nl = match text.find('\n') {

--- a/src-tauri/src/core/server/tests.rs
+++ b/src-tauri/src/core/server/tests.rs
@@ -1136,6 +1136,43 @@ mod server_tests {
         assert_eq!(proxy::strip_anthropic_billing_header(other), other);
     }
 
+    // The crashing system prompt from https://github.com/janhq/jan/issues/8358.
+    // `x-anthropic-billing-header:` is 27 bytes; byte 27 of this string sits
+    // inside a 2-byte Cyrillic character, so a raw `text[..27]` slice panics.
+    const CYRILLIC_CRASHING_SYSTEM: &str = "Ты извлекаешь финансовую";
+
+    #[test]
+    fn strip_billing_header_does_not_panic_on_cyrillic_system_prompt() {
+        const KEY_LEN: usize = "x-anthropic-billing-header:".len();
+        assert!(
+            CYRILLIC_CRASHING_SYSTEM.len() >= KEY_LEN
+                && !CYRILLIC_CRASHING_SYSTEM.is_char_boundary(KEY_LEN),
+            "fixture must land KEY_LEN inside a multi-byte character"
+        );
+
+        assert_eq!(
+            proxy::strip_anthropic_billing_header(CYRILLIC_CRASHING_SYSTEM),
+            CYRILLIC_CRASHING_SYSTEM
+        );
+        // A one-byte shift makes KEY_LEN a char boundary; that path must stay a no-op too.
+        let shifted = format!(" {CYRILLIC_CRASHING_SYSTEM}");
+        assert_eq!(proxy::strip_anthropic_billing_header(&shifted), shifted);
+
+        let mut body = json!({
+            "model": "Jan-v3_5-4B-Q4_K_M",
+            "max_tokens": 16,
+            "messages": [
+                { "role": "system", "content": CYRILLIC_CRASHING_SYSTEM },
+                { "role": "user", "content": "Hello" }
+            ]
+        });
+        proxy::strip_billing_header_in_body(&mut body);
+        assert_eq!(
+            body["messages"][0]["content"],
+            json!(CYRILLIC_CRASHING_SYSTEM)
+        );
+    }
+
     #[test]
     fn strip_billing_header_in_body_covers_system_and_first_message() {
         let header = "x-anthropic-billing-header: cc_version=1; cch=z;\n";


### PR DESCRIPTION
## Describe Your Changes

`strip_anthropic_billing_header` looks for a 27-byte ASCII prefix (`x-anthropic-billing-header:`) with a raw `&str` slice. That prefix check runs on every `/v1/chat/completions` body (system / first message) before the model id is extracted.

If the text is ordinary UTF-8 whose 27th byte is not a character boundary — the system prompt from #8358, `Ты извлекаешь финансовую`, is the case that was reported — Rust panics (`byte index 27 is not a char boundary`). The handler dies, so the client sees a dropped connection and no HTTP response.

The slice is replaced with `str::get`, which returns `None` on a non-boundary instead of panicking. Content that is not the billing header is left unchanged, including the reported Cyrillic prompt. Existing billing-header strip tests still cover the real prefix.

## Fixes Issues

- Closes #8358

## Self Checklist

- [x] Added a regression test that uses the crashing body from #8358
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

## Testing

The full Tauri crate is too large to link in this environment. The new unit test (and the existing billing-header cases) were run with `rustc --test` against a copy of `strip_anthropic_billing_header` that matches this change:

```
end byte index 27 is not a char boundary; it is inside 'ф' (bytes 26..28 of string)
```

before the fix; 3/3 pass after. The same test is in `src-tauri/src/core/server/tests.rs` (`strip_billing_header_does_not_panic_on_cyrillic_system_prompt`).


Made with [Cursor](https://cursor.com)