### PR TITLE
feat: enable MiniMax-M3 video input in the remote attachment pipeline

### DIFF
--- a/web-app/src/constants/models.ts
+++ b/web-app/src/constants/models.ts
@@ -109,12 +109,16 @@ export const providerModels = {
     supportsN: true,
   },
   minimax: {
-    models: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
+    models: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed', 'MiniMax-M3'],
     supportsCompletion: true,
-    supportsStreaming: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
+    supportsStreaming: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed', 'MiniMax-M3'],
     supportsJSON: [],
-    supportsImages: [],
-    supportsToolCalls: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed'],
+    supportsImages: ['MiniMax-M3'],
+    // Video input is opt-in per model. `supportsVideo` is only declared for
+    // providers that accept video parts; a missing key reads as "no model here
+    // takes video input" (see getModelCapabilities).
+    supportsVideo: ['MiniMax-M3'],
+    supportsToolCalls: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed', 'MiniMax-M2.5', 'MiniMax-M2.5-highspeed', 'MiniMax-M3'],
     supportsN: true,
   },
   openrouter: {

--- a/web-app/src/constants/providers.ts
+++ b/web-app/src/constants/providers.ts
@@ -325,6 +325,14 @@ export const predefinedProviders = [
         description: 'Same performance, faster and more agile. 204K context window.',
         capabilities: ['completion', 'tools'],
       },
+      {
+        id: 'MiniMax-M3',
+        name: 'MiniMax-M3',
+        version: '1.0',
+        description:
+          'Multimodal model that accepts text, image and video input. 1M context window.',
+        capabilities: ['completion', 'tools', 'vision', 'video'],
+      },
     ],
   },
   {

--- a/web-app/src/containers/Capabilities.tsx
+++ b/web-app/src/containers/Capabilities.tsx
@@ -11,6 +11,7 @@ import {
   IconWorld,
   IconCodeCircle2,
   IconHeadphones,
+  IconVideo,
 } from '@tabler/icons-react'
 import { Fragment, memo } from 'react'
 
@@ -38,6 +39,8 @@ const Capabilities = memo(function Capabilities({ capabilities }: CapabilitiesPr
           icon = <IconEye className="size-4" />
         } else if (capability === 'audio') {
           icon = <IconHeadphones className="size-3.5" />
+        } else if (capability === 'video') {
+          icon = <IconVideo className="size-3.5" />
         } else if (capability === 'tools') {
           icon = <IconTool className="size-3.5" />
         } else if (capability === 'reasoning') {

--- a/web-app/src/lib/__tests__/models.test.ts
+++ b/web-app/src/lib/__tests__/models.test.ts
@@ -381,4 +381,26 @@ describe('getModelCapabilities', () => {
     expect(capabilities).toContain(ModelCapabilities.TOOLS)
     expect(capabilities).not.toContain(ModelCapabilities.VISION)
   })
+
+  it('includes video capability when the model accepts video input', () => {
+    const capabilities = getModelCapabilities('minimax', 'MiniMax-M3')
+    expect(capabilities).toContain(ModelCapabilities.COMPLETION)
+    expect(capabilities).toContain(ModelCapabilities.TOOLS)
+    expect(capabilities).toContain(ModelCapabilities.VISION)
+    expect(capabilities).toContain(ModelCapabilities.VIDEO)
+  })
+
+  it('excludes video capability from text-only models of the same provider', () => {
+    const capabilities = getModelCapabilities('minimax', 'MiniMax-M2.7')
+    expect(capabilities).toContain(ModelCapabilities.COMPLETION)
+    expect(capabilities).toContain(ModelCapabilities.TOOLS)
+    expect(capabilities).not.toContain(ModelCapabilities.VISION)
+    expect(capabilities).not.toContain(ModelCapabilities.VIDEO)
+  })
+
+  it('omits video capability for providers without a supportsVideo list', () => {
+    const capabilities = getModelCapabilities('openai', 'gpt-4o')
+    expect(capabilities).toContain(ModelCapabilities.VISION)
+    expect(capabilities).not.toContain(ModelCapabilities.VIDEO)
+  })
 })

--- a/web-app/src/lib/models.ts
+++ b/web-app/src/lib/models.ts
@@ -35,10 +35,22 @@ export const getModelCapabilities = (
     ? (providerConfig.supportsImages as unknown as string[])
     : []
 
+  // `supportsVideo` is optional on the provider table — only entries with at
+  // least one video-input model declare it, so read it defensively.
+  const supportsVideoList = (
+    providerConfig as unknown as
+      | { supportsVideo?: readonly string[] }
+      | undefined
+  )?.supportsVideo
+  const supportsVideo = Array.isArray(supportsVideoList)
+    ? (supportsVideoList as string[])
+    : []
+
   return [
     ModelCapabilities.COMPLETION,
     supportsToolCalls.includes(modelId) ? ModelCapabilities.TOOLS : undefined,
     supportsImages.includes(modelId) ? ModelCapabilities.VISION : undefined,
+    supportsVideo.includes(modelId) ? ModelCapabilities.VIDEO : undefined,
   ].filter(Boolean) as string[]
 }
 

--- a/web-app/src/types/models.ts
+++ b/web-app/src/types/models.ts
@@ -15,4 +15,5 @@ export enum ModelCapabilities {
   AUDIO_TO_TEXT = 'audio_to_text',
   // Need to consolidate the capabilities list
   VISION = 'vision',
+  VIDEO = 'video',
 }


### PR DESCRIPTION
Reason: MiniMax-M3 accepts image and video input, but the provider capability table could not express video input at all, so the existing attachment pipeline kept the video picker disabled for it.

## What is missing today

`web-app/src/containers/ChatInput.tsx` already has a complete video attachment
path — a video picker, MIME/extension validation, a 100MB size guard and video
`file` parts appended to the outgoing message. It is gated on
`selectedModel.capabilities.includes('video')`.

For built-in cloud providers, those capabilities are not read from
`predefinedProviders`. `TauriProvidersService.getProviders()` rebuilds every
built-in model from `providerModels` and overwrites `capabilities` with
`getModelCapabilities(provider, modelId)`. That helper only ever derives
`completion`, `tools` and `vision`, and `providerModels` has no video column,
so no built-in cloud model could reach the video path.

## Changes

- `web-app/src/types/models.ts`: add `VIDEO = 'video'` to `ModelCapabilities`,
  matching the `'video'` string the chat input and the Edit Model dialog
  already use.
- `web-app/src/constants/models.ts`: add an optional `supportsVideo` list to
  the MiniMax entry and register `MiniMax-M3` there, in `supportsImages`,
  `supportsStreaming`, `supportsToolCalls` and `models`. `MiniMax-M3` is
  appended, so `defaultModel('minimax')` is unchanged. The other MiniMax
  models stay text-only.
- `web-app/src/lib/models.ts`: derive `ModelCapabilities.VIDEO` from
  `supportsVideo`. The list is read defensively, so provider entries without
  the key keep their current capabilities.
- `web-app/src/constants/providers.ts`: add the `MiniMax-M3` manifest entry
  (name, version, description) with `completion`, `tools`, `vision` and
  `video`.
- `web-app/src/containers/Capabilities.tsx`: render an icon for the `video`
  capability. It was the only capability the chat input honours that had no
  chip, so video-capable models showed a gap in the model picker.
- `web-app/src/lib/__tests__/models.test.ts`: three cases covering video
  derivation for a video-input model, a text-only model of the same provider,
  and a provider with no `supportsVideo` list.

`useReconcileVideoCapability` returns early for non-`llamacpp` providers, so
the declared capability is not overwritten at runtime. New model ids are added
to an existing store through the non-persisted merge branch in
`setProviders`, so no store migration is needed.

## Checks

Full workspace install was not available in this environment, so the runs below
used the versions pinned in `web-app/package.json` against the repository's own
`web-app/vitest.config.ts` and `web-app/eslint.config.js`.

- `vitest run src/lib/__tests__/models.test.ts` — 52 passed (49 existing, 3 new)
- `vitest run src/lib/__tests__/providerReadiness.test.ts` — 18 passed
- `tsc --noEmit` with the `tsconfig.app.json` compiler options over
  `lib/models.ts`, `constants/models.ts` and `types/models.ts` — clean
- `eslint` over the five changed source files — clean
