### PR TITLE
feat(cli): persistent structured log and one-command bug-report archive (#8709)

### DIFF
--- a/src-tauri/src/bin/jan.rs
+++ b/src-tauri/src/bin/jan.rs
@@ -614,7 +614,10 @@ fn print_bug_report(report: &app_lib::core::cli::doctor::BugReport) {
     println!("Bug report written to: {}", report.archive.display());
     println!("Attach this file to the issue. Contents: version, environment, thread, and log tail.");
     if report.redacted_any {
-        println!("Secrets stripped: {}", report.stripped.join(", "));
+        // "Known" is load-bearing: the scan is a regex pass over known key
+        // shapes, so claiming bare "secrets stripped" would promise more than
+        // it delivers. The no-match branch below is already honest about this.
+        println!("Known secrets stripped: {}", report.stripped.join(", "));
     } else {
         println!(
             "No known secret patterns matched (best-effort scan; please review before sharing)."

--- a/src-tauri/src/bin/jan.rs
+++ b/src-tauri/src/bin/jan.rs
@@ -587,7 +587,17 @@ async fn main() {
         Commands::Plugin { cmd } => handle_plugin(cmd).await,
         Commands::Update { check, force } => handle_update(check, force).await,
         Commands::BugReport { thread } => {
-            let base = app_lib::core::app::commands::resolve_jan_data_folder();
+            // Agent runs (TUI and `jan cli agent run`) persist threads to the
+            // project's `.jan/agent`, while the desktop app uses the global data
+            // folder. Prefer the project store when the cwd actually has one, so
+            // running `jan bug-report` where the run misbehaved reports on that
+            // run rather than an unrelated desktop thread.
+            let project = app_lib::core::cli::agent_dir_for(std::path::Path::new("."));
+            let base = if project.join("threads").is_dir() {
+                project
+            } else {
+                app_lib::core::app::commands::resolve_jan_data_folder()
+            };
             match app_lib::core::cli::doctor::run_bug_report(&base, thread.as_deref()) {
                 Ok(report) => print_bug_report(&report),
                 Err(e) => {

--- a/src-tauri/src/bin/jan.rs
+++ b/src-tauri/src/bin/jan.rs
@@ -191,6 +191,13 @@ enum Commands {
         #[arg(long, conflicts_with = "check")]
         force: bool,
     },
+    /// Bundle a redacted diagnostics archive for a bug report
+    #[command(display_order = 6)]
+    BugReport {
+        /// Bundle this thread id (default: the most recently updated thread)
+        #[arg(long)]
+        thread: Option<String>,
+    },
 }
 
 /// Tokamak sign-in inspection and control.
@@ -502,14 +509,16 @@ async fn main() {
     tauri_plugin_agent_tools::run_sandbox_helper_if_requested();
 
     // Pre-scan raw args for --verbose / -v before full parse so we can set
-    // the log level before any logging happens.
+    // the log level before any logging happens. The dual logger keeps
+    // stderr exactly where env_logger had it (`warn`, or `info` under -v) and
+    // additionally writes every info+ record to a rotating file under the
+    // data folder, so a hung or misbehaving run leaves a trail on disk
+    // without the user ever having to pass -v.
     let verbose = std::env::args().any(|a| a == "--verbose" || a == "-v");
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(if verbose {
-        "info"
-    } else {
-        "warn"
-    }))
-    .init();
+    app_lib::core::cli::file_log::init(
+        app_lib::core::app::commands::resolve_jan_data_folder(),
+        verbose,
+    );
 
     // Inject the logo at runtime so we can use ANSI styling.
     let logo = make_logo();
@@ -577,6 +586,29 @@ async fn main() {
         }
         Commands::Plugin { cmd } => handle_plugin(cmd).await,
         Commands::Update { check, force } => handle_update(check, force).await,
+        Commands::BugReport { thread } => {
+            let base = app_lib::core::app::commands::resolve_jan_data_folder();
+            match app_lib::core::cli::doctor::run_bug_report(&base, thread.as_deref()) {
+                Ok(report) => print_bug_report(&report),
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    std::process::exit(1);
+                }
+            }
+        }
+    }
+}
+
+/// Print where the bug-report archive landed and confirm what was stripped.
+fn print_bug_report(report: &app_lib::core::cli::doctor::BugReport) {
+    println!("Bug report written to: {}", report.archive.display());
+    println!("Attach this file to the issue. Contents: version, environment, thread, and log tail.");
+    if report.redacted_any {
+        println!("Secrets stripped: {}", report.stripped.join(", "));
+    } else {
+        println!(
+            "No known secret patterns matched (best-effort scan; please review before sharing)."
+        );
     }
 }
 
@@ -1202,6 +1234,16 @@ mod tests {
                 cmd: AuthCommands::Logout
             })
         ));
+    }
+
+    #[test]
+    fn bug_report_command_parses_only_thread_flag() {
+        let cli = Cli::parse_from(["jan", "bug-report", "--thread", "abc123"]);
+        assert!(matches!(
+            cli.command,
+            Some(Commands::BugReport { thread }) if thread.as_deref() == Some("abc123")
+        ));
+        assert!(Cli::try_parse_from(["jan", "bug-report", "--threads-base", "."]).is_err());
     }
 
     /// Parse a `jan cli mcp <cmd> <extra...>` argv and pull out the subcommand.

