### PR TITLE
fix(agent-tui): Enhance tool call history, input placeholders, and rendering

### DIFF
--- a/docs/src/pages/docs/agent/console.mdx
+++ b/docs/src/pages/docs/agent/console.mdx
@@ -60,6 +60,28 @@ in, so you can see what's being produced before it lands. <kbd>Esc</kbd> cancels
 Type while it's working and your message queues rather than being dropped - see
 [Sessions](/docs/agent/sessions#queueing).
 
+## Reasoning
+
+While a model works it may emit a chain of thought before it lands on an answer. By default the
+console folds that reasoning into a summary row instead of dumping it into the transcript. The
+header shows where it is: `[thinking]` while a reasoning block streams, then `[thought for Ns]`
+once it closes. With folding on, an open block also streams its last few lines into the live tail,
+so you can watch the thought form without pushing the answer off the screen.
+
+<kbd>Ctrl</kbd>+<kbd>O</kbd> expands every folded reasoning block, or click a row to expand just
+that one.
+
+Two knobs in `agent.toml` and two in `~/.jan/config.toml` tune this:
+
+| Key | Where | Default | What it does |
+| --- | --- | --- | --- |
+| `[agent].show_reasoning` | `agent.toml` | `false` | Unfold every reasoning block in the transcript by default. Still folds when off; <kbd>Ctrl</kbd>+<kbd>O</kbd> or a click expands a block either way |
+| `[agent].send_reasoning` | `agent.toml` | `true` | Resend a prior turn's reasoning to the model with the conversation. Turn off for an upstream that rejects the field (Groq), or to keep chains of thought out of the context budget |
+| `think_tags` | `~/.jan/config.toml` | `true` | Treat `<thinking>` tags in model content as reasoning (folded and resendable). Off renders them as ordinary prose |
+| `stream_reasoning` | `~/.jan/config.toml` | `true` | Stream an open reasoning block's last lines into the live tail. Off shows only the `[thinking]` badge |
+
+See [Project config](/docs/agent/project-config) for the `agent.toml` keys.
+
 ## Approving work
 
 Writes and shell commands are auto-approved. Start the console with `jan --safe` and they stop to

--- a/docs/src/pages/docs/agent/project-config.mdx
+++ b/docs/src/pages/docs/agent/project-config.mdx
@@ -62,6 +62,8 @@ Point at a different file with `instructions_file` if you already keep conventio
 # compaction_reserve_tokens = 16384
 # max_tokens = 4096
 # max_parallel_subagents = 10  # max concurrently-running subagents per run; extra dispatches queue FIFO
+# show_reasoning = false  # unfold thinking blocks in the transcript (Ctrl-O still toggles)
+# send_reasoning = true   # resend prior reasoning to the model; false drops it from the request
 instructions_file = "AGENT.md"
 
 # [provider]
@@ -97,6 +99,8 @@ inject = "always"
 | `compaction_reserve_tokens` | `16384` | Headroom kept free before [compaction](/docs/agent/context) |
 | `max_tokens` | unset | Cap on tokens generated per response. Omitted from the request when unset |
 | `max_parallel_subagents` | `10` | Subagents that may run at once (min 1); extra dispatches queue FIFO |
+| `show_reasoning` | `false` | Unfold model reasoning (`<thinking>`) blocks in the transcript instead of folding them to a summary row. <kbd>Ctrl</kbd>+<kbd>O</kbd> still toggles a folded block |
+| `send_reasoning` | `true` | Resend a prior turn's reasoning to the model with the conversation. Set `false` for an upstream that rejects the field (e.g. Groq), or to keep chains of thought out of the context budget |
 | `instructions_file` | `AGENT.md` | Markdown injected into the system prompt |
 
 ### `[provider]`

--- a/src-tauri/plugins/tauri-plugin-llamacpp/permissions/autogenerated/reference.md
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/permissions/autogenerated/reference.md
@@ -948,6 +948,32 @@ Denies the prioritize_backends command without any pre-configured scope.
 <tr>
 <td>
 
+`llamacpp:allow-probe-backend-load`
+
+</td>
+<td>
+
+Enables the probe_backend_load command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`llamacpp:deny-probe-backend-load`
+
+</td>
+<td>
+
+Denies the probe_backend_load command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 `llamacpp:allow-read-gguf-metadata`
 
 </td>

--- a/src-tauri/plugins/tauri-plugin-llamacpp/permissions/schemas/schema.json
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/permissions/schemas/schema.json
@@ -703,6 +703,18 @@
           "markdownDescription": "Denies the prioritize_backends command without any pre-configured scope."
         },
         {
+          "description": "Enables the probe_backend_load command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-probe-backend-load",
+          "markdownDescription": "Enables the probe_backend_load command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the probe_backend_load command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-probe-backend-load",
+          "markdownDescription": "Denies the probe_backend_load command without any pre-configured scope."
+        },
+        {
           "description": "Enables the read_gguf_metadata command without any pre-configured scope.",
           "type": "string",
           "const": "allow-read-gguf-metadata",

--- a/src-tauri/src/core/agent/commands.rs
+++ b/src-tauri/src/core/agent/commands.rs
@@ -57,7 +57,7 @@ fn build_orchestration_args<R: Runtime>(
         Arc::new(Mutex::new(HashMap::new()));
 
     OrchestrationArgs {
-        client: reqwest::Client::new(),
+        client: crate::core::agent::upstream::agent_http_client(),
         provider_configs: state.provider_configs.clone(),
         llama_state: llama_state_arc,
         mlx_sessions,

--- a/src-tauri/src/core/agent/events.rs
+++ b/src-tauri/src/core/agent/events.rs
@@ -9,6 +9,13 @@
 pub enum StreamEvent {
     /// A streamed content delta from the model.
     Token { text: String },
+    /// A streamed reasoning delta, carried natively when the upstream exposes
+    /// it as a dedicated field (`reasoning_content`). Display-only: reasoning
+    /// never joins the assistant `content` that is resent as history, and it
+    /// must never leak into piped stdout. Providers that instead inline
+    /// `<think>` tags in `content` stream those through [`Token`]; consumers
+    /// fall back to stripping the tags manually.
+    Reasoning { text: String },
     /// A new orchestration turn began (`index` is 1-based; `max` is the turn
     /// cap, `0` when the run is unbounded, which is the normal case).
     Step { index: u32, max: u32 },
@@ -234,6 +241,12 @@ mod tests {
     fn token_serializes_with_snake_case_tag() {
         let v = serde_json::to_value(StreamEvent::Token { text: "hi".into() }).unwrap();
         assert_eq!(v, json!({ "type": "token", "text": "hi" }));
+    }
+
+    #[test]
+    fn reasoning_serializes_with_snake_case_tag() {
+        let v = serde_json::to_value(StreamEvent::Reasoning { text: "hmm".into() }).unwrap();
+        assert_eq!(v, json!({ "type": "reasoning", "text": "hmm" }));
     }
 
     #[test]

--- a/src-tauri/src/core/agent/global_config.rs
+++ b/src-tauri/src/core/agent/global_config.rs
@@ -22,6 +22,10 @@ const GLOBAL_CONFIG_TEMPLATE: &str = r#"# Jan Agent global provider config.
 # sandbox = true                      # run `bash` under OS confinement (same as
 #                                     # passing --sandbox); off by default, so
 #                                     # shell commands run with your own access
+# think_tags = false                  # stop treating <think> tags in model
+#                                     # content as reasoning; they render and
+#                                     # are resent as ordinary prose. On by
+#                                     # default
 #
 # [providers.my-provider]
 # api_key = "sk-..."
@@ -48,6 +52,11 @@ struct GlobalConfigToml {
     /// `--sandbox` flag.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     sandbox: Option<bool>,
+    /// Parse `<think>` tags in model *content* as reasoning. `None` = the
+    /// default, on. Native `reasoning_content` streaming is a separate
+    /// mechanism and is unaffected.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    think_tags: Option<bool>,
     #[serde(default)]
     providers: HashMap<String, GlobalProviderEntry>,
 }
@@ -167,6 +176,20 @@ pub(crate) fn mouse_enabled() -> bool {
 /// user cannot parse must not be the thing that blocks a session from starting.
 pub(crate) fn sandbox_setting() -> Option<bool> {
     load_raw().ok().and_then(|config| config.sandbox)
+}
+
+/// Whether inline `<think>` tags in model content are parsed as reasoning
+/// (`think_tags` in `~/.jan/config.toml`), defaulting to on. `false` makes the
+/// tags ordinary prose: rendered verbatim, kept in the answer sent back as
+/// history, and never folded into a reasoning block.
+///
+/// A display preference must never block startup, so an unreadable or malformed
+/// config yields the default rather than an error.
+pub(crate) fn think_tags_enabled() -> bool {
+    load_raw()
+        .ok()
+        .and_then(|config| config.think_tags)
+        .unwrap_or(true)
 }
 
 /// Read `~/.jan/config.toml` into the raw TOML struct for editing. Missing file
@@ -326,6 +349,23 @@ mod tests {
 
             std::fs::write(&path, "not valid toml [[[").unwrap();
             assert!(mouse_enabled(), "an unreadable config keeps the default");
+        });
+    }
+
+    #[test]
+    fn think_tags_default_on_and_read_from_the_toml_key() {
+        with_temp_home(|_| {
+            assert!(think_tags_enabled(), "missing file -> parsing on");
+            let path = ensure_global_config().expect("ensure");
+            assert!(think_tags_enabled(), "scaffolded file -> parsing on");
+
+            std::fs::write(&path, "think_tags = false\n").unwrap();
+            assert!(!think_tags_enabled());
+            std::fs::write(&path, "think_tags = true\n").unwrap();
+            assert!(think_tags_enabled());
+
+            std::fs::write(&path, "not valid toml [[[").unwrap();
+            assert!(think_tags_enabled(), "an unreadable config keeps the default");
         });
     }
 

--- a/src-tauri/src/core/agent/global_config.rs
+++ b/src-tauri/src/core/agent/global_config.rs
@@ -26,6 +26,9 @@ const GLOBAL_CONFIG_TEMPLATE: &str = r#"# Jan Agent global provider config.
 #                                     # content as reasoning; they render and
 #                                     # are resent as ordinary prose. On by
 #                                     # default
+# stream_reasoning = false            # stop streaming reasoning into the TUI
+#                                     # live tail while it folds; only the
+#                                     # [thinking] badge shows it. On by default
 #
 # [providers.my-provider]
 # api_key = "sk-..."
@@ -57,6 +60,11 @@ struct GlobalConfigToml {
     /// mechanism and is unaffected.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     think_tags: Option<bool>,
+    /// Stream reasoning into the TUI live tail while it is still folded. `None`
+    /// = the default, on. Unrelated to `[agent].show_reasoning`, which unfolds
+    /// reasoning for good.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    stream_reasoning: Option<bool>,
     #[serde(default)]
     providers: HashMap<String, GlobalProviderEntry>,
 }
@@ -189,6 +197,19 @@ pub(crate) fn think_tags_enabled() -> bool {
     load_raw()
         .ok()
         .and_then(|config| config.think_tags)
+        .unwrap_or(true)
+}
+
+/// Whether the TUI streams reasoning into its live tail while folding is on
+/// (`stream_reasoning` in `~/.jan/config.toml`), defaulting to on. `false` keeps
+/// a folded block off screen entirely, leaving the header badge to stand for it.
+///
+/// A display preference must never block startup, so an unreadable or malformed
+/// config yields the default rather than an error.
+pub(crate) fn stream_reasoning_enabled() -> bool {
+    load_raw()
+        .ok()
+        .and_then(|config| config.stream_reasoning)
         .unwrap_or(true)
 }
 
@@ -366,6 +387,26 @@ mod tests {
 
             std::fs::write(&path, "not valid toml [[[").unwrap();
             assert!(think_tags_enabled(), "an unreadable config keeps the default");
+        });
+    }
+
+    #[test]
+    fn stream_reasoning_default_on_and_read_from_the_toml_key() {
+        with_temp_home(|_| {
+            assert!(stream_reasoning_enabled(), "missing file -> streaming on");
+            let path = ensure_global_config().expect("ensure");
+            assert!(stream_reasoning_enabled(), "scaffolded file -> streaming on");
+
+            std::fs::write(&path, "stream_reasoning = false\n").unwrap();
+            assert!(!stream_reasoning_enabled());
+            std::fs::write(&path, "stream_reasoning = true\n").unwrap();
+            assert!(stream_reasoning_enabled());
+
+            std::fs::write(&path, "not valid toml [[[").unwrap();
+            assert!(
+                stream_reasoning_enabled(),
+                "an unreadable config keeps the default"
+            );
         });
     }
 

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -1594,6 +1594,32 @@ async fn orchestrate_inner(
 /// overflowing request fails loudly instead of looping forever.
 const MAX_COMPACTION_ATTEMPTS: usize = 4;
 
+/// Deep-copy `messages` with `reasoning_content` removed from every assistant
+/// turn. The request builder applies this when the caller opts out of resending
+/// reasoning ([agent].send_reasoning=false). Mirror of the desktop app's
+/// `stripAssistantReasoningInBody`; kept in one place so every surface (TUI,
+/// headless, subagents) strips consistently. Only assistant messages carry the
+/// field, but the filter is defensive and targets just that role.
+fn strip_assistant_reasoning(messages: &[serde_json::Value]) -> Vec<serde_json::Value> {
+    messages
+        .iter()
+        .map(|m| {
+            if m.get("role").and_then(|r| r.as_str()) != Some("assistant") {
+                return m.clone();
+            }
+            let Some(obj) = m.as_object() else {
+                return m.clone();
+            };
+            if !obj.contains_key("reasoning_content") {
+                return m.clone();
+            }
+            let mut out = obj.clone();
+            out.remove("reasoning_content");
+            serde_json::Value::Object(out)
+        })
+        .collect()
+}
+
 /// Build one OpenAI chat-completion request from the current conversation.
 fn build_completion_request(
     model_id: &str,
@@ -1602,11 +1628,22 @@ fn build_completion_request(
     json_body: &serde_json::Value,
     forced_tool_choice: Option<&str>,
 ) -> serde_json::Value {
+    // `[agent].send_reasoning` is forwarded per-request; default true (resend
+    // reasoning). False opts out of resending prior reason on every turn.
+    let send_reasoning = json_body
+        .get("send_reasoning")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(true);
+    let messages = if send_reasoning {
+        conversation_messages.to_vec()
+    } else {
+        strip_assistant_reasoning(conversation_messages)
+    };
     let mut completion_map = serde_json::Map::new();
     completion_map.insert("model".to_string(), serde_json::json!(model_id));
     completion_map.insert(
         "messages".to_string(),
-        serde_json::Value::Array(conversation_messages.to_vec()),
+        serde_json::Value::Array(messages),
     );
     let tool_choice = forced_tool_choice
         .filter(|name| {
@@ -1936,11 +1973,22 @@ async fn run_turn_cycle(
                 .get("content")
                 .cloned()
                 .unwrap_or(serde_json::Value::Null);
-            conversation_messages.push(serde_json::json!({
+            let mut msg = serde_json::json!({
                 "role": "assistant",
                 "content": assistant_content,
                 "tool_calls": tool_calls.clone()
-            }));
+            });
+            // Carry this turn's reasoning back onto the resumed conversation so
+            // a follow-up request (and the final `MessagesUpdated`) can resend
+            // it. Kept out of `content`, matching the upstream shape.
+            if let Some(r) = choice_message
+                .get("reasoning_content")
+                .and_then(|v| v.as_str())
+                .filter(|r| !r.is_empty())
+            {
+                msg["reasoning_content"] = serde_json::json!(r);
+            }
+            conversation_messages.push(msg);
         } else {
             conversation_messages.push(serde_json::json!({
                 "role": "assistant",
@@ -2338,6 +2386,77 @@ mod tests {
             requests[1]["tool_choice"], "auto",
             "later turns must not keep forcing the same tool"
         );
+    }
+
+    /// Reasoning is resent by default: providers exposing it natively expect it
+    /// back, and llama.cpp templates with `preserve_thinking` re-emit prior
+    /// reasoning from this field (dropping it shrinks earlier turns and forces
+    /// the KV-cache prefix to be reprocessed).
+    #[test]
+    fn assistant_reasoning_is_resent_by_default() {
+        let messages = vec![json!({
+            "role": "assistant",
+            "content": "the answer",
+            "reasoning_content": "the thinking"
+        })];
+        let request = build_completion_request("m", &messages, &[], &json!({}), None);
+        assert_eq!(
+            request["messages"][0]["reasoning_content"], "the thinking",
+            "reasoning must be resent unless the user opts out: {request}"
+        );
+    }
+
+    /// `send_reasoning = false` drops the field from every assistant turn,
+    /// for a strict upstream that rejects it (Groq's validator) or to keep long
+    /// chains of thought out of the context budget.
+    #[test]
+    fn send_reasoning_false_strips_it_from_assistant_turns() {
+        let messages = vec![
+            json!({ "role": "user", "content": "q" }),
+            json!({
+                "role": "assistant",
+                "content": "the answer",
+                "reasoning_content": "the thinking"
+            }),
+        ];
+        let request = build_completion_request(
+            "m",
+            &messages,
+            &[],
+            &json!({ "send_reasoning": false }),
+            None,
+        );
+        assert!(
+            request["messages"][1].get("reasoning_content").is_none(),
+            "opted out, so reasoning must not reach the upstream: {request}"
+        );
+        // The rest of the turn is untouched.
+        assert_eq!(request["messages"][1]["content"], "the answer");
+        assert_eq!(request["messages"][0]["content"], "q");
+    }
+
+    /// Stripping keeps a tool-call turn's `tool_calls` intact: dropping those
+    /// alongside the reasoning would leave a dangling `role: "tool"` reply that
+    /// OpenAI-compatible upstreams reject outright.
+    #[test]
+    fn stripping_reasoning_preserves_tool_calls() {
+        let messages = vec![json!({
+            "role": "assistant",
+            "content": null,
+            "reasoning_content": "need to grep",
+            "tool_calls": [{ "id": "c1", "type": "function",
+                "function": { "name": "bash", "arguments": "{}" } }]
+        })];
+        let request = build_completion_request(
+            "m",
+            &messages,
+            &[],
+            &json!({ "send_reasoning": false }),
+            None,
+        );
+        let msg = &request["messages"][0];
+        assert!(msg.get("reasoning_content").is_none());
+        assert_eq!(msg["tool_calls"][0]["id"], "c1");
     }
 
     #[test]

--- a/src-tauri/src/core/agent/project.rs
+++ b/src-tauri/src/core/agent/project.rs
@@ -110,6 +110,16 @@ pub(crate) struct AgentSection {
     /// this flips the default for every block in the session.
     #[serde(default)]
     pub show_reasoning: Option<bool>,
+    /// Resend a prior assistant turn's `reasoning_content` to the model with the
+    /// rest of the conversation. Default true: providers that expose reasoning
+    /// natively generally expect it back, and local llama.cpp templates with
+    /// `preserve_thinking` re-emit prior reasoning from this field (dropping it
+    /// shrinks earlier turns and forces the KV-cache prefix to be reprocessed).
+    /// Set false for a strict upstream that rejects the key on assistant turns
+    /// (Groq's validator is the known case), or to keep long chains of thought
+    /// out of the context budget.
+    #[serde(default)]
+    pub send_reasoning: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -150,6 +160,7 @@ const AGENT_TOML_TEMPLATE: &str = r#"[agent]
 # max_tokens = 4096  # cap on tokens the model generates per response (OpenAI max_tokens); omitted if unset
 # max_parallel_subagents = 10  # max concurrently-running subagents per run; extra dispatches queue FIFO
 # show_reasoning = false  # expand  reasoning in the transcript (Ctrl-O still toggles)
+# send_reasoning = true  # resend prior reasoning to the model; false drops it from the request
 
 # Project-local provider override. Wins over ~/.jan/config.toml and any
 # provider inherited from Jan Desktop's settings.json. Most projects don't
@@ -584,6 +595,28 @@ mod tests {
         set_agent_key(&path, "show_reasoning", None).expect("unset");
         let cfg = load_agent_config(&root).expect("load");
         assert_eq!(cfg.agent.show_reasoning, None);
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// `send_reasoning` is unset in the template, which the callers read as the
+    /// resend-by-default policy; an explicit false round-trips so a strict
+    /// upstream can be opted out of it.
+    #[cfg(feature = "cli")]
+    #[test]
+    fn send_reasoning_parses_and_round_trips() {
+        let root = unique_root("send_reasoning");
+        ensure_project(&root).expect("scaffold");
+        let cfg = load_agent_config(&root).expect("load");
+        assert_eq!(cfg.agent.send_reasoning, None, "template leaves it unset");
+
+        let path = agent_toml_path(&root);
+        set_agent_key(&path, "send_reasoning", Some(toml_edit::value(false)))
+            .expect("write");
+        let cfg = load_agent_config(&root).expect("load");
+        assert_eq!(cfg.agent.send_reasoning, Some(false));
+        set_agent_key(&path, "send_reasoning", None).expect("unset");
+        let cfg = load_agent_config(&root).expect("load");
+        assert_eq!(cfg.agent.send_reasoning, None);
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/src-tauri/src/core/agent/upstream.rs
+++ b/src-tauri/src/core/agent/upstream.rs
@@ -640,10 +640,6 @@ struct SseAccumulator {
     tool_calls: Vec<ToolCallAccum>,
     finish_reason: Option<String>,
     usage: Option<serde_json::Value>,
-    /// A `<think>` boundary was streamed for `reasoning_content` and not yet
-    /// closed. Reasoning is display-only (dimmed in the TUI) and deliberately
-    /// kept out of `content` so it is never resent to the model as history.
-    reasoning_open: bool,
     /// An error object delivered inside the stream (`data: {"error": {...}}`).
     /// OpenAI-compatible upstreams can fail mid-stream after a `200 OK`; without
     /// capturing it the run would end as a silent "no answer" instead of
@@ -652,15 +648,6 @@ struct SseAccumulator {
 }
 
 impl SseAccumulator {
-    fn close_reasoning(&mut self, events: &mpsc::UnboundedSender<StreamEvent>) {
-        if self.reasoning_open {
-            self.reasoning_open = false;
-            let _ = events.send(StreamEvent::Token {
-                text: "</think>".to_string(),
-            });
-        }
-    }
-
     /// Parse one raw SSE line (`data: {...}`); non-`data:`/blank lines are ignored.
     fn ingest_line(&mut self, line: &str, events: &mpsc::UnboundedSender<StreamEvent>) {
         if let Some(rest) = line.trim_end_matches('\r').strip_prefix("data:") {
@@ -710,22 +697,20 @@ impl SseAccumulator {
 
         if let Some(fr) = choice.get("finish_reason").and_then(|v| v.as_str()) {
             self.finish_reason = Some(fr.to_string());
-            self.close_reasoning(events);
         }
 
         let Some(delta) = choice.get("delta") else {
             return;
         };
 
+        // Native reasoning: providers exposing a dedicated `reasoning_content`
+        // field stream it as `Reasoning` events, never as content tokens, so
+        // consumers get the boundary for free instead of re-parsing synthetic
+        // `<think>` tags. Providers that inline tags in `content` still flow
+        // through `Token`; consumers keep the tag-stripping fallback for them.
         if let Some(text) = delta.get("reasoning_content").and_then(|v| v.as_str()) {
             if !text.is_empty() {
-                if !self.reasoning_open {
-                    self.reasoning_open = true;
-                    let _ = events.send(StreamEvent::Token {
-                        text: "<think>".to_string(),
-                    });
-                }
-                let _ = events.send(StreamEvent::Token {
+                let _ = events.send(StreamEvent::Reasoning {
                     text: text.to_string(),
                 });
             }
@@ -733,7 +718,6 @@ impl SseAccumulator {
 
         if let Some(text) = delta.get("content").and_then(|v| v.as_str()) {
             if !text.is_empty() {
-                self.close_reasoning(events);
                 self.content.push_str(text);
                 let _ = events.send(StreamEvent::Token {
                     text: text.to_string(),
@@ -1170,7 +1154,7 @@ mod tests {
     }
 
     #[test]
-    fn reasoning_content_streams_as_think_wrapped_tokens_but_stays_out_of_content() {
+    fn reasoning_content_streams_as_native_reasoning_events_and_stays_out_of_content() {
         let (tx, mut rx) = sink();
         let mut acc = SseAccumulator::default();
         acc.ingest(
@@ -1196,15 +1180,23 @@ mod tests {
         assert_eq!(completion["choices"][0]["message"]["content"], "answer");
 
         drop(tx);
+        let mut reasoning = Vec::new();
         let mut tokens = Vec::new();
-        while let Ok(StreamEvent::Token { text }) = rx.try_recv() {
-            tokens.push(text);
+        while let Ok(ev) = rx.try_recv() {
+            match ev {
+                StreamEvent::Reasoning { text } => reasoning.push(text),
+                StreamEvent::Token { text } => tokens.push(text),
+                _ => {}
+            }
         }
-        assert_eq!(tokens, vec!["<think>", "let me ", "think", "</think>", "answer"]);
+        // Native events: no synthetic <think> wrapper tokens on the content
+        // stream, so a consumer never has to re-parse tags it did not receive.
+        assert_eq!(reasoning, vec!["let me ", "think"]);
+        assert_eq!(tokens, vec!["answer"]);
     }
 
     #[test]
-    fn reasoning_only_completion_closes_the_open_think_block() {
+    fn reasoning_only_completion_emits_reasoning_and_no_tokens() {
         let (tx, mut rx) = sink();
         let mut acc = SseAccumulator::default();
         acc.ingest(
@@ -1220,11 +1212,41 @@ mod tests {
         assert!(completion["choices"][0]["message"]["content"].is_null());
 
         drop(tx);
+        let mut reasoning = Vec::new();
         let mut tokens = Vec::new();
-        while let Ok(StreamEvent::Token { text }) = rx.try_recv() {
-            tokens.push(text);
+        while let Ok(ev) = rx.try_recv() {
+            match ev {
+                StreamEvent::Reasoning { text } => reasoning.push(text),
+                StreamEvent::Token { text } => tokens.push(text),
+                _ => {}
+            }
         }
-        assert_eq!(tokens, vec!["<think>", "hmm", "</think>"]);
+        assert_eq!(reasoning, vec!["hmm"]);
+        assert!(tokens.is_empty(), "no content tokens for a reasoning-only turn: {tokens:?}");
+    }
+
+    /// Providers that inline `<think>` tags in `content` (no reasoning_content
+    /// field) keep streaming through Token untouched: the tag-stripping
+    /// fallback lives in the consumers.
+    #[test]
+    fn inline_think_tags_in_content_pass_through_as_tokens() {
+        let (tx, mut rx) = sink();
+        let mut acc = SseAccumulator::default();
+        acc.ingest(
+            &json!({ "choices": [{ "delta": { "content": "<think>hmm</think>answer" } }] })
+                .to_string(),
+            &tx,
+        );
+        drop(tx);
+        let mut tokens = Vec::new();
+        while let Ok(ev) = rx.try_recv() {
+            match ev {
+                StreamEvent::Token { text } => tokens.push(text),
+                StreamEvent::Reasoning { .. } => panic!("no native reasoning here"),
+                _ => {}
+            }
+        }
+        assert_eq!(tokens, vec!["<think>hmm</think>answer"]);
     }
 
     #[test]

--- a/src-tauri/src/core/agent/upstream.rs
+++ b/src-tauri/src/core/agent/upstream.rs
@@ -105,6 +105,19 @@ pub(crate) fn parse_openai_messages(
         let mut obj = serde_json::Map::new();
         obj.insert("role".to_string(), serde_json::json!(role));
         obj.insert("content".to_string(), content);
+        // Preserve a resent assistant turn's reasoning alongside its content and
+        // tool calls. Some providers require prior reasoning to be resubmitted
+        // to keep a (local llama.cpp `preserve_thinking`) chat template honest:
+        // dropping it would shrink earlier assistant turns and force reprocessing
+        // of the KV-cache prefix. Only assistant messages carry it; user/tool/
+        // system passes are untouched by construction.
+        if role == "assistant" {
+            if let Some(r) = msg.get("reasoning_content").and_then(|v| v.as_str()) {
+                if !r.is_empty() {
+                    obj.insert("reasoning_content".to_string(), serde_json::json!(r));
+                }
+            }
+        }
         if has_tool_calls {
             obj.insert("tool_calls".to_string(), msg["tool_calls"].clone());
         }
@@ -637,6 +650,11 @@ struct ToolCallAccum {
 #[derive(Default)]
 struct SseAccumulator {
     content: String,
+    /// Natively streamed reasoning (`reasoning_content` deltas), accumulated so
+    /// the reconstructed completion carries it back on the assistant message.
+    /// Kept apart from `content`: reasoning is never part of the answer prose,
+    /// but a caller resending assistant turns may forward it to the model.
+    reasoning: String,
     tool_calls: Vec<ToolCallAccum>,
     finish_reason: Option<String>,
     usage: Option<serde_json::Value>,
@@ -710,6 +728,7 @@ impl SseAccumulator {
         // through `Token`; consumers keep the tag-stripping fallback for them.
         if let Some(text) = delta.get("reasoning_content").and_then(|v| v.as_str()) {
             if !text.is_empty() {
+                self.reasoning.push_str(text);
                 let _ = events.send(StreamEvent::Reasoning {
                     text: text.to_string(),
                 });
@@ -814,6 +833,13 @@ impl SseAccumulator {
                 serde_json::json!(self.content)
             },
         );
+        // Reasoning stays out of `content` but is carried on the message so a
+        // caller that resends assistant turns to the model can forward it (and
+        // so a turn that only reasoned still surfaces its reasoning). Empty is
+        // omitted so non-reasoning providers produce an unchanged shape.
+        if !self.reasoning.is_empty() {
+            message.insert("reasoning_content".to_string(), serde_json::json!(self.reasoning));
+        }
         if !tool_calls.is_empty() {
             message.insert(
                 "tool_calls".to_string(),
@@ -1174,10 +1200,14 @@ mod tests {
             &tx,
         );
 
-        // Reasoning must not leak into the reconstructed message sent back to the
-        // model as history; only the answer prose is persisted.
+        // Reasoning stays out of the answer prose, but is preserved on the
+        // reconstructed message so a caller can resend it as history.
         let completion = acc.into_completion();
         assert_eq!(completion["choices"][0]["message"]["content"], "answer");
+        assert_eq!(
+            completion["choices"][0]["message"]["reasoning_content"],
+            "let me think"
+        );
 
         drop(tx);
         let mut reasoning = Vec::new();
@@ -1223,6 +1253,85 @@ mod tests {
         }
         assert_eq!(reasoning, vec!["hmm"]);
         assert!(tokens.is_empty(), "no content tokens for a reasoning-only turn: {tokens:?}");
+    }
+
+    /// A completion with no `reasoning_content` deltas must keep exactly the
+    /// shape it always had: the field is omitted, not emitted empty, so a
+    /// provider that rejects unknown assistant keys is unaffected.
+    #[test]
+    fn a_turn_without_reasoning_omits_the_field_entirely() {
+        let (tx, _rx) = sink();
+        let mut acc = SseAccumulator::default();
+        acc.ingest(
+            &json!({ "choices": [{ "delta": { "content": "answer" } }] }).to_string(),
+            &tx,
+        );
+        let completion = acc.into_completion();
+        let message = &completion["choices"][0]["message"];
+        assert_eq!(message["content"], "answer");
+        assert!(
+            message.get("reasoning_content").is_none(),
+            "no reasoning streamed, so the key must be absent: {message}"
+        );
+    }
+
+    /// A tool-call turn's reasoning is preserved too: the model reasons about
+    /// which tool to call, and that reasoning has to survive onto the assistant
+    /// turn the loop resends with its `tool_calls`.
+    #[test]
+    fn reasoning_is_preserved_on_a_tool_call_turn() {
+        let (tx, _rx) = sink();
+        let mut acc = SseAccumulator::default();
+        acc.ingest(
+            &json!({ "choices": [{ "delta": { "reasoning_content": "need to grep" } }] })
+                .to_string(),
+            &tx,
+        );
+        acc.ingest(
+            &json!({ "choices": [{ "delta": { "tool_calls": [{
+                "index": 0,
+                "id": "c1",
+                "function": { "name": "bash", "arguments": "{}" }
+            }] } }] })
+            .to_string(),
+            &tx,
+        );
+        let completion = acc.into_completion();
+        let message = &completion["choices"][0]["message"];
+        assert_eq!(message["reasoning_content"], "need to grep");
+        assert_eq!(message["tool_calls"][0]["id"], "c1");
+    }
+
+    /// A resent assistant turn keeps its `reasoning_content` through the message
+    /// normalizer. Local llama.cpp templates with `preserve_thinking` re-emit
+    /// prior reasoning from this field; dropping it would shrink earlier turns
+    /// and force the KV-cache prefix to be reprocessed.
+    #[test]
+    fn parse_messages_preserves_assistant_reasoning_content() {
+        let messages = json!([{
+            "role": "assistant",
+            "content": "the answer",
+            "reasoning_content": "the thinking"
+        }]);
+        let out = parse_openai_messages(&messages).unwrap();
+        assert_eq!(out[0]["content"], "the answer");
+        assert_eq!(out[0]["reasoning_content"], "the thinking");
+    }
+
+    /// Only assistant turns carry reasoning back. A stray field on another role
+    /// is not part of the protocol, so it is dropped rather than forwarded.
+    #[test]
+    fn parse_messages_drops_reasoning_on_non_assistant_roles() {
+        let messages = json!([
+            { "role": "user", "content": "q", "reasoning_content": "nope" },
+            { "role": "assistant", "content": "a" },
+        ]);
+        let out = parse_openai_messages(&messages).unwrap();
+        assert!(out[0].get("reasoning_content").is_none());
+        assert!(
+            out[1].get("reasoning_content").is_none(),
+            "an assistant turn with no reasoning stays unchanged"
+        );
     }
 
     /// Providers that inline `<think>` tags in `content` (no reasoning_content

--- a/src-tauri/src/core/agent/upstream.rs
+++ b/src-tauri/src/core/agent/upstream.rs
@@ -514,10 +514,15 @@ pub(crate) async fn call_openai_chat_completions(
             .body(body.to_string())
             .send()
             .await
-            .map_err(|e| format!("Upstream request failed: {e}"))?;
+            .map_err(|e| format!("Upstream request failed: {}", describe_request_error(&e)))?;
 
         let status = resp.status();
-        let text = resp.text().await.map_err(|e| e.to_string())?;
+        let text = resp.text().await.map_err(|e| {
+            format!(
+                "Reading the upstream response failed ({upstream_url}): {}",
+                describe_request_error(&e)
+            )
+        })?;
 
         if status.is_success() {
             return serde_json::from_str::<serde_json::Value>(&text)
@@ -569,6 +574,84 @@ pub(crate) fn is_context_overflow_error(err: &str) -> bool {
     err.contains(CONTEXT_OVERFLOW_MARKER)
 }
 
+/// Every message in an error's `source()` chain, outermost cause first.
+/// `reqwest::Error` prints only its own layer -- `error sending request for url
+/// (...)` -- so the reason the request never left (DNS failure, refused
+/// connection, TLS mismatch, dropped socket) is one or more sources down and is
+/// otherwise lost to the user. Consecutive duplicates are collapsed: hyper and
+/// its io error often stringify identically.
+fn error_source_chain(err: &dyn std::error::Error) -> Vec<String> {
+    let mut chain = Vec::new();
+    let mut cur = err.source();
+    while let Some(e) = cur {
+        let msg = e.to_string();
+        if !msg.trim().is_empty() && chain.last() != Some(&msg) {
+            chain.push(msg);
+        }
+        cur = e.source();
+    }
+    chain
+}
+
+/// Names the proxy environment variables in force, without their values (they
+/// routinely carry credentials). A proxy set in the environment is a common
+/// reason a request fails for Jan and for nothing else, and it is invisible in
+/// the error itself.
+fn proxy_env_hint() -> Option<String> {
+    const VARS: &[&str] = &[
+        "HTTPS_PROXY",
+        "https_proxy",
+        "HTTP_PROXY",
+        "http_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+        "NO_PROXY",
+        "no_proxy",
+    ];
+    let set: Vec<&str> = VARS
+        .iter()
+        .copied()
+        .filter(|name| {
+            std::env::var_os(name).is_some_and(|v| !v.to_string_lossy().trim().is_empty())
+        })
+        .collect();
+    (!set.is_empty()).then(|| format!("proxy env set: {}", set.join(", ")))
+}
+
+/// A failed HTTP request described well enough to act on: what stage failed, the
+/// `reqwest` message, its whole cause chain, and -- for a connect or timeout
+/// failure, where the environment is usually the culprit -- which proxy
+/// variables are set.
+pub(crate) fn describe_request_error(err: &reqwest::Error) -> String {
+    let stage = if err.is_timeout() {
+        "timed out"
+    } else if err.is_connect() {
+        "could not connect"
+    } else if err.is_redirect() {
+        "too many redirects"
+    } else if err.is_body() || err.is_decode() {
+        "response body failed"
+    } else if err.is_builder() {
+        "request could not be built"
+    } else {
+        "send failed"
+    };
+    let mut msg = format!("{stage}: {err}");
+    let chain = error_source_chain(err);
+    if !chain.is_empty() {
+        msg.push_str(&format!(" (caused by: {})", chain.join(" <- ")));
+    }
+    if let Some(status) = err.status() {
+        msg.push_str(&format!(" [HTTP {status}]"));
+    }
+    if err.is_connect() || err.is_timeout() {
+        if let Some(hint) = proxy_env_hint() {
+            msg.push_str(&format!(" [{hint}]"));
+        }
+    }
+    msg
+}
+
 pub(crate) async fn stream_openai_chat_completions(
     client: &Client,
     upstream_url: &str,
@@ -607,7 +690,7 @@ pub(crate) async fn stream_openai_chat_completions(
             .body(req_body.to_string())
             .send()
             .await
-            .map_err(|e| format!("Upstream request failed: {e}"))?;
+            .map_err(|e| format!("Upstream request failed: {}", describe_request_error(&e)))?;
 
         let status = resp.status();
         if status.is_success() {
@@ -901,12 +984,22 @@ async fn consume_openai_sse(
     resp: reqwest::Response,
     events: &mpsc::UnboundedSender<StreamEvent>,
 ) -> Result<serde_json::Value, String> {
+    let url = resp.url().to_string();
     let mut stream = resp.bytes_stream();
     let mut buf = String::new();
     let mut acc = SseAccumulator::default();
+    let mut bytes = 0usize;
 
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|e| format!("Upstream stream error: {e}"))?;
+        // A stream that dies mid-response is the hardest case to tell apart from
+        // an empty answer, so the byte count so far goes in the message.
+        let chunk = chunk.map_err(|e| {
+            format!(
+                "Upstream stream error ({url}) after {bytes} bytes: {}",
+                describe_request_error(&e)
+            )
+        })?;
+        bytes += chunk.len();
         buf.push_str(&String::from_utf8_lossy(&chunk));
         drain_complete_lines(&mut buf, &mut acc, events);
     }
@@ -934,6 +1027,86 @@ mod tests {
         mpsc::UnboundedReceiver<StreamEvent>,
     ) {
         mpsc::unbounded_channel()
+    }
+
+    /// `reqwest` prints only its own layer, so the cause chain is where the
+    /// actual failure lives -- the whole point of `describe_request_error`.
+    #[test]
+    fn error_source_chain_lists_every_cause_and_collapses_repeats() {
+        #[derive(Debug)]
+        struct Err2(&'static str, Option<Box<Err2>>);
+        impl std::fmt::Display for Err2 {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(self.0)
+            }
+        }
+        impl std::error::Error for Err2 {
+            fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+                self.1.as_ref().map(|e| e.as_ref() as &(dyn std::error::Error + 'static))
+            }
+        }
+
+        // The outermost message is printed by the caller, so the chain starts at
+        // its first source; the repeated innermost layer collapses.
+        let inner = Err2("connection refused", None);
+        let middle = Err2("connection refused", Some(Box::new(inner)));
+        let connect = Err2("tcp connect error", Some(Box::new(middle)));
+        let outer = Err2("error sending request", Some(Box::new(connect)));
+        assert_eq!(
+            error_source_chain(&outer),
+            vec![
+                "tcp connect error".to_string(),
+                "connection refused".to_string()
+            ],
+            "sources only, consecutive duplicates collapsed"
+        );
+        assert!(
+            error_source_chain(&Err2("alone", None)).is_empty(),
+            "no sources -> nothing to add"
+        );
+    }
+
+    /// The reported error must name the stage and carry the OS-level reason, not
+    /// just the URL. Port 1 on loopback refuses without touching the network.
+    #[tokio::test]
+    async fn describe_request_error_names_the_stage_and_the_os_cause() {
+        let err = Client::new()
+            .post("http://127.0.0.1:1/v1/chat/completions")
+            .body("{}")
+            .send()
+            .await
+            .expect_err("loopback port 1 refuses");
+        let msg = describe_request_error(&err);
+        assert!(msg.starts_with("could not connect: "), "stage named: {msg}");
+        assert!(msg.contains("caused by: "), "cause chain present: {msg}");
+        assert!(
+            msg.to_lowercase().contains("refused") || msg.to_lowercase().contains("connect"),
+            "the OS reason survives: {msg}"
+        );
+    }
+
+    /// A proxy in the environment breaks Jan and nothing else, and never shows up
+    /// in the error. Names only: the values carry credentials.
+    #[test]
+    fn proxy_env_hint_names_set_variables_without_their_values() {
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var_os("HTTPS_PROXY");
+        std::env::remove_var("HTTPS_PROXY");
+        let before = proxy_env_hint();
+
+        std::env::set_var("HTTPS_PROXY", "http://user:secret@proxy.internal:8080");
+        let hint = proxy_env_hint().expect("a set proxy is reported");
+        assert!(hint.contains("HTTPS_PROXY"), "names the variable: {hint}");
+        assert!(!hint.contains("secret"), "never prints the value: {hint}");
+
+        std::env::set_var("HTTPS_PROXY", "   ");
+        assert_eq!(proxy_env_hint(), before, "a blank value is not a proxy");
+
+        match prev {
+            Some(v) => std::env::set_var("HTTPS_PROXY", v),
+            None => std::env::remove_var("HTTPS_PROXY"),
+        }
     }
 
     /// A model served both by a Jan desktop API server (reachable over HTTP) and

--- a/src-tauri/src/core/agent/upstream.rs
+++ b/src-tauri/src/core/agent/upstream.rs
@@ -510,11 +510,7 @@ pub(crate) async fn call_openai_chat_completions(
             req = req.header("Authorization", format!("Bearer {key}"));
         }
 
-        let resp = req
-            .body(body.to_string())
-            .send()
-            .await
-            .map_err(|e| format!("Upstream request failed: {}", describe_request_error(&e)))?;
+        let resp = send_with_one_retry(req.body(body.to_string())).await?;
 
         let status = resp.status();
         let text = resp.text().await.map_err(|e| {
@@ -591,6 +587,95 @@ fn error_source_chain(err: &dyn std::error::Error) -> Vec<String> {
         cur = e.source();
     }
     chain
+}
+
+/// True when a failed send can be retried safely: the connection died before any
+/// response arrived, so nothing has been streamed to the caller and no side
+/// effect on the upstream is implied. Covers a refused/failed connect and the
+/// stale-keep-alive family -- hyper reports a pooled connection the peer had
+/// already closed as `connection closed before message completed`, or as an
+/// `ECONNRESET`/`EPIPE` io error if the RST lands while the request is going
+/// out. A timeout is deliberately excluded: retrying one doubles the wait.
+fn is_retryable_send_error(err: &reqwest::Error) -> bool {
+    if err.is_timeout() || err.is_body() || err.is_decode() || err.is_builder() {
+        return false;
+    }
+    err.is_connect() || chain_indicates_dropped_connection(&error_source_chain(err))
+}
+
+/// Whether an error's cause chain names a connection the peer dropped. Matched
+/// on text because the io error is several opaque layers down (hyper's
+/// `SendRequest` -> `connection error` -> `std::io::Error`) and its `ErrorKind`
+/// is not exposed through `reqwest`.
+fn chain_indicates_dropped_connection(chain: &[String]) -> bool {
+    const MARKERS: &[&str] = &[
+        "connection closed before message completed",
+        "connection reset by peer",
+        "broken pipe",
+        "connection aborted",
+        "unexpected eof",
+    ];
+    chain
+        .iter()
+        .any(|msg| {
+            let msg = msg.to_lowercase();
+            MARKERS.iter().any(|m| msg.contains(m))
+        })
+}
+
+/// How long to wait before the one retry of a dropped connection. Long enough
+/// for a load balancer that just recycled a backend to finish, short enough that
+/// the user does not read it as a hang.
+const SEND_RETRY_DELAY: std::time::Duration = std::time::Duration::from_millis(250);
+
+/// Send a request, retrying it once when the connection dropped before any
+/// response arrived. This is the failure a long turn invites: while tools run
+/// locally no bytes flow, an idle keep-alive connection is reclaimed by the peer
+/// or its load balancer, and the next turn's request is written into a socket
+/// that is already gone. Retrying is safe precisely because nothing was received
+/// -- see [`is_retryable_send_error`].
+async fn send_with_one_retry(req: reqwest::RequestBuilder) -> Result<reqwest::Response, String> {
+    // `try_clone` returns `None` only for a streaming body; every caller here
+    // sends a `String`, so the retry path is always available in practice.
+    let retry = req.try_clone();
+    let first = match req.send().await {
+        Ok(resp) => return Ok(resp),
+        Err(e) => e,
+    };
+    let Some(retry) = retry.filter(|_| is_retryable_send_error(&first)) else {
+        return Err(format!(
+            "Upstream request failed: {}",
+            describe_request_error(&first)
+        ));
+    };
+    log::warn!(
+        "upstream: {} -- retrying once",
+        describe_request_error(&first)
+    );
+    tokio::time::sleep(SEND_RETRY_DELAY).await;
+    retry.send().await.map_err(|e| {
+        format!(
+            "Upstream request failed after one retry: {} (first attempt: {})",
+            describe_request_error(&e),
+            describe_request_error(&first)
+        )
+    })
+}
+
+/// The HTTP client every agent turn goes through. `Client::new()`'s defaults are
+/// wrong for this traffic in one specific way: connections idle for up to 90s
+/// stay in the pool, but a turn spends far longer than that running tools, and
+/// the peer (or its load balancer) closes an idle connection well before then.
+/// Reusing one is the `Connection reset by peer` a long session eventually hits,
+/// so the pool is kept shorter-lived than any plausible upstream idle timeout.
+/// No overall request timeout: a streamed answer legitimately runs for minutes.
+pub(crate) fn agent_http_client() -> Client {
+    Client::builder()
+        .pool_idle_timeout(std::time::Duration::from_secs(15))
+        .tcp_keepalive(std::time::Duration::from_secs(30))
+        .connect_timeout(std::time::Duration::from_secs(30))
+        .build()
+        .unwrap_or_else(|_| Client::new())
 }
 
 /// Names the proxy environment variables in force, without their values (they
@@ -686,11 +771,7 @@ pub(crate) async fn stream_openai_chat_completions(
             req = req.header("Authorization", format!("Bearer {key}"));
         }
 
-        let resp = req
-            .body(req_body.to_string())
-            .send()
-            .await
-            .map_err(|e| format!("Upstream request failed: {}", describe_request_error(&e)))?;
+        let resp = send_with_one_retry(req.body(req_body.to_string())).await?;
 
         let status = resp.status();
         if status.is_success() {
@@ -1083,6 +1164,113 @@ mod tests {
             msg.to_lowercase().contains("refused") || msg.to_lowercase().contains("connect"),
             "the OS reason survives: {msg}"
         );
+    }
+
+    #[test]
+    fn dropped_connection_is_recognised_from_the_cause_chain() {
+        assert!(chain_indicates_dropped_connection(&[
+            "client error (SendRequest)".to_string(),
+            "connection error".to_string(),
+            "Connection reset by peer (os error 104)".to_string(),
+        ]));
+        assert!(chain_indicates_dropped_connection(&[
+            "connection closed before message completed".to_string()
+        ]));
+        assert!(
+            !chain_indicates_dropped_connection(&[
+                "dns error".to_string(),
+                "failed to lookup address information".to_string()
+            ]),
+            "a name that does not resolve is not a dropped connection"
+        );
+        assert!(!chain_indicates_dropped_connection(&[]));
+    }
+
+    /// A refused connect never reached the peer, so retrying it is safe; a
+    /// timeout is excluded on purpose (retrying one doubles the wait).
+    #[tokio::test]
+    async fn a_refused_connect_is_retryable_but_a_timeout_is_not() {
+        let refused = Client::new()
+            .post("http://127.0.0.1:1/v1/chat/completions")
+            .body("{}")
+            .send()
+            .await
+            .expect_err("loopback port 1 refuses");
+        assert!(is_retryable_send_error(&refused), "{refused}");
+
+        // 10.255.255.1 is a reserved address that black-holes rather than
+        // refusing, so the connect attempt hits the timeout instead.
+        let timed_out = Client::builder()
+            .connect_timeout(std::time::Duration::from_millis(50))
+            .build()
+            .expect("client")
+            .post("http://10.255.255.1:81/v1/chat/completions")
+            .body("{}")
+            .send()
+            .await
+            .expect_err("black-holed address times out");
+        if timed_out.is_timeout() {
+            assert!(!is_retryable_send_error(&timed_out), "{timed_out}");
+        }
+    }
+
+    /// The failure a long turn invites: the peer reclaims a keep-alive
+    /// connection while tools run, and the next request is written into a socket
+    /// that is already gone. One retry must carry the turn through, transparently
+    /// -- the caller sees a normal completion, not an error.
+    #[tokio::test]
+    async fn a_dropped_first_connection_is_retried_and_the_turn_succeeds() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let server = tokio::spawn(async move {
+            // First connection: read the request, then hang up without a byte of
+            // response -- exactly what a reclaimed pooled connection looks like.
+            let (mut first, _) = listener.accept().await.expect("first accept");
+            let mut scratch = [0u8; 1024];
+            let _ = first.read(&mut scratch).await;
+            drop(first);
+
+            // Second connection: a normal one-token SSE answer.
+            let (mut second, _) = listener.accept().await.expect("second accept");
+            let _ = second.read(&mut scratch).await;
+            let sse = "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n\
+                       data: [DONE]\n\n";
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nContent-Length: {}\r\n\r\n{sse}",
+                sse.len()
+            );
+            let _ = second.write_all(resp.as_bytes()).await;
+            let _ = second.flush().await;
+        });
+
+        let (tx, mut rx) = sink();
+        let url = format!("http://{addr}/v1/chat/completions");
+        let completion = stream_openai_chat_completions(
+            &Client::new(),
+            &url,
+            &[],
+            &json!({ "model": "m", "messages": [] }),
+            &tx,
+        )
+        .await
+        .expect("the retry carries the turn");
+
+        assert_eq!(
+            completion["choices"][0]["message"]["content"], "hi",
+            "answer from the second connection: {completion}"
+        );
+        let mut tokens = Vec::new();
+        while let Ok(ev) = rx.try_recv() {
+            if let StreamEvent::Token { text } = ev {
+                tokens.push(text);
+            }
+        }
+        assert_eq!(tokens, vec!["hi".to_string()], "streamed once, not twice");
+        server.await.expect("server task");
     }
 
     /// A proxy in the environment breaks Jan and nothing else, and never shows up

--- a/src-tauri/src/core/cli/journal.rs
+++ b/src-tauri/src/core/cli/journal.rs
@@ -1,12 +1,12 @@
 //! Display journal: the transcript as it was shown, so `/resume` can restore
 //! reasoning, tool calls and their results.
 //!
-//! `messages.jsonl` is the wire conversation and cannot carry this: reasoning is
-//! deliberately kept out of it (never resent to the model), tool calls are
-//! flattened to text on save, and a `/compact` rewrites it. The journal is a
-//! separate append-only log of what the TUI rendered, in emission order, written
-//! off the render loop at each turn boundary and replayed through the same
-//! rendering path on resume.
+//! `messages.jsonl` is the wire conversation and cannot carry this: it keeps
+//! reasoning out of `content` (it rides along on `reasoning_content` instead),
+//! tool calls are flattened to text on save, and a `/compact` rewrites it. The
+//! journal is a separate append-only log of what the TUI rendered, in emission
+//! order, written off the render loop at each turn boundary and replayed through
+//! the same rendering path on resume.
 
 use std::path::{Path, PathBuf};
 
@@ -20,9 +20,16 @@ pub enum DisplayEntry {
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         images: Vec<String>,
     },
-    /// Assistant text exactly as streamed, `<think>` markers included, so the
-    /// replay folds reasoning the same way the live turn did.
-    Assistant { text: String },
+    /// Answer prose exactly as streamed. Reasoning is not inlined into it:
+    /// natively streamed `reasoning_content` rides along in `reasoning`, while
+    /// an inline-tag provider's `<think>` markers are simply part of the prose
+    /// it sent. A journal written before `reasoning` existed has its reasoning
+    /// inside `text` as markers, which replays down the inline path unchanged.
+    Assistant {
+        text: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        reasoning: Vec<ReasoningSeg>,
+    },
     ToolCall {
         id: String,
         name: String,
@@ -46,6 +53,16 @@ pub enum DisplayEntry {
         #[serde(default = "default_true")]
         finished: bool,
     },
+}
+
+/// One stretch of natively streamed reasoning, anchored to the byte offset in
+/// the answer prose it arrived at. Keeping the offset (rather than splicing the
+/// text into the prose) preserves emission order without ever encoding
+/// reasoning as markup a later pass would have to parse back out.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ReasoningSeg {
+    pub at: usize,
+    pub text: String,
 }
 
 fn default_true() -> bool {
@@ -177,6 +194,7 @@ mod tests {
             user("do it"),
             DisplayEntry::Assistant {
                 text: "<think>plan</think>".into(),
+                reasoning: Vec::new(),
             },
             DisplayEntry::ToolCall {
                 id: "c1".into(),
@@ -196,6 +214,7 @@ mod tests {
             },
             DisplayEntry::Assistant {
                 text: "Done.".into(),
+                reasoning: Vec::new(),
             },
         ]
     }
@@ -251,6 +270,7 @@ mod tests {
         entries.push(user("second"));
         entries.push(DisplayEntry::Assistant {
             text: "more".into(),
+            reasoning: Vec::new(),
         });
         assert_eq!(truncate_at_user(&entries, 0), 0);
         assert_eq!(truncate_at_user(&entries, 1), 6, "cuts at the second user");

--- a/src-tauri/src/core/cli/mod.rs
+++ b/src-tauri/src/core/cli/mod.rs
@@ -304,7 +304,7 @@ pub fn cli_set_project_model(agent_dir: &std::path::Path, model: &str) -> Result
 
 /// Stands in for a tool result that never reached disk, so the call it answers
 /// stays valid. Says what happened rather than inventing an outcome.
-const MISSING_TOOL_RESULT: &str =
+pub(crate) const MISSING_TOOL_RESULT: &str =
     "(result not saved: the session ended before this call's output was recorded)";
 
 /// Rebuild the wire conversation from persisted `thread.message` records: the

--- a/src-tauri/src/core/cli/mod.rs
+++ b/src-tauri/src/core/cli/mod.rs
@@ -1258,6 +1258,12 @@ async fn print_event(ev: StreamEvent, registry: &PermissionRegistry) {
             print!("{text}");
             let _ = std::io::stdout().flush();
         }
+        // Reasoning is progress, not answer: dimmed on stderr so piping stdout
+        // yields only the real completion.
+        StreamEvent::Reasoning { text } => {
+            eprint!("\x1b[2m{text}\x1b[0m");
+            let _ = std::io::stderr().flush();
+        }
         StreamEvent::Step { index, max } => match max {
             0 => eprintln!("\n\x1b[2m[turn {index}]\x1b[0m"),
             m => eprintln!("\n\x1b[2m[turn {index}/{m}]\x1b[0m"),

--- a/src-tauri/src/core/cli/mod.rs
+++ b/src-tauri/src/core/cli/mod.rs
@@ -681,7 +681,7 @@ fn build_cli_orchestration_args(
     sandbox: Option<bool>,
 ) -> OrchestrationArgs {
     OrchestrationArgs {
-        client: reqwest::Client::new(),
+        client: crate::core::agent::upstream::agent_http_client(),
         provider_configs: Arc::new(Mutex::new(provider_configs)),
         mcp_servers,
         mcp_settings: Arc::new(Mutex::new(mcp_settings)),

--- a/src-tauri/src/core/cli/mod.rs
+++ b/src-tauri/src/core/cli/mod.rs
@@ -763,6 +763,10 @@ pub(crate) struct AgentSession {
     pub limits: SessionLimits,
     /// Whether the TUI expands `<think>` reasoning blocks (default false).
     pub show_reasoning: bool,
+    /// Whether the TUI streams reasoning into the live tail while it folds
+    /// (`stream_reasoning` in `~/.jan/config.toml`, default true). Independent
+    /// of `show_reasoning`, which unfolds it for good.
+    pub stream_reasoning: bool,
     /// Whether to resend a prior assistant turn's reasoning to the model
     /// (default true). False drops `reasoning_content` from outgoing assistant
     /// messages; the display journal still keeps reasoning for a resume.
@@ -939,6 +943,7 @@ fn prepare_agent_session(
             max_session_tokens: cfg.budget.max_tokens.unwrap_or(DEFAULT_MAX_SESSION_TOKENS),
         },
         show_reasoning: cfg.agent.show_reasoning.unwrap_or(false),
+        stream_reasoning: crate::core::agent::global_config::stream_reasoning_enabled(),
         send_reasoning: cfg.agent.send_reasoning.unwrap_or(true),
         mcp_servers,
         mcp_task,

--- a/src-tauri/src/core/cli/mod.rs
+++ b/src-tauri/src/core/cli/mod.rs
@@ -905,6 +905,10 @@ fn prepare_agent_session(
         None
     };
 
+    // `think_tags` is user-wide and read from free rendering functions, so it is
+    // applied to the process here, the one path every agent surface takes.
+    tui::set_think_tags_parsed(crate::core::agent::global_config::think_tags_enabled());
+
     let permission_requests: PermissionRegistry = Arc::new(Mutex::new(HashMap::new()));
     let max_parallel_subagents = cfg
         .agent

--- a/src-tauri/src/core/cli/mod.rs
+++ b/src-tauri/src/core/cli/mod.rs
@@ -763,6 +763,10 @@ pub(crate) struct AgentSession {
     pub limits: SessionLimits,
     /// Whether the TUI expands `<think>` reasoning blocks (default false).
     pub show_reasoning: bool,
+    /// Whether to resend a prior assistant turn's reasoning to the model
+    /// (default true). False drops `reasoning_content` from outgoing assistant
+    /// messages; the display journal still keeps reasoning for a resume.
+    pub send_reasoning: bool,
     /// Shared MCP connection map (same Arc held by `args`), so the TUI can
     /// connect/disconnect servers live via `/mcp` and later turns pick them up.
     pub mcp_servers: crate::core::state::SharedMcpServers,
@@ -785,6 +789,9 @@ impl AgentSession {
         if let Some(max) = self.limits.max_tokens {
             body["max_tokens"] = serde_json::json!(max);
         }
+        // Reasoning resend policy: the request-level flag the loop reads to
+        // decide whether prior assistant `reasoning_content` goes back out.
+        body["send_reasoning"] = serde_json::json!(self.send_reasoning);
         body
     }
 }
@@ -928,6 +935,7 @@ fn prepare_agent_session(
             max_session_tokens: cfg.budget.max_tokens.unwrap_or(DEFAULT_MAX_SESSION_TOKENS),
         },
         show_reasoning: cfg.agent.show_reasoning.unwrap_or(false),
+        send_reasoning: cfg.agent.send_reasoning.unwrap_or(true),
         mcp_servers,
         mcp_task,
     })

--- a/src-tauri/src/core/cli/run_report.rs
+++ b/src-tauri/src/core/cli/run_report.rs
@@ -58,6 +58,9 @@ impl RunReport {
                 self.partial.clear();
             }
             StreamEvent::Token { text } => self.partial.push_str(text),
+            // Reasoning is display-only: it must not enter the piped/plain-text
+            // report answer, which is reserved for the final completion.
+            StreamEvent::Reasoning { .. } => {}
             StreamEvent::TurnUsage { usage } => {
                 self.prompt_tokens += usage.prompt_tokens.unwrap_or(0);
                 self.completion_tokens += usage.completion_tokens.unwrap_or(0);

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -1132,6 +1132,14 @@ struct App {
     /// In-progress assistant text for the current turn, flushed on the next
     /// step/tool/terminal event.
     assistant_buf: String,
+    /// Reasoning streamed natively via `StreamEvent::Reasoning` since the last
+    /// flush, each segment anchored to the `assistant_buf` offset it arrived at.
+    /// Kept apart from `assistant_buf` so it is never wrapped into the wire
+    /// history: it is display-only, folded like `<think>` blocks. Anchoring
+    /// (rather than one flat buffer) is what keeps a turn that interleaves
+    /// reasoning with prose in emission order, and what lets `reasoning_open`
+    /// tell "still reasoning" from "prose has started".
+    reasoning_segs: Vec<ReasoningSeg>,
     /// The current run of consecutive collapsible tool calls, rendered as one
     /// transcript row that updates in real time and finalizes to a short summary.
     /// edit/write are excluded (they render their own diff panel).
@@ -1513,6 +1521,7 @@ impl App {
             display_log: Vec::new(),
             journal_writer: None,
             assistant_buf: String::new(),
+            reasoning_segs: Vec::new(),
             tool_group: None,
             grouped_ids: std::collections::HashSet::new(),
             groups: Vec::new(),
@@ -1653,6 +1662,7 @@ impl App {
         self.expanded.clear();
         self.reveal = None;
         self.assistant_buf.clear();
+        self.reasoning_segs.clear();
         self.message_queue.clear();
         self.pending_queue.clear();
         self.ask_queue.clear();
@@ -1752,7 +1762,10 @@ impl App {
     }
 
     fn flush_assistant(&mut self) {
-        let text = self.assistant_buf.trim_end().to_string();
+        let segs = std::mem::take(&mut self.reasoning_segs);
+        let text = fold_native_reasoning(&self.assistant_buf, &segs)
+            .trim_end()
+            .to_string();
         self.assistant_buf.clear();
         // The buffered stream is committed: any open reasoning window closes
         // (its elapsed time was stashed when the block itself closed, so this
@@ -1765,9 +1778,9 @@ impl App {
         }
         // Model prose ends the current run of tool calls.
         self.finalize_tool_group();
-        // Journaled with its `<think>` markers intact: this is the only place the
-        // reasoning exists (it is kept out of `history` on purpose), and the
-        // replay folds it exactly as the live turn did.
+        // Native reasoning is already folded into `text` as wrapped blocks at the
+        // offsets it streamed at. Display-logged here (out of `history` on
+        // purpose) so the replay folds it like the live turn did.
         self.display_log.push(DisplayEntry::Assistant {
             text: text.clone(),
         });
@@ -2028,7 +2041,27 @@ impl App {
     /// stretch of a run that puts nothing on screen, so the header badge is the
     /// only place progress can show.
     fn is_thinking(&self) -> bool {
-        self.status != Status::Idle && !self.show_reasoning && thinking_open(&self.assistant_buf)
+        self.status != Status::Idle && !self.show_reasoning && self.reasoning_open()
+    }
+
+    /// True while the model is mid-reasoning: either a `<think>` block is live
+    /// in the answer buffer (inline-tag providers) or the newest native segment
+    /// is still at the tail, i.e. no content token has arrived since
+    /// (`reasoning_content` providers). The tail check is what closes the window
+    /// when prose starts, since native segments live on until the next flush.
+    fn reasoning_open(&self) -> bool {
+        thinking_open(&self.assistant_buf)
+            || self
+                .reasoning_segs
+                .last()
+                .is_some_and(|seg| seg.at == self.assistant_buf.len())
+    }
+
+    /// The live assistant text with native reasoning folded in as wrapped blocks,
+    /// exactly as `flush_assistant` will commit it. Lets the shared renderer
+    /// treat native and inline-tag reasoning identically while streaming.
+    fn live_assistant_text(&self) -> String {
+        fold_native_reasoning(&self.assistant_buf, &self.reasoning_segs)
     }
 
     /// Header status while a turn is running with reasoning folding on:
@@ -2037,7 +2070,7 @@ impl App {
     /// plain `[working]`) once the model is working again. `None` when no
     /// reasoning has happened recently this turn.
     fn reasoning_status(&self) -> Option<(String, Style)> {
-        if thinking_open(&self.assistant_buf) {
+        if self.reasoning_open() {
             Some(("thinking".to_string(), Style::new().yellow().bold()))
         } else {
             // The summary is transient: it lasts only `THOUGHT_FOR_TTL` after the
@@ -3068,10 +3101,13 @@ impl App {
             StreamEvent::Token { text } => {
                 self.assistant_buf.push_str(&text);
                 // Track the live thinking state so the header can fold reasoning
-                // to `[thinking]` / `[thought for Ns]`. Start the timer when a
-                //  block opens; close it (stashing the duration) once the block
-                // closes or the tool group proceeds.
-                let open = thinking_open(&self.assistant_buf);
+                // to `[thinking]` / `[thought for Ns]`. Start the timer when
+                // reasoning is open; close it (stashing the duration) once the
+                // block ends. `reasoning_open` covers both inline ` think>` tags
+                // and native reasoning_buf, so a content token after reasoning
+                // closes the window (and prose arriving with no reasoning leaves
+                // it closed).
+                let open = self.reasoning_open();
                 if open && self.thinking_since.is_none() {
                     self.thinking_since = Some(Instant::now());
                 } else if !open {
@@ -3086,6 +3122,23 @@ impl App {
                 // into its own row.
                 if self.tool_group.is_some() && has_answer_text(&self.assistant_buf) {
                     self.finalize_tool_group();
+                }
+            }
+            StreamEvent::Reasoning { text } => {
+                // Native reasoning stays out of the answer buffer entirely; it is
+                // folded into the display log on the next flush. Deltas that
+                // arrive with no prose in between extend the open segment;
+                // reasoning after prose starts a new one, so the timeline keeps
+                // emission order instead of hoisting every thought to the top.
+                if !text.is_empty() {
+                    let at = self.assistant_buf.len();
+                    match self.reasoning_segs.last_mut() {
+                        Some(seg) if seg.at == at => seg.text.push_str(&text),
+                        _ => self.reasoning_segs.push(ReasoningSeg { at, text }),
+                    }
+                    if self.thinking_since.is_none() {
+                        self.thinking_since = Some(Instant::now());
+                    }
                 }
             }
             StreamEvent::Step { index, max } => {
@@ -4743,6 +4796,49 @@ fn split_reasoning(text: &str) -> Vec<(bool, String)> {
         out.push((in_think, seg.to_string()));
     }
     out
+}
+
+/// One stretch of natively streamed reasoning, anchored to the byte offset in
+/// `App::assistant_buf` it arrived at, so it can be folded back into the answer
+/// text in emission order.
+#[derive(Debug, Clone, PartialEq)]
+struct ReasoningSeg {
+    at: usize,
+    text: String,
+}
+
+/// Splice native reasoning segments into `prose` as `<think>` blocks at the
+/// offsets they streamed at, yielding the one string form both the live renderer
+/// and the display journal use. Offsets come from `prose.len()` at emission time,
+/// so they are always char boundaries and always ascending.
+fn fold_native_reasoning(prose: &str, segs: &[ReasoningSeg]) -> String {
+    if segs.is_empty() {
+        return prose.to_string();
+    }
+    let extra: usize = segs.iter().map(|s| s.text.len() + 16).sum();
+    let mut out = String::with_capacity(prose.len() + extra);
+    let mut last = 0;
+    for seg in segs {
+        let at = seg.at.min(prose.len());
+        out.push_str(&prose[last..at]);
+        if !seg.text.trim().is_empty() {
+            out.push_str("<think>");
+            out.push_str(escape_think_tags(seg.text.trim_end()).trim_end());
+            out.push_str("</think>");
+        }
+        last = at;
+    }
+    out.push_str(&prose[last..]);
+    out
+}
+
+/// Neutralize `<think>`-family tags inside reasoning text before it is wrapped in
+/// one. A model reasoning *about* thinking tags would otherwise close the block
+/// early and have the rest of its thought rendered and journaled as answer prose.
+fn escape_think_tags(text: &str) -> std::borrow::Cow<'_, str> {
+    think_re().replace_all(text, |m: &regex::Captures| {
+        format!("&lt;{}", &m[0][1..])
+    })
 }
 
 /// True if `text` ends inside an unclosed ` think>` block (an opening tag whose
@@ -8856,6 +8952,7 @@ fn rebuild_transcript(app: &mut App) {
     app.expanded.clear();
     app.reveal = None;
     app.assistant_buf.clear();
+    app.reasoning_segs.clear();
     app.last_kind = Kind::None;
     if !app.display_log.is_empty() {
         let logged = std::mem::take(&mut app.display_log);
@@ -8920,6 +9017,7 @@ async fn load_thread(app: &mut App, thread: &serde_json::Value) {
     app.expanded.clear();
     app.reveal = None;
     app.assistant_buf.clear();
+    app.reasoning_segs.clear();
     app.turn = (0, 0);
     app.tokens = 0;
     app.scrollback = 0;
@@ -9375,16 +9473,19 @@ fn draw(f: &mut Frame, app: &mut App) {
     // Streaming prose and the awaiting throbbers have no transcript index; they
     // are rebuilt every frame and ride along as one trailing segment.
     let mut tail: Vec<Line<'static>> = Vec::new();
-    if !app.assistant_buf.is_empty() {
-        let live = live_assistant_lines(&app.assistant_buf, width, !app.show_reasoning);
+    if !app.assistant_buf.is_empty() || !app.reasoning_segs.is_empty() {
+        // Native reasoning is folded into a wrapped block beside the live text
+        // so the shared renderer dims/folds it exactly like inline-tag providers.
+        let live_text = app.live_assistant_text();
+        let live = live_assistant_lines(&live_text, width, !app.show_reasoning);
         if !live.is_empty() {
             // Mirror flush_assistant's `gap(Kind::Prose)` so the separator above
-            // streaming prose is present live, not only once it's finalized.
+            // streaming prose is present live, not only once it is finalized.
             if !trailing_blank(&tail, &app.transcript, width) {
                 tail.push(Line::raw(""));
             }
             // Live tail: same renderer as finalized messages, so an open
-            // (unterminated) <think> block dims and grows during streaming.
+            // (unterminated) wrapped reasoning block dims and grows during streaming.
             tail.extend(live);
         }
     }
@@ -10932,7 +11033,7 @@ fn input_box(app: &App) -> Paragraph<'static> {
             // synonyms in orange while a reasoning block streams -- so the row
             // reads alive without shifting under the eye.
             let step = app.spinner_frame / WORD_ROTATE_FRAMES;
-            let (word, style) = if thinking_open(&app.assistant_buf) {
+            let (word, style) = if app.reasoning_open() {
                 (
                     THINKING_WORDS[step % THINKING_WORDS.len()],
                     Style::new().fg(THINKING_ORANGE).italic(),
@@ -17337,6 +17438,139 @@ mod tests {
             .find(|r| r.contains("Queued"))
             .expect("queued row present");
         assert!(row.contains(SPINNER[5]), "expected frame 5 glyph: {row:?}");
+    }
+
+    /// Native reasoning events (a dedicated `reasoning_content` field) drive the
+    /// same orange thinking placeholder as inline `<`> tags, are folded into the
+    /// transcript like a wrapped block on flush, and never enter the wire answer.
+    #[test]
+    fn native_reasoning_drives_thinking_placeholder_and_folds_on_flush() {
+        let mut app = test_app();
+        app.submit_user("go".into());
+        app.apply(StreamEvent::Reasoning {
+            text: "ponder the plan".into(),
+        });
+        // Orange thinking synonyms while reasoning streams.
+        let row = render_rows(&mut app, 80, 12)
+            .into_iter()
+            .find(|r| r.contains("(Esc to cancel, type to queue next message)"))
+            .expect("running placeholder present");
+        assert!(
+            THINKING_WORDS.iter().any(|w| row.contains(w)),
+            "expected a thinking synonym while reasoning: {row:?}"
+        );
+        // The answer arrives: reasoning stays folded into a summary row.
+        app.apply(StreamEvent::Token {
+            text: "Here is the answer".into(),
+        });
+        app.on_done("stop".into(), None);
+        assert_eq!(app.reasoning_blocks.len(), 1, "reasoning folded into one block");
+        // The wire history carries the answer without the reasoning.
+        let wire = app
+            .history
+            .iter()
+            .map(serde_json::Value::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(wire.contains("Here is the answer"), "answer missing: {wire}");
+        assert!(!wire.contains("ponder the plan"), "reasoning leaked into history: {wire}");
+    }
+
+    /// The `[thinking]` badge and the orange placeholder must close when the
+    /// answer starts streaming: native segments live until the next flush, so
+    /// only the "newest segment is still at the tail" check can tell the two
+    /// apart. Without it the badge shimmered through the whole answer and
+    /// `[thought for Ns]` never appeared for a `reasoning_content` provider.
+    #[test]
+    fn native_reasoning_badge_closes_once_prose_starts() {
+        let mut app = test_app();
+        app.submit_user("go".into());
+        app.apply(StreamEvent::Reasoning { text: "ponder".into() });
+        assert_eq!(
+            app.reasoning_status().map(|(w, _)| w),
+            Some("thinking".to_string())
+        );
+        assert!(app.is_thinking(), "reasoning is live");
+        app.apply(StreamEvent::Token { text: "Answer".into() });
+        assert!(!app.is_thinking(), "prose has started");
+        assert_eq!(
+            app.reasoning_status().map(|(w, _)| w),
+            Some("thought for 0s".to_string()),
+            "the closed block reports its duration"
+        );
+    }
+
+    fn detail_text(block: &super::ReasoningBlock) -> String {
+        block
+            .detail
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|sp| sp.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    /// Reasoning that mentions a `</think>` tag must not close the block it is
+    /// wrapped in and spill the rest of the thought into the answer.
+    #[test]
+    fn native_reasoning_mentioning_a_close_tag_stays_reasoning() {
+        let mut app = test_app();
+        app.submit_user("go".into());
+        app.apply(StreamEvent::Reasoning {
+            text: "the </think> tag is tricky".into(),
+        });
+        app.on_done("stop".into(), None);
+        let rows = render_rows(&mut app, 80, 30).join("\n");
+        assert!(
+            !rows.contains("tag is tricky"),
+            "reasoning rendered as answer prose: {rows}"
+        );
+        assert_eq!(app.reasoning_blocks.len(), 1, "one folded reasoning block");
+        assert!(
+            detail_text(&app.reasoning_blocks[0]).contains("&lt;/think>"),
+            "the tag is neutralized, not dropped: {}",
+            detail_text(&app.reasoning_blocks[0])
+        );
+    }
+
+    /// Interleaved reasoning keeps emission order: each stretch folds where it
+    /// streamed instead of every thought being hoisted above all the prose.
+    #[test]
+    fn interleaved_native_reasoning_keeps_emission_order() {
+        let mut app = test_app();
+        app.submit_user("go".into());
+        app.apply(StreamEvent::Reasoning { text: "first thought".into() });
+        app.apply(StreamEvent::Token { text: "Part one.".into() });
+        app.apply(StreamEvent::Reasoning { text: "second thought".into() });
+        app.apply(StreamEvent::Token { text: " Part two.".into() });
+        app.on_done("stop".into(), None);
+        assert_eq!(app.reasoning_blocks.len(), 2, "two separate stretches");
+        let DisplayEntry::Assistant { text } = app
+            .display_log
+            .iter()
+            .rev()
+            .find(|e| matches!(e, DisplayEntry::Assistant { .. }))
+            .expect("assistant entry journaled")
+        else {
+            unreachable!()
+        };
+        assert_eq!(
+            text,
+            "<think>first thought</think>Part one.<think>second thought</think> Part two."
+        );
+        // The wire answer carries neither thought.
+        let wire = app
+            .history
+            .iter()
+            .map(serde_json::Value::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(wire.contains("Part one. Part two."), "answer missing: {wire}");
+        assert!(!wire.contains("thought"), "reasoning leaked into history: {wire}");
     }
 
     #[test]

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -1484,14 +1484,38 @@ const SPINNER_ADVANCE_MS: u64 = 80;
 
 /// Rotating action words for the running input placeholder, replacing a static
 /// "working…" so a long turn does not read as a hung UI.
-const WORKING_WORDS: [&str; 6] =
-    ["working", "computing", "processing", "analyzing", "crunching", "grinding"];
+const WORKING_WORDS: [&str; 12] = [
+    "working",
+    "computing",
+    "processing",
+    "analyzing",
+    "crunching",
+    "grinding",
+    "executing",
+    "running",
+    "handling",
+    "compiling",
+    "operating",
+    "fetching",
+];
 
 /// Rotating action words shown while the model is reasoning (a ` think>` block
 /// is streaming), coloured orange. Mirrors the working list so the two states
 /// read as the same kind of progress, just distinct in wording and colour.
-const THINKING_WORDS: [&str; 6] =
-    ["thinking", "reasoning", "pondering", "reflecting", "deliberating", "musing"];
+const THINKING_WORDS: [&str; 12] = [
+    "thinking",
+    "reasoning",
+    "pondering",
+    "reflecting",
+    "deliberating",
+    "musing",
+    "ruminating",
+    "meditating",
+    "contemplating",
+    "weighing",
+    "cogitating",
+    "calculating",
+];
 
 /// Spinner frames per placeholder-word change, so the action word turns over
 /// at a relaxed pace (60 frames x 80ms ~= 4.8s) rather than shifting under
@@ -11542,7 +11566,7 @@ mod tests {
         row_width, user_content_parts, App, CurrentRun, Pending, PendingImage, PickerKind,
         ResumeTarget, RowKind,
         SnapshotJob, Status, AGENT_SETTINGS, ALT_SCROLL_RESTORE, ALT_SCROLL_SAVE_OFF,
-        COMMAND_LABEL_MAX, DIFF_ADD_BG, DIFF_DEL_BG, DIFF_MAX_ROWS, DIFF_PREVIEW_MAX_ROWS,
+        DIFF_ADD_BG, DIFF_DEL_BG, DIFF_MAX_ROWS, DIFF_PREVIEW_MAX_ROWS,
         KEY_BINDINGS, MOUSE_TRACK_ON, SLASH_COMMANDS, SPINNER, PROVIDERS_SETTINGS_ROW,
         SPINNER_ADVANCE_MS, THINKING_WORDS, WORKING_WORDS,
         alt_scroll_restore, alt_scroll_save_off,

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -1494,9 +1494,9 @@ const THINKING_WORDS: [&str; 6] =
     ["thinking", "reasoning", "pondering", "reflecting", "deliberating", "musing"];
 
 /// Spinner frames per placeholder-word change, so the action word turns over
-/// at a readable pace (10 frames x 80ms ~= 0.8s) rather than on the braille
-/// spinner's every sub-frame.
-const WORD_ROTATE_FRAMES: usize = 10;
+/// at a relaxed pace (60 frames x 80ms ~= 4.8s) rather than shifting under
+/// the eye alongside the braille spinner.
+const WORD_ROTATE_FRAMES: usize = 60;
 
 /// Orange used for the "thinking" action word, matching the markdown bold
 /// accent so reasoning reads consistently across the TUI.

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -877,28 +877,7 @@ impl Row {
                 label,
                 label_style,
                 reserve,
-            } => {
-                let max = width.saturating_sub(*reserve).max(1) as usize;
-                let tag_w = tag.chars().count() + 1;
-                let mut rows = wrap_text(label, *label_style, max);
-                if rows.len() > TOOL_ROW_MAX_LINES {
-                    rows.truncate(TOOL_ROW_MAX_LINES);
-                    if let Some(last) = rows.last_mut() {
-                        last.push(Span::styled(" …", *label_style));
-                    }
-                }
-                gutter_lines(
-                    rows,
-                    vec![
-                        Span::styled("│ ", Style::new().dark_gray()),
-                        Span::styled(format!("{tag} "), *tag_style),
-                    ],
-                    vec![
-                        Span::styled("│ ", Style::new().dark_gray()),
-                        Span::raw(" ".repeat(tag_w)),
-                    ],
-                )
-            }
+            } => tool_row_lines(tag, *tag_style, label, *label_style, *reserve, width, None),
             RowKind::Result {
                 tag,
                 tag_style,
@@ -1573,16 +1552,22 @@ struct SubagentBlock {
 }
 
 impl SubagentBlock {
+    /// The child's call list, revealed by Ctrl-O. Wrapped, not elided, for the
+    /// same reason as `group_detail_lines`: this is the surface the folded
+    /// summary row sends the user to, so it is the one that has to be complete.
     fn detail_lines(&self, width: u16) -> Vec<Line<'static>> {
         let max = width.saturating_sub(8).max(1) as usize;
         self.calls
             .iter()
-            .map(|label| {
-                Line::from(vec![
-                    Span::styled("│   ", Style::new().dark_gray()),
-                    Span::styled("▸ ", Style::new().magenta()),
-                    Span::styled(truncate(label, max), Style::new().dim()),
-                ])
+            .flat_map(|label| {
+                gutter_lines(
+                    wrap_text(label, Style::new().dim(), max),
+                    vec![
+                        Span::styled("│   ", Style::new().dark_gray()),
+                        Span::styled("▸ ", Style::new().magenta()),
+                    ],
+                    vec![Span::styled("│     ", Style::new().dark_gray())],
+                )
             })
             .collect()
     }
@@ -2832,18 +2817,7 @@ impl App {
         let args = args.trim();
         self.history
             .push(serde_json::json!({ "role": "user", "content": msg }));
-        let mut spans = vec![Span::styled("› ", Style::new().light_magenta().bold())];
-        spans.push(Span::styled(
-            format!("[skill:{name}]"),
-            Style::new().cyan().bold(),
-        ));
-        if !args.is_empty() {
-            spans.push(Span::raw(format!(" {args}")));
-        } else if !description.is_empty() {
-            spans.push(Span::raw(format!(" - {description}")));
-        }
-        self.gap(Kind::User);
-        self.push(Line::from(spans));
+        self.push_invocation_row(&format!("[skill:{name}]"), args, &description);
         self.begin_turn();
         // A fresh user turn is new context: same reminder reset as submit_user.
         self.last_todo_reminder = None;
@@ -2871,18 +2845,7 @@ impl App {
         let args = args.trim();
         self.history
             .push(serde_json::json!({ "role": "user", "content": msg }));
-        let mut spans = vec![Span::styled("› ", Style::new().light_magenta().bold())];
-        spans.push(Span::styled(
-            format!("[command:{name}]"),
-            Style::new().cyan().bold(),
-        ));
-        if !args.is_empty() {
-            spans.push(Span::raw(format!(" {args}")));
-        } else if !description.is_empty() {
-            spans.push(Span::raw(format!(" - {description}")));
-        }
-        self.gap(Kind::User);
-        self.push(Line::from(spans));
+        self.push_invocation_row(&format!("[command:{name}]"), args, &description);
         self.begin_turn();
         // A fresh user turn is new context: same reminder reset as submit_user.
         self.last_todo_reminder = None;
@@ -3016,10 +2979,32 @@ impl App {
     /// the label only, never the template body (see `super::invocation_label`).
     fn push_invocation_label(&mut self, label: String) {
         self.gap(Kind::User);
-        self.push(Line::from(vec![
-            Span::styled("› ", Style::new().light_magenta().bold()),
-            Span::styled(label, Style::new().cyan().bold()),
-        ]));
+        self.push_row(RowKind::System {
+            glyph: "›",
+            cont: " ",
+            gutter: Style::new().light_magenta().bold(),
+            body: vec![Span::styled(label, Style::new().cyan().bold())],
+        });
+    }
+
+    /// The `› [skill:foo] <args>` row a slash invocation commits. A `System`
+    /// row for the same reason as `push_user_line`: `args` is user text and can
+    /// arrive pasted and multi-line, which a single `Line` renders as blank
+    /// cells in one run-on row.
+    fn push_invocation_row(&mut self, label: &str, args: &str, description: &str) {
+        let mut body = vec![Span::styled(label.to_string(), Style::new().cyan().bold())];
+        if !args.is_empty() {
+            body.push(Span::raw(format!(" {args}")));
+        } else if !description.is_empty() {
+            body.push(Span::raw(format!(" - {description}")));
+        }
+        self.gap(Kind::User);
+        self.push_row(RowKind::System {
+            glyph: "›",
+            cont: " ",
+            gutter: Style::new().light_magenta().bold(),
+            body,
+        });
     }
 
     /// Stage the OS clipboard's image for the next message, noting the result.
@@ -4132,12 +4117,14 @@ const DIFF_MAX_ROWS: usize = 1000;
 /// long diff has to collapse rather than crowd out the options.
 const DIFF_PREVIEW_MAX_ROWS: usize = 20;
 
-/// Max chars shown for a bash/shell/exec command label in the transcript.
-const COMMAND_LABEL_MAX: usize = 80;
-
 /// Cells a `tool_row` spends on its gutter and tag, subtracted from the draw
 /// width before the label is wrapped.
 const TOOL_ROW_RESERVE: u16 = 6;
+
+/// Columns held back for the live row's elapsed badge. Fixed rather than
+/// measured so the body's wrap points never move as the counter ticks; wide
+/// enough for the four digits a single tool call will not outlive.
+const ELAPSED_RESERVE: usize = 8;
 
 /// Rows one tool label may occupy before it elides. A label is wrapped rather
 /// than cut so a long command stays readable, but a heredoc body would
@@ -4366,7 +4353,7 @@ fn tool_activity(name: &str, args: &serde_json::Value) -> String {
             if q.is_empty() {
                 "Searching the web".to_string()
             } else {
-                format!("Searching the web: {}", truncate(q, COMMAND_LABEL_MAX))
+                format!("Searching the web: {q}")
             }
         }
         "web_fetch" => {
@@ -4374,7 +4361,7 @@ fn tool_activity(name: &str, args: &serde_json::Value) -> String {
             if u.is_empty() {
                 "Fetching a page".to_string()
             } else {
-                format!("Fetching: {}", truncate(u, COMMAND_LABEL_MAX))
+                format!("Fetching: {u}")
             }
         }
         "ask" => "Asking a question".to_string(),
@@ -4410,7 +4397,7 @@ fn todo_op_verb(args: &serde_json::Value, past: bool) -> &'static str {
 /// item count for `append`, or "todos" as a generic fallback.
 fn todo_target_label(args: &serde_json::Value) -> String {
     if let Some(task) = args.get("task").and_then(|v| v.as_str()) {
-        return format!("task: {}", truncate(task, COMMAND_LABEL_MAX));
+        return format!("task: {task}");
     }
     if let Some(phase) = args.get("phase").and_then(|v| v.as_str()) {
         if let Some(items) = args.get("items").and_then(|v| v.as_array()) {
@@ -4493,7 +4480,7 @@ fn tool_finished(name: &str, args: &serde_json::Value) -> String {
             if q.is_empty() {
                 "Searched the web".to_string()
             } else {
-                format!("Searched the web: {}", truncate(q, COMMAND_LABEL_MAX))
+                format!("Searched the web: {q}")
             }
         }
         "web_fetch" => {
@@ -4501,7 +4488,7 @@ fn tool_finished(name: &str, args: &serde_json::Value) -> String {
             if u.is_empty() {
                 "Fetched a page".to_string()
             } else {
-                format!("Fetched: {}", truncate(u, COMMAND_LABEL_MAX))
+                format!("Fetched: {u}")
             }
         }
         "ask" => "Asked a question".to_string(),
@@ -4738,6 +4725,53 @@ fn starting_call_lines(call: &mut StartingCall, frame: &str) -> Vec<Line<'static
     out
 }
 
+/// A tool row laid out at `width`: `tag` in the gutter, `label` wrapped
+/// beneath it with continuations aligned under the label rather than under the
+/// tag, bounded by `TOOL_ROW_MAX_LINES`. Shared by the committed `RowKind::Tool`
+/// and the live group row so the running command and the finished one wrap
+/// identically -- the row must not re-flow at the moment it resolves.
+///
+/// `suffix` rides the end of the last row (the live row's elapsed badge). The
+/// wrap reserves `ELAPSED_RESERVE` for it up front instead of measuring it, so a
+/// counter ticking past 9s or 99s cannot re-flow the command above it.
+fn tool_row_lines(
+    tag: &str,
+    tag_style: Style,
+    label: &str,
+    label_style: Style,
+    reserve: u16,
+    width: u16,
+    suffix: Option<(String, Style)>,
+) -> Vec<Line<'static>> {
+    let held = if suffix.is_some() { ELAPSED_RESERVE } else { 0 };
+    let max = (width.saturating_sub(reserve) as usize)
+        .saturating_sub(held)
+        .max(1);
+    let mut rows = wrap_text(label, label_style, max);
+    if rows.len() > TOOL_ROW_MAX_LINES {
+        rows.truncate(TOOL_ROW_MAX_LINES);
+        if let Some(last) = rows.last_mut() {
+            last.push(Span::styled(" …", label_style));
+        }
+    }
+    if let Some((text, style)) = suffix {
+        rows.last_mut()
+            .expect("wrap_text yields at least one row")
+            .push(Span::styled(format!(" {text}"), style));
+    }
+    gutter_lines(
+        rows,
+        vec![
+            Span::styled("│ ", Style::new().dark_gray()),
+            Span::styled(format!("{tag} "), tag_style),
+        ],
+        vec![
+            Span::styled("│ ", Style::new().dark_gray()),
+            Span::raw(" ".repeat(tag.chars().count() + 1)),
+        ],
+    )
+}
+
 fn tool_row(tag: &str, tag_style: Style, text: &str, text_style: Style) -> Line<'static> {
     Line::from(vec![
         Span::styled("│ ", Style::new().dark_gray()),
@@ -4823,17 +4857,29 @@ fn group_summary(nouns: &[(&str, bool)]) -> String {
     group_clauses(nouns, "Read", "ran")
 }
 
-/// Live row for the still-open tool group: a braille throbber in place of the
-/// static `▸` tag, plus elapsed time, so the user can see it's actively
-/// working and how long it's taken. Rebuilt fresh every draw (not stored in
-/// `transcript`) since the group's row there is only overwritten on the next
-/// tool call, not every tick.
-fn running_group_row(group: &ToolGroup, spinner_frame: usize, width: u16) -> Line<'static> {
+/// Live rows for the still-open tool group: a braille throbber in place of the
+/// static `▸` tag, the running call's label, and elapsed time, so the user can
+/// see it's actively working and how long it's taken. Rebuilt fresh every draw
+/// (not stored in `transcript`) since the group's row there is only overwritten
+/// on the next tool call, not every tick.
+///
+/// The label wraps exactly as the committed row will, so a long command is
+/// readable *while* it runs -- which is when the user most wants to check what
+/// they approved -- and the row does not re-lay itself out the instant the call
+/// resolves. The elapsed badge is dark rather than dim cyan: at the tail of a
+/// wrapped command it has to read as chrome, not as another argument.
+fn running_group_rows(group: &ToolGroup, spinner_frame: usize, width: u16) -> Vec<Line<'static>> {
     let frame = SPINNER[spinner_frame % SPINNER.len()];
     let elapsed = group.started.elapsed().as_secs();
-    let text = format!("{} ({elapsed}s)", single_line(&group.activity()));
-    let max = (width as usize).saturating_sub(6).max(1);
-    tool_row(frame, Style::new().cyan(), &truncate(&text, max), Style::new().cyan().dim())
+    tool_row_lines(
+        frame,
+        Style::new().cyan(),
+        &group.activity(),
+        Style::new().cyan().dim(),
+        TOOL_ROW_RESERVE,
+        width,
+        Some((format!("({elapsed}s)"), Style::new().dark_gray())),
+    )
 }
 
 /// Bucket `nouns` into read-style and run-style clauses (first-seen order,
@@ -9637,7 +9683,7 @@ fn draw(f: &mut Frame, app: &mut App) {
         {
             Some(g) => Segment::eager(
                 Some(i),
-                vec![running_group_row(g, app.spinner_frame, width)],
+                running_group_rows(g, app.spinner_frame, width),
                 width,
             ),
             None => Segment {
@@ -9837,7 +9883,9 @@ fn draw(f: &mut Frame, app: &mut App) {
     // `/login` is modal and user-initiated (only reachable while idle), so it
     // outranks the queues below: nothing else may take keystrokes meant for a key.
     if let Some(prompt) = &app.login {
-        let height = (LOGIN_PROMPT_ROWS + u16::from(prompt.error.is_some())).min(chunks[1].height);
+        let height = (login_prompt_lines(prompt, chunks[2].width.saturating_sub(2)).len() as u16
+            + 2)
+        .min(chunks[1].height);
         let y = chunks[2].y.saturating_sub(height).max(chunks[1].y);
         let rect = ratatui::layout::Rect {
             x: chunks[2].x,
@@ -9847,7 +9895,11 @@ fn draw(f: &mut Frame, app: &mut App) {
         };
         draw_login(f, rect, prompt);
     } else if let Some(prompt) = &app.settings_prompt {
-        let height = (5 + u16::from(prompt.error.is_some())).min(chunks[1].height);
+        let toml_path = app.agent_dir.join("agent.toml");
+        let height = (settings_prompt_lines(prompt, &toml_path, chunks[2].width.saturating_sub(2))
+            .len() as u16
+            + 2)
+        .min(chunks[1].height);
         let y = chunks[2].y.saturating_sub(height).max(chunks[1].y);
         let rect = ratatui::layout::Rect {
             x: chunks[2].x,
@@ -9855,11 +9907,10 @@ fn draw(f: &mut Frame, app: &mut App) {
             width: chunks[2].width,
             height,
         };
-        let toml_path = app.agent_dir.join("agent.toml");
         draw_settings_prompt(f, rect, prompt, &toml_path);
     } else if let Some(prompt) = &app.mcp_prompt {
-        let height = prompt.visible_fields().len() as u16 + 3;
-        let height = height.min(chunks[1].height);
+        let height = (mcp_prompt_lines(prompt, chunks[2].width.saturating_sub(2)).len() as u16 + 2)
+            .min(chunks[1].height);
         let y = chunks[2].y.saturating_sub(height).max(chunks[1].y);
         let rect = ratatui::layout::Rect {
             x: chunks[2].x,
@@ -10034,31 +10085,32 @@ fn draw_ask(f: &mut Frame, area: Rect, ask: &mut PendingAsk, queue_len: usize) {
     f.render_widget(Paragraph::new(help), rows[2]);
 }
 
-/// Rows the `/login` box needs: two borders, the URL, the field, and the help
-/// line. An error adds one more (see the `draw` call site).
-const LOGIN_PROMPT_ROWS: u16 = 5;
-
 /// The `/login` prompt: the API-keys URL, a masked key field, and a help line.
 /// The key is never rendered, so a shared screen or scrollback capture cannot
 /// leak it.
-fn draw_login(f: &mut Frame, area: ratatui::layout::Rect, prompt: &LoginPrompt) {
-    use ratatui::widgets::Clear;
-
+/// The `/login` box's contents at `width`. Separate from `draw_login` so the
+/// call site can size the box from the rows it will actually need: the error
+/// carries an arbitrary-length upstream message, and it is the one line in
+/// there the user has to be able to read.
+fn login_prompt_lines(prompt: &LoginPrompt, width: u16) -> Vec<Line<'static>> {
     let dim = Style::new().dark_gray();
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::new().cyan())
-        .title(Span::styled(
-            " tokamak sign-in ",
-            Style::new().on_cyan().black().bold(),
-        ));
-
-    let mut lines = vec![Line::from(vec![
-        Span::styled("get a key at ", dim),
-        Span::styled(super::tokamak::API_KEYS_URL, Style::new().cyan()),
-    ])];
+    let max = width.max(1) as usize;
+    let mut lines: Vec<Line<'static>> = wrap_spans_hard(
+        vec![
+            Span::styled("get a key at ", dim),
+            Span::styled(super::tokamak::API_KEYS_URL, Style::new().cyan()),
+        ],
+        max,
+    )
+    .into_iter()
+    .map(Line::from)
+    .collect();
     if let Some(error) = &prompt.error {
-        lines.push(Line::styled(error.clone(), Style::new().red()));
+        lines.extend(
+            wrap_text(error, Style::new().red(), max)
+                .into_iter()
+                .map(Line::from),
+        );
     }
     if prompt.verifying {
         lines.push(Line::styled(
@@ -10067,21 +10119,57 @@ fn draw_login(f: &mut Frame, area: ratatui::layout::Rect, prompt: &LoginPrompt) 
         ));
         lines.push(Line::styled("Esc cancel".to_string(), dim));
     } else {
-        lines.push(Line::from(vec![
-            Span::styled("API key: ", Style::new().bold()),
-            Span::raw(prompt.masked()),
-            Span::styled("█", Style::new().cyan()),
-        ]));
+        lines.extend(field_lines(
+            vec![Span::styled("API key: ", Style::new().bold())],
+            &prompt.masked(),
+            Style::new(),
+            max,
+        ));
         lines.push(Line::styled(
             "paste the key · Enter verify · Esc cancel".to_string(),
             dim,
         ));
     }
+    lines
+}
+
+/// One edited field: `lead` (a label) then the value wrapped beneath it,
+/// continuations aligned under the value rather than under the label, with the
+/// cursor block on the last row. Shared by the `/login`, `/settings` and MCP
+/// prompts -- a value long enough to leave the box is exactly the one the user
+/// needs to see, since they are still typing it.
+fn field_lines(
+    lead: Vec<Span<'static>>,
+    value: &str,
+    value_style: Style,
+    width: usize,
+) -> Vec<Line<'static>> {
+    let lead_w: usize = lead.iter().map(|s| s.content.chars().count()).sum();
+    let mut rows = wrap_text(value, value_style, width.saturating_sub(lead_w + 1).max(1));
+    rows.last_mut()
+        .expect("wrap_text yields at least one row")
+        .push(Span::styled("█", Style::new().cyan()));
+    gutter_lines(rows, lead, vec![Span::raw(" ".repeat(lead_w))])
+}
+
+fn draw_login(f: &mut Frame, area: ratatui::layout::Rect, prompt: &LoginPrompt) {
+    use ratatui::widgets::Clear;
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::new().cyan())
+        .title(Span::styled(
+            " tokamak sign-in ",
+            Style::new().on_cyan().black().bold(),
+        ));
 
     f.render_widget(Clear, area);
     let inner = block.inner(area);
     f.render_widget(block, area);
-    f.render_widget(Paragraph::new(lines), inner);
+    f.render_widget(
+        Paragraph::new(login_prompt_lines(prompt, inner.width)),
+        inner,
+    );
 }
 
 /// Docked `/settings` edit prompt, styled like the `/login` dock: description,
@@ -10095,59 +10183,82 @@ fn draw_settings_prompt(
 ) {
     use ratatui::widgets::Clear;
 
-    let dim = Style::new().dark_gray();
-    let def = prompt.def();
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::new().cyan())
         .title(Span::styled(
-            format!(" agent settings: {} ", def.key),
+            format!(" agent settings: {} ", prompt.def().key),
             Style::new().on_cyan().black().bold(),
         ));
 
-    let mut lines = vec![Line::from(vec![
+    f.render_widget(Clear, area);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    f.render_widget(
+        Paragraph::new(settings_prompt_lines(prompt, toml_path, inner.width)),
+        inner,
+    );
+}
+
+/// The `/settings` box's contents at `width`, sized by the call site the same
+/// way as `login_prompt_lines`. The description, the current value and the
+/// enum `valid:` list are all long enough to leave a narrow box.
+fn settings_prompt_lines(
+    prompt: &SettingsPrompt,
+    toml_path: &std::path::Path,
+    width: u16,
+) -> Vec<Line<'static>> {
+    let dim = Style::new().dark_gray();
+    let def = prompt.def();
+    let max = width.max(1) as usize;
+    let wrapped = |spans: Vec<Span<'static>>| {
+        wrap_spans_hard(spans, max)
+            .into_iter()
+            .map(Line::from)
+            .collect::<Vec<_>>()
+    };
+
+    let mut lines = wrapped(vec![
         Span::styled(def.desc, dim),
         Span::styled("   current: ", dim),
         Span::styled(
             current_agent_value(toml_path, def.key).unwrap_or_else(|| "unset".to_string()),
             Style::new().cyan(),
         ),
-    ])];
-    lines.push(Line::styled(
-        match def.kind {
-            AgentSettingKind::Int { default, min } => {
-                let d = default
-                    .map(|d| d.to_string())
-                    .unwrap_or_else(|| "unset".to_string());
-                format!("default: {d} · valid: >= {min}")
-            }
-            AgentSettingKind::Text { default } => format!("default: {default}"),
-            AgentSettingKind::Enum { options, default } => {
-                format!("default: {default} · valid: {}", options.join(" | "))
-            }
-            AgentSettingKind::Bool { default } => {
-                format!("default: {default} · valid: true | false")
-            }
-        },
-        dim,
-    ));
+    ]);
+    let meta = match def.kind {
+        AgentSettingKind::Int { default, min } => {
+            let d = default
+                .map(|d| d.to_string())
+                .unwrap_or_else(|| "unset".to_string());
+            format!("default: {d} · valid: >= {min}")
+        }
+        AgentSettingKind::Text { default } => format!("default: {default}"),
+        AgentSettingKind::Enum { options, default } => {
+            format!("default: {default} · valid: {}", options.join(" | "))
+        }
+        AgentSettingKind::Bool { default } => {
+            format!("default: {default} · valid: true | false")
+        }
+    };
+    lines.extend(wrapped(vec![Span::styled(meta, dim)]));
     if let Some(error) = &prompt.error {
-        lines.push(Line::styled(error.clone(), Style::new().red()));
+        lines.extend(wrapped(vec![Span::styled(
+            error.clone(),
+            Style::new().red(),
+        )]));
     }
-    lines.push(Line::from(vec![
-        Span::styled("value: ", Style::new().bold()),
-        Span::raw(prompt.input.clone()),
-        Span::styled("█", Style::new().cyan()),
-    ]));
+    lines.extend(field_lines(
+        vec![Span::styled("value: ", Style::new().bold())],
+        &prompt.input,
+        Style::new(),
+        max,
+    ));
     lines.push(Line::styled(
         "Enter save · Esc cancel · clear field to unset (default applies)".to_string(),
         dim,
     ));
-
-    f.render_widget(Clear, area);
-    let inner = block.inner(area);
-    f.render_widget(block, area);
-    f.render_widget(Paragraph::new(lines), inner);
+    lines
 }
 
 /// Dock the MCP add/edit wizard above the input: one row per visible field,
@@ -10155,7 +10266,6 @@ fn draw_settings_prompt(
 fn draw_mcp_prompt(f: &mut Frame, area: ratatui::layout::Rect, prompt: &McpPrompt) {
     use ratatui::widgets::Clear;
 
-    let dim = Style::new().dark_gray();
     let title = if prompt.editing.is_some() {
         " mcp server: edit "
     } else {
@@ -10166,52 +10276,77 @@ fn draw_mcp_prompt(f: &mut Frame, area: ratatui::layout::Rect, prompt: &McpPromp
         .border_style(Style::new().cyan())
         .title(Span::styled(title, Style::new().on_cyan().black().bold()));
 
+    f.render_widget(Clear, area);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    f.render_widget(Paragraph::new(mcp_prompt_lines(prompt, inner.width)), inner);
+}
+
+/// The MCP wizard's contents at `width`, sized by the call site the same way as
+/// `login_prompt_lines`. These fields are being *typed*: a command line, an
+/// args string or an env/headers blob easily outruns the box, and clipping the
+/// field you are editing leaves no way to see what you entered.
+fn mcp_prompt_lines(prompt: &McpPrompt, width: u16) -> Vec<Line<'static>> {
+    let dim = Style::new().dark_gray();
+    let max = width.max(1) as usize;
     let mut lines = Vec::new();
     for field in prompt.visible_fields() {
         let selected = field == prompt.field;
         let (label, value, toggle) = match field {
             McpField::Name => ("name", prompt.name.as_str(), None),
-            McpField::Transport => ("type", prompt.transport.as_str(), Some(prompt.transport.as_str())),
+            McpField::Transport => (
+                "type",
+                prompt.transport.as_str(),
+                Some(prompt.transport.as_str()),
+            ),
             McpField::Command => ("command", prompt.command.as_str(), None),
             McpField::Args => ("args", prompt.args.as_str(), None),
             McpField::Env => ("env", prompt.env.as_str(), None),
             McpField::Url => ("url", prompt.url.as_str(), None),
             McpField::Headers => ("headers", prompt.headers.as_str(), None),
-            McpField::Active => {
-                ("active", if prompt.active { "yes" } else { "no" }, Some(if prompt.active { "yes" } else { "no" }))
-            }
+            McpField::Active => (
+                "active",
+                if prompt.active { "yes" } else { "no" },
+                Some(if prompt.active { "yes" } else { "no" }),
+            ),
         };
         let marker = if selected { "› " } else { "  " };
-        let style = if selected {
-            Style::new().bold()
-        } else {
-            dim
-        };
-        let mut spans = vec![
-            Span::styled(format!("{marker}{label}: "), style),
-        ];
-        if let Some(toggle) = toggle {
-            spans.push(Span::styled(toggle.to_string(), if selected { Style::new().cyan() } else { dim }));
-        } else {
-            spans.push(Span::styled(value.to_string(), style));
-            if selected {
-                spans.push(Span::styled("█", Style::new().cyan()));
+        let style = if selected { Style::new().bold() } else { dim };
+        let lead = vec![Span::styled(format!("{marker}{label}: "), style)];
+        match toggle {
+            // A toggle row is a fixed word, never typed into: no cursor, and
+            // nothing long enough to wrap.
+            Some(toggle) => {
+                let mut spans = lead;
+                spans.push(Span::styled(
+                    toggle.to_string(),
+                    if selected { Style::new().cyan() } else { dim },
+                ));
+                lines.push(Line::from(spans));
+            }
+            None if selected => lines.extend(field_lines(lead, value, style, max)),
+            None => {
+                let lead_w: usize = lead.iter().map(|s| s.content.chars().count()).sum();
+                lines.extend(gutter_lines(
+                    wrap_text(value, style, max.saturating_sub(lead_w).max(1)),
+                    lead,
+                    vec![Span::raw(" ".repeat(lead_w))],
+                ));
             }
         }
-        lines.push(Line::from(spans));
     }
     if let Some(error) = &prompt.error {
-        lines.push(Line::styled(error.clone(), Style::new().red()));
+        lines.extend(
+            wrap_text(error, Style::new().red(), max)
+                .into_iter()
+                .map(Line::from),
+        );
     }
     lines.push(Line::styled(
         "↑/↓ move · Enter save · Space toggle · Esc cancel".to_string(),
         dim,
     ));
-
-    f.render_widget(Clear, area);
-    let inner = block.inner(area);
-    f.render_widget(block, area);
-    f.render_widget(Paragraph::new(lines), inner);
+    lines
 }
 
 /// Dock the provider add/edit wizard above the input: one row per field, the
@@ -11400,7 +11535,7 @@ mod tests {
         ProviderField,
         autoscroll_selection, selection_text, Selection, SelectionMode, COPY_NOTICE,
         run_command, starting_call_lines, unescape_partial_json_string,
-        running_group_row, split_reasoning, strip_system_xml_tags, subagent_activity,
+        running_group_rows, split_reasoning, strip_system_xml_tags, subagent_activity,
         subagent_name_from_run_id, summarize_result, tilde_path, tokens_per_second,
         tool_activity, tool_finished,
         transcript_top_padding, rewind_to,
@@ -11970,7 +12105,8 @@ mod tests {
         app.push_user_line("first line\nsecond line", &[]);
         let rows = render_rows(&mut app, 60, 12);
         assert!(
-            rows.iter().any(|r| r.trim_end().ends_with("\u{203a} first line")),
+            rows.iter()
+                .any(|r| r.trim_end().ends_with("\u{203a} first line")),
             "first line not on its own row: {rows:?}"
         );
         assert!(
@@ -12040,6 +12176,135 @@ mod tests {
             assert!(row.chars().count() <= 50, "row overflows: {row:?}");
         }
     }
+
+    /// The Ctrl-O expansion of a finished subagent wraps its call list, like
+    /// the tool-group expansion it sits beside -- it is the surface the folded
+    /// summary row sends the user to, so it has to be complete.
+    #[test]
+    fn expanded_subagent_detail_wraps_instead_of_eliding() {
+        let mut app = test_app();
+        let long = "Executing: cargo test --no-default-features --features cli -- cli::tui::tests";
+        app.push_subagent_summary("reviewer", vec![long.to_string()], true);
+        let block = app.subagent_blocks.last().expect("no subagent block");
+        let lines = block.detail_lines(50);
+        assert!(lines.len() > 1, "detail was not wrapped: {lines:?}");
+        let text: String = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(!text.contains('\u{2026}'), "detail elided: {text:?}");
+        for word in ["--no-default-features", "cli::tui::tests"] {
+            assert!(text.contains(word), "dropped {word:?}: {text:?}");
+        }
+        for line in &lines {
+            let w: usize = line.spans.iter().map(|s| s.content.chars().count()).sum();
+            assert!(w <= 50, "row overflows: {w}");
+        }
+    }
+
+    /// Web and todo labels are stored whole like the bash one: the row wraps
+    /// them at the draw width, so a long URL is not cut at a fixed 80 on a
+    /// terminal with room for it.
+    #[test]
+    fn web_and_todo_labels_are_not_capped_at_a_fixed_width() {
+        let url = format!("https://example.com/{}", "segment/".repeat(20));
+        assert_eq!(
+            tool_activity("web_fetch", &json!({ "url": url.clone() })),
+            format!("Fetching: {url}")
+        );
+        assert_eq!(
+            tool_finished("web_fetch", &json!({ "url": url.clone() })),
+            format!("Fetched: {url}")
+        );
+        let query = "rust async runtime ".repeat(12);
+        assert_eq!(
+            tool_activity("web_search", &json!({ "query": query.clone() })),
+            format!("Searching the web: {query}")
+        );
+        let task = "refactor the transport layer ".repeat(6);
+        assert_eq!(
+            tool_activity("todo", &json!({ "op": "start", "task": task.clone() })),
+            format!("Starting task: {task}")
+        );
+    }
+
+    /// A slash invocation's args are user text and can arrive pasted and
+    /// multi-line, so its row breaks on newlines like `push_user_line`.
+    #[test]
+    fn invocation_row_keeps_its_line_breaks() {
+        let mut app = test_app();
+        app.push_invocation_label("[skill:deploy] first line\nsecond line".to_string());
+        let rows = render_rows(&mut app, 60, 12);
+        assert!(
+            rows.iter()
+                .any(|r| r.trim_end().ends_with("\u{203a} [skill:deploy] first line")),
+            "first line not on its own row: {rows:?}"
+        );
+        assert!(
+            rows.iter().any(|r| r.trim_end().ends_with("  second line")),
+            "second line not on its own row: {rows:?}"
+        );
+    }
+
+    /// The docked prompts size themselves from the rows they will need, so an
+    /// arbitrary-length upstream error is readable rather than clipped to the
+    /// one row a fixed height budgeted for it.
+    #[test]
+    fn login_prompt_grows_to_fit_a_long_error() {
+        let mut app = test_app();
+        let error = "verification failed: the upstream returned 502 Bad Gateway \
+                     from https://api.tokamak.sh/v1/models after three attempts";
+        app.login = Some(super::LoginPrompt {
+            input: String::new(),
+            error: Some(error.to_string()),
+            verifying: false,
+        });
+        let rows = render_rows(&mut app, 56, 24);
+        let joined = rows.join(" ");
+        // Single tokens: the assertion must not straddle a wrap point.
+        for word in ["502", "api.tokamak.sh/v1/models", "attempts"] {
+            assert!(
+                joined.contains(word),
+                "error clipped ({word}):\n{}",
+                rows.join("\n")
+            );
+        }
+    }
+
+    /// An MCP field is being typed into: a long command line wraps inside the
+    /// box instead of running off its right edge with no way to see the rest.
+    #[test]
+    fn mcp_prompt_wraps_the_field_being_edited() {
+        let mut app = test_app();
+        let command = "npx -y @modelcontextprotocol/server-filesystem /home/user/projects/jan";
+        app.mcp_prompt = Some(super::McpPrompt {
+            editing: None,
+            field: super::McpField::Command,
+            name: "files".to_string(),
+            transport: "stdio".to_string(),
+            command: command.to_string(),
+            args: String::new(),
+            env: String::new(),
+            url: String::new(),
+            headers: String::new(),
+            active: true,
+            error: None,
+        });
+        let rows = render_rows(&mut app, 52, 26);
+        let joined = rows.join(" ");
+        for word in ["@modelcontextprotocol/server-", "/home/user/projects/jan"] {
+            assert!(
+                joined.contains(word),
+                "field clipped ({word}):\n{}",
+                rows.join("\n")
+            );
+        }
+        for row in &rows {
+            assert!(row.chars().count() <= 52, "row overflows: {row:?}");
+        }
+    }
+
 
     /// Degenerate frames (a sliver of a terminal mid-drag) must render, not panic.
     #[test]
@@ -12776,7 +13041,7 @@ mod tests {
         );
         // Kept whole: the row clamps to the draw width, so a long command fills
         // the terminal instead of being cut at a fixed 80.
-        let long = format!("echo {}", "x".repeat(2 * COMMAND_LABEL_MAX));
+        let long = format!("echo {}", "x".repeat(200));
         assert_eq!(
             tool_activity("bash", &json!({ "command": long })),
             format!("Executing: {long}")
@@ -12800,7 +13065,7 @@ mod tests {
         );
         // Whole command on the finished row too, for the same reason as
         // `tool_activity`: the row clamps to the draw width.
-        let long = format!("echo {}", "x".repeat(2 * COMMAND_LABEL_MAX));
+        let long = format!("echo {}", "x".repeat(200));
         assert_eq!(
             tool_finished("bash", &json!({ "command": long })),
             format!("Ran: {long}")
@@ -12881,6 +13146,10 @@ mod tests {
 
     fn line_text(line: &ratatui::text::Line) -> String {
         line.spans.iter().map(|s| s.content.as_ref()).collect()
+    }
+
+    fn lines_text(lines: &[ratatui::text::Line]) -> String {
+        lines.iter().map(line_text).collect::<Vec<_>>().join("\n")
     }
 
     /// Text of a streaming write preview's tail, dropping the highlight styles.
@@ -16063,8 +16332,7 @@ mod tests {
             args: json!({ "pattern": "foo" }),
         });
         let group = app.tool_group.as_ref().expect("group open");
-        let row = running_group_row(group, 2, 80);
-        let text = line_text(&row);
+        let text = lines_text(&running_group_rows(group, 2, 80));
         assert!(text.contains(SPINNER[2]), "{text}");
         assert!(text.contains("(0s)") || text.contains("(1s)"), "{text}");
     }
@@ -16081,7 +16349,7 @@ mod tests {
             args: json!({ "command": cmd }),
         });
         let group = app.tool_group.as_ref().expect("group open");
-        let text = line_text(&running_group_row(group, 0, 200));
+        let text = lines_text(&running_group_rows(group, 0, 200));
         assert!(text.contains(&format!("Executing: {cmd}")), "{text}");
         assert!(!text.contains("running 1 command"), "{text}");
     }
@@ -16100,9 +16368,78 @@ mod tests {
             });
         }
         let group = app.tool_group.as_ref().expect("group open");
-        let text = line_text(&running_group_row(group, 0, 200));
+        let text = lines_text(&running_group_rows(group, 0, 200));
         assert!(text.contains("Executing: cargo clippy"), "{text}");
         assert!(!text.contains("Running 2 commands"), "{text}");
+    }
+
+    /// The live row wraps its command like the committed one, keeping its line
+    /// breaks, so a long command is readable while it runs -- which is when the
+    /// user most wants to check what they approved.
+    #[test]
+    fn running_row_wraps_a_long_multiline_command() {
+        let mut app = test_app();
+        app.apply(StreamEvent::ToolCall {
+            id: "c1".into(),
+            name: "bash".into(),
+            args: json!({ "command": "cd /tmp\nmake -j8 all install DESTDIR=/opt/somewhere/deep" }),
+        });
+        let group = app.tool_group.as_ref().expect("group open");
+        let rows = running_group_rows(group, 0, 40);
+        assert!(rows.len() > 2, "long command was not wrapped: {rows:?}");
+        for row in &rows {
+            assert!(
+                line_text(row).chars().count() <= 40,
+                "row overflows: {:?}",
+                line_text(row)
+            );
+        }
+        let text = lines_text(&rows).replace(['\u{2502}', '\n'], " ");
+        // Not the long `DESTDIR=` token: at 40 columns it is wider than the
+        // body and hard-breaks, which is the correct fallback, not a drop.
+        for word in ["cd /tmp", "make -j8", "all install"] {
+            assert!(text.contains(word), "dropped {word:?}: {text}");
+        }
+        assert!(
+            line_text(rows.first().expect("no rows")).contains("cd /tmp"),
+            "the first command line did not lead the row"
+        );
+    }
+
+    /// The elapsed badge trails the last row and its width is reserved up
+    /// front, so a counter ticking past 9s or 99s cannot re-flow the command
+    /// above it -- a live row that re-wraps every second is unreadable.
+    #[test]
+    fn running_row_elapsed_badge_does_not_reflow_the_command() {
+        let mut app = test_app();
+        let cmd = "grep -rn needle src/ --include=*.rs --exclude-dir=target";
+        app.apply(StreamEvent::ToolCall {
+            id: "c1".into(),
+            name: "bash".into(),
+            args: json!({ "command": cmd }),
+        });
+        let group = app.tool_group.as_mut().expect("group open");
+        // The body's wrap points must be the same at 0s and at four digits.
+        let strip = |rows: &[ratatui::text::Line]| {
+            rows.iter()
+                .map(|r| {
+                    let t = line_text(r);
+                    t.split(" (").next().unwrap_or_default().to_string()
+                })
+                .collect::<Vec<_>>()
+        };
+        let fresh = strip(&running_group_rows(group, 0, 44));
+        group.started = Instant::now() - Duration::from_secs(4321);
+        let old = running_group_rows(group, 0, 44);
+        assert_eq!(strip(&old), fresh, "the counter re-flowed the command");
+        assert!(
+            line_text(old.last().expect("no rows")).contains("(4321s)"),
+            "badge is not on the last row: {:?}",
+            lines_text(&old)
+        );
+        for row in &old {
+            assert!(line_text(row).chars().count() <= 44, "row overflows");
+        }
     }
 
     #[test]

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -279,6 +279,46 @@ impl Pending {
         }
     }
 
+    /// The prompt's header rows -- who is asking, for what capability, and on
+    /// which command or path -- laid out at `inner`. A command keeps its own
+    /// newlines and wraps, so a heredoc is approved on what it actually says
+    /// rather than on its first 60 columns.
+    fn detail_lines(&self, inner: u16) -> Vec<Line<'static>> {
+        let dim = Style::new().dark_gray();
+        let max = inner.max(1) as usize;
+        let mut out = Vec::new();
+        if let Some(name) = &self.subagent {
+            out.push(Line::from(vec![
+                Span::styled("subagent ", dim),
+                Span::styled(name.clone(), Style::new().magenta().bold()),
+                Span::styled(" is asking:", dim),
+            ]));
+        }
+        out.extend(
+            wrap_spans_hard(
+                vec![
+                    Span::styled(self.tool_name.clone(), Style::new().cyan().bold()),
+                    Span::styled(" wants ", dim),
+                    Span::styled(self.capability.clone(), Style::new().yellow().bold()),
+                ],
+                max,
+            )
+            .into_iter()
+            .map(Line::from),
+        );
+        let (lead, body) = match (&self.command, &self.path) {
+            (Some(command), _) => ("$ ", command.clone()),
+            (None, Some(path)) => ("on ", path.clone()),
+            (None, None) => return out,
+        };
+        out.extend(gutter_lines(
+            wrap_text(&body, Style::new().white(), max.saturating_sub(2).max(1)),
+            vec![Span::styled(lead, dim)],
+            vec![Span::raw("  ")],
+        ));
+        out
+    }
+
     /// Boxed diff preview for the prompt, sized to `inner` width; empty when the
     /// tool carries no diff (exec/read). No gutter: the panel sits flush in the
     /// prompt box, unlike the tool-row-aligned result diff.
@@ -819,19 +859,17 @@ impl Row {
             } => {
                 let lead = glyph.chars().count() + 1;
                 let max = width.saturating_sub(lead as u16).max(8) as usize;
-                markdown::wrap_spans_at_words(body.clone(), max)
-                    .into_iter()
-                    .enumerate()
-                    .map(|(i, spans)| {
-                        let mark = if i == 0 { *glyph } else { *cont };
-                        let mut row = vec![Span::styled(
-                            format!("{mark:<width$}", width = lead),
-                            *gutter,
-                        )];
-                        row.extend(spans);
-                        Line::from(row)
-                    })
-                    .collect()
+                gutter_lines(
+                    wrap_spans_hard(body.clone(), max),
+                    vec![Span::styled(
+                        format!("{glyph:<width$}", width = lead),
+                        *gutter,
+                    )],
+                    vec![Span::styled(
+                        format!("{cont:<width$}", width = lead),
+                        *gutter,
+                    )],
+                )
             }
             RowKind::Tool {
                 tag,
@@ -841,12 +879,25 @@ impl Row {
                 reserve,
             } => {
                 let max = width.saturating_sub(*reserve).max(1) as usize;
-                vec![tool_row(
-                    tag,
-                    *tag_style,
-                    &truncate(label, max),
-                    *label_style,
-                )]
+                let tag_w = tag.chars().count() + 1;
+                let mut rows = wrap_text(label, *label_style, max);
+                if rows.len() > TOOL_ROW_MAX_LINES {
+                    rows.truncate(TOOL_ROW_MAX_LINES);
+                    if let Some(last) = rows.last_mut() {
+                        last.push(Span::styled(" …", *label_style));
+                    }
+                }
+                gutter_lines(
+                    rows,
+                    vec![
+                        Span::styled("│ ", Style::new().dark_gray()),
+                        Span::styled(format!("{tag} "), *tag_style),
+                    ],
+                    vec![
+                        Span::styled("│ ", Style::new().dark_gray()),
+                        Span::raw(" ".repeat(tag_w)),
+                    ],
+                )
             }
             RowKind::Result {
                 tag,
@@ -968,6 +1019,84 @@ impl PendingAsk {
     }
     fn row_count(&self) -> usize {
         self.question().options.len() + 1 + usize::from(self.question().multi)
+    }
+
+    /// Cells the `List` leaves an item after `highlight_symbol`.
+    const HIGHLIGHT_W: u16 = 2;
+
+    /// The question, wrapped to `width`.
+    fn question_lines(&self, width: u16) -> Vec<Line<'static>> {
+        wrap_text(
+            &self.question().question,
+            Style::new().bold(),
+            width.max(1) as usize,
+        )
+        .into_iter()
+        .map(Line::from)
+        .collect()
+    }
+
+    /// One entry per selectable row, each already laid out at `width`. Both the
+    /// box height and `draw_ask` build from this, so a wrapped label cannot put
+    /// the mouse hitboxes out of step with what is on screen.
+    fn option_lines(&self, width: u16) -> Vec<Vec<Line<'static>>> {
+        let question = self.question();
+        let answer = &self.answers[self.question_index];
+        let dim = Style::new().dark_gray();
+        let mark_w = if question.multi { 4 } else { 2 };
+        let body = width.saturating_sub(Self::HIGHLIGHT_W + mark_w).max(1) as usize;
+        let indent = || vec![Span::raw(" ".repeat(mark_w as usize))];
+        let mark = |selected: bool| {
+            let glyph = match (question.multi, selected) {
+                (true, true) => "[x] ",
+                (true, false) => "[ ] ",
+                (false, true) => "● ",
+                (false, false) => "○ ",
+            };
+            vec![Span::styled(glyph, Style::new().cyan())]
+        };
+
+        let mut out: Vec<Vec<Line<'static>>> = Vec::with_capacity(self.row_count());
+        for (index, option) in question.options.iter().enumerate() {
+            let mut head = vec![Span::raw(option.label.clone())];
+            if question.recommended == Some(index) {
+                head.push(Span::styled("  recommended", Style::new().green().dim()));
+            }
+            let selected = answer.selected.iter().any(|label| label == &option.label);
+            let mut lines = gutter_lines(wrap_spans_hard(head, body), mark(selected), indent());
+            // The description gets its own rows rather than trailing the label:
+            // inline, one long description pushes the next option's label off
+            // the bottom of a box that has to fit above the input.
+            if let Some(description) = &option.description {
+                lines.extend(gutter_lines(
+                    wrap_text(description, dim, body),
+                    indent(),
+                    indent(),
+                ));
+            }
+            out.push(lines);
+        }
+        out.push(gutter_lines(
+            wrap_text("Other (type your own)", Style::new(), body),
+            mark(answer.custom_input.is_some()),
+            indent(),
+        ));
+        if question.multi {
+            out.push(vec![Line::styled(
+                "Submit answers",
+                Style::new().green().bold(),
+            )]);
+        }
+        out
+    }
+
+    /// Rows the whole box needs at `width`: borders, question, every option and
+    /// the help line.
+    fn box_height(&self, width: u16) -> u16 {
+        let inner = width.saturating_sub(2);
+        let options: usize = self.option_lines(inner).iter().map(|item| item.len()).sum();
+        let question = self.question_lines(inner).len();
+        (question + options + 3).min(u16::MAX as usize) as u16
     }
 
     fn move_selection(&mut self, delta: isize) {
@@ -2861,10 +2990,15 @@ impl App {
     /// attached image ending in an `[IMAGE]` label (basename when known).
     fn push_user_line(&mut self, text: &str, images: &[String]) {
         self.gap(Kind::User);
-        self.push(Line::from(vec![
-            Span::styled("› ", Style::new().light_magenta().bold()),
-            Span::styled(text.to_string(), Style::new().bold()),
-        ]));
+        // A `System` row rather than a `Line`: a pasted or shift-entered message
+        // carries its own newlines, and a single `Line` renders those as blank
+        // cells in one run-on row.
+        self.push_row(RowKind::System {
+            glyph: "›",
+            cont: " ",
+            gutter: Style::new().light_magenta().bold(),
+            body: vec![Span::styled(text.to_string(), Style::new().bold())],
+        });
         for name in images {
             let label = if name.is_empty() {
                 "[IMAGE]".to_string()
@@ -3863,6 +3997,65 @@ fn truncate(s: &str, max: usize) -> String {
     format!("{head}…")
 }
 
+/// `s` on one line: every newline (and the whitespace around it) becomes a
+/// single space. For the surfaces whose height is fixed at one row -- the live
+/// group row, the subagent panel -- where an embedded `\n` would either be
+/// swallowed by ratatui or silently change the row's height.
+fn single_line(s: &str) -> String {
+    s.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+/// Word-wrap `spans` to `max`, breaking hard at their embedded newlines first.
+/// `wrap_spans_at_words` treats `\n` as an ordinary character, so a multi-line
+/// command or user message laid out through it alone renders as one run-on line
+/// with blank cells where the breaks were.
+fn wrap_spans_hard(spans: Vec<Span<'static>>, max: usize) -> Vec<Vec<Span<'static>>> {
+    let mut segments: Vec<Vec<Span<'static>>> = vec![Vec::new()];
+    for span in spans {
+        let style = span.style;
+        let mut parts = span.content.split('\n').peekable();
+        while let Some(part) = parts.next() {
+            let part = part.strip_suffix('\r').unwrap_or(part);
+            if !part.is_empty() {
+                segments
+                    .last_mut()
+                    .expect("seeded with one segment")
+                    .push(Span::styled(part.to_string(), style));
+            }
+            if parts.peek().is_some() {
+                segments.push(Vec::new());
+            }
+        }
+    }
+    segments
+        .into_iter()
+        .flat_map(|segment| markdown::wrap_spans_at_words(segment, max))
+        .collect()
+}
+
+/// `text` laid out at `max` in one style. The single-span case of
+/// `wrap_spans_hard`.
+fn wrap_text(text: &str, style: Style, max: usize) -> Vec<Vec<Span<'static>>> {
+    wrap_spans_hard(vec![Span::styled(text.to_string(), style)], max)
+}
+
+/// Prefix each wrapped row with its gutter: `lead` on the first, `cont` on the
+/// rest, so the body keeps one left edge no matter how many rows it took.
+fn gutter_lines(
+    rows: Vec<Vec<Span<'static>>>,
+    lead: Vec<Span<'static>>,
+    cont: Vec<Span<'static>>,
+) -> Vec<Line<'static>> {
+    rows.into_iter()
+        .enumerate()
+        .map(|(i, spans)| {
+            let mut row = if i == 0 { lead.clone() } else { cont.clone() };
+            row.extend(spans);
+            Line::from(row)
+        })
+        .collect()
+}
+
 /// Per-message envelope (role, delimiters) in the estimate below, the usual
 /// OpenAI-accounting constant.
 const TOKENS_PER_MESSAGE: u64 = 4;
@@ -3943,8 +4136,14 @@ const DIFF_PREVIEW_MAX_ROWS: usize = 20;
 const COMMAND_LABEL_MAX: usize = 80;
 
 /// Cells a `tool_row` spends on its gutter and tag, subtracted from the draw
-/// width to bound the label so the row never wraps.
+/// width before the label is wrapped.
 const TOOL_ROW_RESERVE: u16 = 6;
+
+/// Rows one tool label may occupy before it elides. A label is wrapped rather
+/// than cut so a long command stays readable, but a heredoc body would
+/// otherwise push the conversation off screen; the full text is still under
+/// Ctrl-O.
+const TOOL_ROW_MAX_LINES: usize = 8;
 
 /// Diff row backgrounds. Dark and desaturated on purpose: the syntax-highlighted
 /// foreground is drawn on top of them, so the tint has to read as added/removed
@@ -4119,6 +4318,19 @@ fn subagent_name_from_run_id(run_id: &str) -> &str {
     }
 }
 
+/// A command as the transcript shows it: each line's internal whitespace
+/// collapsed, but the line structure kept, so a heredoc or a script written one
+/// step per line reads the way it was authored. `RowKind::Tool` breaks on those
+/// newlines and wraps whatever is still too wide.
+fn collapse_command(cmd: &str) -> String {
+    cmd.lines()
+        .map(single_line)
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim_matches('\n')
+        .to_string()
+}
+
 fn tool_activity(name: &str, args: &serde_json::Value) -> String {
     let s = |k: &str| args.get(k).and_then(|v| v.as_str()).unwrap_or("");
     let base = |p: &str| {
@@ -4134,10 +4346,9 @@ fn tool_activity(name: &str, args: &serde_json::Value) -> String {
             if cmd.trim().is_empty() {
                 "Executing command".to_string()
             } else {
-                // Untruncated: the row clamps to the draw width, so the command
+                // Untruncated: the row wraps at the draw width, so the command
                 // fills the terminal rather than eliding at a fixed 80.
-                let collapsed = cmd.split_whitespace().collect::<Vec<_>>().join(" ");
-                format!("Executing: {collapsed}")
+                format!("Executing: {}", collapse_command(cmd))
             }
         }
         "grep" | "search" => "Searching".to_string(),
@@ -4232,7 +4443,9 @@ fn subagent_activity(name: &str, args: &serde_json::Value) -> String {
             if cmd.trim().is_empty() {
                 "command".to_string()
             } else {
-                format!("$ {}", cmd.split_whitespace().collect::<Vec<_>>().join(" "))
+                // The live panel gives each call exactly one row, so this one
+                // stays flattened where the transcript's label keeps its breaks.
+                format!("$ {}", single_line(cmd))
             }
         }
         "grep" | "search" => format!("grep {}", s("pattern")),
@@ -4262,8 +4475,7 @@ fn tool_finished(name: &str, args: &serde_json::Value) -> String {
             if cmd.trim().is_empty() {
                 "Ran command".to_string()
             } else {
-                let collapsed = cmd.split_whitespace().collect::<Vec<_>>().join(" ");
-                format!("Ran: {collapsed}")
+                format!("Ran: {}", collapse_command(cmd))
             }
         }
         "grep" | "search" => "Searched".to_string(),
@@ -4550,11 +4762,14 @@ fn group_detail_lines(group: &ToolGroup, width: u16) -> Vec<Line<'static>> {
     };
     for call in &group.calls {
         if show_headers {
-            out.push(Line::from(vec![
-                Span::styled("│   ", Style::new().dark_gray()),
-                Span::styled("▸ ", Style::new().cyan()),
-                Span::styled(truncate(&call.done, max), Style::new().dim()),
-            ]));
+            out.extend(gutter_lines(
+                wrap_text(&call.done, Style::new().dim(), max),
+                vec![
+                    Span::styled("│   ", Style::new().dark_gray()),
+                    Span::styled("▸ ", Style::new().cyan()),
+                ],
+                vec![Span::styled("│     ", Style::new().dark_gray())],
+            ));
         }
         if let Some(content) = &call.content {
             let (tag, tag_style) = if call.is_error {
@@ -4562,22 +4777,19 @@ fn group_detail_lines(group: &ToolGroup, width: u16) -> Vec<Line<'static>> {
             } else {
                 ("✓", Style::new().green())
             };
-            // Expanded view shows the full output verbatim (one row per line,
-            // width-clamped): the tag rides the first line, the rest indent to
-            // align under it. Empty content still gets a bare tag row.
-            let mut content_lines = content.lines();
-            let first = content_lines.next().unwrap_or("");
-            out.push(Line::from(vec![
-                Span::styled(tag_gutter, Style::new().dark_gray()),
-                Span::styled(format!("{tag} "), tag_style),
-                Span::styled(truncate(first, max), Style::new().dim()),
-            ]));
-            for line in content_lines {
-                out.push(Line::from(vec![
-                    Span::styled(cont_gutter, Style::new().dark_gray()),
-                    Span::styled(truncate(line, max), Style::new().dim()),
-                ]));
-            }
+            // Expanded view shows the full output verbatim: the tag rides the
+            // first line, the rest indent to align under it, and a line wider
+            // than the terminal wraps rather than eliding -- this is the surface
+            // the transcript's one-line summary sends the user to. Empty content
+            // still gets a bare tag row.
+            out.extend(gutter_lines(
+                wrap_text(content, Style::new().dim(), max),
+                vec![
+                    Span::styled(tag_gutter, Style::new().dark_gray()),
+                    Span::styled(format!("{tag} "), tag_style),
+                ],
+                vec![Span::styled(cont_gutter, Style::new().dark_gray())],
+            ));
             if let Some(diff) = &call.diff {
                 for line in diff_lines(diff, width as usize, DIFF_MAX_ROWS, cont_gutter, None) {
                     out.push(line);
@@ -4619,7 +4831,7 @@ fn group_summary(nouns: &[(&str, bool)]) -> String {
 fn running_group_row(group: &ToolGroup, spinner_frame: usize, width: u16) -> Line<'static> {
     let frame = SPINNER[spinner_frame % SPINNER.len()];
     let elapsed = group.started.elapsed().as_secs();
-    let text = format!("{} ({elapsed}s)", group.activity());
+    let text = format!("{} ({elapsed}s)", single_line(&group.activity()));
     let max = (width as usize).saturating_sub(6).max(1);
     tool_row(frame, Style::new().cyan(), &truncate(&text, max), Style::new().cyan().dim())
 }
@@ -9669,7 +9881,7 @@ fn draw(f: &mut Frame, app: &mut App) {
     } else if !app.ask_queue.is_empty() {
         let queue_len = app.ask_queue.len();
         let ask = app.ask_queue.front_mut().expect("checked non-empty above");
-        let height = (ask.row_count() as u16 + 4).min(chunks[1].height);
+        let height = ask.box_height(chunks[2].width).min(chunks[1].height);
         let y = chunks[2].y.saturating_sub(height).max(chunks[1].y);
         let rect = ratatui::layout::Rect {
             x: chunks[2].x,
@@ -9679,10 +9891,9 @@ fn draw(f: &mut Frame, app: &mut App) {
         };
         draw_ask(f, rect, ask, queue_len);
     } else if let Some(pending) = app.pending() {
-        let detail_rows = 1
-            + u16::from(pending.path.is_some() || pending.command.is_some())
-            + u16::from(pending.subagent.is_some());
-        let diff_rows = pending.diff_preview(chunks[2].width.saturating_sub(2)).len() as u16;
+        let inner_w = chunks[2].width.saturating_sub(2);
+        let detail_rows = pending.detail_lines(inner_w).len() as u16;
+        let diff_rows = pending.diff_preview(inner_w).len() as u16;
         let height =
             (pending.options().len() as u16 + detail_rows + diff_rows + 2).min(chunks[1].height);
         let y = chunks[2].y.saturating_sub(height).max(chunks[1].y);
@@ -9746,12 +9957,10 @@ fn draw(f: &mut Frame, app: &mut App) {
 fn draw_ask(f: &mut Frame, area: Rect, ask: &mut PendingAsk, queue_len: usize) {
     use ratatui::widgets::{Clear, List, ListItem, ListState};
 
-    let question = ask.question().clone();
-    let answer = ask.answers[ask.question_index].clone();
     let dim = Style::new().dark_gray();
     let title = if queue_len > 1 {
         format!(
-            " question {}/{} · request 1/{queue_len} ",
+            " question {}/{} \u{b7} request 1/{queue_len} ",
             ask.question_index + 1,
             ask.request.questions.len()
         )
@@ -9767,93 +9976,57 @@ fn draw_ask(f: &mut Frame, area: Rect, ask: &mut PendingAsk, queue_len: usize) {
         .border_style(Style::new().cyan())
         .title(Span::styled(title, Style::new().on_cyan().black().bold()));
     let inner = block.inner(area);
+    let question = ask.question_lines(inner.width);
+    let items = ask.option_lines(inner.width);
+    let heights: Vec<u16> = items.iter().map(|item| item.len() as u16).collect();
     let rows = Layout::vertical([
-        Constraint::Length(1),
-        Constraint::Min(ask.row_count() as u16),
+        Constraint::Length(question.len() as u16),
+        Constraint::Min(1),
         Constraint::Length(1),
     ])
     .split(inner);
 
-    let mut items = Vec::with_capacity(ask.row_count());
-    for (index, option) in question.options.iter().enumerate() {
-        let selected = answer.selected.iter().any(|label| label == &option.label);
-        let mark = if question.multi {
-            if selected {
-                "[x] "
-            } else {
-                "[ ] "
-            }
-        } else if selected {
-            "● "
-        } else {
-            "○ "
-        };
-        let mut spans = vec![
-            Span::styled(mark, Style::new().cyan()),
-            Span::raw(option.label.clone()),
-        ];
-        if question.recommended == Some(index) {
-            spans.push(Span::styled("  recommended", Style::new().green().dim()));
-        }
-        if let Some(description) = &option.description {
-            spans.push(Span::styled(format!("  {description}"), dim));
-        }
-        items.push(ListItem::new(Line::from(spans)));
-    }
-    let custom_mark = if question.multi {
-        if answer.custom_input.is_some() {
-            "[x] "
-        } else {
-            "[ ] "
-        }
-    } else if answer.custom_input.is_some() {
-        "● "
-    } else {
-        "○ "
-    };
-    items.push(ListItem::new(Line::from(vec![
-        Span::styled(custom_mark, Style::new().cyan()),
-        Span::raw("Other (type your own)"),
-    ])));
-    if question.multi {
-        items.push(ListItem::new(Line::styled(
-            "Submit answers",
-            Style::new().green().bold(),
-        )));
-    }
-
-    ask.rect = area;
-    ask.row_hitboxes = (0..items.len())
-        .filter_map(|index| {
-            let y = rows[1].y.saturating_add(index as u16);
-            (y < rows[1].y.saturating_add(rows[1].height)).then_some((y, index))
-        })
-        .collect();
-
     f.render_widget(Clear, area);
     f.render_widget(block, area);
-    f.render_widget(
-        Paragraph::new(Line::styled(question.question, Style::new().bold())),
-        rows[0],
-    );
-    let list = List::new(items)
+    f.render_widget(Paragraph::new(question), rows[0]);
+
+    let list = List::new(items.into_iter().map(ListItem::new).collect::<Vec<_>>())
         .highlight_style(Style::new().reversed().bold())
-        .highlight_symbol("▶ ");
+        .highlight_symbol("\u{25b6} ");
     let mut state = ListState::default();
     state.select(Some(ask.selected));
     f.render_stateful_widget(list, rows[1], &mut state);
+
+    // Hitboxes come from the same heights the list just laid out, offset by the
+    // scroll the list chose to keep the selection visible -- an item may be
+    // several rows tall, and a box clamped to the space above the input may not
+    // show every item at all.
+    ask.rect = area;
+    ask.row_hitboxes.clear();
+    let mut y = rows[1].y;
+    let bottom = rows[1].y.saturating_add(rows[1].height);
+    for (index, height) in heights.iter().enumerate().skip(state.offset()) {
+        for _ in 0..*height {
+            if y >= bottom {
+                break;
+            }
+            ask.row_hitboxes.push((y, index));
+            y = y.saturating_add(1);
+        }
+    }
+
     let help = if ask.editing_custom {
         Line::from(vec![
             Span::styled("Other: ", Style::new().cyan()),
             Span::raw(ask.custom_input.clone()),
-            Span::styled("█", Style::new().cyan()),
+            Span::styled("\u{2588}", Style::new().cyan()),
         ])
     } else {
         Line::styled(
-            if question.multi {
-                "↑↓ move · Space toggle · Enter choose · ←→ question · Esc cancel"
+            if ask.question().multi {
+                "\u{2191}\u{2193} move \u{b7} Space toggle \u{b7} Enter choose \u{b7} \u{2190}\u{2192} question \u{b7} Esc cancel"
             } else {
-                "↑↓ move · Enter choose · ←→ question · Esc cancel"
+                "\u{2191}\u{2193} move \u{b7} Enter choose \u{b7} \u{2190}\u{2192} question \u{b7} Esc cancel"
             },
             dim,
         )
@@ -10227,32 +10400,6 @@ fn draw_path_hints(
 fn draw_permission(f: &mut Frame, area: ratatui::layout::Rect, pending: &Pending, queue_len: usize) {
     use ratatui::widgets::{Clear, List, ListItem, ListState};
 
-    let dim = Style::new().dark_gray();
-    let mut detail = Vec::new();
-    if let Some(name) = &pending.subagent {
-        detail.push(Line::from(vec![
-            Span::styled("subagent ", dim),
-            Span::styled(name.clone(), Style::new().magenta().bold()),
-            Span::styled(" is asking:", dim),
-        ]));
-    }
-    detail.push(Line::from(vec![
-        Span::styled(pending.tool_name.clone(), Style::new().cyan().bold()),
-        Span::styled(" wants ", dim),
-        Span::styled(pending.capability.clone(), Style::new().yellow().bold()),
-    ]));
-    if let Some(command) = &pending.command {
-        detail.push(Line::from(vec![
-            Span::styled("$ ", dim),
-            Span::styled(command.clone(), Style::new().white()),
-        ]));
-    } else if let Some(path) = &pending.path {
-        detail.push(Line::from(vec![
-            Span::styled("on ", dim),
-            Span::styled(path.clone(), Style::new().white()),
-        ]));
-    }
-
     let title = if queue_len > 1 {
         format!(" permission required (1 of {queue_len}) ")
     } else {
@@ -10266,6 +10413,7 @@ fn draw_permission(f: &mut Frame, area: ratatui::layout::Rect, pending: &Pending
     f.render_widget(Clear, area);
     f.render_widget(block, area);
 
+    let detail = pending.detail_lines(inner.width);
     let diff = pending.diff_preview(inner.width);
     let rows = Layout::vertical([
         Constraint::Length(detail.len() as u16),
@@ -10273,7 +10421,7 @@ fn draw_permission(f: &mut Frame, area: ratatui::layout::Rect, pending: &Pending
         Constraint::Length(pending.options().len() as u16),
     ])
     .split(inner);
-    f.render_widget(Paragraph::new(detail).wrap(Wrap { trim: false }), rows[0]);
+    f.render_widget(Paragraph::new(detail), rows[0]);
     if !diff.is_empty() {
         f.render_widget(Paragraph::new(diff), rows[1]);
     }
@@ -11706,10 +11854,11 @@ mod tests {
         );
     }
 
-    /// A tool row's label is stored untruncated and clamped at draw time, so it
-    /// grows back when the terminal widens rather than staying elided.
+    /// A tool row's label is stored untruncated and laid out at draw time: it
+    /// wraps onto as many rows as the width needs, and re-packs onto fewer when
+    /// the terminal widens.
     #[test]
-    fn tool_row_labels_retruncate_on_resize() {
+    fn tool_row_labels_rewrap_on_resize() {
         let mut app = test_app();
         app.apply(StreamEvent::ToolCall {
             id: "t1".into(),
@@ -11725,21 +11874,171 @@ mod tests {
         // Close the group so its row reads as the finished command, not the
         // live "running 1 command" throbber.
         app.finalize_tool_group();
-        let label = |rows: &[String]| {
-            rows.iter()
-                .find(|r| r.contains("Ran: echo"))
-                .expect("no tool row")
-                .trim_end()
-                .to_string()
+        // The label's rows, stripped of gutter and tag and joined back into the
+        // text they display.
+        let label = |rows: &[String], width: usize| {
+            let start = rows
+                .iter()
+                .position(|r| r.contains("Ran: echo"))
+                .expect("no tool row");
+            let body: Vec<String> = rows[start..]
+                .iter()
+                .take_while(|r| r.starts_with('│') && r.trim_end() != "│")
+                .map(|r| {
+                    assert!(
+                        r.trim_end().chars().count() <= width,
+                        "row overflows: {r:?}"
+                    );
+                    r.trim_end().trim_start_matches(['│', ' ', '✓']).to_string()
+                })
+                .collect();
+            (body.len(), body.join(" "))
         };
-        let narrow = label(&render_rows(&mut app, 40, 12));
-        let wide = label(&render_rows(&mut app, 100, 12));
-        assert!(narrow.contains('…'), "narrow row was not elided: {narrow:?}");
-        assert!(narrow.chars().count() <= 40, "narrow row overflows: {narrow:?}");
+        let (narrow_rows, narrow) = label(&render_rows(&mut app, 40, 12), 40);
+        let (wide_rows, wide) = label(&render_rows(&mut app, 100, 12), 100);
+        let full = "Ran: echo the quick brown fox jumps over the lazy dog";
+        assert_eq!(narrow, full, "narrow layout dropped text");
+        assert_eq!(wide, full, "wide layout dropped text");
         assert!(
-            wide.chars().count() > narrow.chars().count(),
-            "row did not grow back: {wide:?}"
+            narrow_rows > wide_rows,
+            "label did not re-pack when widened: {narrow_rows} vs {wide_rows}"
         );
+    }
+
+    /// A multi-line command keeps its breaks in the transcript row: the label
+    /// is not flattened onto one line, and the row is not one wide `Line` whose
+    /// newlines ratatui swallows.
+    #[test]
+    fn multiline_command_label_keeps_its_line_breaks() {
+        let mut app = test_app();
+        app.apply(StreamEvent::ToolCall {
+            id: "t1".into(),
+            name: "bash".into(),
+            args: json!({"command": "cd /tmp\ncargo build\ncargo test"}),
+        });
+        app.apply(StreamEvent::ToolResult {
+            id: "t1".into(),
+            content: "ok".into(),
+            is_error: false,
+            diff: None,
+        });
+        app.finalize_tool_group();
+        let rows = render_rows(&mut app, 80, 16);
+        let has = |needle: &str| rows.iter().any(|r| r.trim_end().ends_with(needle));
+        assert!(has("Ran: cd /tmp"), "first command line missing: {rows:?}");
+        assert!(has("cargo build"), "second command line missing: {rows:?}");
+        assert!(has("cargo test"), "third command line missing: {rows:?}");
+    }
+
+    /// A tool label wraps, but a pathological one (a pasted heredoc body) is
+    /// bounded so it cannot push the conversation off screen.
+    #[test]
+    fn tool_label_wrapping_is_bounded() {
+        let mut app = test_app();
+        let command = (0..40)
+            .map(|i| format!("echo line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        app.apply(StreamEvent::ToolCall {
+            id: "t1".into(),
+            name: "bash".into(),
+            args: json!({ "command": command }),
+        });
+        app.finalize_tool_group();
+        let rendered = app.transcript.last().expect("no row").lines(80);
+        assert_eq!(
+            rendered.len(),
+            super::TOOL_ROW_MAX_LINES,
+            "label was not bounded"
+        );
+        let last: String = rendered[super::TOOL_ROW_MAX_LINES - 1]
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(
+            last.ends_with('\u{2026}'),
+            "elision was not marked: {last:?}"
+        );
+    }
+
+    /// A newline in a user message is a line break in the transcript, not a
+    /// blank cell in one run-on row.
+    #[test]
+    fn user_message_keeps_its_line_breaks() {
+        let mut app = test_app();
+        app.push_user_line("first line\nsecond line", &[]);
+        let rows = render_rows(&mut app, 60, 12);
+        assert!(
+            rows.iter().any(|r| r.trim_end().ends_with("\u{203a} first line")),
+            "first line not on its own row: {rows:?}"
+        );
+        assert!(
+            rows.iter().any(|r| r.trim_end().ends_with("  second line")),
+            "second line not on its own row: {rows:?}"
+        );
+    }
+
+    /// The expanded (Ctrl-O) view is where the full output lives, so a line
+    /// wider than the terminal wraps there instead of eliding.
+    #[test]
+    fn expanded_group_detail_wraps_instead_of_eliding() {
+        let mut app = test_app();
+        app.apply(StreamEvent::ToolCall {
+            id: "t1".into(),
+            name: "bash".into(),
+            args: json!({"command": "cat notes"}),
+        });
+        let long = "alpha bravo charlie delta echo foxtrot golf hotel india juliett kilo lima";
+        app.apply(StreamEvent::ToolResult {
+            id: "t1".into(),
+            content: long.into(),
+            is_error: false,
+            diff: None,
+        });
+        app.finalize_tool_group();
+        let group = app.groups.last().expect("no group");
+        let text: String = super::group_detail_lines(group, 40)
+            .iter()
+            .flat_map(|line| line.spans.iter())
+            .map(|s| s.content.as_ref())
+            .collect::<String>();
+        assert!(!text.contains('\u{2026}'), "detail elided: {text:?}");
+        for word in long.split(' ') {
+            assert!(text.contains(word), "detail dropped {word:?}: {text:?}");
+        }
+    }
+
+    /// A long option label and its description wrap inside the ask box, and the
+    /// box grows to hold them rather than clipping.
+    #[test]
+    fn ask_options_wrap_and_size_the_box() {
+        let mut app = test_app();
+        let request = crate::core::agent::interaction::AskRequest::parse(&json!({
+            "questions": [{
+                "id": "scope",
+                "question": "Which of these two rather long scopes should the agent take on next?",
+                "options": [
+                    {"label": "A thoroughly long option label that cannot fit one row",
+                     "description": "and a description that is longer still, needing rows of its own"},
+                    {"label": "Short"}
+                ],
+                "multi": false
+            }]
+        }))
+        .expect("valid ask request");
+        app.apply(StreamEvent::AskRequest {
+            request_id: "r1".into(),
+            request,
+        });
+        let rows = render_rows(&mut app, 50, 30);
+        let joined = rows.join("\n");
+        for word in ["thoroughly", "fit one row", "longer still", "Short"] {
+            assert!(joined.contains(word), "ask box clipped {word:?}:\n{joined}");
+        }
+        for row in &rows {
+            assert!(row.chars().count() <= 50, "row overflows: {row:?}");
+        }
     }
 
     /// Degenerate frames (a sliver of a terminal mid-drag) must render, not panic.
@@ -11983,7 +12282,18 @@ mod tests {
         });
         let mut terminal = Terminal::new(TestBackend::new(36, 24)).unwrap();
         terminal.draw(|frame| super::draw(frame, &mut app)).unwrap();
-        let other_row = app.ask_queue.front().unwrap().row_hitboxes[2].0;
+        // Hitboxes are per screen row and an option may be several rows tall,
+        // so find the first row belonging to the "Other" item rather than the
+        // third entry in the list.
+        let other_row = app
+            .ask_queue
+            .front()
+            .unwrap()
+            .row_hitboxes
+            .iter()
+            .find(|(_, index)| *index == 2)
+            .expect("no hitbox for the custom row")
+            .0;
 
         assert!(
             handle_ask_mouse(

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -1366,6 +1366,26 @@ const SPINNER: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "�
 /// Milliseconds per spinner frame, decoupled from the 50ms render tick.
 const SPINNER_ADVANCE_MS: u64 = 80;
 
+/// Rotating action words for the running input placeholder, replacing a static
+/// "working…" so a long turn does not read as a hung UI.
+const WORKING_WORDS: [&str; 6] =
+    ["working", "computing", "processing", "analyzing", "crunching", "grinding"];
+
+/// Rotating action words shown while the model is reasoning (a ` think>` block
+/// is streaming), coloured orange. Mirrors the working list so the two states
+/// read as the same kind of progress, just distinct in wording and colour.
+const THINKING_WORDS: [&str; 6] =
+    ["thinking", "reasoning", "pondering", "reflecting", "deliberating", "musing"];
+
+/// Spinner frames per placeholder-word change, so the action word turns over
+/// at a readable pace (10 frames x 80ms ~= 0.8s) rather than on the braille
+/// spinner's every sub-frame.
+const WORD_ROTATE_FRAMES: usize = 10;
+
+/// Orange used for the "thinking" action word, matching the markdown bold
+/// accent so reasoning reads consistently across the TUI.
+const THINKING_ORANGE: Color = Color::Rgb(255, 165, 0);
+
 /// How long the `[thought for Ns]` header summary lingers after a reasoning
 /// block closes before it falls back to the plain `[working]` status. The
 /// summary is only a transient cue that a block finished; it should not pin the
@@ -10907,12 +10927,27 @@ fn input_box(app: &App) -> Paragraph<'static> {
     } else if app.status == Status::Running && app.input.is_empty() {
         // Show queue status when running with empty input
         if app.message_queue.is_empty() {
-            // The spinner carries the motion; the rest of the row is static so
-            // the text stays readable rather than shifting under the eye.
+            // The spinner carries the fast motion; the action word turns over
+            // on a slower cadence, cycling "working" synonyms -- or "thinking"
+            // synonyms in orange while a reasoning block streams -- so the row
+            // reads alive without shifting under the eye.
+            let step = app.spinner_frame / WORD_ROTATE_FRAMES;
+            let (word, style) = if thinking_open(&app.assistant_buf) {
+                (
+                    THINKING_WORDS[step % THINKING_WORDS.len()],
+                    Style::new().fg(THINKING_ORANGE).italic(),
+                )
+            } else {
+                (
+                    WORKING_WORDS[step % WORKING_WORDS.len()],
+                    Style::new().dim().italic(),
+                )
+            };
             Paragraph::new(Line::from(vec![
                 Span::styled(format!("{} ", app.spinner()), Style::new().cyan()),
+                Span::styled(format!("{word}…"), style),
                 Span::styled(
-                    "working… (Esc to cancel, type to queue next message)",
+                    " (Esc to cancel, type to queue next message)",
                     Style::new().dim().italic(),
                 ),
             ]))
@@ -11125,7 +11160,8 @@ mod tests {
         SnapshotJob, Status, AGENT_SETTINGS, ALT_SCROLL_RESTORE, ALT_SCROLL_SAVE_OFF,
         COMMAND_LABEL_MAX, DIFF_ADD_BG, DIFF_DEL_BG, DIFF_MAX_ROWS, DIFF_PREVIEW_MAX_ROWS,
         KEY_BINDINGS, MOUSE_TRACK_ON, SLASH_COMMANDS, SPINNER, PROVIDERS_SETTINGS_ROW,
-        SPINNER_ADVANCE_MS, alt_scroll_restore, alt_scroll_save_off,
+        SPINNER_ADVANCE_MS, THINKING_WORDS, WORKING_WORDS,
+        alt_scroll_restore, alt_scroll_save_off,
     };
     use crate::core::agent::events::{StreamEvent, Usage};
     use crate::core::agent::r#loop::PermissionRegistry;
@@ -17184,7 +17220,8 @@ mod tests {
 
     /// The running placeholder is the row a user stares at during a long turn.
     /// A static "working…" reads as a hung UI, so it animates on the same
-    /// cadence as every other throbber.
+    /// cadence as every other throbber: the spinner glyph rotates, and the
+    /// action word cycles through synonyms of "working".
     #[test]
     fn working_placeholder_animates() {
         let mut app = test_app();
@@ -17194,7 +17231,7 @@ mod tests {
         let frame_of = |app: &mut App| {
             render_rows(app, 80, 12)
                 .into_iter()
-                .find(|r| r.contains("working…"))
+                .find(|r| r.contains("(Esc to cancel, type to queue next message)"))
                 .expect("running placeholder present")
         };
 
@@ -17202,13 +17239,90 @@ mod tests {
         let first = frame_of(&mut app);
         assert!(first.contains(SPINNER[0]), "expected frame 0 glyph: {first:?}");
 
+        // While a plain turn is running (no reasoning), the row shows a
+        // rotating synonym of "working".
+        assert!(
+            WORKING_WORDS.iter().any(|w| first.contains(w)),
+            "expected a working synonym in: {first:?}"
+        );
+
         app.spinner_frame = 3;
         let later = frame_of(&mut app);
         assert!(later.contains(SPINNER[3]), "expected frame 3 glyph: {later:?}");
         assert_ne!(first, later, "row must change as the frame advances");
 
-        // The wording itself does not move, only the glyph.
         assert!(later.contains("(Esc to cancel, type to queue next message)"), "{later:?}");
+    }
+
+    /// When the model is reasoning (a ` think>` block is streaming), the input
+    /// placeholder cycles through synonyms of "thinking".
+    #[test]
+    fn thinking_placeholder_uses_thinking_synonyms() {
+        let mut app = test_app();
+        app.submit_user("go".into());
+        app.apply(StreamEvent::Token {
+            text: "<think>ponder the plan".into(),
+        });
+        let row = render_rows(&mut app, 80, 12)
+            .into_iter()
+            .find(|r| r.contains("(Esc to cancel, type to queue next message)"))
+            .expect("running placeholder present");
+        assert!(
+            THINKING_WORDS.iter().any(|w| row.contains(w)),
+            "expected a thinking synonym in: {row:?}"
+        );
+        assert!(
+            !WORKING_WORDS.iter().any(|w| row.contains(w)),
+            "no working synonym while reasoning: {row:?}"
+        );
+    }
+
+    /// Thinking synonyms are coloured orange so the active reasoning state
+    /// stands out from the quiet working rows.
+    #[test]
+    fn thinking_synonym_is_orange() {
+        use ratatui::{backend::TestBackend, Terminal};
+        let mut app = test_app();
+        app.submit_user("go".into());
+        app.apply(StreamEvent::Token {
+            text: "<think>ponder the plan".into(),
+        });
+        let mut terminal = Terminal::new(TestBackend::new(80, 12)).unwrap();
+        terminal.draw(|f| super::draw(f, &mut app)).unwrap();
+        let buf = terminal.backend().buffer().clone();
+        // Locate the placeholder row, then assert the action word's cells are
+        // orange (the trailing hint stays dim, so only the word carries it).
+        let orange = (0..buf.area.height).any(|y| {
+            let row: String = (0..buf.area.width).map(|x| buf[(x, y)].symbol()).collect();
+            if !THINKING_WORDS.iter().any(|w| row.contains(w)) {
+                return false;
+            }
+            (0..buf.area.width)
+                .any(|x| buf[(x, y)].style().fg == Some(super::THINKING_ORANGE))
+        });
+        assert!(orange, "thinking synonym not orange");
+    }
+
+    /// The working word rotates to a different synonym as the frame advances.
+    #[test]
+    fn working_synonym_rotates_across_frames() {
+        let mut app = test_app();
+        app.submit_user("go".into());
+        let mut word_at = |frame: usize| {
+            app.spinner_frame = frame;
+            let row = render_rows(&mut app, 80, 12)
+                .into_iter()
+                .find(|r| r.contains("(Esc to cancel, type to queue next message)"))
+                .expect("running placeholder present");
+            WORKING_WORDS
+                .iter()
+                .find(|w| row.contains(*w))
+                .map(|w| w.to_string())
+                .expect("working synonym present")
+        };
+        let a = word_at(0);
+        let b = word_at(super::WORD_ROTATE_FRAMES);
+        assert_ne!(a, b, "working word must rotate as frames advance: {a}");
     }
 
     /// A queued-message row is still a running row, so it animates too.

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -3693,6 +3693,7 @@ impl App {
         // preceding tool calls stay in the transcript, and record the partial
         // answer in history so the next turn and a later /resume both see it.
         self.abort_tool_rows();
+        self.append_cancelled_turn_tools();
         let answer = answer_without_reasoning(&self.take_answer());
         if !answer.is_empty() {
             self.history
@@ -3714,6 +3715,69 @@ impl App {
         // Auto-dequeue the next queued message, if any
         self.dequeue_next();
         self.persist();
+    }
+
+    /// Fold this cancelled turn's completed tool calls and their results into
+    /// `history` (wire form), so the model on the next prompt sees the tools it
+    /// ran and what they returned instead of only the streamed prose. Without
+    /// this, `self.history` only ever carries tool exchanges when the backend
+    /// publishes a `MessagesUpdated` at a natural stop -- a run killed mid-way
+    /// by a cancel loses them from the model's view (they still render from the
+    /// display journal). Calls still in flight at the cancel are paired with a
+    /// placeholder result so the exchange stays protocol-valid.
+    fn append_cancelled_turn_tools(&mut self) {
+        let start = self
+            .display_log
+            .iter()
+            .rposition(|e| matches!(e, DisplayEntry::User { .. }))
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        let mut calls: Vec<(String, String, serde_json::Value)> = Vec::new();
+        let mut results: Vec<(String, String)> = Vec::new();
+        for entry in self.display_log.iter().skip(start) {
+            match entry {
+                DisplayEntry::ToolCall { id, name, args } => {
+                    calls.push((id.clone(), name.clone(), args.clone()));
+                }
+                DisplayEntry::ToolResult { id, content, .. } => {
+                    results.push((id.clone(), content.clone()));
+                }
+                _ => {}
+            }
+        }
+        if calls.is_empty() {
+            return;
+        }
+        let tool_calls: serde_json::Value = calls
+            .iter()
+            .map(|(id, name, args)| {
+                serde_json::json!({
+                    "id": id,
+                    "type": "function",
+                    "function": {
+                        "name": name,
+                        "arguments": args.to_string(),
+                    }
+                })
+            })
+            .collect();
+        self.history.push(serde_json::json!({
+            "role": "assistant",
+            "content": serde_json::Value::Null,
+            "tool_calls": tool_calls,
+        }));
+        for (id, _, _) in &calls {
+            let content = results
+                .iter()
+                .find(|(rid, _)| rid == id)
+                .map(|(_, c)| c.clone())
+                .unwrap_or_else(|| super::MISSING_TOOL_RESULT.to_string());
+            self.history.push(serde_json::json!({
+                "role": "tool",
+                "tool_call_id": id,
+                "content": content,
+            }));
+        }
     }
 }
 
@@ -15148,6 +15212,70 @@ mod tests {
                 .unwrap_or_default()
                 .contains("Here is what I found so far"),
             "partial answer not in history: {last}"
+        );
+    }
+
+    #[test]
+    fn cancel_preserves_completed_tool_calls_and_results_in_history() {
+        let mut app = test_app();
+        app.submit_user("do a thing".into());
+        app.apply(StreamEvent::ToolCall {
+            id: "c1".into(),
+            name: "bash".into(),
+            args: json!({ "command": "grep -n foo src/" }),
+        });
+        app.apply(StreamEvent::ToolResult {
+            id: "c1".into(),
+            content: "match on line 3\n[exit 0]".into(),
+            is_error: false,
+            diff: None,
+        });
+        // The run is cancelled before the model emits any answer prose, so
+        // nothing is streamed to be committed as assistant text.
+        app.cancel_run();
+        let wire = app
+            .history
+            .iter()
+            .map(serde_json::Value::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            wire.contains("\"tool_calls\"") && wire.contains("c1"),
+            "tool call missing from wire history on cancel: {wire}"
+        );
+        assert!(
+            wire.contains("\"tool_call_id\":\"c1\"") && wire.contains("match on line 3"),
+            "tool result missing from wire history on cancel: {wire}"
+        );
+    }
+
+    #[test]
+    fn cancel_surfaces_interrupted_calls_paired_with_a_placeholder_result() {
+        let mut app = test_app();
+        app.submit_user("do a thing".into());
+        app.apply(StreamEvent::ToolCall {
+            id: "c1".into(),
+            name: "bash".into(),
+            args: json!({ "command": "sleep 300" }),
+        });
+        // No ToolResult arrives: the call was still in flight at cancel. It
+        // must still reach the wire history, paired with a placeholder result
+        // so the upstream sees a valid (call, result) exchange, not a dangling
+        // call that OpenAI-compatible endpoints reject.
+        app.cancel_run();
+        let wire = app
+            .history
+            .iter()
+            .map(serde_json::Value::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            wire.contains("\"tool_calls\"") && wire.contains("c1"),
+            "interrupted call missing from wire history: {wire}"
+        );
+        assert!(
+            wire.contains("\"tool_call_id\":\"c1\""),
+            "interrupted call must be paired with a result for a valid exchange: {wire}"
         );
     }
 

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -1268,6 +1268,12 @@ struct App {
     /// from `[agent].show_reasoning` in agent.toml (false). Ctrl-O toggles every
     /// existing block between its summary row and full detail for the session.
     show_reasoning: bool,
+    /// Whether reasoning streams into the live tail while folding is on.
+    /// Defaults from `stream_reasoning` in `~/.jan/config.toml` (true). The open
+    /// block shows its last `LIVE_REASONING_TAIL_LINES` lines and still folds to
+    /// a summary row when the turn commits; false shows nothing but the header
+    /// badge, as before. Orthogonal to `show_reasoning`, which unfolds for good.
+    stream_reasoning: bool,
     /// Whether a prior assistant turn's reasoning is resent to the model.
     /// Defaults from `[agent].send_reasoning` in agent.toml (true). False keeps
     /// long chains of thought out of the request (and satisfies upstreams that
@@ -1673,6 +1679,7 @@ impl App {
             reasoning_blocks: Vec::new(),
             show_reasoning,
             // Overwritten from the session config right after construction.
+            stream_reasoning: true,
             send_reasoning: true,
             expanded: std::collections::HashSet::new(),
             reveal: None,
@@ -2189,11 +2196,15 @@ impl App {
             .is_some_and(|closed| closed.elapsed() >= TODO_HIDE_AFTER)
     }
 
-    /// True while a reasoning block is streaming with folding on: the one
-    /// stretch of a run that puts nothing on screen, so the header badge is the
-    /// only place progress can show.
+    /// True while a reasoning block is streaming and nothing of it is on screen:
+    /// the one stretch of a run with no visible motion, which is what the
+    /// header's shimmering `[thinking]` badge stands in for. With
+    /// `stream_reasoning` on the tail itself is moving, so the badge stays flat.
     fn is_thinking(&self) -> bool {
-        self.status != Status::Idle && !self.show_reasoning && self.reasoning_open()
+        self.status != Status::Idle
+            && !self.show_reasoning
+            && !self.stream_reasoning
+            && self.reasoning_open()
     }
 
     /// True while the model is mid-reasoning: either a `<think>` block is live
@@ -5466,6 +5477,7 @@ pub async fn run(
         smol_model,
         limits,
         show_reasoning,
+        stream_reasoning,
         send_reasoning,
         mcp_servers,
         mcp_task,
@@ -5516,6 +5528,7 @@ pub async fn run(
         repo_root,
     );
     app.smol_model = smol_model;
+    app.stream_reasoning = stream_reasoning;
     app.send_reasoning = send_reasoning;
     app.args = Some(args.clone());
     // Adopt the session's startup run mode (e.g. `--plan`) so the header badge
@@ -9885,6 +9898,7 @@ fn draw(f: &mut Frame, app: &mut App) {
             &app.reasoning_segs,
             width,
             !app.show_reasoning,
+            app.stream_reasoning,
         );
         if !live.is_empty() {
             // Mirror flush_assistant's `gap(Kind::Prose)` so the separator above
@@ -13021,37 +13035,80 @@ mod tests {
     }
 
     #[test]
-    fn live_tail_hides_open_think_block_and_shows_it_when_revealed() {
-        use ratatui::{backend::TestBackend, Terminal};
+    fn live_tail_streams_open_reasoning_and_the_gate_hides_it() {
         let mut app = test_app();
         app.assistant_buf = "<think>pondering the answer".to_string();
 
-        let render = |app: &mut App| {
-            let mut terminal = Terminal::new(TestBackend::new(60, 30)).unwrap();
-            terminal.draw(|f| super::draw(f, app)).unwrap();
-            let buf = terminal.backend().buffer().clone();
-            (0..buf.area.height)
-                .map(|y| {
-                    (0..buf.area.width)
-                        .map(|x| buf[(x, y)].symbol())
-                        .collect::<String>()
-                })
-                .collect::<Vec<_>>()
-                .join("\n")
-        };
-
-        // Reasoning folding is the default: an open  block is hidden from
-        // the live tail (the header shows [thinking] instead).
-        let hidden = render(&mut app);
+        // Streaming is the default: a folded, still-open block shows its tail so
+        // the user can watch the thought form.
+        let streamed = render_rows(&mut app, 60, 30).join("\n");
         assert!(
-            !hidden.contains("pondering"),
-            "open reasoning must be hidden by default"
+            streamed.contains("pondering"),
+            "open reasoning streams by default: {streamed}"
         );
 
-        // With show_reasoning on, the streaming reasoning renders dimmed as before.
+        // With the gate off only the header's [thinking] badge stands for it.
+        app.stream_reasoning = false;
+        let hidden = render_rows(&mut app, 60, 30).join("\n");
+        assert!(
+            !hidden.contains("pondering"),
+            "stream_reasoning = false hides the open block"
+        );
+
+        // With show_reasoning on, folding is off entirely and it renders whole.
         app.show_reasoning = true;
-        let shown = render(&mut app);
+        let shown = render_rows(&mut app, 60, 30).join("\n");
         assert!(shown.contains("pondering"), "revealed live tail must contain it");
+    }
+
+    /// A long chain of thought must not push the answer, or the conversation
+    /// above it, off the screen: the live tail keeps only the last few lines.
+    #[test]
+    fn live_tail_bounds_streaming_reasoning_to_its_last_lines() {
+        let body: String = (1..=20).map(|n| format!("step {n}\n")).collect();
+        let lines = super::live_assistant_lines(
+            &format!("<think>{body}"),
+            &[],
+            60,
+            true,
+            true,
+        );
+        let text: Vec<String> = lines
+            .iter()
+            .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect();
+        assert_eq!(text.len(), 6, "capped at the tail: {text:?}");
+        assert!(text[0].contains("step 15"), "starts at the tail: {text:?}");
+        assert!(text[5].contains("step 20"), "ends at the newest: {text:?}");
+    }
+
+    /// A block that already closed mid-turn folds to the very summary row the
+    /// commit will emit, so finalizing the turn does not move the transcript.
+    #[test]
+    fn live_tail_folds_a_closed_reasoning_run_to_its_summary_row() {
+        let lines = super::live_assistant_lines(
+            "<think>weighed it\ntwice</think>Here is the answer.",
+            &[],
+            60,
+            true,
+            true,
+        );
+        let text: Vec<String> = lines
+            .iter()
+            .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect())
+            .collect();
+        assert!(
+            text.iter().any(|l| l.contains("reasoning (2 lines)")),
+            "closed run folds to a summary: {text:?}"
+        );
+        assert!(
+            !text.iter().any(|l| l.contains("weighed it")),
+            "closed run is not shown in full: {text:?}"
+        );
+        assert!(
+            text.iter().any(|l| l.contains("Here is the answer.")),
+            "prose still renders: {text:?}"
+        );
     }
 
     #[test]
@@ -18595,9 +18652,9 @@ mod tests {
             app.reasoning_status().map(|(w, _)| w),
             Some("thinking".to_string())
         );
-        assert!(app.is_thinking(), "reasoning is live");
+        assert!(app.reasoning_open(), "reasoning is live");
         app.apply(StreamEvent::Token { text: "Answer".into() });
-        assert!(!app.is_thinking(), "prose has started");
+        assert!(!app.reasoning_open(), "prose has started");
         assert_eq!(
             app.reasoning_status().map(|(w, _)| w),
             Some("thought for 0s".to_string()),
@@ -19787,8 +19844,11 @@ mod tests {
     /// The animation is scoped to the state that needs it: a folded, streaming
     /// reasoning block. Everything else keeps its flat badge.
     #[test]
-    fn only_folded_live_reasoning_animates_the_badge() {
+    fn only_invisible_live_reasoning_animates_the_badge() {
         let mut app = test_app();
+        // Streaming reasoning puts the thought on screen, so the badge has
+        // nothing to stand in for; the shimmer is for the hidden case.
+        app.stream_reasoning = false;
         assert!(!app.is_thinking(), "idle");
         app.submit_user("hi".into());
         assert!(!app.is_thinking(), "running, but nothing thinking yet");
@@ -19805,12 +19865,15 @@ mod tests {
         });
         assert!(!app.is_thinking(), "the block closed");
 
-        // With reasoning shown inline the transcript itself is moving, so the
-        // badge stays flat.
-        app.show_reasoning = true;
+        // With reasoning on screen -- streamed into the live tail, or unfolded
+        // outright -- the transcript itself is moving, so the badge stays flat.
+        app.stream_reasoning = true;
         app.apply(StreamEvent::Token {
             text: "<think>more".into(),
         });
+        assert!(!app.is_thinking(), "streamed reasoning needs no badge motion");
+        app.stream_reasoning = false;
+        app.show_reasoning = true;
         assert!(!app.is_thinking(), "unfolded reasoning needs no badge motion");
     }
 

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -41,7 +41,7 @@ use markdown::{
 };
 
 use super::brand;
-use super::journal::{self, DisplayEntry};
+use super::journal::{self, DisplayEntry, ReasoningSeg};
 use super::mcp::McpServerEntry;
 use super::{sort_threads_recent, AgentSession, ResumeTarget, SessionLimits};
 use serde_json::Value;
@@ -1909,36 +1909,42 @@ impl App {
 
     fn flush_assistant(&mut self) {
         let segs = std::mem::take(&mut self.reasoning_segs);
-        let text = fold_native_reasoning(&self.assistant_buf, &segs)
-            .trim_end()
-            .to_string();
+        let prose = self.assistant_buf.trim_end().to_string();
         self.assistant_buf.clear();
         // The buffered stream is committed: any open reasoning window closes
         // (its elapsed time was stashed when the block itself closed, so this
         // only matters for a flush that happens mid-block, e.g. a tool call).
         self.thinking_since = None;
         // No-op (and, crucially, don't finalize the tool group) on an empty or
-        // whitespace-only buffer, so silent consecutive tool calls keep folding.
-        if !assistant_has_content(&text) {
+        // whitespace-only turn, so silent consecutive tool calls keep folding.
+        if !assistant_has_content(&prose, &segs) {
             return;
         }
         // Model prose ends the current run of tool calls.
         self.finalize_tool_group();
-        // Native reasoning is already folded into `text` as wrapped blocks at the
-        // offsets it streamed at. Display-logged here (out of `history` on
-        // purpose) so the replay folds it like the live turn did.
+        // Display-logged here (out of `history` on purpose) so the replay folds
+        // reasoning like the live turn did. Prose and reasoning are journaled
+        // apart, exactly as they arrived.
         self.display_log.push(DisplayEntry::Assistant {
-            text: text.clone(),
+            text: prose.clone(),
+            reasoning: segs.clone(),
         });
-        self.push_assistant_blocks(&text);
+        self.push_assistant_blocks(&prose, &segs);
     }
 
     /// Commit assistant `text` to the transcript in emission order: answer prose
     /// through markdown, each `<think>` block folded to a one-line summary row
     /// whose full dimmed detail is retained for expansion.
-    fn push_assistant_blocks(&mut self, text: &str) {
-        let text = strip_system_xml_tags(text);
-        for (reasoning, seg) in split_reasoning(&text) {
+    fn push_assistant_blocks(&mut self, prose: &str, segs: &[ReasoningSeg]) {
+        for (reasoning, seg) in assistant_runs(prose, segs) {
+            // Only answer prose can carry an injected `<system>` block; stripping
+            // per run rather than over the whole turn keeps the reasoning
+            // offsets meaningful.
+            let seg = if reasoning {
+                seg
+            } else {
+                strip_system_xml_tags(&seg).to_string()
+            };
             if seg.trim().is_empty() {
                 continue;
             }
@@ -2201,13 +2207,6 @@ impl App {
                 .reasoning_segs
                 .last()
                 .is_some_and(|seg| seg.at == self.assistant_buf.len())
-    }
-
-    /// The live assistant text with native reasoning folded in as wrapped blocks,
-    /// exactly as `flush_assistant` will commit it. Lets the shared renderer
-    /// treat native and inline-tag reasoning identically while streaming.
-    fn live_assistant_text(&self) -> String {
-        fold_native_reasoning(&self.assistant_buf, &self.reasoning_segs)
     }
 
     /// Header status while a turn is running with reasoning folding on:
@@ -3676,7 +3675,7 @@ impl App {
 
     /// The concatenated natively-streamed reasoning text for the current turn.
     /// Used to resend the final answer's reasoning on the wire. Inline
-    /// ` thinking` blocks (which arrive through `Token` and live in the buffer)
+    /// `<think>` blocks (which arrive through `Token` and live in the buffer)
     /// are handled separately by `answer_without_reasoning` and the loop path;
     /// this covers the `reasoning_content` delta case, which never touches the
     /// buffer.
@@ -5036,8 +5035,9 @@ fn has_answer_text(buf: &str) -> bool {
 }
 
 /// `text` with its reasoning removed, for the copy that goes into `history`.
-/// Reasoning is display-only and must never be resent to the model (see
-/// `SseAccumulator`); the display journal is what keeps it for a resume.
+/// Reasoning never belongs in `content`; it rides along on the message's
+/// `reasoning_content` instead (see `on_done`), and the display journal is what
+/// keeps it for a resume.
 pub(crate) fn answer_without_reasoning(text: &str) -> String {
     split_reasoning(text)
         .into_iter()
@@ -5124,10 +5124,61 @@ fn think_re() -> &'static regex::Regex {
     RE.get_or_init(|| regex::Regex::new(r"</?[a-zA-Z:]*think>").unwrap())
 }
 
+/// Whether inline `<think>` tags in model content are parsed as reasoning.
+/// Process-wide rather than a session field because the split runs on every
+/// rendered row, from free functions a `Row` reaches with no session in hand.
+/// Seeded once from `~/.jan/config.toml` by `set_think_tags_parsed`; `true`
+/// until then, which is also the default.
+static PARSE_THINK_TAGS: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(true);
+
+#[cfg(test)]
+thread_local! {
+    /// Per-test override. A test flips its own thread's answer instead of the
+    /// shared static, so a gate-off test cannot race the rest of the suite.
+    static PARSE_THINK_TAGS_OVERRIDE: std::cell::Cell<Option<bool>> =
+        const { std::cell::Cell::new(None) };
+}
+
+/// Apply the `think_tags` setting for the process. Called once per session from
+/// `prepare_agent_session`, the chokepoint every agent surface goes through.
+pub(crate) fn set_think_tags_parsed(enabled: bool) {
+    PARSE_THINK_TAGS.store(enabled, std::sync::atomic::Ordering::Relaxed);
+}
+
+fn think_tags_parsed() -> bool {
+    #[cfg(test)]
+    {
+        if let Some(over) = PARSE_THINK_TAGS_OVERRIDE.with(|c| c.get()) {
+            return over;
+        }
+    }
+    PARSE_THINK_TAGS.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Run `f` with `<think>` parsing off on this thread only.
+#[cfg(test)]
+fn without_think_tags<T>(f: impl FnOnce() -> T) -> T {
+    PARSE_THINK_TAGS_OVERRIDE.with(|c| c.set(Some(false)));
+    let out = f();
+    PARSE_THINK_TAGS_OVERRIDE.with(|c| c.set(None));
+    out
+}
+
 /// Split assistant text into `(is_reasoning, segment)` runs by `<think>` /
 /// `<mm:think>` tags (tags themselves dropped). An unterminated open tag makes
 /// the trailing text reasoning, which keeps live streaming clean.
+///
+/// With `think_tags = false` in `~/.jan/config.toml` the tags carry no meaning:
+/// the whole text is one answer run, so it renders verbatim and stays in the
+/// answer that goes back as history.
 fn split_reasoning(text: &str) -> Vec<(bool, String)> {
+    if !think_tags_parsed() {
+        return if text.is_empty() {
+            Vec::new()
+        } else {
+            vec![(false, text.to_string())]
+        };
+    }
     let mut out = Vec::new();
     let mut in_think = false;
     let mut last = 0;
@@ -5146,53 +5197,44 @@ fn split_reasoning(text: &str) -> Vec<(bool, String)> {
     out
 }
 
-/// One stretch of natively streamed reasoning, anchored to the byte offset in
-/// `App::assistant_buf` it arrived at, so it can be folded back into the answer
-/// text in emission order.
-#[derive(Debug, Clone, PartialEq)]
-struct ReasoningSeg {
-    at: usize,
-    text: String,
-}
-
-/// Splice native reasoning segments into `prose` as `<think>` blocks at the
-/// offsets they streamed at, yielding the one string form both the live renderer
-/// and the display journal use. Offsets come from `prose.len()` at emission time,
-/// so they are always char boundaries and always ascending.
-fn fold_native_reasoning(prose: &str, segs: &[ReasoningSeg]) -> String {
+/// Interleave a turn's answer prose with its natively streamed reasoning
+/// segments into `(is_reasoning, run)` in emission order -- the one form every
+/// consumer (live tail, committed rows, replay) reads.
+///
+/// The two sources stay apart end to end: native reasoning arrives structurally
+/// and is placed by its offset, never encoded into the prose, while an
+/// inline-tag provider's `<think>` markers are found by `split_reasoning` inside
+/// the prose runs alone. So a model writing about `<think>` tags cannot close a
+/// native block, and the `think_tags` gate governs only the inline case.
+///
+/// Offsets come from `prose.len()` at emission time, so they are always char
+/// boundaries and always ascending.
+fn assistant_runs(prose: &str, segs: &[ReasoningSeg]) -> Vec<(bool, String)> {
     if segs.is_empty() {
-        return prose.to_string();
+        return split_reasoning(prose);
     }
-    let extra: usize = segs.iter().map(|s| s.text.len() + 16).sum();
-    let mut out = String::with_capacity(prose.len() + extra);
+    let mut out = Vec::new();
     let mut last = 0;
     for seg in segs {
-        let at = seg.at.min(prose.len());
-        out.push_str(&prose[last..at]);
-        if !seg.text.trim().is_empty() {
-            out.push_str("<think>");
-            out.push_str(escape_think_tags(seg.text.trim_end()).trim_end());
-            out.push_str("</think>");
+        let at = seg.at.min(prose.len()).max(last);
+        out.extend(split_reasoning(&prose[last..at]));
+        let text = seg.text.trim_end();
+        if !text.is_empty() {
+            out.push((true, text.to_string()));
         }
         last = at;
     }
-    out.push_str(&prose[last..]);
+    out.extend(split_reasoning(&prose[last..]));
     out
-}
-
-/// Neutralize `<think>`-family tags inside reasoning text before it is wrapped in
-/// one. A model reasoning *about* thinking tags would otherwise close the block
-/// early and have the rest of its thought rendered and journaled as answer prose.
-fn escape_think_tags(text: &str) -> std::borrow::Cow<'_, str> {
-    think_re().replace_all(text, |m: &regex::Captures| {
-        format!("&lt;{}", &m[0][1..])
-    })
 }
 
 /// True if `text` ends inside an unclosed ` think>` block (an opening tag whose
 /// matching close has not yet streamed). Used to show `[thinking]` while
 /// reasoning streams. Re-uses the same tag matcher as `split_reasoning`.
 fn thinking_open(text: &str) -> bool {
+    if !think_tags_parsed() {
+        return false;
+    }
     let mut open = false;
     for m in think_re().find_iter(text) {
         open = !m.as_str().starts_with("</");
@@ -5200,9 +5242,9 @@ fn thinking_open(text: &str) -> bool {
     open
 }
 
-/// True if `text` has any non-whitespace content in any reasoning/answer run.
-fn assistant_has_content(text: &str) -> bool {
-    split_reasoning(text)
+/// True if the turn has any non-whitespace content in any reasoning/answer run.
+fn assistant_has_content(prose: &str, segs: &[ReasoningSeg]) -> bool {
+    assistant_runs(prose, segs)
         .iter()
         .any(|(_, seg)| !seg.trim().is_empty())
 }
@@ -9258,8 +9300,9 @@ fn replay_display_log(app: &mut App, entries: Vec<DisplayEntry>) {
             // the blocks directly leaves the group open, so every later call
             // folds back into one row that is never committed -- the whole turn's
             // tool calls then render as nothing at all.
-            DisplayEntry::Assistant { text } => {
+            DisplayEntry::Assistant { text, reasoning } => {
                 app.assistant_buf = text.clone();
+                app.reasoning_segs = reasoning.clone();
                 app.flush_assistant();
             }
             DisplayEntry::ToolCall { id, name, args } => app.apply(StreamEvent::ToolCall {
@@ -9336,7 +9379,7 @@ fn rebuild_transcript(app: &mut App) {
         } else if role == "assistant" {
             let text = m.get("content").and_then(|v| v.as_str()).unwrap_or("");
             if !text.is_empty() {
-                app.push_assistant_blocks(text);
+                app.push_assistant_blocks(text, &[]);
             }
         }
     }
@@ -9835,10 +9878,14 @@ fn draw(f: &mut Frame, app: &mut App) {
     // are rebuilt every frame and ride along as one trailing segment.
     let mut tail: Vec<Line<'static>> = Vec::new();
     if !app.assistant_buf.is_empty() || !app.reasoning_segs.is_empty() {
-        // Native reasoning is folded into a wrapped block beside the live text
-        // so the shared renderer dims/folds it exactly like inline-tag providers.
-        let live_text = app.live_assistant_text();
-        let live = live_assistant_lines(&live_text, width, !app.show_reasoning);
+        // Native reasoning is placed beside the live prose by its offset, so the
+        // shared renderer dims/folds it exactly like inline-tag providers.
+        let live = live_assistant_lines(
+            &app.assistant_buf,
+            &app.reasoning_segs,
+            width,
+            !app.show_reasoning,
+        );
         if !live.is_empty() {
             // Mirror flush_assistant's `gap(Kind::Prose)` so the separator above
             // streaming prose is present live, not only once it is finalized.
@@ -11639,6 +11686,8 @@ mod tests {
         autoscroll_selection, selection_text, Selection, SelectionMode, COPY_NOTICE,
         run_command, starting_call_lines, unescape_partial_json_string,
         running_group_rows, split_reasoning, strip_system_xml_tags, subagent_activity,
+        answer_without_reasoning, assistant_runs, replay_display_log, thinking_open,
+        without_think_tags, ReasoningSeg,
         subagent_name_from_run_id, summarize_result, tilde_path, tokens_per_second,
         tool_activity, tool_finished,
         transcript_top_padding, rewind_to,
@@ -11990,6 +12039,7 @@ mod tests {
         app.push_assistant_blocks(
             "| column one heading | column two heading |\n|---|---|\n\
              | a reasonably long value here | another reasonably long value |",
+            &[],
         );
         let wide = render_rows(&mut app, 100, 20);
         let narrow = render_rows(&mut app, 46, 20);
@@ -12414,7 +12464,7 @@ mod tests {
     fn tiny_frames_render_without_panicking() {
         let mut app = test_app();
         app.push_user_line("hello", &[]);
-        app.push_assistant_blocks("| a | b |\n|---|---|\n| 1 | 2 |\n\n```rs\nlet x = 1;\n```");
+        app.push_assistant_blocks("| a | b |\n|---|---|\n| 1 | 2 |\n\n```rs\nlet x = 1;\n```", &[]);
         app.apply(StreamEvent::ToolResult {
             id: "x".into(),
             content: "done".into(),
@@ -12786,6 +12836,156 @@ mod tests {
     fn split_reasoning_handles_namespaced_and_unterminated_tags() {
         let segs = split_reasoning("<mm:think>reasoning tail");
         assert_eq!(segs, vec![(true, "reasoning tail".to_string())]);
+    }
+
+    /// With `think_tags = false` the tags carry no meaning: one answer run, so
+    /// the text renders verbatim instead of folding into a reasoning block.
+    #[test]
+    fn think_tags_gate_off_makes_the_whole_text_answer_prose() {
+        let text = "before<think>hidden</think>after";
+        let segs = without_think_tags(|| split_reasoning(text));
+        assert_eq!(segs, vec![(false, text.to_string())]);
+    }
+
+    /// The tags stay in the answer that goes back as history: not parsing them
+    /// means there is no reasoning to strip.
+    #[test]
+    fn think_tags_gate_off_keeps_the_tags_in_the_wire_answer() {
+        let text = "<think>hidden</think>answer";
+        assert_eq!(
+            without_think_tags(|| answer_without_reasoning(text)),
+            text,
+            "nothing is reasoning with the gate off"
+        );
+        assert_eq!(
+            answer_without_reasoning(text),
+            "answer",
+            "the default still strips it"
+        );
+    }
+
+    /// An unterminated tag no longer opens a thinking window, so the header
+    /// badge and the folded live tail stay off.
+    #[test]
+    fn think_tags_gate_off_never_reports_an_open_block() {
+        assert!(thinking_open("<think>still going"));
+        assert!(!without_think_tags(|| thinking_open("<think>still going")));
+    }
+
+    /// A journal written before reasoning was stored apart has its markers
+    /// inside `text` and no `reasoning` field. It must still replay as a folded
+    /// block: the markers go down the inline path, which is exactly what they
+    /// were before the split.
+    #[test]
+    fn a_pre_split_journal_entry_still_replays_its_reasoning() {
+        let raw = r#"{"kind":"assistant","text":"<think>old thought</think>Answer."}"#;
+        let entry: DisplayEntry = serde_json::from_str(raw).expect("legacy entry parses");
+        assert_eq!(
+            entry,
+            DisplayEntry::Assistant {
+                text: "<think>old thought</think>Answer.".into(),
+                reasoning: Vec::new(),
+            }
+        );
+        let mut app = test_app();
+        replay_display_log(&mut app, vec![entry]);
+        assert_eq!(
+            app.reasoning_blocks.len(),
+            1,
+            "legacy markers must still fold into a reasoning block"
+        );
+    }
+
+    /// A turn journaled with reasoning apart replays to the same rows, without
+    /// any marker round-trip.
+    #[test]
+    fn a_split_journal_entry_replays_prose_and_reasoning_apart() {
+        let entry = DisplayEntry::Assistant {
+            text: "Answer.".into(),
+            reasoning: vec![ReasoningSeg { at: 0, text: "a thought".into() }],
+        };
+        let round_tripped: DisplayEntry =
+            serde_json::from_str(&serde_json::to_string(&entry).unwrap()).unwrap();
+        assert_eq!(round_tripped, entry);
+        let mut app = test_app();
+        replay_display_log(&mut app, vec![entry]);
+        assert_eq!(app.reasoning_blocks.len(), 1);
+    }
+
+    /// The gate governs inline tags only. Native reasoning is carried
+    /// structurally, so it keeps rendering as its own run either way.
+    #[test]
+    fn think_tags_gate_does_not_touch_native_reasoning() {
+        let segs = vec![ReasoningSeg {
+            at: 0,
+            text: "a thought".into(),
+        }];
+        let expected = vec![
+            (true, "a thought".to_string()),
+            (false, "answer".to_string()),
+        ];
+        assert_eq!(assistant_runs("answer", &segs), expected);
+        assert_eq!(
+            without_think_tags(|| assistant_runs("answer", &segs)),
+            expected,
+            "native reasoning is not encoded as tags, so the gate cannot hide it"
+        );
+    }
+
+    /// Native segments are placed at the offset they streamed at, so a turn that
+    /// reasons, answers, then reasons again keeps emission order.
+    #[test]
+    fn assistant_runs_interleaves_native_reasoning_by_offset() {
+        let segs = vec![
+            ReasoningSeg { at: 0, text: "first".into() },
+            ReasoningSeg { at: 6, text: "second".into() },
+        ];
+        assert_eq!(
+            assistant_runs("prose tail", &segs),
+            vec![
+                (true, "first".to_string()),
+                (false, "prose ".to_string()),
+                (true, "second".to_string()),
+                (false, "tail".to_string()),
+            ]
+        );
+    }
+
+    /// A model writing *about* think tags cannot close a native reasoning
+    /// segment: the two sources never share a string, so no escaping is needed.
+    #[test]
+    fn a_think_tag_inside_native_reasoning_stays_in_that_run() {
+        let segs = vec![ReasoningSeg {
+            at: 0,
+            text: "the </think> tag closes a block".into(),
+        }];
+        assert_eq!(
+            assistant_runs("answer", &segs),
+            vec![
+                (true, "the </think> tag closes a block".to_string()),
+                (false, "answer".to_string()),
+            ]
+        );
+    }
+
+    /// The gate reaches the App: a turn whose content carries tags commits them
+    /// as ordinary prose, with no reasoning block folded out of the transcript.
+    #[test]
+    fn think_tags_gate_off_commits_tagged_content_as_one_answer() {
+        without_think_tags(|| {
+            let mut app = test_app();
+            app.submit_user("go".into());
+            app.apply(StreamEvent::Token {
+                text: "<think>ponder</think>Answer.".into(),
+            });
+            app.on_done("stop".into(), None);
+            assert!(
+                app.reasoning_blocks.is_empty(),
+                "nothing may fold with the gate off"
+            );
+            let last = app.history.last().expect("assistant turn in history");
+            assert_eq!(last["content"], "<think>ponder</think>Answer.");
+        });
     }
 
     #[test]
@@ -16877,7 +17077,7 @@ mod tests {
         // its header row can scroll out of view. A click on any of its detail
         // rows -- not just the header -- must still collapse it.
         let mut app = test_app();
-        app.push_assistant_blocks("<think>line one\nline two\nline three</think>answer");
+        app.push_assistant_blocks("<think>line one\nline two\nline three</think>answer", &[]);
         assert_eq!(app.reasoning_blocks.len(), 1);
         let idx = app.reasoning_blocks[0].idx;
 
@@ -18435,9 +18635,11 @@ mod tests {
             "reasoning rendered as answer prose: {rows}"
         );
         assert_eq!(app.reasoning_blocks.len(), 1, "one folded reasoning block");
+        // Kept verbatim: reasoning never shares a string with the prose, so
+        // there is no block for the tag to close and nothing to neutralize.
         assert!(
-            detail_text(&app.reasoning_blocks[0]).contains("&lt;/think>"),
-            "the tag is neutralized, not dropped: {}",
+            detail_text(&app.reasoning_blocks[0]).contains("</think>"),
+            "the tag is preserved as written: {}",
             detail_text(&app.reasoning_blocks[0])
         );
     }
@@ -18454,7 +18656,9 @@ mod tests {
         app.apply(StreamEvent::Token { text: " Part two.".into() });
         app.on_done("stop".into(), None);
         assert_eq!(app.reasoning_blocks.len(), 2, "two separate stretches");
-        let DisplayEntry::Assistant { text } = app
+        // Journaled apart: prose verbatim, each stretch at the offset it
+        // streamed at, so a replay rebuilds the order without parsing markers.
+        let DisplayEntry::Assistant { text, reasoning } = app
             .display_log
             .iter()
             .rev()
@@ -18463,9 +18667,13 @@ mod tests {
         else {
             unreachable!()
         };
+        assert_eq!(text, "Part one. Part two.");
         assert_eq!(
-            text,
-            "<think>first thought</think>Part one.<think>second thought</think> Part two."
+            reasoning,
+            &vec![
+                ReasoningSeg { at: 0, text: "first thought".into() },
+                ReasoningSeg { at: 9, text: "second thought".into() },
+            ]
         );
         // The wire answer is prose only; both thoughts ride along on
         // `reasoning_content`, concatenated in emission order.

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -1268,6 +1268,12 @@ struct App {
     /// from `[agent].show_reasoning` in agent.toml (false). Ctrl-O toggles every
     /// existing block between its summary row and full detail for the session.
     show_reasoning: bool,
+    /// Whether a prior assistant turn's reasoning is resent to the model.
+    /// Defaults from `[agent].send_reasoning` in agent.toml (true). False keeps
+    /// long chains of thought out of the request (and satisfies upstreams that
+    /// reject the key); the display journal keeps reasoning for a resume either
+    /// way.
+    send_reasoning: bool,
     /// Transcript row indices of collapsed regions (tool groups or reasoning
     /// blocks) the user has expanded to full detail.
     expanded: std::collections::HashSet<usize>,
@@ -1666,6 +1672,8 @@ impl App {
             pending_rows: Vec::new(),
             reasoning_blocks: Vec::new(),
             show_reasoning,
+            // Overwritten from the session config right after construction.
+            send_reasoning: true,
             expanded: std::collections::HashSet::new(),
             reveal: None,
             input: String::new(),
@@ -3070,6 +3078,11 @@ impl App {
         if self.goal.as_ref().is_some_and(|g| g.is_active()) {
             body["goal_mode"] = serde_json::json!(true);
         }
+        // Reasoning resend policy: forwarded only when the user opted out, so a
+        // default session sends an unchanged body (the loop defaults to true).
+        if !self.send_reasoning {
+            body["send_reasoning"] = serde_json::json!(false);
+        }
         body
     }
 
@@ -3661,6 +3674,18 @@ impl App {
         answer
     }
 
+    /// The concatenated natively-streamed reasoning text for the current turn.
+    /// Used to resend the final answer's reasoning on the wire. Inline
+    /// ` thinking` blocks (which arrive through `Token` and live in the buffer)
+    /// are handled separately by `answer_without_reasoning` and the loop path;
+    /// this covers the `reasoning_content` delta case, which never touches the
+    /// buffer.
+    fn native_reasoning_text(&self) -> String {
+        self.reasoning_segs
+            .iter()
+            .map(|s| s.text.clone())
+            .collect::<String>()
+    }
     fn on_done(&mut self, stop_reason: String, usage: Option<Usage>) {
         self.finalize_tool_group();
         // Done is terminal: nothing more arrives on this stream, so a call that
@@ -3670,11 +3695,23 @@ impl App {
         // arrive on its stream. Any panel still open here never got its own
         // `SubagentEnd`.
         self.close_live_subagents();
+        // Capture the turn's reasoning before `take_answer` flushes it: native
+        // reasoning lives in `reasoning_segs` until the flush, and inline
+        // ` thinking` blocks are folded into the buffer. Preserved so the
+        // final assistant turn can be resent with its reasoning (see below).
+        let reasoning = self.native_reasoning_text();
         let answer = self.take_answer();
         let wire = answer_without_reasoning(&answer);
         if !wire.is_empty() {
-            self.history
-                .push(serde_json::json!({ "role": "assistant", "content": wire }));
+            let mut msg = serde_json::json!({ "role": "assistant", "content": wire });
+            // Resend the final answer's reasoning on the wire turn, mirroring
+            // how tool-call turns are threaded in the loop. Kept out of
+            // `content`; only added when the upstream actually streamed it, so
+            // non-reasoning providers send an unchanged shape.
+            if !reasoning.is_empty() {
+                msg["reasoning_content"] = serde_json::json!(reasoning);
+            }
+            self.history.push(msg);
         }
         // A closing receipt for the turn: when, how much context went up, how
         // much came back, how long it took, how fast. Cheap to skim, and the
@@ -3823,6 +3860,16 @@ impl App {
     /// `finish_compaction` when an overflow recovery is abandoned, so the two
     /// paths cannot drift.
     fn halt_turn(&mut self) {
+        // A run that died on an error rather than Esc is still an abnormal exit:
+        // it may well have run tools whose side effects exist on disk, but a
+        // mid-turn `MessagesUpdated` was never published (the stream errored
+        // before a natural stop), so those calls are absent from `history`.
+        // Fold them in exactly as a hard cancel does, so a later prompt or
+        // /resume sees the tools it ran and what they returned. The overflow-
+        // retry path deliberately avoids this (see `on_error`): that turn
+        // re-runs, so folding now would resend completed calls into the retried
+        // request before the model asks for them again.
+        self.append_cancelled_turn_tools();
         // An errored turn halts the goal loop; the user decides how to recover.
         self.goal_eval_pending = false;
         if let Some(goal) = self.goal.as_ref() {
@@ -3910,10 +3957,16 @@ impl App {
         // answer in history so the next turn and a later /resume both see it.
         self.abort_tool_rows();
         self.append_cancelled_turn_tools();
+        // Captured before the flush clears it, like `on_done`, so a cancelled
+        // turn's partial answer keeps the reasoning that produced it.
+        let reasoning = self.native_reasoning_text();
         let answer = answer_without_reasoning(&self.take_answer());
         if !answer.is_empty() {
-            self.history
-                .push(serde_json::json!({ "role": "assistant", "content": answer }));
+            let mut msg = serde_json::json!({ "role": "assistant", "content": answer });
+            if !reasoning.is_empty() {
+                msg["reasoning_content"] = serde_json::json!(reasoning);
+            }
+            self.history.push(msg);
         }
         self.status = Status::Idle;
         self.run_started = None;
@@ -5371,6 +5424,7 @@ pub async fn run(
         smol_model,
         limits,
         show_reasoning,
+        send_reasoning,
         mcp_servers,
         mcp_task,
     } = session;
@@ -5420,6 +5474,7 @@ pub async fn run(
         repo_root,
     );
     app.smol_model = smol_model;
+    app.send_reasoning = send_reasoning;
     app.args = Some(args.clone());
     // Adopt the session's startup run mode (e.g. `--plan`) so the header badge
     // shows immediately; a resumed thread overrides this via restore_run_mode.
@@ -5801,6 +5856,11 @@ async fn chat_loop<B: Backend>(
                     if app.status == Status::Running {
                         app.flush_assistant();
                         app.abort_tool_rows();
+                        // The task was killed without a natural stop, so the
+                        // mid-turn `MessagesUpdated` that would have folded the
+                        // completed tool calls never fired -- fold them here,
+                        // exactly as the cancel/error paths do.
+                        app.append_cancelled_turn_tools();
                         app.status = Status::Idle;
                         app.run_started = None;
                     }
@@ -7409,6 +7469,12 @@ const AGENT_SETTINGS: &[AgentSettingDef] = &[
         label: "show_reasoning",
         desc: "expand  reasoning in the transcript (Ctrl-O still toggles)",
         kind: AgentSettingKind::Bool { default: false },
+    },
+    AgentSettingDef {
+        key: "send_reasoning",
+        label: "send_reasoning",
+        desc: "resend prior reasoning to the model (false drops it from requests)",
+        kind: AgentSettingKind::Bool { default: true },
     },
 ];
 
@@ -16003,6 +16069,101 @@ mod tests {
     }
 
     #[test]
+    fn on_error_preserves_completed_tool_calls_and_results_in_history() {
+        let mut app = test_app();
+        app.submit_user("do a thing".into());
+        app.apply(StreamEvent::ToolCall {
+            id: "c1".into(),
+            name: "bash".into(),
+            args: json!({ "command": "grep -n foo src/" }),
+        });
+        app.apply(StreamEvent::ToolResult {
+            id: "c1".into(),
+            content: "match on line 3\n[exit 0]".into(),
+            is_error: false,
+            diff: None,
+        });
+        // The run dies on an upstream error before the model emits any answer
+        // prose. The backend never publishes a mid-turn `MessagesUpdated`, so
+        // the completed call must be folded into history by the error path
+        // (the same guarantee the Esc-cancel path already provides).
+        app.on_error("upstream".into(), "connection reset".into());
+        let wire = app
+            .history
+            .iter()
+            .map(serde_json::Value::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            wire.contains("\"tool_calls\"") && wire.contains("c1"),
+            "tool call missing from wire history on error: {wire}"
+        );
+        assert!(
+            wire.contains("\"tool_call_id\":\"c1\"") && wire.contains("match on line 3"),
+            "tool result missing from wire history on error: {wire}"
+        );
+    }
+
+    #[test]
+    fn on_error_pairs_in_flight_calls_with_a_placeholder_result() {
+        let mut app = test_app();
+        app.submit_user("do a thing".into());
+        app.apply(StreamEvent::ToolCall {
+            id: "c1".into(),
+            name: "bash".into(),
+            args: json!({ "command": "sleep 300" }),
+        });
+        // The call was still in flight when the stream errored; no ToolResult
+        // ever arrives. It must still reach the wire, paired with a placeholder
+        // result so the exchange is protocol-valid for a later prompt.
+        app.on_error("upstream".into(), "connection reset".into());
+        let wire = app
+            .history
+            .iter()
+            .map(serde_json::Value::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            wire.contains("\"tool_calls\"") && wire.contains("c1"),
+            "interrupted call missing from wire history on error: {wire}"
+        );
+        assert!(
+            wire.contains("\"tool_call_id\":\"c1\""),
+            "interrupted call must be paired with a result: {wire}"
+        );
+    }
+
+    #[test]
+    fn on_error_does_not_double_fold_when_flush_assistant_committed_prose() {
+        let mut app = test_app();
+        app.submit_user("do a thing".into());
+        app.apply(StreamEvent::ToolCall {
+            id: "c1".into(),
+            name: "bash".into(),
+            args: json!({ "command": "ls" }),
+        });
+        app.apply(StreamEvent::ToolResult {
+            id: "c1".into(),
+            content: "ok".into(),
+            is_error: false,
+            diff: None,
+        });
+        // Some prose streamed before the error, so `on_error`'s flush_assistant
+        // commits it. The completed call must still be folded - and folded only
+        // once regardless of the prose that preceded the error.
+        app.apply(StreamEvent::Token {
+            text: "I found it".into(),
+        });
+        app.on_error("upstream".into(), "connection reset".into());
+        let assistant_tool_turns = app
+            .history
+            .iter()
+            .filter(|m| m.get("tool_calls").is_some())
+            .count();
+        assert_eq!(assistant_tool_turns, 1, "tool call folded exactly once");
+    }
+
+    #[test]
     fn cancel_surfaces_interrupted_calls_paired_with_a_placeholder_result() {
         let mut app = test_app();
         app.submit_user("do a thing".into());
@@ -18149,15 +18310,75 @@ mod tests {
         });
         app.on_done("stop".into(), None);
         assert_eq!(app.reasoning_blocks.len(), 1, "reasoning folded into one block");
-        // The wire history carries the answer without the reasoning.
-        let wire = app
-            .history
-            .iter()
-            .map(serde_json::Value::to_string)
-            .collect::<Vec<_>>()
-            .join("\n");
-        assert!(wire.contains("Here is the answer"), "answer missing: {wire}");
-        assert!(!wire.contains("ponder the plan"), "reasoning leaked into history: {wire}");
+        // The wire history carries the answer, with the reasoning preserved on
+        // the message's `reasoning_content` rather than inlined into `content`.
+        let last = app.history.last().expect("assistant turn in history");
+        assert_eq!(last["content"], "Here is the answer");
+        assert_eq!(
+            last["reasoning_content"], "ponder the plan",
+            "reasoning must be preserved for resend: {last}"
+        );
+        assert!(
+            !last["content"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("ponder the plan"),
+            "reasoning must not be inlined into the answer content: {last}"
+        );
+    }
+
+    /// The resend policy reaches the wire: a default session sends an unchanged
+    /// body (the loop defaults to resending), and opting out forwards the flag.
+    #[test]
+    fn send_reasoning_opt_out_is_forwarded_in_the_request_body() {
+        let mut app = test_app();
+        app.submit_user("go".into());
+        assert!(
+            app.body().get("send_reasoning").is_none(),
+            "the default session must send an unchanged body"
+        );
+        app.send_reasoning = false;
+        assert_eq!(
+            app.body()["send_reasoning"],
+            serde_json::json!(false),
+            "opting out must reach the loop"
+        );
+    }
+
+    /// A cancelled turn keeps the reasoning that produced its partial answer,
+    /// so the next prompt resumes with the same context the model had.
+    #[test]
+    fn cancel_preserves_native_reasoning_on_the_partial_answer() {
+        let mut app = test_app();
+        app.submit_user("go".into());
+        app.apply(StreamEvent::Reasoning {
+            text: "half a thought".into(),
+        });
+        app.apply(StreamEvent::Token {
+            text: "Partial answer".into(),
+        });
+        app.cancel_run();
+        let last = app.history.last().expect("assistant turn in history");
+        assert_eq!(last["content"], "Partial answer");
+        assert_eq!(last["reasoning_content"], "half a thought");
+    }
+
+    /// A turn with no native reasoning must not grow a `reasoning_content` key:
+    /// providers that reject unknown assistant fields see an unchanged shape.
+    #[test]
+    fn a_turn_without_reasoning_adds_no_reasoning_key_to_history() {
+        let mut app = test_app();
+        app.submit_user("go".into());
+        app.apply(StreamEvent::Token {
+            text: "Just an answer".into(),
+        });
+        app.on_done("stop".into(), None);
+        let last = app.history.last().expect("assistant turn in history");
+        assert_eq!(last["content"], "Just an answer");
+        assert!(
+            last.get("reasoning_content").is_none(),
+            "no reasoning streamed, so the key must be absent: {last}"
+        );
     }
 
     /// The `[thinking]` badge and the orange placeholder must close when the
@@ -18246,15 +18467,14 @@ mod tests {
             text,
             "<think>first thought</think>Part one.<think>second thought</think> Part two."
         );
-        // The wire answer carries neither thought.
-        let wire = app
-            .history
-            .iter()
-            .map(serde_json::Value::to_string)
-            .collect::<Vec<_>>()
-            .join("\n");
-        assert!(wire.contains("Part one. Part two."), "answer missing: {wire}");
-        assert!(!wire.contains("thought"), "reasoning leaked into history: {wire}");
+        // The wire answer is prose only; both thoughts ride along on
+        // `reasoning_content`, concatenated in emission order.
+        let last = app.history.last().expect("assistant turn in history");
+        assert_eq!(last["content"], "Part one. Part two.");
+        assert_eq!(
+            last["reasoning_content"], "first thoughtsecond thought",
+            "both stretches must be preserved for resend: {last}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -14382,7 +14382,7 @@ mod tests {
             let provider_configs: std::collections::HashMap<String, crate::core::state::ProviderConfig> =
                 std::collections::HashMap::new();
             let args = std::sync::Arc::new(super::OrchestrationArgs {
-                client: reqwest::Client::new(),
+                client: crate::core::agent::upstream::agent_http_client(),
                 provider_configs: std::sync::Arc::new(tokio::sync::Mutex::new(
                     provider_configs,
                 )),

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -4162,6 +4162,19 @@ const TOOL_ROW_MAX_LINES: usize = 8;
 const DIFF_ADD_BG: Color = Color::Rgb(22, 52, 32);
 const DIFF_DEL_BG: Color = Color::Rgb(66, 26, 30);
 
+/// Selection style shared by every arrow-navigable list (ask, permission, slash
+/// hints, path hints, pickers). Palette-only on purpose: `reversed()` swaps in
+/// the terminal's default foreground as a background, which lands as an opaque
+/// white block matching nothing else on screen. Bold survives `Style::patch`
+/// even where a row's spans set their own colors, so it marks the row
+/// everywhere; the cyan reaches `SELECT_MARK` and any unstyled label, and both
+/// follow the terminal's own theme.
+fn select_style() -> Style {
+    Style::new().cyan().bold()
+}
+
+const SELECT_MARK: &str = "\u{25b6} ";
+
 /// Render focused-diff text as a boxed panel: a light rule frames the change,
 /// `+` rows on a green background and `-` rows on a red one across the whole row
 /// (so the change reads as a band), `@@` headers dim-cyan. Every row keeps its
@@ -10066,8 +10079,8 @@ fn draw_ask(f: &mut Frame, area: Rect, ask: &mut PendingAsk, queue_len: usize) {
     f.render_widget(Paragraph::new(question), rows[0]);
 
     let list = List::new(items.into_iter().map(ListItem::new).collect::<Vec<_>>())
-        .highlight_style(Style::new().reversed().bold())
-        .highlight_symbol("\u{25b6} ");
+        .highlight_style(select_style())
+        .highlight_symbol(SELECT_MARK);
     let mut state = ListState::default();
     state.select(Some(ask.selected));
     f.render_stateful_widget(list, rows[1], &mut state);
@@ -10500,8 +10513,8 @@ fn draw_slash_hints(
     f.render_widget(Clear, area);
     let list = List::new(items)
         .block(block)
-        .highlight_style(Style::new().reversed())
-        .highlight_symbol("▶ ");
+        .highlight_style(select_style())
+        .highlight_symbol(SELECT_MARK);
     let mut state = ListState::default();
     state.select(Some(selected.min(matches.len().saturating_sub(1))));
     f.render_stateful_widget(list, area, &mut state);
@@ -10546,8 +10559,8 @@ fn draw_path_hints(
     f.render_widget(Clear, area);
     let list = List::new(items)
         .block(block)
-        .highlight_style(Style::new().reversed())
-        .highlight_symbol("▶ ");
+        .highlight_style(select_style())
+        .highlight_symbol(SELECT_MARK);
     let mut state = ListState::default();
     state.select(Some(selected.min(entries.len().saturating_sub(1))));
     f.render_stateful_widget(list, area, &mut state);
@@ -10591,8 +10604,8 @@ fn draw_permission(f: &mut Frame, area: ratatui::layout::Rect, pending: &Pending
         .map(|(_, label)| ListItem::new(Line::raw(label)))
         .collect();
     let list = List::new(items)
-        .highlight_style(Style::new().reversed().bold())
-        .highlight_symbol("▶ ");
+        .highlight_style(select_style())
+        .highlight_symbol(SELECT_MARK);
     let mut state = ListState::default();
     state.select(Some(pending.selected));
     f.render_stateful_widget(list, rows[2], &mut state);
@@ -10628,8 +10641,8 @@ fn draw_picker(
         .collect();
     let list = List::new(items)
         .block(Block::default().borders(Borders::ALL).title(picker.title()))
-        .highlight_style(Style::new().reversed())
-        .highlight_symbol("▶ ");
+        .highlight_style(select_style())
+        .highlight_symbol(SELECT_MARK);
     let mut state = ListState::default();
     state.select(Some(picker.selected));
 

--- a/src-tauri/src/core/cli/tui/markdown.rs
+++ b/src-tauri/src/core/cli/tui/markdown.rs
@@ -24,26 +24,47 @@ pub(super) fn format_assistant_lines(
     lines
 }
 
+/// Lines of an open reasoning block kept in the live tail: enough to see the
+/// thought moving without letting a long chain of thought push the answer, and
+/// the conversation above it, off the screen.
+const LIVE_REASONING_TAIL_LINES: usize = 6;
+
 /// Live tail rendering for the in-progress assistant buffer. With reasoning
-/// folding on (`fold_reasoning`), an open (unterminated) think block is hidden
-/// entirely so the user sees only the answer prose stream, matching the
-/// `[thinking]` header state; once the tag closes (or prose begins) the rest
-/// renders as usual. When folding is off this is identical to
-/// `format_assistant_lines`, so the existing live-tail tests hold.
+/// folding on (`fold_reasoning`) the block is bounded rather than shown whole:
+/// the open (unterminated) one keeps its last [`LIVE_REASONING_TAIL_LINES`]
+/// lines when `stream_reasoning` is on, and a block that already closed shows
+/// the same summary row `push_assistant_blocks` will commit for it, so nothing
+/// jumps as the turn finalizes. With `stream_reasoning` off the open block is
+/// hidden entirely and only the `[thinking]` header stands for it. When folding
+/// is off this is identical to `format_assistant_lines`, so the existing
+/// live-tail tests hold.
 pub(super) fn live_assistant_lines(
     prose: &str,
     segs: &[super::ReasoningSeg],
     width: u16,
     fold_reasoning: bool,
+    stream_reasoning: bool,
 ) -> Vec<Line<'static>> {
     if !fold_reasoning {
         return format_assistant_lines(prose, segs, width);
     }
+    let runs = super::assistant_runs(prose, segs);
+    let last = runs.len().saturating_sub(1);
     let mut lines = Vec::new();
-    for (reasoning, seg) in super::assistant_runs(prose, segs) {
+    for (i, (reasoning, seg)) in runs.into_iter().enumerate() {
         if reasoning {
-            // Folded: the streaming content is hidden; nothing to show. (Once it
-            // commits, `push_assistant_blocks` emits the summary row instead.)
+            // Only the trailing run can still be open; anything a later run
+            // follows has ended and folds to its summary row.
+            let body: Vec<&str> = seg.lines().filter(|l| !l.trim().is_empty()).collect();
+            if body.is_empty() {
+                continue;
+            }
+            if i < last {
+                lines.push(reasoning_summary_row(body.len()));
+            } else if stream_reasoning {
+                let tail = &body[body.len().saturating_sub(LIVE_REASONING_TAIL_LINES)..];
+                lines.extend(reasoning_detail_lines(&tail.join("\n")));
+            }
             continue;
         }
         if !seg.trim().is_empty() {
@@ -1398,6 +1419,4 @@ mod tests {
             .collect();
         assert_eq!(joined, long);
     }
-
 }
-

--- a/src-tauri/src/core/cli/tui/markdown.rs
+++ b/src-tauri/src/core/cli/tui/markdown.rs
@@ -4,11 +4,17 @@
 
 use ratatui::prelude::*;
 
-/// Render assistant text to styled lines: reasoning dimmed, answer prose passed
-/// through markdown formatting. `width` bounds table wrapping.
-pub(super) fn format_assistant_lines(text: &str, width: u16) -> Vec<Line<'static>> {
+/// Render a turn to styled lines: reasoning dimmed, answer prose passed through
+/// markdown formatting. Native reasoning arrives as `segs` and is placed by its
+/// offset; inline `<think>` markers are found inside the prose. `width` bounds
+/// table wrapping.
+pub(super) fn format_assistant_lines(
+    prose: &str,
+    segs: &[super::ReasoningSeg],
+    width: u16,
+) -> Vec<Line<'static>> {
     let mut lines = Vec::new();
-    for (reasoning, seg) in super::split_reasoning(text) {
+    for (reasoning, seg) in super::assistant_runs(prose, segs) {
         if reasoning {
             lines.extend(reasoning_detail_lines(&seg));
         } else {
@@ -24,12 +30,17 @@ pub(super) fn format_assistant_lines(text: &str, width: u16) -> Vec<Line<'static
 /// `[thinking]` header state; once the tag closes (or prose begins) the rest
 /// renders as usual. When folding is off this is identical to
 /// `format_assistant_lines`, so the existing live-tail tests hold.
-pub(super) fn live_assistant_lines(text: &str, width: u16, fold_reasoning: bool) -> Vec<Line<'static>> {
+pub(super) fn live_assistant_lines(
+    prose: &str,
+    segs: &[super::ReasoningSeg],
+    width: u16,
+    fold_reasoning: bool,
+) -> Vec<Line<'static>> {
     if !fold_reasoning {
-        return format_assistant_lines(text, width);
+        return format_assistant_lines(prose, segs, width);
     }
     let mut lines = Vec::new();
-    for (reasoning, seg) in super::split_reasoning(text) {
+    for (reasoning, seg) in super::assistant_runs(prose, segs) {
         if reasoning {
             // Folded: the streaming content is hidden; nothing to show. (Once it
             // commits, `push_assistant_blocks` emits the summary row instead.)


### PR DESCRIPTION
## Describe Your Changes


### Native reasoning streaming
- Providers that expose a dedicated `reasoning_content` field now stream it as a new `StreamEvent::Reasoning` event instead of manufacturing synthetic ` think>` / ` response` wrapper tokens on the content stream (`events.rs`, `upstream.rs`). Reasoning stays display-only: folded in the TUI like ` think>` blocks, dimmed on stderr in headless mode, and rigorously excluded from wire history and piped/plain-text reports so it is never resent to the model as history (`cli/mod.rs`, `run_report.rs`, `tui.rs`). Providers that still inline tags in `content` continue through `Token` with the tag-stripping fallback intact.

### Robust tool history on cancel
- Cancelling a run mid-way now folds this turn's completed tool calls and their results into the wire history, so the model on the next prompt sees the tools it actually ran. In-flight calls are paired with a placeholder result, keeping the exchange protocol-valid (no dangling `tool_calls` that OpenAI-compatible endpoints reject). Previously a cancel dropped these from the model's view (though they still rendered).

### Text wrapping
- Long tool labels, ask-tool option labels, the live tool row, and remaining clipped surfaces now wrap instead of being truncated (`tui.rs`). Wrapped labels keep the mouse hitboxes in step with what's on screen.

### Progress feedback
- The static `working…` input placeholder now rotates through action synonyms, with a matching (orange) set shown while the model is reasoning — so a long turn no longer reads as a hung UI.

### Polish fixes
- Select rows with the terminal palette instead of reversed video (better theming in many terminals).

## Testing
All changes are covered by unit tests:
- `upstream.rs`: reasoning streams as native events and stays out of `content`; reasoning-only turns emit no content tokens; inline ` think>` tags still pass through as tokens.
- `events.rs`: `Reasoning` serializes with a snake_case tag.
- `global_config.rs`: empty-key clearing vs. `None` merge semantics.
- `providers.rs`: `fetch_missing_models` populates/persists empty providers via a loopback stub.
- `tui.rs`: cancel preserves completed tool calls and results in history.


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
