### PR TITLE
fix(agent-tools): resolve bash and bwrap via PATH for NixOS

### DIFF
--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/jail.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/jail.rs
@@ -258,6 +258,11 @@ pub fn wrap(cfg: &ShellConfig, policy: &Policy) -> Option<ShellConfig> {
 // bubblewrap (Linux)
 // ---------------------------------------------------------------------------
 
+/// The fixed FHS locations are preferred so a directory prepended to `PATH`
+/// cannot shadow the system bwrap; `PATH` is the fallback for distros with no
+/// FHS layout at all (NixOS keeps bwrap only at a Nix-store path). A planted
+/// `bwrap` found via `PATH` gains nothing: it runs as the same user, and
+/// [`bwrap_usable`]'s live probe still has to pass before it is trusted.
 #[cfg(target_os = "linux")]
 fn bwrap_path() -> Option<PathBuf> {
     static PATH: OnceLock<Option<PathBuf>> = OnceLock::new();
@@ -266,6 +271,7 @@ fn bwrap_path() -> Option<PathBuf> {
             .into_iter()
             .map(PathBuf::from)
             .find(|p| p.is_file())
+            .or_else(|| super::proc::which("bwrap"))
     })
     .clone()
 }

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/proc.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/proc.rs
@@ -50,15 +50,22 @@ fn resolve_shell() -> ShellConfig {
     }
     #[cfg(unix)]
     {
-        if Path::new("/bin/bash").exists() {
-            return c("/bin/bash", &["-c"]);
-        }
+        // Prefer the bash on `PATH` over the fixed `/bin/bash`: on NixOS the
+        // shell lives only at a Nix-store path resolved via `which`, so a
+        // hardcoded `/bin/bash` does not exist there and the fixed path would be
+        // wrong.
+        // `/bin/bash` stays as the fallback for systems where `which` is absent
+        // or `PATH` is degenerate but `/bin/bash` is real (e.g. cron); `/bin/sh`
+        // is the guaranteed-POSIX last resort.
         if let Some(p) = which("bash") {
             return ShellConfig {
                 program: p,
                 args: vec!["-c".to_string()],
                 via_stdin: false,
             };
+        }
+        if Path::new("/bin/bash").exists() {
+            return c("/bin/bash", &["-c"]);
         }
         c("/bin/sh", &["-c"])
     }
@@ -100,8 +107,10 @@ fn resolve_shell() -> ShellConfig {
     }
 }
 
-/// Locate an executable on PATH via the platform's own resolver.
-fn which(name: &str) -> Option<PathBuf> {
+/// Locate an executable on PATH via the platform's own resolver. Also used by
+/// [`super::jail`] to find `bwrap` on distros with no FHS paths (NixOS keeps it
+/// only at a Nix-store path).
+pub(crate) fn which(name: &str) -> Option<PathBuf> {
     #[cfg(unix)]
     let finder = "which";
     #[cfg(windows)]


### PR DESCRIPTION
## Describe Your Changes

The bash tool resolved unix shells by checking the fixed /bin/bash first, and bwrap was probed only at FHS paths (/usr/bin/bwrap, /bin/bwrap, /usr/local/bin/bwrap). Neither exists on NixOS, where both live only at Nix-store paths reachable via PATH.

- resolve_shell (unix): prefer which('bash') over /bin/bash, keeping /bin/bash and /bin/sh as fallbacks. which() is now pub(crate).
- bwrap_path (linux): keep the FHS paths first so a PATH-prepended dir cannot shadow the system bwrap, then fall back to which('bwrap') for distros with no FHS layout. A planted PATH bwrap gains nothing (same user) and must still pass the live bwrap_usable() probe.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