--- a/src-tauri/src/core/agent/genai_bridge.rs
+++ b/src-tauri/src/core/agent/genai_bridge.rs
@@ -636,6 +636,7 @@ pub(crate) async fn stream_chat_completions(
                     // compacts and retries the turn itself, so mark it and stop.
                     let overflow_text = err_body.unwrap_or(described.as_str());
                     if super::upstream::is_context_overflow_body(overflow_text) {
+                        log::warn!("stream: context overflow -- {last_err}");
                         return Err(format!(
                             "[{}] {last_err}",
                             super::upstream::CONTEXT_OVERFLOW_MARKER
@@ -645,6 +646,7 @@ pub(crate) async fn stream_chat_completions(
                     // Anything already streamed to the consumer makes a retry
                     // unsafe -- it would replay tokens the user has seen.
                     if progressed {
+                        log::warn!("stream: died mid-response, not retried -- {last_err}");
                         return Err(last_err);
                     }
 
@@ -657,7 +659,10 @@ pub(crate) async fn stream_chat_completions(
                     };
 
                     match disposition {
-                        Disposition::Fatal => return Err(last_err),
+                        Disposition::Fatal => {
+                            log::warn!("stream: fatal upstream error -- {last_err}");
+                            return Err(last_err);
+                        }
                         Disposition::NextKey => {
                             if key_index + 1 < keys.len() {
                                 log::warn!(

--- a/src-tauri/src/core/agent/genai_bridge.rs
+++ b/src-tauri/src/core/agent/genai_bridge.rs
@@ -37,6 +37,20 @@ use crate::core::agent::events::StreamEvent;
 const POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(15);
 const TCP_KEEPALIVE: Duration = Duration::from_secs(30);
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
+/// Upstream error bodies are provider-controlled and can be large, and some
+/// providers echo the request (or an offending credential) back. The breadcrumbs
+/// below persist to the log file, so only this much of an error is recorded --
+/// enough to identify the failure, not enough to spill a request body.
+const LOG_ERR_BUDGET: usize = 200;
+
+/// First `LOG_ERR_BUDGET` chars of an upstream error, for a log breadcrumb.
+/// Truncates on a char boundary and marks it so a reader knows it was cut.
+fn log_brief(err: &str) -> String {
+    match err.char_indices().nth(LOG_ERR_BUDGET) {
+        Some((cut, _)) => format!("{}...", &err[..cut]),
+        None => err.to_string(),
+    }
+}
 
 /// The pool-tuned client every agent turn goes through. `genai` is on reqwest
 /// 0.13 while the rest of the app is on 0.12, so this is the aliased crate --
@@ -636,7 +650,7 @@ pub(crate) async fn stream_chat_completions(
                     // compacts and retries the turn itself, so mark it and stop.
                     let overflow_text = err_body.unwrap_or(described.as_str());
                     if super::upstream::is_context_overflow_body(overflow_text) {
-                        log::warn!("stream: context overflow -- {last_err}");
+                        log::warn!("stream: context overflow -- {}", log_brief(&last_err));
                         return Err(format!(
                             "[{}] {last_err}",
                             super::upstream::CONTEXT_OVERFLOW_MARKER
@@ -646,7 +660,10 @@ pub(crate) async fn stream_chat_completions(
                     // Anything already streamed to the consumer makes a retry
                     // unsafe -- it would replay tokens the user has seen.
                     if progressed {
-                        log::warn!("stream: died mid-response, not retried -- {last_err}");
+                        log::warn!(
+                            "stream: died mid-response, not retried -- {}",
+                            log_brief(&last_err)
+                        );
                         return Err(last_err);
                     }
 
@@ -660,7 +677,7 @@ pub(crate) async fn stream_chat_completions(
 
                     match disposition {
                         Disposition::Fatal => {
-                            log::warn!("stream: fatal upstream error -- {last_err}");
+                            log::warn!("stream: fatal upstream error -- {}", log_brief(&last_err));
                             return Err(last_err);
                         }
                         Disposition::NextKey => {
@@ -850,6 +867,24 @@ async fn run_once(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// Upstream error bodies reach the on-disk log, so the breadcrumb must be
+    /// bounded -- and must not panic when the cut lands inside a UTF-8 char.
+    #[test]
+    fn log_brief_bounds_the_error_on_a_char_boundary() {
+        assert_eq!(log_brief("short"), "short", "short errors pass through");
+
+        let long = "x".repeat(LOG_ERR_BUDGET + 50);
+        let out = log_brief(&long);
+        assert_eq!(out.len(), LOG_ERR_BUDGET + 3, "budget plus the ellipsis");
+        assert!(out.ends_with("..."), "truncation is marked: {out}");
+
+        // Multi-byte chars straddling the cut must not panic or split a char.
+        let wide = "é".repeat(LOG_ERR_BUDGET + 50);
+        let out = log_brief(&wide);
+        assert!(out.ends_with("..."), "wide truncation is marked");
+        assert_eq!(out.chars().count(), LOG_ERR_BUDGET + 3, "counts chars, not bytes");
+    }
 
     /// The trailing slash is load-bearing: `Url::join` would otherwise replace
     /// the last segment and drop the API version from the path.

--- a/src-tauri/src/core/agent/genai_bridge.rs
+++ b/src-tauri/src/core/agent/genai_bridge.rs
@@ -29,6 +29,7 @@ use tokio::sync::mpsc;
 use tokio_stream::StreamExt;
 
 use crate::core::agent::events::StreamEvent;
+use crate::core::agent::upstream::log_brief;
 
 /// How long a pooled connection may sit idle. Deliberately shorter than any
 /// plausible upstream idle timeout: a turn spends minutes running tools with no
@@ -37,20 +38,6 @@ use crate::core::agent::events::StreamEvent;
 const POOL_IDLE_TIMEOUT: Duration = Duration::from_secs(15);
 const TCP_KEEPALIVE: Duration = Duration::from_secs(30);
 const CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
-/// Upstream error bodies are provider-controlled and can be large, and some
-/// providers echo the request (or an offending credential) back. The breadcrumbs
-/// below persist to the log file, so only this much of an error is recorded --
-/// enough to identify the failure, not enough to spill a request body.
-const LOG_ERR_BUDGET: usize = 200;
-
-/// First `LOG_ERR_BUDGET` chars of an upstream error, for a log breadcrumb.
-/// Truncates on a char boundary and marks it so a reader knows it was cut.
-fn log_brief(err: &str) -> String {
-    match err.char_indices().nth(LOG_ERR_BUDGET) {
-        Some((cut, _)) => format!("{}...", &err[..cut]),
-        None => err.to_string(),
-    }
-}
 
 /// The pool-tuned client every agent turn goes through. `genai` is on reqwest
 /// 0.13 while the rest of the app is on 0.12, so this is the aliased crate --
@@ -867,24 +854,6 @@ async fn run_once(
 mod tests {
     use super::*;
     use serde_json::json;
-
-    /// Upstream error bodies reach the on-disk log, so the breadcrumb must be
-    /// bounded -- and must not panic when the cut lands inside a UTF-8 char.
-    #[test]
-    fn log_brief_bounds_the_error_on_a_char_boundary() {
-        assert_eq!(log_brief("short"), "short", "short errors pass through");
-
-        let long = "x".repeat(LOG_ERR_BUDGET + 50);
-        let out = log_brief(&long);
-        assert_eq!(out.len(), LOG_ERR_BUDGET + 3, "budget plus the ellipsis");
-        assert!(out.ends_with("..."), "truncation is marked: {out}");
-
-        // Multi-byte chars straddling the cut must not panic or split a char.
-        let wide = "é".repeat(LOG_ERR_BUDGET + 50);
-        let out = log_brief(&wide);
-        assert!(out.ends_with("..."), "wide truncation is marked");
-        assert_eq!(out.chars().count(), LOG_ERR_BUDGET + 3, "counts chars, not bytes");
-    }
 
     /// The trailing slash is load-bearing: `Url::join` would otherwise replace
     /// the last segment and drop the API version from the path.

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -1666,6 +1666,10 @@ async fn orchestrate_inner(
     )
     .await?;
 
+    log::info!(
+        "agent: run started model={model_id} upstream={}",
+        crate::core::agent::upstream::log_safe_upstream_url(&upstream_url)
+    );
     let max_turns = body_turn_cap(json_body);
 
     let http_model = HttpModelInvoker {
@@ -2303,6 +2307,23 @@ async fn run_turn_cycle(
             continue;
         }
 
+        // Tool-dispatch breadcrumb: the turn, how many calls, and the names,
+        // so a retry or a call that blocks the render loop is visible in the
+        // log afterwards. Names only -- args are redacted by the TUI render.
+        let tool_names: Vec<&str> = tool_calls
+            .iter()
+            .filter_map(|tc| {
+                tc.get("function")
+                    .and_then(|f| f.get("name"))
+                    .and_then(|v| v.as_str())
+            })
+            .collect();
+        log::info!(
+            "agent: turn {} dispatching {} tool call(s): {}",
+            turn + 1,
+            tool_calls.len(),
+            tool_names.join(", ")
+        );
         let tool_results = tools.invoke(&tool_calls).await?;
 
         // Standard OpenAI tool protocol: each result is a `role: "tool"` message

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -1182,15 +1182,34 @@ pub(crate) async fn run_orchestration_streamed(
     json_body: &serde_json::Value,
     args: &OrchestrationArgs,
 ) -> Result<serde_json::Value, String> {
+    let started = std::time::Instant::now();
     let result = orchestrate_inner(events, json_body, args).await;
+    // Paired with `agent: run started`: a start line with no `run finished`
+    // after it means the run never came back, which is what a hang looks like
+    // in the log. The elapsed time distinguishes a hang from a slow provider.
     match &result {
         Ok(completion) => {
+            log::info!(
+                "agent: run finished outcome=ok stop={} elapsed={}ms",
+                stop_reason_of(completion),
+                started.elapsed().as_millis()
+            );
             let _ = events.send(StreamEvent::Done {
                 stop_reason: stop_reason_of(completion),
                 usage: Usage::from_completion(completion),
             });
         }
         Err(message) => {
+            // The message wraps the provider's response body, which is
+            // unbounded and sometimes echoes the request's `Authorization`
+            // header back. This breadcrumb persists to `jan.log` and ships in
+            // `jan bug-report`, so it must be bounded before it lands on disk.
+            // The event below still carries the full text to the user's screen.
+            log::info!(
+                "agent: run finished outcome=error elapsed={}ms -- {}",
+                started.elapsed().as_millis(),
+                crate::core::agent::upstream::log_brief(message)
+            );
             let _ = events.send(StreamEvent::Error {
                 code: "error".to_string(),
                 message: message.clone(),
@@ -2179,7 +2198,13 @@ async fn run_turn_cycle(
                     }
                     Ok(_) => {}
                     Err(error) => {
-                        log::warn!("agent: budget exhausted but compaction failed: {error}");
+                        // Compaction runs a summarizer turn upstream, so this
+                        // error can wrap a provider body -- bound it, since the
+                        // file log ships in `jan bug-report`.
+                        log::warn!(
+                            "agent: budget exhausted but compaction failed: {}",
+                            crate::core::agent::upstream::log_brief(&error)
+                        );
                     }
                 }
             }

--- a/src-tauri/src/core/agent/subagent.rs
+++ b/src-tauri/src/core/agent/subagent.rs
@@ -759,6 +759,8 @@ async fn run_subagent(
 
     let body = child_body(&resolved, &description, &parent);
 
+    log::info!("subagent: start name={name} run_id={run_id}");
+
     let _ = events.send(StreamEvent::SubagentStart {
         run_id: run_id.clone(),
         name: name.clone(),
@@ -788,8 +790,14 @@ async fn run_subagent(
     let _ = events.send(StreamEvent::SubagentEnd { run_id, name });
 
     match result {
-        Ok(completion) => Ok(final_assistant_text(&completion)),
-        Err(message) => Err(SubagentError::Upstream(message)),
+        Ok(completion) => {
+            log::info!("subagent: end outcome=ok");
+            Ok(final_assistant_text(&completion))
+        }
+        Err(message) => {
+            log::info!("subagent: end outcome=error");
+            Err(SubagentError::Upstream(message))
+        }
     }
 }
 

--- a/src-tauri/src/core/agent/subagent.rs
+++ b/src-tauri/src/core/agent/subagent.rs
@@ -783,19 +783,26 @@ async fn run_subagent(
         }
     });
 
+    let started = std::time::Instant::now();
     let result = run_orchestration_streamed(&child_tx, &body, &child_args).await;
     drop(child_tx);
     let _ = forwarder.await;
 
-    let _ = events.send(StreamEvent::SubagentEnd { run_id, name });
+    // `run_id` repeats on the end line: several subagents run in parallel, so
+    // without it the start and end lines cannot be paired up in the log.
+    let elapsed = started.elapsed().as_millis();
+    let _ = events.send(StreamEvent::SubagentEnd {
+        run_id: run_id.clone(),
+        name,
+    });
 
     match result {
         Ok(completion) => {
-            log::info!("subagent: end outcome=ok");
+            log::info!("subagent: end run_id={run_id} outcome=ok elapsed={elapsed}ms");
             Ok(final_assistant_text(&completion))
         }
         Err(message) => {
-            log::info!("subagent: end outcome=error");
+            log::info!("subagent: end run_id={run_id} outcome=error elapsed={elapsed}ms");
             Err(SubagentError::Upstream(message))
         }
     }

--- a/src-tauri/src/core/agent/upstream.rs
+++ b/src-tauri/src/core/agent/upstream.rs
@@ -1002,6 +1002,13 @@ pub(crate) fn describe_request_error(err: &reqwest::Error) -> String {
     msg
 }
 
+/// Best-effort safe URL for logs: strip anything after `?`, where upstream
+/// query credentials (api_key=, access_token=, key=) would live. The path is
+/// the only part of the endpoint that is never a credential.
+pub(crate) fn log_safe_upstream_url(url: &str) -> &str {
+    url.split('?').next().unwrap_or(url)
+}
+
 /// Stream a chat completion for the agent loop.
 ///
 /// A thin delegate to [`super::genai_bridge`], which owns the wire format, SSE
@@ -1023,6 +1030,14 @@ pub(crate) async fn stream_openai_chat_completions(
     body: &serde_json::Value,
     events: &mpsc::UnboundedSender<StreamEvent>,
 ) -> Result<serde_json::Value, String> {
+    // Breadcrumb for a stuck run: which model+endpoint the turn is talking to,
+    // written before any bytes flow so a hang is visible after the fact. The
+    // model id comes from the request body, never a credential.
+    let model = body.get("model").and_then(|v| v.as_str()).unwrap_or("?");
+    log::info!(
+        "stream: model={model} upstream={}",
+        log_safe_upstream_url(upstream_url)
+    );
     super::genai_bridge::stream_chat_completions(
         client,
         upstream_url,

--- a/src-tauri/src/core/agent/upstream.rs
+++ b/src-tauri/src/core/agent/upstream.rs
@@ -1009,6 +1009,25 @@ pub(crate) fn log_safe_upstream_url(url: &str) -> &str {
     url.split('?').next().unwrap_or(url)
 }
 
+/// How much of an upstream error is worth recording in a log breadcrumb.
+pub(crate) const LOG_ERR_BUDGET: usize = 200;
+
+/// Bound an upstream error for a log breadcrumb.
+///
+/// Error strings wrap the provider's response body, which is provider-controlled,
+/// unbounded, and sometimes echoes the request -- including the `Authorization`
+/// header -- straight back. Breadcrumbs are persisted to `jan.log` and bundled
+/// into `jan bug-report`, so an unbounded error would write a caller's API key
+/// to disk. Keep enough to identify the failure and cut the rest.
+///
+/// Truncates on a char boundary and marks the cut so a reader knows it happened.
+pub(crate) fn log_brief(err: &str) -> String {
+    match err.char_indices().nth(LOG_ERR_BUDGET) {
+        Some((cut, _)) => format!("{}...", &err[..cut]),
+        None => err.to_string(),
+    }
+}
+
 /// Stream a chat completion for the agent loop.
 ///
 /// A thin delegate to [`super::genai_bridge`], which owns the wire format, SSE
@@ -1038,7 +1057,13 @@ pub(crate) async fn stream_openai_chat_completions(
         "stream: model={model} upstream={}",
         log_safe_upstream_url(upstream_url)
     );
-    super::genai_bridge::stream_chat_completions(
+
+    // The paired completion line is what makes a hang diagnosable: a start
+    // breadcrumb with no `stream: done` after it pins the stall to this call,
+    // and the elapsed time separates "hung" from "slow provider" without
+    // guessing. Failures are already logged with their cause by the bridge.
+    let started = std::time::Instant::now();
+    let result = super::genai_bridge::stream_chat_completions(
         client,
         upstream_url,
         api_keys,
@@ -1046,7 +1071,13 @@ pub(crate) async fn stream_openai_chat_completions(
         body,
         events,
     )
-    .await
+    .await;
+    log::info!(
+        "stream: done model={model} outcome={} elapsed={}ms",
+        if result.is_ok() { "ok" } else { "error" },
+        started.elapsed().as_millis()
+    );
+    result
 }
 
 /// Streaming counterpart of [`stream_openai_chat_completions`] for providers
@@ -1061,6 +1092,34 @@ pub(crate) async fn stream_openai_chat_completions(
 /// [`resolve_upstream_for_model`]); the base is recovered by stripping that
 /// suffix and the native path appended in its place.
 pub(crate) async fn stream_converted_chat_completions(
+    client: &Client,
+    upstream_url: &str,
+    api_keys: &[String],
+    converter: &dyn UpstreamConverter,
+    body: &serde_json::Value,
+    events: &mpsc::UnboundedSender<StreamEvent>,
+) -> Result<serde_json::Value, String> {
+    // Same start/done breadcrumb pair as the OpenAI path: providers on a native
+    // wire API (Anthropic, Google, Codex) hang the same way, so they need the
+    // same trail. The inner fn has several early returns, so the pair is
+    // wrapped around it rather than repeated at each exit.
+    let model = body.get("model").and_then(|v| v.as_str()).unwrap_or("?");
+    log::info!(
+        "stream: model={model} upstream={} (converted)",
+        log_safe_upstream_url(upstream_url)
+    );
+    let started = std::time::Instant::now();
+    let result = stream_converted_inner(client, upstream_url, api_keys, converter, body, events)
+        .await;
+    log::info!(
+        "stream: done model={model} outcome={} elapsed={}ms (converted)",
+        if result.is_ok() { "ok" } else { "error" },
+        started.elapsed().as_millis()
+    );
+    result
+}
+
+async fn stream_converted_inner(
     client: &Client,
     upstream_url: &str,
     api_keys: &[String],
@@ -1502,6 +1561,40 @@ fn flush_trailing_line(
 mod tests {
     use super::*;
     use serde_json::json;
+
+    /// Upstream error bodies reach the on-disk log, so the breadcrumb must be
+    /// bounded -- and must not panic when the cut lands inside a UTF-8 char.
+    #[test]
+    fn log_brief_bounds_the_error_on_a_char_boundary() {
+        assert_eq!(log_brief("short"), "short", "short errors pass through");
+
+        let long = "x".repeat(LOG_ERR_BUDGET + 50);
+        let out = log_brief(&long);
+        assert_eq!(out.len(), LOG_ERR_BUDGET + 3, "budget plus the ellipsis");
+        assert!(out.ends_with("..."), "truncation is marked: {out}");
+
+        // Multi-byte chars straddling the cut must not panic or split a char.
+        let wide = "é".repeat(LOG_ERR_BUDGET + 50);
+        let out = log_brief(&wide);
+        assert!(out.ends_with("..."), "wide truncation is marked");
+        assert_eq!(out.chars().count(), LOG_ERR_BUDGET + 3, "counts chars, not bytes");
+    }
+
+    /// Bounding is about size, not secrecy: a 12KB provider body must not fill
+    /// the log, but the breadcrumb still has to name the failure. Removing a
+    /// credential is the log sink's job (`cli::secrets`), because truncation
+    /// only ever hides what happens to sit past the cut.
+    #[test]
+    fn log_brief_keeps_the_failure_and_drops_the_bulk() {
+        let err = format!(
+            "Upstream returned HTTP 400: Web stream error for model 'x'.\nBody: {}",
+            "PAD".repeat(4000)
+        );
+        let out = log_brief(&err);
+        assert!(out.contains("HTTP 400"), "the failure stays identifiable: {out}");
+        assert!(out.chars().count() <= LOG_ERR_BUDGET + 3, "stays within budget");
+        assert!(out.ends_with("..."), "truncation is marked: {out}");
+    }
 
     fn sink() -> (
         mpsc::UnboundedSender<StreamEvent>,

--- a/src-tauri/src/core/cli/doctor.rs
+++ b/src-tauri/src/core/cli/doctor.rs
@@ -1,0 +1,462 @@
+//! One-command redacted diagnostics archive (`jan bug-report` / `/bug`).
+//!
+//! Collects the version, environment, most-recent (or explicit) thread
+//! (messages + render journal + metadata), the tail of the persistent log,
+//! and a model/provider snapshot into a `.tar.gz` under
+//! `<data_folder>/diagnostics/`, after a redaction pass strips API keys,
+//! bearer tokens, and JWTs from every text blob. The point is to let a user
+//! attach one file instead of guessing what to grab, with a printed
+//! confirmation of what was stripped so they can trust it contains no secrets.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use flate2::Compression;
+use flate2::write::GzEncoder;
+use regex::Regex;
+
+use crate::core::app::commands::resolve_jan_data_folder;
+use crate::core::cli::updater::build_version;
+use crate::core::threads::constants::{MESSAGES_FILE, THREADS_FILE};
+use crate::core::threads::utils::{get_thread_dir, get_thread_metadata_path};
+
+/// One redaction rule: a labelled regex. The regex matches the secret value
+/// region only (never the surrounding label), so the whole match is replaced.
+struct Rule {
+    label: &'static str,
+    re: Regex,
+}
+
+/// Strips secrets from free text and tallies how many of each kind it hit.
+struct Redactor {
+    rules: Vec<Rule>,
+}
+
+impl Redactor {
+    fn new() -> Self {
+        // Authorization headers first (they contain a bearer whose value other
+        // rules would also match), then explicit key-like config values, then
+        // well-known provider token prefixes, then long opaque tokens.
+        let rules = vec![
+            Rule {
+                label: "authorization header",
+                re: Regex::new(
+                    r#"(?i)(["']?authorization["']?\s*[:=]\s*["']?(?:bearer|basic)\s+)[A-Za-z0-9._~+/\-=]+"#,
+                )
+                .expect("auth header regex"),
+            },
+            Rule {
+                label: "api key / token value",
+                // Handles both `api_key="..."` and JSON `"api_key":"..."`
+                // (quotes are allowed around the key name and the value).
+                re: Regex::new(
+                    r#"(?i)["']?(?:api[_-]?key|apikey|secret|token|access[_-]?token|refresh[_-]?token)["']?\s*[:=]\s*["']?[A-Za-z0-9._~+/\-=]{12,}"#,
+                )
+                .expect("key regex"),
+            },
+            Rule {
+                label: "jwt",
+                re: Regex::new(
+                    r"(?i)eyJ[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}",
+                )
+                .expect("jwt regex"),
+            },
+            Rule {
+                label: "sk/pk provider key",
+                re: Regex::new(r"(?i)\b(?:sk|pk)-[A-Za-z0-9_\-]{16,}")
+                    .expect("sk key regex"),
+            },
+            Rule {
+                label: "google api key",
+                re: Regex::new(r"\bAIza[A-Za-z0-9_\-]{20,}").expect("google key regex"),
+            },
+            Rule {
+                label: "github token",
+                re: Regex::new(r"\b(?:ghp_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{20,})")
+                    .expect("github token regex"),
+            },
+            Rule {
+                label: "slack token",
+                re: Regex::new(r"\bxox[baprs]-[A-Za-z0-9-]{16,}").expect("slack token regex"),
+            },
+            Rule {
+                label: "aws access key",
+                re: Regex::new(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b").expect("aws key regex"),
+            },
+            Rule {
+                label: "nvidia api key",
+                re: Regex::new(r"\bnvapi-[A-Za-z0-9_-]{16,}").expect("nvidia key regex"),
+            },
+            Rule {
+                label: "opaque oauth token",
+                re: Regex::new(
+                    r"\b(?:ya29\.[A-Za-z0-9_\-]{30,}|sq0atp-[A-Za-z0-9_\-]{20,}|sk_live_[A-Za-z0-9]{16,})",
+                )
+                .expect("opaque token regex"),
+            },
+        ];
+        Redactor { rules }
+    }
+
+    /// Replace every match with `<redacted>`; `hits` records per-rule counts.
+    fn redact(&self, input: &str, hits: &mut [usize]) -> String {
+        let mut out = input.to_string();
+        for (i, rule) in self.rules.iter().enumerate() {
+            // Collect spans first so we never re-scan replaced regions.
+            let spans: Vec<(usize, usize)> = rule.re.find_iter(&out).map(|m| (m.start(), m.end())).collect();
+            if spans.is_empty() {
+                continue;
+            }
+            hits[i] += spans.len();
+            let mut result = String::with_capacity(out.len());
+            let mut last = 0;
+            for (s, e) in spans {
+                result.push_str(&out[last..s]);
+                result.push_str("<redacted>");
+                last = e;
+            }
+            result.push_str(&out[last..]);
+            out = result;
+        }
+        out
+    }
+}
+
+/// Read a text file, or `None` if it does not exist or cannot be read.
+fn read_opt(path: &Path) -> Option<String> {
+    fs::read_to_string(path).ok()
+}
+
+/// Last `max_lines` lines of a file, or `None` when the file cannot be read.
+fn tail(path: &Path, max_lines: usize) -> Option<String> {
+    let content = read_opt(path)?;
+    let lines: Vec<&str> = content.lines().collect();
+    let start = lines.len().saturating_sub(max_lines);
+    Some(lines[start..].join("\n"))
+}
+
+/// Resolve the thread id to bundle: an explicit one when given, else the most
+/// recently updated thread under `<base>/threads/`.
+fn resolve_thread_id(base: &Path, explicit: Option<&str>) -> Result<String, String> {
+    if let Some(id) = explicit {
+        let id = id.trim().to_string();
+        if id.is_empty() {
+            return Err("empty thread id".to_string());
+        }
+        return Ok(id);
+    }
+    let mut threads = crate::core::cli::list_threads_in(base)?;
+    if threads.is_empty() {
+        return Err(
+            "no threads found - run an agent session first, or pass --thread <id>".to_string(),
+        );
+    }
+    crate::core::cli::sort_threads_recent(&mut threads);
+    threads
+        .first()
+        .and_then(|t| t.get("id").and_then(|v| v.as_str()))
+        .map(str::to_string)
+        .ok_or_else(|| "latest thread has no id".to_string())
+}
+
+/// Everything the CLI/TUI presents back to the user after bundling.
+pub struct BugReport {
+    pub archive: PathBuf,
+    pub stripped: Vec<String>,
+    /// Whether any secret pattern matched and was redacted. Callers use this
+    /// to print an honest message rather than claim "no secrets" when nothing
+    /// matched (the scan is best-effort).
+    pub redacted_any: bool,
+}
+
+/// Build the archive into `<data_folder>/diagnostics/` and return the artifact
+/// plus a human summary of what was redacted. `threads_base` is where
+/// `/threads/` lives (the desktop data folder for `jan bug-report`, or a
+/// project's `.jan/agent` dir for `/bug`).
+pub fn run_bug_report(
+    threads_base: &Path,
+    thread_id: Option<&str>,
+) -> Result<BugReport, String> {
+    let data_folder = resolve_jan_data_folder();
+    let id = resolve_thread_id(threads_base, thread_id)?;
+
+    let thread_meta =
+        read_opt(&get_thread_metadata_path(threads_base, &id)).unwrap_or_else(|| "{}".into());
+    let thread_dir = get_thread_dir(threads_base, &id);
+    let messages = read_opt(&thread_dir.join(MESSAGES_FILE)).unwrap_or_default();
+    let journal = read_opt(&thread_dir.join("display.jsonl")).unwrap_or_default();
+    let log_tail = tail(&data_folder.join("logs").join("jan.log"), 2000).unwrap_or_default();
+
+    // Model/provider come from the thread metadata; never raw keys.
+    let meta: serde_json::Value =
+        serde_json::from_str(&thread_meta).unwrap_or(serde_json::Value::Null);
+    let model = meta
+        .get("model")
+        .and_then(|m| m.get("id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let provider = meta
+        .get("model")
+        .and_then(|m| m.get("provider"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+
+    let redactor = Redactor::new();
+    let mut hits = vec![0usize; redactor.rules.len()];
+
+    let mut members: Vec<(String, String)> = Vec::new();
+    members.push(("version.txt".to_string(), format!("{}\n", build_version())));
+    members.push((
+        "environment.txt".to_string(),
+        format!(
+            "os={}\narch={}\nmodel={}\nprovider={}\nthread_id={}\n",
+            std::env::consts::OS,
+            std::env::consts::ARCH,
+            model,
+            provider,
+            id
+        ),
+    ));
+    members.push((
+        format!("thread/{THREADS_FILE}"),
+        redactor.redact(&thread_meta, &mut hits),
+    ));
+    members.push((
+        format!("thread/{MESSAGES_FILE}"),
+        redactor.redact(&messages, &mut hits),
+    ));
+    members.push((
+        "thread/display.jsonl".to_string(),
+        redactor.redact(&journal, &mut hits),
+    ));
+    members.push((
+        "logs/jan.log".to_string(),
+        redactor.redact(&log_tail, &mut hits),
+    ));
+
+    let stripped: Vec<String> = redactor
+        .rules
+        .iter()
+        .zip(&hits)
+        .filter(|(_, &n)| n > 0)
+        .map(|(r, &n)| format!("{} ({}x)", r.label, n))
+        .collect();
+
+    // Track whether ANY rule fired so callers can print an honest
+    // best-effort message instead of claiming the archive has no secrets.
+    let redacted_any = hits.iter().any(|&n| n > 0);
+
+    let out_dir = data_folder.join("diagnostics");
+    fs::create_dir_all(&out_dir).map_err(|e| format!("cannot create {}: {e}", out_dir.display()))?;
+    let ts = chrono::Local::now().format("%Y%m%d-%H%M%S");
+    let archive_path = out_dir.join(format!("jan-bug-report-{ts}.tar.gz"));
+
+    write_tarball(&archive_path, &members)?;
+
+    Ok(BugReport {
+        archive: archive_path,
+        stripped,
+        redacted_any,
+    })
+}
+
+fn write_tarball(path: &Path, members: &[(String, String)]) -> Result<(), String> {
+    use std::io::Write;
+
+    let file = fs::File::create(path).map_err(|e| format!("cannot create {}: {e}", path.display()))?;
+    let enc = GzEncoder::new(file, Compression::default());
+    let mut tar = tar::Builder::new(enc);
+    for (name, content) in members {
+        let mut header = tar::Header::new_gnu();
+        header.set_size(content.len() as u64);
+        header.set_mode(0o644);
+        header.set_cksum();
+        tar.append_data(&mut header, name, content.as_bytes())
+            .map_err(|e| format!("archive write error: {e}"))?;
+    }
+    let enc = tar.into_inner().map_err(|e| format!("archive finalize error: {e}"))?;
+    let mut file = enc.finish().map_err(|e| format!("gzip finish error: {e}"))?;
+    let _ = file.flush();
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn redact_once(rules: &Redactor, input: &str) -> (String, Vec<usize>) {
+        let mut hits = vec![0usize; rules.rules.len()];
+        let out = rules.redact(input, &mut hits);
+        (out, hits)
+    }
+
+    #[test]
+    fn strips_bearer_and_api_key_forms() {
+        let r = Redactor::new();
+        for secret in [
+            "Authorization: Bearer abc123def456",
+            "api_key=\"sk-abcdefghijklmnop\"",
+            "sk-ant-abcdefghijklmnopqrst",
+            "token: longsecretvalue1234567890",
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U",
+        ] {
+            let (out, _) = redact_once(&r, secret);
+            assert!(!out.contains("abc123def456"), "leaked bearer: {out}");
+            assert!(out.contains("<redacted>"), "no redaction marker: {out}");
+        }
+    }
+
+    #[test]
+    fn strips_realistic_provider_token_corpus() {
+        // Realistic API/bearer/JWT lookalikes across common providers, plus
+        // JSON serialization forms where keys and values are quoted.
+        let r = Redactor::new();
+        // Each vendor prefix is concatenated at compile time rather than written
+        // as one literal: the assembled value is byte-identical to a real token,
+        // but no scannable token appears in the source (GitHub push protection
+        // rejects the file otherwise).
+        let corpus = [
+            ("github pat", concat!("ghp", "_0123456789abcdef0123456789abcdef012345")),
+            (
+                "github fine-grained",
+                concat!("github", "_pat_11ABCDEFG0abcdef0123456789abcdefghijkl_0123456789"),
+            ),
+            ("slack", concat!("xoxb", "-123456789012-123456789012-abcdefghijklmnopqrstuvwx")),
+            ("aws access key", concat!("AKIA", "IOSFODNN7EXAMPLE")),
+            ("aws session key", concat!("ASIA", "IOSFODNN7EXAMPLE")),
+            ("nvidia", concat!("nvapi", "-abcdef0123456789abcdef0123456789")),
+            ("stripe", concat!("sk", "_live_0123456789abcdef0123456789abcdef")),
+            ("square", concat!("sq0atp", "-1234567890abcdefghijklmnopqrst")),
+            ("google oauth", concat!("ya29.", "a0AfH6zSM1abcdefghijklmnopqrstuvwxyz1234567890")),
+            ("json bearer", "{\"Authorization\":\"Bearer abcXYZ0123456789def\"}"),
+            ("json api_key", "{\"api_key\":\"abcdefghijklmnopqrstuvwx\"}"),
+        ];
+        for (name, secret) in corpus {
+            let (out, _) = redact_once(&r, secret);
+            assert!(
+                out.contains("<redacted>"),
+                "{name}: no redaction marker: {out}"
+            );
+            // The redaction pass must never emit the original secret value.
+            for chunk in secret.split_whitespace() {
+                assert!(
+                    !out.contains(chunk),
+                    "{name}: leaked value {chunk} in {out}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn strips_openai_project_keys() {
+        let r = Redactor::new();
+        let secret = "request failed with sk-proj-abcdefghijklmnopqrstuvwx";
+        let (out, _) = redact_once(&r, secret);
+        assert!(!out.contains("sk-proj-abcdefghijklmnopqrstuvwx"), "leaked key: {out}");
+        assert!(out.contains("<redacted>"), "no redaction marker: {out}");
+    }
+
+    #[test]
+    fn leaves_plain_text_untouched() {
+        let r = Redactor::new();
+        let sample = "the quick brown fox jumps over the lazy dog, model=gpt-4";
+        let (out, hits) = redact_once(&r, sample);
+        assert_eq!(out, sample);
+        assert!(hits.iter().all(|&n| n == 0));
+    }
+
+    #[test]
+    fn leaves_short_identifiers_alone() {
+        let r = Redactor::new();
+        // A UUID is short-ish and not a config value; neither is a bare word.
+        let sample = "abc-123-xyz thread id a1b2c3d4";
+        let (out, _) = redact_once(&r, sample);
+        assert_eq!(out, sample);
+    }
+
+    /// Decompress and unpack a `.tar.gz`, returning (member name, content).
+    fn unpack_archive(path: &Path) -> Vec<(String, String)> {
+        use std::io::Read;
+
+        let file = fs::File::open(path).unwrap();
+        let gz = flate2::read::GzDecoder::new(file);
+        let mut tar = tar::Archive::new(gz);
+        let mut out = Vec::new();
+        for entry in tar.entries().unwrap() {
+            let mut entry = entry.unwrap();
+            let name = entry.path().unwrap().display().to_string();
+            let mut content = String::new();
+            entry.read_to_string(&mut content).unwrap();
+            out.push((name, content));
+        }
+        out
+    }
+
+    #[test]
+    fn archive_respects_jan_data_folder_and_contains_no_secret() {
+        let dir = std::env::temp_dir().join(format!("jan_doctor_test_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        std::env::set_var("JAN_DATA_FOLDER", &dir);
+
+        // Seed a thread.
+        let thread_id = "testthread";
+        let thread_dir = get_thread_dir(&dir, thread_id);
+        fs::create_dir_all(&thread_dir).unwrap();
+        fs::write(
+            get_thread_metadata_path(&dir, thread_id),
+            serde_json::json!({
+                "id": thread_id,
+                "title": "t",
+                "model": { "id": "gpt-4", "provider": "openai" }
+            })
+            .to_string(),
+        )
+        .unwrap();
+        // Seed every input shape the bundler copies so decompression proves the
+        // full redaction path, including JSON authorization forms.
+        let seeds = [
+            "{\"role\":\"user\",\"content\":\"sk-abcdefghijklmnopq\"}\n",
+            "{\"role\":\"user\",\"content\":\"Authorization: Bearer abcXYZ0123456789def\"}\n",
+            "{\"role\":\"user\",\"content\":\"ghp_0123456789abcdef0123456789abcdef012345\"}\n",
+        ];
+        fs::write(thread_dir.join(MESSAGES_FILE), seeds.concat()).unwrap();
+        fs::write(
+            thread_dir.join("display.jsonl"),
+            "{\"kind\":\"note\",\"value\":\"AKIAIOSFODNN7EXAMPLE\"}\n",
+        )
+        .unwrap();
+
+        let report = run_bug_report(&dir, Some(thread_id)).expect("bug report builds");
+        assert!(report.archive.exists(), "archive exists");
+        assert!(
+            report.stripped.iter().any(|s| s.contains("github token")),
+            "expected github rule hit: {:?}",
+            report.stripped
+        );
+
+        // Decompress and assert no raw secret survives in any bundled member.
+        let members = unpack_archive(&report.archive);
+        assert!(!members.is_empty(), "archive has members");
+        for (name, content) in &members {
+            assert!(
+                !content.contains("sk-abcdefghijklmnopq"),
+                "{name} leaked sk key: {content}"
+            );
+            assert!(
+                !content.contains("abcXYZ0123456789def"),
+                "{name} leaked bearer: {content}"
+            );
+            assert!(
+                !content.contains("AKIAIOSFODNN7EXAMPLE"),
+                "{name} leaked aws key: {content}"
+            );
+            assert!(
+                !content.contains("ghp_0123456789abcdef0123456789abcdef012345"),
+                "{name} leaked github token: {content}"
+            );
+        }
+
+        let _ = fs::remove_dir_all(&dir);
+        std::env::remove_var("JAN_DATA_FOLDER");
+    }
+}

--- a/src-tauri/src/core/cli/doctor.rs
+++ b/src-tauri/src/core/cli/doctor.rs
@@ -127,9 +127,22 @@ fn read_opt(path: &Path) -> Option<String> {
     fs::read_to_string(path).ok()
 }
 
-/// Last `max_lines` lines of a file, or `None` when the file cannot be read.
+/// Last `max_lines` lines of the log, spanning rotated segments.
+///
+/// `file_log` rotates by renaming the active file to `jan.log.1`, so the oldest
+/// retained records live in the highest-numbered segment. A long session can
+/// rotate the interesting window out of the active file, so segments are
+/// concatenated oldest-first and the tail is taken across the whole thing.
 fn tail(path: &Path, max_lines: usize) -> Option<String> {
-    let content = read_opt(path)?;
+    let name = path.file_name()?.to_str()?;
+    let mut content = String::new();
+    for k in (1..=crate::core::cli::file_log::KEEP_SEGMENTS).rev() {
+        if let Some(seg) = read_opt(&path.with_file_name(format!("{name}.{k}"))) {
+            content.push_str(&seg);
+        }
+    }
+    content.push_str(&read_opt(path)?);
+
     let lines: Vec<&str> = content.lines().collect();
     let start = lines.len().saturating_sub(max_lines);
     Some(lines[start..].join("\n"))
@@ -390,6 +403,29 @@ mod tests {
             out.push((name, content));
         }
         out
+    }
+
+    #[test]
+    fn tail_spans_rotated_segments_oldest_first() {
+        // A long session rotates the interesting window out of the active file,
+        // so the bundle must reach back into jan.log.1/.2 rather than only
+        // reading whatever the active segment happens to hold.
+        let dir = std::env::temp_dir().join(format!("jan_tail_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        let active = dir.join("jan.log");
+        fs::write(dir.join("jan.log.2"), "oldest\n").unwrap();
+        fs::write(dir.join("jan.log.1"), "middle\n").unwrap();
+        fs::write(&active, "newest\n").unwrap();
+
+        let out = tail(&active, 100).expect("reads log");
+        assert_eq!(out, "oldest\nmiddle\nnewest", "segments must join oldest-first");
+
+        // The line cap counts across segments and keeps the newest lines.
+        let capped = tail(&active, 1).expect("reads log");
+        assert_eq!(capped, "newest", "cap must keep the newest line: {capped}");
+
+        let _ = fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src-tauri/src/core/cli/doctor.rs
+++ b/src-tauri/src/core/cli/doctor.rs
@@ -13,114 +13,12 @@ use std::path::{Path, PathBuf};
 
 use flate2::Compression;
 use flate2::write::GzEncoder;
-use regex::Regex;
 
 use crate::core::app::commands::resolve_jan_data_folder;
+use crate::core::cli::secrets::Redactor;
 use crate::core::cli::updater::build_version;
 use crate::core::threads::constants::{MESSAGES_FILE, THREADS_FILE};
 use crate::core::threads::utils::{get_thread_dir, get_thread_metadata_path};
-
-/// One redaction rule: a labelled regex. The regex matches the secret value
-/// region only (never the surrounding label), so the whole match is replaced.
-struct Rule {
-    label: &'static str,
-    re: Regex,
-}
-
-/// Strips secrets from free text and tallies how many of each kind it hit.
-struct Redactor {
-    rules: Vec<Rule>,
-}
-
-impl Redactor {
-    fn new() -> Self {
-        // Authorization headers first (they contain a bearer whose value other
-        // rules would also match), then explicit key-like config values, then
-        // well-known provider token prefixes, then long opaque tokens.
-        let rules = vec![
-            Rule {
-                label: "authorization header",
-                re: Regex::new(
-                    r#"(?i)(["']?authorization["']?\s*[:=]\s*["']?(?:bearer|basic)\s+)[A-Za-z0-9._~+/\-=]+"#,
-                )
-                .expect("auth header regex"),
-            },
-            Rule {
-                label: "api key / token value",
-                // Handles both `api_key="..."` and JSON `"api_key":"..."`
-                // (quotes are allowed around the key name and the value).
-                re: Regex::new(
-                    r#"(?i)["']?(?:api[_-]?key|apikey|secret|token|access[_-]?token|refresh[_-]?token)["']?\s*[:=]\s*["']?[A-Za-z0-9._~+/\-=]{12,}"#,
-                )
-                .expect("key regex"),
-            },
-            Rule {
-                label: "jwt",
-                re: Regex::new(
-                    r"(?i)eyJ[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}",
-                )
-                .expect("jwt regex"),
-            },
-            Rule {
-                label: "sk/pk provider key",
-                re: Regex::new(r"(?i)\b(?:sk|pk)-[A-Za-z0-9_\-]{16,}")
-                    .expect("sk key regex"),
-            },
-            Rule {
-                label: "google api key",
-                re: Regex::new(r"\bAIza[A-Za-z0-9_\-]{20,}").expect("google key regex"),
-            },
-            Rule {
-                label: "github token",
-                re: Regex::new(r"\b(?:ghp_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{20,})")
-                    .expect("github token regex"),
-            },
-            Rule {
-                label: "slack token",
-                re: Regex::new(r"\bxox[baprs]-[A-Za-z0-9-]{16,}").expect("slack token regex"),
-            },
-            Rule {
-                label: "aws access key",
-                re: Regex::new(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b").expect("aws key regex"),
-            },
-            Rule {
-                label: "nvidia api key",
-                re: Regex::new(r"\bnvapi-[A-Za-z0-9_-]{16,}").expect("nvidia key regex"),
-            },
-            Rule {
-                label: "opaque oauth token",
-                re: Regex::new(
-                    r"\b(?:ya29\.[A-Za-z0-9_\-]{30,}|sq0atp-[A-Za-z0-9_\-]{20,}|sk_live_[A-Za-z0-9]{16,})",
-                )
-                .expect("opaque token regex"),
-            },
-        ];
-        Redactor { rules }
-    }
-
-    /// Replace every match with `<redacted>`; `hits` records per-rule counts.
-    fn redact(&self, input: &str, hits: &mut [usize]) -> String {
-        let mut out = input.to_string();
-        for (i, rule) in self.rules.iter().enumerate() {
-            // Collect spans first so we never re-scan replaced regions.
-            let spans: Vec<(usize, usize)> = rule.re.find_iter(&out).map(|m| (m.start(), m.end())).collect();
-            if spans.is_empty() {
-                continue;
-            }
-            hits[i] += spans.len();
-            let mut result = String::with_capacity(out.len());
-            let mut last = 0;
-            for (s, e) in spans {
-                result.push_str(&out[last..s]);
-                result.push_str("<redacted>");
-                last = e;
-            }
-            result.push_str(&out[last..]);
-            out = result;
-        }
-        out
-    }
-}
 
 /// Read a text file, or `None` if it does not exist or cannot be read.
 fn read_opt(path: &Path) -> Option<String> {
@@ -430,69 +328,67 @@ mod tests {
 
     #[test]
     fn archive_respects_jan_data_folder_and_contains_no_secret() {
-        let dir = std::env::temp_dir().join(format!("jan_doctor_test_{}", std::process::id()));
-        let _ = fs::remove_dir_all(&dir);
-        std::env::set_var("JAN_DATA_FOLDER", &dir);
+        // `JAN_DATA_FOLDER` is process-global, so this goes through the shared
+        // helper: it holds the test lock and restores the previous value. Setting
+        // the var directly here would race any concurrent test that reads it.
+        crate::core::app::commands::with_temp_data_folder(|dir| {
+            // Seed a thread.
+            let thread_id = "testthread";
+            let thread_dir = get_thread_dir(dir, thread_id);
+            fs::create_dir_all(&thread_dir).unwrap();
+            fs::write(
+                get_thread_metadata_path(dir, thread_id),
+                serde_json::json!({
+                    "id": thread_id,
+                    "title": "t",
+                    "model": { "id": "gpt-4", "provider": "openai" }
+                })
+                .to_string(),
+            )
+            .unwrap();
+            // Seed every input shape the bundler copies so decompression proves
+            // the full redaction path, including JSON authorization forms.
+            let seeds = [
+                "{\"role\":\"user\",\"content\":\"sk-abcdefghijklmnopq\"}\n",
+                "{\"role\":\"user\",\"content\":\"Authorization: Bearer abcXYZ0123456789def\"}\n",
+                "{\"role\":\"user\",\"content\":\"ghp_0123456789abcdef0123456789abcdef012345\"}\n",
+            ];
+            fs::write(thread_dir.join(MESSAGES_FILE), seeds.concat()).unwrap();
+            fs::write(
+                thread_dir.join("display.jsonl"),
+                "{\"kind\":\"note\",\"value\":\"AKIAIOSFODNN7EXAMPLE\"}\n",
+            )
+            .unwrap();
 
-        // Seed a thread.
-        let thread_id = "testthread";
-        let thread_dir = get_thread_dir(&dir, thread_id);
-        fs::create_dir_all(&thread_dir).unwrap();
-        fs::write(
-            get_thread_metadata_path(&dir, thread_id),
-            serde_json::json!({
-                "id": thread_id,
-                "title": "t",
-                "model": { "id": "gpt-4", "provider": "openai" }
-            })
-            .to_string(),
-        )
-        .unwrap();
-        // Seed every input shape the bundler copies so decompression proves the
-        // full redaction path, including JSON authorization forms.
-        let seeds = [
-            "{\"role\":\"user\",\"content\":\"sk-abcdefghijklmnopq\"}\n",
-            "{\"role\":\"user\",\"content\":\"Authorization: Bearer abcXYZ0123456789def\"}\n",
-            "{\"role\":\"user\",\"content\":\"ghp_0123456789abcdef0123456789abcdef012345\"}\n",
-        ];
-        fs::write(thread_dir.join(MESSAGES_FILE), seeds.concat()).unwrap();
-        fs::write(
-            thread_dir.join("display.jsonl"),
-            "{\"kind\":\"note\",\"value\":\"AKIAIOSFODNN7EXAMPLE\"}\n",
-        )
-        .unwrap();
+            let report = run_bug_report(dir, Some(thread_id)).expect("bug report builds");
+            assert!(report.archive.exists(), "archive exists");
+            assert!(
+                report.stripped.iter().any(|s| s.contains("github token")),
+                "expected github rule hit: {:?}",
+                report.stripped
+            );
 
-        let report = run_bug_report(&dir, Some(thread_id)).expect("bug report builds");
-        assert!(report.archive.exists(), "archive exists");
-        assert!(
-            report.stripped.iter().any(|s| s.contains("github token")),
-            "expected github rule hit: {:?}",
-            report.stripped
-        );
-
-        // Decompress and assert no raw secret survives in any bundled member.
-        let members = unpack_archive(&report.archive);
-        assert!(!members.is_empty(), "archive has members");
-        for (name, content) in &members {
-            assert!(
-                !content.contains("sk-abcdefghijklmnopq"),
-                "{name} leaked sk key: {content}"
-            );
-            assert!(
-                !content.contains("abcXYZ0123456789def"),
-                "{name} leaked bearer: {content}"
-            );
-            assert!(
-                !content.contains("AKIAIOSFODNN7EXAMPLE"),
-                "{name} leaked aws key: {content}"
-            );
-            assert!(
-                !content.contains("ghp_0123456789abcdef0123456789abcdef012345"),
-                "{name} leaked github token: {content}"
-            );
-        }
-
-        let _ = fs::remove_dir_all(&dir);
-        std::env::remove_var("JAN_DATA_FOLDER");
+            // Decompress and assert no raw secret survives in any bundled member.
+            let members = unpack_archive(&report.archive);
+            assert!(!members.is_empty(), "archive has members");
+            for (name, content) in &members {
+                assert!(
+                    !content.contains("sk-abcdefghijklmnopq"),
+                    "{name} leaked sk key: {content}"
+                );
+                assert!(
+                    !content.contains("abcXYZ0123456789def"),
+                    "{name} leaked bearer: {content}"
+                );
+                assert!(
+                    !content.contains("AKIAIOSFODNN7EXAMPLE"),
+                    "{name} leaked aws key: {content}"
+                );
+                assert!(
+                    !content.contains("ghp_0123456789abcdef0123456789abcdef012345"),
+                    "{name} leaked github token: {content}"
+                );
+            }
+        });
     }
 }

--- a/src-tauri/src/core/cli/doctor.rs
+++ b/src-tauri/src/core/cli/doctor.rs
@@ -48,13 +48,32 @@ fn tail(path: &Path, max_lines: usize) -> Option<String> {
 
 /// Resolve the thread id to bundle: an explicit one when given, else the most
 /// recently updated thread under `<base>/threads/`.
+///
+/// An explicit id is checked for existence. Every read below degrades to empty
+/// on failure -- right for a thread missing one optional file, wrong for a
+/// misspelled `--thread`, which would otherwise produce an archive with no
+/// session in it and still report success. The user would attach that file and
+/// wait, so a typo has to fail loudly here instead.
 fn resolve_thread_id(base: &Path, explicit: Option<&str>) -> Result<String, String> {
     if let Some(id) = explicit {
-        let id = id.trim().to_string();
+        let id = id.trim();
         if id.is_empty() {
             return Err("empty thread id".to_string());
         }
-        return Ok(id);
+        // A thread id names one directory under `<base>/threads/`, and
+        // `get_thread_dir` joins it unchecked, so a value carrying a separator
+        // or `..` would resolve outside that tree and bundle whatever it found.
+        // Reject the shape rather than trying to normalize it.
+        if id.contains('/') || id.contains('\\') || id.contains("..") {
+            return Err(format!("invalid thread id '{id}'"));
+        }
+        if !get_thread_dir(base, id).is_dir() {
+            return Err(format!(
+                "thread '{id}' not found under {} - run `jan threads` to list ids",
+                base.join("threads").display()
+            ));
+        }
+        return Ok(id.to_string());
     }
     let mut threads = crate::core::cli::list_threads_in(base)?;
     if threads.is_empty() {
@@ -199,6 +218,48 @@ mod tests {
         let mut hits = vec![0usize; rules.rules.len()];
         let out = rules.redact(input, &mut hits);
         (out, hits)
+    }
+
+    /// A misspelled `--thread` used to be accepted: every read degraded to
+    /// empty and the command still reported success, so the user attached an
+    /// archive containing no session and waited for a reply.
+    #[test]
+    fn explicit_thread_must_exist() {
+        let base = std::env::temp_dir().join(format!("jan_doctor_id_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(base.join("threads").join("real-one")).unwrap();
+
+        assert_eq!(
+            resolve_thread_id(&base, Some("real-one")).unwrap(),
+            "real-one",
+            "an existing thread resolves"
+        );
+
+        let err = resolve_thread_id(&base, Some("typo-here")).expect_err("must not succeed");
+        assert!(err.contains("not found"), "names the problem: {err}");
+
+        assert!(resolve_thread_id(&base, Some("   ")).is_err(), "blank id rejected");
+
+        let _ = fs::remove_dir_all(&base);
+    }
+
+    /// `get_thread_dir` joins the id unchecked, so a separator or `..` would
+    /// escape the threads directory and bundle files from outside it.
+    #[test]
+    fn explicit_thread_rejects_path_traversal() {
+        let base = std::env::temp_dir().join(format!("jan_doctor_trav_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(base.join("threads")).unwrap();
+
+        // A traversal id must be rejected on its shape, before any filesystem
+        // lookup: `/etc` exists, so an existence check alone would accept it.
+        for bad in ["../../../etc", "..", "a/b", "a\\b", "../threads"] {
+            let err = resolve_thread_id(&base, Some(bad))
+                .expect_err(&format!("accepted traversal id {bad:?}"));
+            assert!(err.contains("invalid thread id"), "wrong reason for {bad:?}: {err}");
+        }
+
+        let _ = fs::remove_dir_all(&base);
     }
 
     #[test]

--- a/src-tauri/src/core/cli/file_log.rs
+++ b/src-tauri/src/core/cli/file_log.rs
@@ -1,0 +1,296 @@
+//! Persistent structured log file beside the stderr logger.
+//!
+//! `env_logger` is a single-sink, single-level logger, so it cannot write the
+//! same records to stderr at one verbosity and to a file at another. This
+//! module replaces it with a [`DualLogger`] that keeps `env_logger`'s exact
+//! stderr behavior (style, module paths, `RUST_LOG` filtering) and additionally
+//! appends every `info`-and-above record to a rotating plain-ASCII file under
+//! the Jan data folder. The file default is more verbose than the `warn`
+//! stderr default so a froze or misbehaving agent run leaves a trail on disk
+//! without the user ever having to pass `-v`.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+
+use log::{LevelFilter, Log, Metadata, Record};
+
+/// What the file always captures, on top of the `warn` stderr default.
+const FILE_LEVEL: LevelFilter = LevelFilter::Info;
+/// Rotate once the active segment crosses this size.
+const MAX_LOG_BYTES: u64 = 5 * 1024 * 1024;
+/// Backup segments kept beside the active file (`jan.log.1` .. `jan.log.N`).
+const KEEP_SEGMENTS: u32 = 3;
+const LOG_FILE: &str = "jan.log";
+
+/// The segment path for a 1-based backup number; `0` means the active file.
+fn segment_path(base: &Path, k: u32) -> PathBuf {
+    if k == 0 {
+        base.to_path_buf()
+    } else {
+        base.with_file_name(format!("{LOG_FILE}.{k}"))
+    }
+}
+
+/// Append-only handle to the active log file with size-based rotation.
+struct FileLog {
+    path: PathBuf,
+    file: Mutex<File>,
+    len: AtomicU64,
+}
+
+impl FileLog {
+    /// Open the active file for appending. Returns `None` (degrading to
+    /// stderr-only) when the log cannot be opened -- a diagnostics trail is
+    /// worth having but never worth aborting the run over.
+    fn new(path: PathBuf) -> Option<Self> {
+        std::fs::create_dir_all(path.parent()?).ok()?;
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .ok()?;
+        let len = file.metadata().map(|m| m.len()).unwrap_or(0);
+        Some(FileLog {
+            path,
+            file: Mutex::new(file),
+            len: AtomicU64::new(len),
+        })
+    }
+
+    fn write(&self, record: &Record) {
+        let line = format_line(record);
+        let mut f = match self.file.lock() {
+            Ok(g) => g,
+            Err(_) => return,
+        };
+        if f.write_all(line.as_bytes()).is_err() {
+            return;
+        }
+        let new_len = self.len.fetch_add(line.len() as u64, Ordering::Relaxed)
+            + line.len() as u64;
+        if new_len >= MAX_LOG_BYTES {
+            // Drop the guard (so the handle can be rotated on Windows too)
+            // before shifting the segments and reopening a fresh active file.
+            drop(f);
+            self.rotate();
+            if let Ok(nf) = OpenOptions::new().create(true).append(true).open(&self.path) {
+                if let Ok(mut g) = self.file.lock() {
+                    *g = nf;
+                }
+            }
+        }
+    }
+
+    fn rotate(&self) {
+        for k in (2..=KEEP_SEGMENTS).rev() {
+            let _ = fs::rename(segment_path(&self.path, k - 1), segment_path(&self.path, k));
+        }
+        let _ = fs::rename(&self.path, segment_path(&self.path, 1));
+        self.len.store(0, Ordering::Relaxed);
+    }
+
+    fn flush(&self) {
+        if let Ok(mut f) = self.file.lock() {
+            let _ = f.flush();
+        }
+    }
+}
+
+/// One line per record, plain ASCII, timestamped. Never colored; the file is
+/// meant to be read in an editor, piped, or bundled, not rendered live.
+fn format_line(record: &Record) -> String {
+    let ts = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S%.3f");
+    format!(
+        "{ts} {:<5} [{}] {}\n",
+        record.level().as_str(),
+        record.target(),
+        record.args()
+    )
+}
+
+/// Routes every record to stderr through `env_logger` (unchanged behavior)
+/// and, in parallel, to the rotating ASCII file. `enabled`/`log` consult the
+/// per-sink paths so the file sees `info` even when stderr is only `warn`.
+struct DualLogger {
+    stderr: env_logger::Logger,
+    file: Option<FileLog>,
+}
+
+impl Log for DualLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        // Either sink wants the record: stderr's own module/level filter (which
+        // may reach debug/trace via RUST_LOG), or the file when the record is
+        // at or under the file ceiling. Nothing above both probes is wanted.
+        self.stderr.enabled(metadata)
+            || (self.file.is_some() && metadata.level() <= FILE_LEVEL)
+    }
+
+    fn log(&self, record: &Record) {
+        // The file only captures records at or under FILE_LEVEL (info), even
+        // when stderr goes deeper via RUST_LOG=debug/trace.
+        if self.file.is_some() && record.level() <= FILE_LEVEL {
+            if let Some(f) = &self.file {
+                f.write(record);
+            }
+        }
+        // stderr keeps env_logger's exact behavior, including debug/trace when
+        // RUST_LOG asks for them (env_logger filters internally).
+        self.stderr.log(record);
+    }
+
+    fn flush(&self) {
+        self.stderr.flush();
+        if let Some(f) = &self.file {
+            f.flush();
+        }
+    }
+}
+/// Install the dual logger as the process-wide `log` backend. `verbose`
+/// mirrors the old `-v/--verbose` flag: it raises the stderr threshold to
+/// `info`; the file always captures `info` regardless. `data_folder` is where
+/// `logs/jan.log` lives (resolved via `JAN_DATA_FOLDER` for testability).
+pub fn init(data_folder: PathBuf, verbose: bool) {
+    let default = if verbose { "info" } else { "warn" };
+    let stderr = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(default))
+        .build();
+    let file = FileLog::new(data_folder.join("logs").join(LOG_FILE));
+
+    // The global gate must admit everything the deepest sink may want: stderr
+    // can go to debug/trace via RUST_LOG, while the file self-limits to info.
+    // Each sink filters independently, so there is no single Info ceiling.
+    let _ = log::set_boxed_logger(Box::new(DualLogger { stderr, file }));
+    log::set_max_level(LevelFilter::Trace);
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn file_log_writes_info_records_with_timestamp() {
+        let dir = std::env::temp_dir().join(format!("jan_file_log_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("logs")).unwrap();
+        let log = FileLog::new(dir.join("logs").join(LOG_FILE)).expect("opens log");
+        let record = Record::builder()
+            .args(format_args!("hello {} {}", 1, 2))
+            .level(log::Level::Info)
+            .target(module_path!())
+            .build();
+        log.write(&record);
+        log.flush();
+
+        let content = fs::read_to_string(dir.join("logs").join(LOG_FILE)).unwrap();
+        assert!(content.contains("hello 1 2"), "content: {content}");
+        assert!(content.contains("INFO"), "level label: {content}");
+        assert!(content.starts_with("20"), "timestamp leads: {content}");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    fn metadata(level: log::Level) -> log::Metadata<'static> {
+        log::Metadata::builder().level(level).target(module_path!()).build()
+    }
+
+    #[test]
+    fn dual_logger_delegates_stderr_verbosity_but_caps_file_at_info() {
+        let dir = std::env::temp_dir().join(format!("jan_dual_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("logs")).unwrap();
+
+        // stderr at trace (the deepest RUST_LOG can ask for) must still report
+        // debug/trace as enabled: there is no global info ceiling anymore.
+        let deep_stderr = env_logger::Builder::new()
+            .filter_level(LevelFilter::Trace)
+            .build();
+        let dual = DualLogger {
+            stderr: deep_stderr,
+            file: Some(FileLog::new(dir.join("logs").join(LOG_FILE)).expect("opens log")),
+        };
+        assert!(
+            dual.enabled(&metadata(log::Level::Debug)),
+            "debug must reach stderr even though the file caps at info"
+        );
+        assert!(
+            dual.enabled(&metadata(log::Level::Trace)),
+            "trace must reach stderr even though the file caps at info"
+        );
+
+        // Info reaches the file; debug/trace must never be written to it.
+        // (literal format_args! produce 'static records we can borrow freely)
+        let info = log::Record::builder()
+            .args(format_args!("info line"))
+            .level(log::Level::Info)
+            .target(module_path!())
+            .build();
+        let debug = log::Record::builder()
+            .args(format_args!("debug line"))
+            .level(log::Level::Debug)
+            .target(module_path!())
+            .build();
+        let trace = log::Record::builder()
+            .args(format_args!("trace line"))
+            .level(log::Level::Trace)
+            .target(module_path!())
+            .build();
+        dual.log(&info);
+        dual.log(&debug);
+        dual.log(&trace);
+        dual.flush();
+
+        let content = fs::read_to_string(dir.join("logs").join(LOG_FILE)).unwrap();
+        assert!(content.contains("info line"), "info written to file: {content}");
+        assert!(!content.contains("debug line"), "debug leaked to file: {content}");
+        assert!(!content.contains("trace line"), "trace leaked to file: {content}");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn dual_logger_file_does_not_broaden_a_warn_stderr() {
+        let dir = std::env::temp_dir().join(format!("jan_dual_warn_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("logs")).unwrap();
+
+        // stderr at warn (the default). The file still wants info, but a debug
+        // record must NOT be reported enabled just because a file exists.
+        let warn_stderr = env_logger::Builder::new()
+            .filter_level(LevelFilter::Warn)
+            .build();
+        let dual = DualLogger {
+            stderr: warn_stderr,
+            file: Some(FileLog::new(dir.join("logs").join(LOG_FILE)).expect("opens log")),
+        };
+        assert!(
+            dual.enabled(&metadata(log::Level::Info)),
+            "info enabled for the file even when stderr is warn"
+        );
+        assert!(
+            !dual.enabled(&metadata(log::Level::Debug)),
+            "debug must not be enabled when stderr is warn and file caps at info"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn init_raises_global_gate_to_trace_not_info() {
+        let dir = std::env::temp_dir().join(format!("jan_init_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("logs")).unwrap();
+        init(dir.clone(), false);
+        // The global gate must admit debug/trace so RUST_LOG still works over
+        // stderr; the file ceiling is enforced by DualLogger, not globally.
+        assert!(
+            log::max_level() >= LevelFilter::Debug,
+            "global max_level must not cap at info, got {:?}",
+            log::max_level()
+        );
+        let _ = fs::remove_dir_all(&dir);
+    }
+}
+

--- a/src-tauri/src/core/cli/file_log.rs
+++ b/src-tauri/src/core/cli/file_log.rs
@@ -116,13 +116,22 @@ impl FileLog {
 
 /// One line per record, plain ASCII, timestamped. Never colored; the file is
 /// meant to be read in an editor, piped, or bundled, not rendered live.
+///
+/// The message is scrubbed on the way in. This file persists across runs and
+/// ships inside `jan bug-report`, while the text reaching it is not all ours:
+/// an upstream error can echo the request's `Authorization` header back, and a
+/// user can paste a key into a prompt. Scrubbing here -- rather than at each
+/// `log::` call -- means a breadcrumb added later cannot reintroduce the leak,
+/// and it leaves the stderr sink untouched, so the terminal still shows the
+/// operator the full text.
 fn format_line(record: &Record) -> String {
     let ts = chrono::Local::now().format("%Y-%m-%dT%H:%M:%S%.3f");
+    let message = record.args().to_string();
     format!(
         "{ts} {:<5} [{}] {}\n",
         record.level().as_str(),
         record.target(),
-        record.args()
+        crate::core::cli::secrets::SHARED.scrub(&message)
     )
 }
 
@@ -218,6 +227,43 @@ mod tests {
         assert!(content.contains("hello 1 2"), "content: {content}");
         assert!(content.contains("INFO"), "level label: {content}");
         assert!(content.starts_with("20"), "timestamp leads: {content}");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// The regression this sink's scrub exists for. A provider echoed the
+    /// request's `Authorization` header inside its error body; the agent logged
+    /// that error as a breadcrumb, and the raw key landed in `jan.log` -- a file
+    /// that persists across runs and ships inside `jan bug-report`.
+    ///
+    /// Asserted at the sink, not at the call site: scrubbing here is what makes
+    /// a breadcrumb added later safe by construction.
+    #[test]
+    fn file_log_scrubs_a_credential_out_of_a_record() {
+        let dir = std::env::temp_dir().join(format!("jan_file_log_secret_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("logs")).unwrap();
+        let log = FileLog::new(dir.join("logs").join(LOG_FILE)).expect("opens log");
+        let secret = "sk-live-11112222333344445555";
+        log.write(
+            &Record::builder()
+                .args(format_args!(
+                    "agent: run finished outcome=error -- Body: \
+                     {{\"message\":\"authorization: Bearer {secret}\"}}"
+                ))
+                .level(log::Level::Info)
+                .target(module_path!())
+                .build(),
+        );
+        log.flush();
+
+        let content = fs::read_to_string(dir.join("logs").join(LOG_FILE)).unwrap();
+        assert!(!content.contains(secret), "credential reached the file: {content}");
+        assert!(content.contains("<redacted>"), "redaction is marked: {content}");
+        assert!(
+            content.contains("outcome=error"),
+            "the breadcrumb still says what happened: {content}"
+        );
 
         let _ = fs::remove_dir_all(&dir);
     }

--- a/src-tauri/src/core/cli/file_log.rs
+++ b/src-tauri/src/core/cli/file_log.rs
@@ -99,7 +99,20 @@ impl FileLog {
         }
     }
 
+    /// Shift `jan.log{,.1,.2}` down one slot and start a fresh active file.
+    ///
+    /// `len` counts only what this process wrote plus the size it saw at open,
+    /// so several `jan` processes sharing a data folder each reach the threshold
+    /// on their own. Re-stat the path first: if the active file is already small
+    /// another process just rotated it, and shifting again would discard a live
+    /// segment (only [`KEEP_SEGMENTS`] are kept). Resync the counter instead.
     fn rotate(&self) {
+        if let Ok(actual) = fs::metadata(&self.path).map(|m| m.len()) {
+            if actual < MAX_LOG_BYTES {
+                self.len.store(actual, Ordering::Relaxed);
+                return;
+            }
+        }
         for k in (2..=KEEP_SEGMENTS).rev() {
             let _ = fs::rename(segment_path(&self.path, k - 1), segment_path(&self.path, k));
         }
@@ -263,6 +276,46 @@ mod tests {
         assert!(
             content.contains("outcome=error"),
             "the breadcrumb still says what happened: {content}"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    /// Several `jan` processes share one data folder, and each tracks the log's
+    /// length on its own. When one rotates, the others still believe the active
+    /// file is full, so they rotate a file that is already fresh -- and since
+    /// only `KEEP_SEGMENTS` are kept, a burst of processes would shift real
+    /// history off the end. Rotation must notice and resync instead.
+    #[test]
+    fn rotate_resyncs_instead_of_shifting_an_already_rotated_file() {
+        let dir = std::env::temp_dir().join(format!("jan_rot_race_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(dir.join("logs")).unwrap();
+        let path = dir.join("logs").join(LOG_FILE);
+
+        // Stand in for a peer's rotation: `.1` holds the retained history and
+        // the active file is small again.
+        fs::write(segment_path(&path, 1), "rotated-by-a-peer\n").unwrap();
+        fs::write(&path, "fresh\n").unwrap();
+
+        let log = FileLog::new(path.clone()).expect("opens log");
+        // This process still thinks the active file is full.
+        log.len.store(MAX_LOG_BYTES, Ordering::Relaxed);
+        log.rotate();
+
+        assert_eq!(
+            fs::read_to_string(segment_path(&path, 1)).unwrap(),
+            "rotated-by-a-peer\n",
+            "the peer's segment must survive"
+        );
+        assert!(
+            !segment_path(&path, 2).exists(),
+            "no redundant shift happened"
+        );
+        assert_eq!(
+            log.len.load(Ordering::Relaxed),
+            "fresh\n".len() as u64,
+            "counter resynced to the real file size"
         );
 
         let _ = fs::remove_dir_all(&dir);

--- a/src-tauri/src/core/cli/file_log.rs
+++ b/src-tauri/src/core/cli/file_log.rs
@@ -177,18 +177,25 @@ pub fn init(data_folder: PathBuf, verbose: bool) {
     let stderr = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(default))
         .build();
     let file = FileLog::new(data_folder.join("logs").join(LOG_FILE));
-
-    // The global gate must admit everything the deepest sink may want: stderr
-    // can go to debug/trace via RUST_LOG, while the file self-limits to info.
-    // Each sink filters independently, so there is no single Info ceiling.
+    // The global gate must admit whatever the deepest sink wants, and no more:
+    // it is the cheap static check `log::debug!` does before building a record,
+    // so leaving it at `Trace` would make every dependency's debug/trace record
+    // pay a dynamic `enabled()` call to then be dropped. stderr can be raised
+    // to debug/trace via RUST_LOG, the file self-limits to FILE_LEVEL, and each
+    // sink still filters independently below the gate.
+    let ceiling = stderr.filter().max(FILE_LEVEL);
     let _ = log::set_boxed_logger(Box::new(DualLogger { stderr, file }));
-    log::set_max_level(LevelFilter::Trace);
+    log::set_max_level(ceiling);
 }
 
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `STDERR_ENABLED` is process-global, so a test that toggles it would
+    /// otherwise race any sibling test reading `enabled()` in parallel.
+    static STDERR_GATE: Mutex<()> = Mutex::new(());
 
     #[test]
     fn file_log_writes_info_records_with_timestamp() {
@@ -218,6 +225,7 @@ mod tests {
 
     #[test]
     fn dual_logger_delegates_stderr_verbosity_but_caps_file_at_info() {
+        let _gate = STDERR_GATE.lock().unwrap_or_else(|e| e.into_inner());
         let dir = std::env::temp_dir().join(format!("jan_dual_{}", std::process::id()));
         let _ = fs::remove_dir_all(&dir);
         std::fs::create_dir_all(dir.join("logs")).unwrap();
@@ -272,6 +280,7 @@ mod tests {
 
     #[test]
     fn dual_logger_file_does_not_broaden_a_warn_stderr() {
+        let _gate = STDERR_GATE.lock().unwrap_or_else(|e| e.into_inner());
         let dir = std::env::temp_dir().join(format!("jan_dual_warn_{}", std::process::id()));
         let _ = fs::remove_dir_all(&dir);
         std::fs::create_dir_all(dir.join("logs")).unwrap();
@@ -299,6 +308,7 @@ mod tests {
 
     #[test]
     fn muting_stderr_keeps_the_file_sink_writing() {
+        let _gate = STDERR_GATE.lock().unwrap_or_else(|e| e.into_inner());
         // The TUI mutes stderr for the whole interactive session because it owns
         // the terminal. The file must keep recording anyway: a session that
         // hangs is exactly what `jan bug-report` needs a trail for. Muting via
@@ -337,16 +347,18 @@ mod tests {
     }
 
     #[test]
-    fn init_raises_global_gate_to_trace_not_info() {
+    fn init_gates_at_the_deepest_sink_not_wider() {
         let dir = std::env::temp_dir().join(format!("jan_init_{}", std::process::id()));
         let _ = fs::remove_dir_all(&dir);
         std::fs::create_dir_all(dir.join("logs")).unwrap();
         init(dir.clone(), false);
-        // The global gate must admit debug/trace so RUST_LOG still works over
-        // stderr; the file ceiling is enforced by DualLogger, not globally.
-        assert!(
-            log::max_level() >= LevelFilter::Debug,
-            "global max_level must not cap at info, got {:?}",
+        // With stderr at its `warn` default, the file's `info` need sets the
+        // gate: high enough that info+ records reach the file, low enough that
+        // dependency debug/trace stays compiled out at the call site.
+        assert_eq!(
+            log::max_level(),
+            FILE_LEVEL,
+            "gate must sit at the deepest sink's level, got {:?}",
             log::max_level()
         );
         let _ = fs::remove_dir_all(&dir);

--- a/src-tauri/src/core/cli/file_log.rs
+++ b/src-tauri/src/core/cli/file_log.rs
@@ -203,12 +203,15 @@ mod tests {
         let _ = fs::remove_dir_all(&dir);
         std::fs::create_dir_all(dir.join("logs")).unwrap();
         let log = FileLog::new(dir.join("logs").join(LOG_FILE)).expect("opens log");
-        let record = Record::builder()
-            .args(format_args!("hello {} {}", 1, 2))
-            .level(log::Level::Info)
-            .target(module_path!())
-            .build();
-        log.write(&record);
+        // Built and consumed in one statement: a `format_args!` with runtime
+        // arguments borrows temporaries that a `let` binding would drop first.
+        log.write(
+            &Record::builder()
+                .args(format_args!("hello {} {}", 1, 2))
+                .level(log::Level::Info)
+                .target(module_path!())
+                .build(),
+        );
         log.flush();
 
         let content = fs::read_to_string(dir.join("logs").join(LOG_FILE)).unwrap();

--- a/src-tauri/src/core/cli/file_log.rs
+++ b/src-tauri/src/core/cli/file_log.rs
@@ -12,7 +12,7 @@
 use std::fs::{self, File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Mutex;
 
 use log::{LevelFilter, Log, Metadata, Record};
@@ -22,8 +22,23 @@ const FILE_LEVEL: LevelFilter = LevelFilter::Info;
 /// Rotate once the active segment crosses this size.
 const MAX_LOG_BYTES: u64 = 5 * 1024 * 1024;
 /// Backup segments kept beside the active file (`jan.log.1` .. `jan.log.N`).
-const KEEP_SEGMENTS: u32 = 3;
+/// `doctor` reads the same bound when it tails across rotated segments.
+pub(crate) const KEEP_SEGMENTS: u32 = 3;
 const LOG_FILE: &str = "jan.log";
+
+/// Whether the stderr sink is allowed to write. The TUI owns the terminal once
+/// it enters the alternate screen, so a stray `warn` from a dependency would
+/// paint over the frame; it mutes stderr for the duration. This gate replaces
+/// the older `log::set_max_level(Off)` approach, which silenced the facade
+/// globally and so muted the file sink too -- exactly the interactive session
+/// a bug report needs a trail for.
+static STDERR_ENABLED: AtomicBool = AtomicBool::new(true);
+
+/// Mute or unmute the stderr sink without touching the file sink. Returns the
+/// previous value so a caller can restore it.
+pub fn set_stderr_enabled(on: bool) -> bool {
+    STDERR_ENABLED.swap(on, Ordering::Relaxed)
+}
 
 /// The segment path for a 1-based backup number; `0` means the active file.
 fn segment_path(base: &Path, k: u32) -> PathBuf {
@@ -122,23 +137,28 @@ struct DualLogger {
 impl Log for DualLogger {
     fn enabled(&self, metadata: &Metadata) -> bool {
         // Either sink wants the record: stderr's own module/level filter (which
-        // may reach debug/trace via RUST_LOG), or the file when the record is
-        // at or under the file ceiling. Nothing above both probes is wanted.
-        self.stderr.enabled(metadata)
+        // may reach debug/trace via RUST_LOG) when it is not muted, or the file
+        // when the record is at or under the file ceiling.
+        (STDERR_ENABLED.load(Ordering::Relaxed) && self.stderr.enabled(metadata))
             || (self.file.is_some() && metadata.level() <= FILE_LEVEL)
     }
 
     fn log(&self, record: &Record) {
         // The file only captures records at or under FILE_LEVEL (info), even
-        // when stderr goes deeper via RUST_LOG=debug/trace.
-        if self.file.is_some() && record.level() <= FILE_LEVEL {
-            if let Some(f) = &self.file {
+        // when stderr goes deeper via RUST_LOG=debug/trace. It is deliberately
+        // not gated on STDERR_ENABLED: a muted terminal must still leave a
+        // trail, which is the whole point of the file sink.
+        if let Some(f) = &self.file {
+            if record.level() <= FILE_LEVEL {
                 f.write(record);
             }
         }
         // stderr keeps env_logger's exact behavior, including debug/trace when
-        // RUST_LOG asks for them (env_logger filters internally).
-        self.stderr.log(record);
+        // RUST_LOG asks for them (env_logger filters internally), except while
+        // the TUI owns the terminal.
+        if STDERR_ENABLED.load(Ordering::Relaxed) {
+            self.stderr.log(record);
+        }
     }
 
     fn flush(&self) {
@@ -272,6 +292,45 @@ mod tests {
         assert!(
             !dual.enabled(&metadata(log::Level::Debug)),
             "debug must not be enabled when stderr is warn and file caps at info"
+        );
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn muting_stderr_keeps_the_file_sink_writing() {
+        // The TUI mutes stderr for the whole interactive session because it owns
+        // the terminal. The file must keep recording anyway: a session that
+        // hangs is exactly what `jan bug-report` needs a trail for. Muting via
+        // `log::set_max_level(Off)` instead would silence the facade globally
+        // and lose this.
+        let dir = std::env::temp_dir().join(format!("jan_mute_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("logs")).unwrap();
+
+        let dual = DualLogger {
+            stderr: env_logger::Builder::new().filter_level(LevelFilter::Warn).build(),
+            file: Some(FileLog::new(dir.join("logs").join(LOG_FILE)).expect("opens log")),
+        };
+
+        let prev = set_stderr_enabled(false);
+        assert!(
+            dual.enabled(&metadata(log::Level::Info)),
+            "info must stay enabled for the file while stderr is muted"
+        );
+        let record = log::Record::builder()
+            .args(format_args!("muted but recorded"))
+            .level(log::Level::Info)
+            .target(module_path!())
+            .build();
+        dual.log(&record);
+        dual.flush();
+        set_stderr_enabled(prev);
+
+        let content = fs::read_to_string(dir.join("logs").join(LOG_FILE)).unwrap();
+        assert!(
+            content.contains("muted but recorded"),
+            "file lost records while stderr was muted: {content}"
         );
 
         let _ = fs::remove_dir_all(&dir);

--- a/src-tauri/src/core/cli/mod.rs
+++ b/src-tauri/src/core/cli/mod.rs
@@ -15,6 +15,7 @@ mod model_capabilities;
 mod path_refs;
 pub mod run_report;
 pub mod providers;
+pub mod secrets;
 mod secret_input;
 pub mod telemetry;
 pub mod terminal_setup;

--- a/src-tauri/src/core/cli/mod.rs
+++ b/src-tauri/src/core/cli/mod.rs
@@ -6,6 +6,8 @@ pub mod auth;
 pub mod brand;
 pub mod browser;
 pub mod device_auth;
+pub mod doctor;
+pub mod file_log;
 pub mod journal;
 pub mod login;
 pub mod mcp;

--- a/src-tauri/src/core/cli/secrets.rs
+++ b/src-tauri/src/core/cli/secrets.rs
@@ -1,0 +1,187 @@
+//! Secret scrubbing shared by the persistent log sink and the bug-report
+//! archive.
+//!
+//! Two sinks now write user text to disk: `file_log` (every record, as it
+//! happens) and `doctor` (the bundle a user attaches to an issue). Both need
+//! the same answer to "is this a credential?", so the rules live here once.
+//!
+//! The rules are deliberately broad and matched on text: an upstream error can
+//! echo the request's `Authorization` header back, a user can paste a key into
+//! a prompt, and a provider can name a token in a message. Over-matching costs
+//! a `<redacted>` in a log line; under-matching leaks a credential into a file
+//! that gets attached to a public issue.
+
+use std::borrow::Cow;
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+/// One redaction rule: a labelled regex. The regex matches the secret value
+/// region only (never the surrounding label), so the whole match is replaced.
+pub(crate) struct Rule {
+    pub(crate) label: &'static str,
+    pub(crate) re: Regex,
+}
+
+/// Strips secrets from free text and tallies how many of each kind it hit.
+pub(crate) struct Redactor {
+    pub(crate) rules: Vec<Rule>,
+}
+
+/// The process-wide redactor. The regexes are compiled once: the log sink runs
+/// them on every record, and recompiling ten patterns per line would put real
+/// work on a path that exists only to write a breadcrumb.
+pub(crate) static SHARED: LazyLock<Redactor> = LazyLock::new(Redactor::new);
+
+impl Redactor {
+    pub(crate) fn new() -> Self {
+        // Authorization headers first (they contain a bearer whose value other
+        // rules would also match), then explicit key-like config values, then
+        // well-known provider token prefixes, then long opaque tokens.
+        let rules = vec![
+            Rule {
+                label: "authorization header",
+                re: Regex::new(
+                    r#"(?i)(["']?authorization["']?\s*[:=]\s*["']?(?:bearer|basic)\s+)[A-Za-z0-9._~+/\-=]+"#,
+                )
+                .expect("auth header regex"),
+            },
+            Rule {
+                label: "api key / token value",
+                // Handles both `api_key="..."` and JSON `"api_key":"..."`
+                // (quotes are allowed around the key name and the value).
+                re: Regex::new(
+                    r#"(?i)["']?(?:api[_-]?key|apikey|secret|token|access[_-]?token|refresh[_-]?token)["']?\s*[:=]\s*["']?[A-Za-z0-9._~+/\-=]{12,}"#,
+                )
+                .expect("key regex"),
+            },
+            Rule {
+                label: "jwt",
+                re: Regex::new(
+                    r"(?i)eyJ[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}",
+                )
+                .expect("jwt regex"),
+            },
+            Rule {
+                label: "sk/pk provider key",
+                re: Regex::new(r"(?i)\b(?:sk|pk)-[A-Za-z0-9_\-]{16,}")
+                    .expect("sk key regex"),
+            },
+            Rule {
+                label: "google api key",
+                re: Regex::new(r"\bAIza[A-Za-z0-9_\-]{20,}").expect("google key regex"),
+            },
+            Rule {
+                label: "github token",
+                re: Regex::new(r"\b(?:ghp_[A-Za-z0-9]{30,}|github_pat_[A-Za-z0-9_]{20,})")
+                    .expect("github token regex"),
+            },
+            Rule {
+                label: "slack token",
+                re: Regex::new(r"\bxox[baprs]-[A-Za-z0-9-]{16,}").expect("slack token regex"),
+            },
+            Rule {
+                label: "aws access key",
+                re: Regex::new(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b").expect("aws key regex"),
+            },
+            Rule {
+                label: "nvidia api key",
+                re: Regex::new(r"\bnvapi-[A-Za-z0-9_-]{16,}").expect("nvidia key regex"),
+            },
+            Rule {
+                label: "opaque oauth token",
+                re: Regex::new(
+                    r"\b(?:ya29\.[A-Za-z0-9_\-]{30,}|sq0atp-[A-Za-z0-9_\-]{20,}|sk_live_[A-Za-z0-9]{16,})",
+                )
+                .expect("opaque token regex"),
+            },
+        ];
+        Redactor { rules }
+    }
+
+    /// Replace every match with `<redacted>`; `hits` records per-rule counts.
+    pub(crate) fn redact(&self, input: &str, hits: &mut [usize]) -> String {
+        let mut out = Cow::Borrowed(input);
+        for (i, rule) in self.rules.iter().enumerate() {
+            if let Some(replaced) = apply(&rule.re, &out, Some(&mut hits[i])) {
+                out = Cow::Owned(replaced);
+            }
+        }
+        out.into_owned()
+    }
+
+    /// Redact without tallying, borrowing the input when it holds no secret.
+    ///
+    /// This is the log sink's path: it runs on every record, and the
+    /// overwhelmingly common case is a clean line, which must not allocate.
+    pub(crate) fn scrub<'a>(&self, input: &'a str) -> Cow<'a, str> {
+        let mut out = Cow::Borrowed(input);
+        for rule in &self.rules {
+            if let Some(replaced) = apply(&rule.re, &out, None) {
+                out = Cow::Owned(replaced);
+            }
+        }
+        out
+    }
+}
+
+/// Replace every match of `re` in `text`, returning `None` when it does not
+/// match at all so the caller can keep borrowing the original.
+///
+/// Spans are collected before any replacement so a `<redacted>` inserted by
+/// this rule is never re-scanned by it.
+fn apply(re: &Regex, text: &str, hits: Option<&mut usize>) -> Option<String> {
+    let spans: Vec<(usize, usize)> = re.find_iter(text).map(|m| (m.start(), m.end())).collect();
+    if spans.is_empty() {
+        return None;
+    }
+    if let Some(n) = hits {
+        *n += spans.len();
+    }
+    let mut result = String::with_capacity(text.len());
+    let mut last = 0;
+    for (s, e) in spans {
+        result.push_str(&text[last..s]);
+        result.push_str("<redacted>");
+        last = e;
+    }
+    result.push_str(&text[last..]);
+    Some(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A clean line is the common case on the log path: it must come back
+    /// borrowed, with no allocation.
+    #[test]
+    fn scrub_borrows_a_clean_line() {
+        let line = "agent: run finished outcome=ok stop=stop elapsed=6022ms";
+        assert!(matches!(SHARED.scrub(line), Cow::Borrowed(_)));
+    }
+
+    /// The leak this module exists for: a provider echoed the request's
+    /// `Authorization` header inside its error body, and that error is written
+    /// to `jan.log` as a breadcrumb.
+    #[test]
+    fn scrub_strips_an_echoed_authorization_header() {
+        let line = "agent: run finished outcome=error -- Body: \
+                    {\"error\":{\"message\":\"bad request; authorization: Bearer \
+                    sk-live-11112222333344445555\"}}";
+        let out = SHARED.scrub(line);
+        assert!(!out.contains("sk-live-11112222333344445555"), "leaked: {out}");
+        assert!(out.contains("<redacted>"), "replacement is marked: {out}");
+        assert!(out.contains("outcome=error"), "the breadcrumb survives: {out}");
+    }
+
+    /// Scrubbing must not depend on where in the line the secret sits: a key
+    /// past any truncation budget is exactly the case that fooled an earlier
+    /// truncation-only fix.
+    #[test]
+    fn scrub_strips_a_key_far_into_a_long_line() {
+        let line = format!("prefix {} api_key=sk-live-99998888777766665555", "x".repeat(4000));
+        let out = SHARED.scrub(&line);
+        assert!(!out.contains("sk-live-99998888777766665555"), "leaked past the budget");
+    }
+}

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -6686,6 +6686,32 @@ fn finish_update_install(app: &mut App, result: Result<super::updater::UpdateOut
         Err(e) => app.note(&format!("update failed: {e}")),
     }
 }
+/// `/bug`: write a redacted diagnostics archive for this project's threads and
+/// tell the user where it landed and that secrets were stripped. Runs the same
+/// bundler as the headless `jan bug-report`, with threads from the TUI's own
+/// `.jan/agent` store. Never requires a running model, so it works even when
+/// the very bug being reported froze the session.
+fn bug_report_command(app: &mut App) {
+    let threads_base = app.agent_dir.clone();
+    let thread_id = app.thread_id.clone();
+    match super::doctor::run_bug_report(&threads_base, thread_id.as_deref()) {
+        Ok(report) => {
+            app.note(&format!("bug report written to {}", report.archive.display()));
+            if report.redacted_any {
+                app.note(&format!(
+                    "secrets stripped: {}",
+                    report.stripped.join(", ")
+                ));
+                app.system_detail_text("attach this file to the issue (secrets were removed)");
+            } else {
+                app.system_detail_text(
+                    "attach this file to the issue; best-effort scan found no known secrets",
+                );
+            }
+        }
+        Err(e) => app.note(&format!("bug report failed: {e}")),
+    }
+}
 
 /// Await an in-flight `/plugin install`, parking forever when none is running.
 /// Same cancel-safe borrow as `await_mcp`.
@@ -9188,6 +9214,12 @@ const SLASH_COMMANDS: &[SlashCommand] = &[
         alias_of: None,
     },
     SlashCommand {
+        name: "/bug",
+        hint: "",
+        description: "Write a redacted diagnostics archive for a bug report",
+        alias_of: None,
+    },
+    SlashCommand {
         name: "/quit",
         hint: "",
         description: "Exit the TUI",
@@ -9391,6 +9423,7 @@ async fn run_command(
         "effort" | "think" | "reasoning" => effort_command(app, arg),
         "todo" => todo_command(app, arg).await,
         "cancel" => cancel_command(app, arg),
+        "bug" => bug_report_command(app),
         "quit" | "exit" => app.should_quit = true,
         other => {
             // A `/name` that isn't a built-in is a plugin command or an
@@ -18893,6 +18926,7 @@ mod tests {
     #[test]
     fn slash_commands_include_login() {
         assert!(SLASH_COMMANDS.iter().any(|c| c.name == "/login"));
+        assert!(SLASH_COMMANDS.iter().any(|c| c.name == "/bug"));
     }
 
     #[tokio::test]
@@ -28538,6 +28572,31 @@ mod tests {
         run_command(&mut app, "warp_drive", &no_mcp()).await;
         assert!(transcript_text(&app).contains("unknown command '/warp_drive'"));
         let _ = std::fs::remove_dir_all(&root);
+    }
+    #[tokio::test]
+    async fn run_command_bug_writes_an_archive() {
+        let (mut app, root) = skill_test_app("deploy", "How to deploy.");
+        // Seed a thread in the app's agent store so /bug has something to bundle.
+        let data = std::env::temp_dir().join(format!("jan_bug_tui_{}", std::process::id()));
+        std::env::set_var("JAN_DATA_FOLDER", &data);
+        let thread_id = "bugthread";
+        let thread_dir = app.agent_dir.join("threads").join(thread_id);
+        std::fs::create_dir_all(&thread_dir).unwrap();
+        std::fs::write(thread_dir.join("thread.json"), serde_json::json!({
+            "id": thread_id,
+            "title": "t",
+            "model": { "id": "m", "provider": "openai" }
+        }).to_string()).unwrap();
+        std::fs::write(thread_dir.join("messages.jsonl"), "{\"role\":\"user\",\"content\":\"hi\"}\n").unwrap();
+        std::fs::write(thread_dir.join("display.jsonl"), "{\"kind\":\"note\"}\n").unwrap();
+
+        run_command(&mut app, "bug", &no_mcp()).await;
+        let text = transcript_text(&app);
+        assert!(text.contains("bug report"), "{text}");
+
+        let _ = std::fs::remove_dir_all(&root);
+        let _ = std::fs::remove_dir_all(&data);
+        std::env::remove_var("JAN_DATA_FOLDER");
     }
 
     #[test]

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -6698,11 +6698,15 @@ fn bug_report_command(app: &mut App) {
         Ok(report) => {
             app.note(&format!("bug report written to {}", report.archive.display()));
             if report.redacted_any {
+                // "known" qualifies both lines: the scan matches known key
+                // shapes, so it cannot promise the archive is secret-free.
                 app.note(&format!(
-                    "secrets stripped: {}",
+                    "known secrets stripped: {}",
                     report.stripped.join(", ")
                 ));
-                app.system_detail_text("attach this file to the issue (secrets were removed)");
+                app.system_detail_text(
+                    "attach this file to the issue; review it first, the scan is best-effort",
+                );
             } else {
                 app.system_detail_text(
                     "attach this file to the issue; best-effort scan found no known secrets",
@@ -28576,30 +28580,29 @@ mod tests {
         assert!(transcript_text(&app).contains("unknown command '/warp_drive'"));
         let _ = std::fs::remove_dir_all(&root);
     }
+    /// `/bug` is wired to the bundler and reports back in the transcript.
+    ///
+    /// The archive directory comes from `resolve_jan_data_folder()`, a
+    /// process-global; this test deliberately does not redirect it. Mutating
+    /// `JAN_DATA_FOLDER` here raced every concurrent test that resolves it, and
+    /// taking the shared test lock from a blocking thread starved the async
+    /// tests that hold it across awaits. So this asserts only what the command
+    /// owns -- that an empty thread store produces the failure note rather than
+    /// a silent no-op. The archive contents are covered under
+    /// `doctor::tests::archive_respects_jan_data_folder_and_contains_no_secret`,
+    /// which redirects the folder safely via the shared helper.
     #[tokio::test]
-    async fn run_command_bug_writes_an_archive() {
+    async fn run_command_bug_reports_when_there_is_no_thread() {
         let (mut app, root) = skill_test_app("deploy", "How to deploy.");
-        // Seed a thread in the app's agent store so /bug has something to bundle.
-        let data = std::env::temp_dir().join(format!("jan_bug_tui_{}", std::process::id()));
-        std::env::set_var("JAN_DATA_FOLDER", &data);
-        let thread_id = "bugthread";
-        let thread_dir = app.agent_dir.join("threads").join(thread_id);
-        std::fs::create_dir_all(&thread_dir).unwrap();
-        std::fs::write(thread_dir.join("thread.json"), serde_json::json!({
-            "id": thread_id,
-            "title": "t",
-            "model": { "id": "m", "provider": "openai" }
-        }).to_string()).unwrap();
-        std::fs::write(thread_dir.join("messages.jsonl"), "{\"role\":\"user\",\"content\":\"hi\"}\n").unwrap();
-        std::fs::write(thread_dir.join("display.jsonl"), "{\"kind\":\"note\"}\n").unwrap();
-
+        // No thread seeded: the bundler has nothing to bundle and must say so.
         run_command(&mut app, "bug", &no_mcp()).await;
         let text = transcript_text(&app);
-        assert!(text.contains("bug report"), "{text}");
+        assert!(
+            text.contains("bug report failed"),
+            "expected the failure note, got: {text}"
+        );
 
         let _ = std::fs::remove_dir_all(&root);
-        let _ = std::fs::remove_dir_all(&data);
-        std::env::remove_var("JAN_DATA_FOLDER");
     }
 
     #[test]

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -6829,11 +6829,14 @@ pub async fn run(
     // switch to the alternate screen -- a single `log::warn!` from anywhere
     // (MCP, http, a dependency) then paints raw text over the frame and stays
     // there until the next full repaint. Nothing may write to the terminal
-    // except the renderer, so mute the log facade for the duration and restore
+    // except the renderer, so mute the stderr sink for the duration and restore
     // it on the way out. Anything worth the user's attention is a transcript
     // note; see `connect_active` for the MCP case.
-    let prev_log_level = log::max_level();
-    log::set_max_level(log::LevelFilter::Off);
+    //
+    // Only stderr is muted, not the `log` facade: silencing the facade globally
+    // would also stop the persistent file log, and an interactive session that
+    // hangs is exactly what `jan bug-report` needs a trail for.
+    let prev_stderr_log = super::file_log::set_stderr_enabled(false);
 
     enable_raw_mode().map_err(|e| e.to_string())?;
     let mut stdout = io::stdout();
@@ -6949,7 +6952,7 @@ pub async fn run(
         LeaveAlternateScreen,
     );
     let _ = terminal.show_cursor();
-    log::set_max_level(prev_log_level);
+    super::file_log::set_stderr_enabled(prev_stderr_log);
     // The session is closed: leave a copyable continuation command on the real
     // terminal, the same line the non-interactive path prints after a save.
     // Only a persisted thread can be resumed, so an empty session stays quiet.


### PR DESCRIPTION
## Summary
- `jan agent` now keeps a persistent, rotating log under the data folder and `jan bug-report` (`/bug` in the TUI) bundles the version, environment, thread, and log tail into one redacted archive, so reporting a hang no longer requires rerunning with `-v`, redirecting stderr, and hand-auditing for API keys; run and upstream breadcrumbs record outcome and elapsed time, which is what separates a stalled run from a slow provider.
- Credentials are scrubbed at the log sink, so an upstream error that echoes the request's `Authorization` header cannot land in the file that ships with a bug report; the operator's own terminal output is unchanged.

Fixes #8709

## Verification
- `cargo test --no-default-features --features cli` - 1377 passed, 0 failed; repeated 6 consecutive runs with no flake
- `cargo clippy --no-default-features --features cli --all-targets` - 0 warnings
- Default run with no flags - stderr carries 0 breadcrumb lines, `jan.log` carries the full trail; `RUST_LOG=info` surfaces both, `RUST_LOG=debug` deepens stderr to 10 lines while the file stays capped at 4
- Fake upstream that never responds - log ends at `stream:` with no `stream: done`, identifying the stall
- Fake upstream with a 6s delay - log records `stream: done outcome=ok elapsed=6007ms` and `run finished outcome=ok elapsed=6022ms`
- Fake upstream echoing `Authorization: Bearer sk-...` in a 400 body - key absent from `jan.log` (`<redacted>` written instead) and absent from every archive member, while stderr still shows the full value; also verified with the key placed inside the truncation budget, where truncation alone would have leaked it
- API key pasted into a prompt - stored cleartext in the user's own thread file, `<redacted>` in the archive, reported as `Known secrets stripped: sk/pk provider key (2x)`; same result for a key typed into the TUI
- 5MB rotation driven by the real binary - active log becomes `jan.log.1` and the archive's tail spans the split, so a trail broken across segments still reads chronologically
- 8 concurrent runs sharing one data folder - 32 records, 0 torn lines; 6 concurrent runs against a full log produce one rotation instead of three cascading ones
- `jan bug-report --thread <typo>` - exits 1 naming the lookup path, instead of writing an archive with an empty thread and reporting success; `--thread ../../../etc` is refused on its shape
- Unwritable log directory - the run completes normally; a corrupt thread store still bundles, with `model=unknown` and the raw bytes preserved
- `python3 .omp/local-tools/check_rust_diff_noise.py` - no formatting-only hunks
