### PR TITLE
fix(agent-tui): keep the live TUI responsive and its live rows readable

### DIFF
--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -1206,6 +1206,14 @@ struct App {
     /// so the diff in its `ToolResult` (which carries no path) can be
     /// syntax-highlighted for the right language. Removed as results arrive.
     diff_paths: HashMap<String, String>,
+    /// Command of each in-flight `bash` call, keyed by call id, kept only until
+    /// its result lands -- which is where a job id would appear.
+    bash_commands: HashMap<String, String>,
+    /// Commands the `bash` tool backgrounded, keyed by the `job_id` it handed
+    /// out. The later call that collects a job carries only that id, and blocks
+    /// until the command finishes, so without this its row -- live for as long
+    /// as the command runs -- has nothing to name.
+    bash_jobs: HashMap<String, String>,
     /// Base snapshot (working-tree state before the first turn) for the active
     /// thread. `Some` once snapshotting is armed; `None` = no workspace restore.
     base_snapshot: Option<String>,
@@ -1664,6 +1672,8 @@ impl App {
             project_root,
             turn_touched: Vec::new(),
             diff_paths: HashMap::new(),
+            bash_commands: HashMap::new(),
+            bash_jobs: HashMap::new(),
             base_snapshot: None,
             checkpoints: Vec::new(),
             snap_queue: std::collections::VecDeque::new(),
@@ -2118,6 +2128,43 @@ impl App {
             self.push_subagent_summary(&panel.name, panel.calls, false);
         }
         self.awaiting.clear();
+    }
+
+    /// Pair a `bash` call with the backgrounded command it is about.
+    ///
+    /// Both directions run off the same maps: a call carrying a `command` is
+    /// remembered against its call id until its result lands (which is where a
+    /// `job_id` would appear), and a call carrying only a `job_id` gets that
+    /// command filled back in, so every row labelling the call names the work
+    /// rather than an opaque id. Labels are built from the returned value; the
+    /// journal keeps the arguments as they arrived, so a replay rebuilds the
+    /// pairing from the same events in the same order.
+    fn track_bash_job(
+        &mut self,
+        id: &str,
+        name: &str,
+        mut args: serde_json::Value,
+    ) -> serde_json::Value {
+        if !matches!(name, "bash" | "shell" | "exec") {
+            return args;
+        }
+        let cmd = args
+            .get("command")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if !cmd.is_empty() {
+            self.bash_commands.insert(id.to_string(), cmd);
+            return args;
+        }
+        let remembered = bash_job_id(&args)
+            .and_then(|job| self.bash_jobs.get(job))
+            .cloned();
+        if let (Some(cmd), Some(obj)) = (remembered, args.as_object_mut()) {
+            obj.insert("command".to_string(), serde_json::Value::String(cmd));
+        }
+        args
     }
 
     /// Rewrite a standalone tool row to its resolved form once its result lands:
@@ -3378,6 +3425,7 @@ impl App {
                     self.awaiting.push((id, run_id.to_string(), sub));
                     return;
                 }
+                let args = self.track_bash_job(&id, &name, args);
                 // Untruncated: every row that shows these clamps to the width it
                 // is drawn at, so they survive a resize either way.
                 let label = tool_activity(&name, &args);
@@ -3423,6 +3471,14 @@ impl App {
                     is_error,
                     diff: diff.clone(),
                 });
+                // Before the grouped-call early return: a backgrounded command
+                // is reported by its result, and the call that later collects it
+                // needs the pairing whichever way this row renders.
+                if let Some(cmd) = self.bash_commands.remove(&id) {
+                    if let Some(job) = backgrounded_job_id(&content) {
+                        self.bash_jobs.insert(job.to_string(), cmd);
+                    }
+                }
                 let resolved = self.resolve_pending_row(&id, is_error);
                 // Any tool result means the model took some action since the last
                 // reminder fired; let a later stop remind again if work is still
@@ -4448,6 +4504,28 @@ fn collapse_command(cmd: &str) -> String {
         .to_string()
 }
 
+/// The `job_id` of a `bash` poll: a call that collects an already-backgrounded
+/// command instead of starting a new one. Blank is treated as absent.
+fn bash_job_id(args: &serde_json::Value) -> Option<&str> {
+    args.get("job_id")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+}
+
+/// The job id in a `bash` result reporting that its command was backgrounded.
+/// Matched on the `job_id=` marker the tool prints and stopping at the first
+/// character that cannot be part of an id, so the instruction text repeating
+/// the id parses to the same value.
+fn backgrounded_job_id(content: &str) -> Option<&str> {
+    let at = content.find("job_id=")? + "job_id=".len();
+    let rest = &content[at..];
+    let end = rest
+        .find(|c: char| !c.is_ascii_alphanumeric() && c != '-' && c != '_')
+        .unwrap_or(rest.len());
+    Some(&rest[..end]).filter(|id| !id.is_empty())
+}
+
 fn tool_activity(name: &str, args: &serde_json::Value) -> String {
     let s = |k: &str| args.get(k).and_then(|v| v.as_str()).unwrap_or("");
     let base = |p: &str| {
@@ -4460,12 +4538,13 @@ fn tool_activity(name: &str, args: &serde_json::Value) -> String {
     match name {
         "bash" | "shell" | "exec" => {
             let cmd = s("command");
-            if cmd.trim().is_empty() {
-                "Executing command".to_string()
-            } else {
-                // Untruncated: the row wraps at the draw width, so the command
-                // fills the terminal rather than eliding at a fixed 80.
-                format!("Executing: {}", collapse_command(cmd))
+            // Untruncated: the row wraps at the draw width, so the command
+            // fills the terminal rather than eliding at a fixed 80.
+            match (bash_job_id(args), cmd.trim()) {
+                (Some(job), "") => format!("Waiting for background job {job}"),
+                (Some(_), cmd) => format!("Waiting for: {}", collapse_command(cmd)),
+                (None, "") => "Executing command".to_string(),
+                (None, cmd) => format!("Executing: {}", collapse_command(cmd)),
             }
         }
         "grep" | "search" => "Searching".to_string(),
@@ -4557,12 +4636,13 @@ fn subagent_activity(name: &str, args: &serde_json::Value) -> String {
     match name {
         "bash" | "shell" | "exec" => {
             let cmd = s("command");
-            if cmd.trim().is_empty() {
-                "command".to_string()
-            } else {
-                // The live panel gives each call exactly one row, so this one
-                // stays flattened where the transcript's label keeps its breaks.
-                format!("$ {}", single_line(cmd))
+            // The live panel gives each call exactly one row, so this one stays
+            // flattened where the transcript's label keeps its breaks.
+            match (bash_job_id(args), cmd.trim()) {
+                (Some(job), "") => format!("awaiting job {job}"),
+                (Some(_), cmd) => format!("awaiting $ {}", single_line(cmd)),
+                (None, "") => "command".to_string(),
+                (None, cmd) => format!("$ {}", single_line(cmd)),
             }
         }
         "grep" | "search" => format!("grep {}", s("pattern")),
@@ -4589,10 +4669,11 @@ fn tool_finished(name: &str, args: &serde_json::Value) -> String {
     match name {
         "bash" | "shell" | "exec" => {
             let cmd = s("command");
-            if cmd.trim().is_empty() {
-                "Ran command".to_string()
-            } else {
-                format!("Ran: {}", collapse_command(cmd))
+            match (bash_job_id(args), cmd.trim()) {
+                (Some(job), "") => format!("Collected background job {job}"),
+                (Some(_), cmd) => format!("Collected: {}", collapse_command(cmd)),
+                (None, "") => "Ran command".to_string(),
+                (None, cmd) => format!("Ran: {}", collapse_command(cmd)),
             }
         }
         "grep" | "search" => "Searched".to_string(),
@@ -11909,7 +11990,8 @@ mod tests {
         McpPrompt, McpField, pairs_to_str,
         ProviderField,
         autoscroll_selection, selection_text, Selection, SelectionMode, COPY_NOTICE,
-        drain_stream_events, run_command, starting_call_lines, unescape_partial_json_string,
+        backgrounded_job_id, drain_stream_events, run_command, starting_call_lines,
+        unescape_partial_json_string,
         running_group_rows, split_reasoning, strip_system_xml_tags, subagent_activity,
         answer_without_reasoning, assistant_runs, replay_display_log, thinking_open,
         without_think_tags, ReasoningSeg,
@@ -13597,6 +13679,101 @@ mod tests {
                 ("command", false),
             ]),
             "Read 1 directory, 1 file; ran 1 search, 1 command"
+        );
+    }
+
+    /// A `bash` call carrying only a `job_id` is a poll of an already
+    /// backgrounded command: it blocks until that command finishes, so its row
+    /// can stay live for minutes. "Executing command" said nothing at all
+    /// about what was running.
+    #[test]
+    fn a_backgrounded_bash_poll_names_the_job_it_waits_on() {
+        assert_eq!(
+            tool_activity("bash", &json!({ "job_id": "bash-3" })),
+            "Waiting for background job bash-3"
+        );
+        assert_eq!(
+            tool_finished("bash", &json!({ "job_id": "bash-3" })),
+            "Collected background job bash-3"
+        );
+        assert_eq!(
+            subagent_activity("bash", &json!({ "job_id": "bash-3" })),
+            "awaiting job bash-3"
+        );
+        // The command, once the run remembers which one the job is:
+        let args = json!({ "job_id": "bash-3", "command": "cargo build --release" });
+        assert_eq!(
+            tool_activity("bash", &args),
+            "Waiting for: cargo build --release"
+        );
+        assert_eq!(
+            tool_finished("bash", &args),
+            "Collected: cargo build --release"
+        );
+        assert_eq!(
+            subagent_activity("bash", &args),
+            "awaiting $ cargo build --release"
+        );
+        // A blank job id is no job id: an ordinary call is unaffected.
+        assert_eq!(
+            tool_activity("bash", &json!({ "command": "ls", "job_id": "  " })),
+            "Executing: ls"
+        );
+    }
+
+    /// The job id is read back out of the result that handed it out, so the
+    /// marker the tool prints is what this has to match.
+    #[test]
+    fn a_backgrounding_notice_yields_its_job_id() {
+        let notice = "Command exceeded 30s and is continuing in the background \
+             (job_id=bash-7). Call bash again with {\"job_id\": \"bash-7\"} (no \
+             command) to wait for and collect its output once it finishes.";
+        assert_eq!(backgrounded_job_id(notice), Some("bash-7"));
+        // Not every bash result carries one.
+        assert_eq!(backgrounded_job_id("hello\n[exit 0]"), None);
+        assert_eq!(
+            backgrounded_job_id("ERROR: unknown or already-collected job_id 'nope'"),
+            None
+        );
+    }
+
+    /// End to end: the command a job was started with reaches the poll's row.
+    #[tokio::test]
+    async fn a_polled_job_row_names_the_command_it_was_started_with() {
+        let mut app = test_app();
+        app.apply(StreamEvent::ToolCall {
+            id: "c1".into(),
+            name: "bash".into(),
+            args: json!({ "command": "cargo build --release", "timeout": 1 }),
+        });
+        app.apply(StreamEvent::ToolResult {
+            id: "c1".into(),
+            content: "Command exceeded 1s and is continuing in the background \
+                      (job_id=bash-1). Call bash again with {\"job_id\": \"bash-1\"}."
+                .into(),
+            is_error: false,
+            diff: None,
+        });
+        app.apply(StreamEvent::ToolCall {
+            id: "c2".into(),
+            name: "bash".into(),
+            args: json!({ "job_id": "bash-1" }),
+        });
+
+        let text: String = app
+            .transcript
+            .iter()
+            .map(row_text)
+            .chain(std::iter::once(
+                app.tool_group
+                    .as_ref()
+                    .map(|g| g.calls.iter().map(|c| c.activity.clone()).collect())
+                    .unwrap_or_default(),
+            ))
+            .collect();
+        assert!(
+            text.contains("Waiting for: cargo build --release"),
+            "the poll row does not name its command: {text}"
         );
     }
 

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -13375,6 +13375,32 @@ mod tests {
         assert!(text[5].contains("step 20"), "ends at the newest: {text:?}");
     }
 
+    /// The tail is bounded in *rendered* rows, not source lines. Reasoning
+    /// usually arrives as one long paragraph, so a newline-counted cap let a
+    /// single line wrap into an unpredictable number of screen rows and the
+    /// block's height jittered between frames as that line grew.
+    #[test]
+    fn live_tail_height_is_stable_as_one_long_line_grows() {
+        let width = 40u16;
+        let words: Vec<String> = (1..=120).map(|n| format!("word{n}")).collect();
+        let mut seen = 0u16;
+        for n in (1..=words.len()).step_by(3) {
+            let body = words[..n].join(" ");
+            let lines =
+                super::live_assistant_lines(&format!("<think>{body}"), &[], width, true, true);
+            let rows = lines.len() as u16;
+            assert_eq!(
+                rows,
+                super::wrapped_height(lines.clone(), width),
+                "a pre-wrapped tail must not re-wrap ({n} words)"
+            );
+            assert!(rows <= 6, "tail grew to {rows} rows ({n} words)");
+            assert!(rows >= seen, "tail shrank from {seen} to {rows} rows ({n} words)");
+            seen = rows;
+        }
+        assert_eq!(seen, 6, "tail never filled to its cap");
+    }
+
     /// A block that already closed mid-turn folds to the very summary row the
     /// commit will emit, so finalizing the turn does not move the transcript.
     #[test]

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -4695,12 +4695,57 @@ impl StartingCall {
         tail.reverse();
         let total = body.bytes().filter(|&b| b == b'\n').count() + 1;
         self.preview.skipped = total - tail.len();
-        // Highlighted here rather than in the row builder so the cost tracks
-        // arriving bytes, not the frame rate: this window is a fresh cache key
-        // on every delta, and highlighting 12 lines costs ~4.6ms.
+        // The last line is the one still being written; the rest are finished.
+        let open = tail.len().saturating_sub(1);
+        let clamped: Vec<(String, bool)> = tail
+            .iter()
+            .enumerate()
+            .map(|(i, line)| clamp_preview_line(line, i == open))
+            .collect();
+        let window: Vec<&str> = clamped.iter().map(|(text, _)| text.as_str()).collect();
+        // Highlighted here rather than in the row builder so it happens once
+        // per derivation rather than once per frame; highlighting 12 lines
+        // costs ~4.6ms, and this window is a fresh cache key every time the
+        // body grows.
         let lang = self.preview.path.clone().unwrap_or_default();
-        self.preview.tail = Some(highlight::block(&tail, &lang));
+        let mut rows = highlight::block(&window, &lang);
+        for (i, (row, (_, truncated))) in rows.iter_mut().zip(&clamped).enumerate() {
+            if !truncated {
+                continue;
+            }
+            let marker = Span::styled("\u{2026}", Style::new().dark_gray());
+            if i == open {
+                row.insert(0, marker);
+            } else {
+                row.push(marker);
+            }
+        }
+        self.preview.tail = Some(rows);
     }
+}
+
+/// Clamp one preview line to `STREAM_MAX_LINE_CHARS`, reporting whether
+/// anything was dropped.
+///
+/// `open` marks the line still being written, which keeps its tail: that is
+/// where new bytes land, so it is the end that shows the write progressing. A
+/// finished line keeps its head, where it reads from.
+fn clamp_preview_line(line: &str, open: bool) -> (String, bool) {
+    // A line can only exceed the char budget if it exceeds it in bytes.
+    if line.len() <= STREAM_MAX_LINE_CHARS {
+        return (line.to_string(), false);
+    }
+    let count = line.chars().count();
+    if count <= STREAM_MAX_LINE_CHARS {
+        return (line.to_string(), false);
+    }
+    let at = |n: usize| line.char_indices().nth(n).map_or(line.len(), |(i, _)| i);
+    let kept = if open {
+        &line[at(count - STREAM_MAX_LINE_CHARS)..]
+    } else {
+        &line[..at(STREAM_MAX_LINE_CHARS)]
+    };
+    (kept.to_string(), true)
 }
 
 impl StartingCall {
@@ -4722,6 +4767,13 @@ const STREAM_TAIL_LINES: usize = 12;
 /// Minimum width of the line-number gutter, so a short preview doesn't jitter
 /// sideways as the count crosses 10 / 100.
 const STREAM_GUTTER_MIN: usize = 3;
+/// Longest preview line handed to the highlighter. Minified content (a bundle,
+/// a JSON blob) is one line that grows for the whole write, and both costs it
+/// drives are linear in its length: syntect re-highlights the line on every
+/// delta, and the wrapped row count grows with it until the preview owns the
+/// viewport. Wide enough to fill any real terminal row, so nothing a user could
+/// have read is dropped.
+const STREAM_MAX_LINE_CHARS: usize = 300;
 
 /// Pull one *string-valued* field out of a JSON object that is still streaming
 /// and therefore almost certainly truncated mid-value.
@@ -4796,12 +4848,15 @@ fn unescape_partial_json_string(raw: &str) -> String {
 /// `content` field opens -- falls back to a one-line throbber, which is all
 /// there is to say about a call whose arguments haven't arrived.
 ///
-/// Derivation is cached on the call (see `refresh_preview`), so the cost
-/// tracks how fast bytes arrive rather than the frame rate: ~0.15ms per frame
-/// at 400KB of arguments, against ~2ms without the cache. A rescan is still
-/// linear in the whole buffer, so a multi-megabyte write would make each
-/// *delta* expensive -- if that shows up, unescape only from the last
-/// `STREAM_TAIL_LINES` newline escapes instead of the whole body.
+/// Derivation is cached on the call (see `refresh_preview`) and re-runs only
+/// when the argument buffer has grown, so it costs at most one rescan per
+/// frame -- and, because `drain_stream_events` collapses a burst of deltas into
+/// one frame, far fewer than one per delta. A rescan is still linear in the
+/// whole buffer (~1.4ms at 314KB), so a multi-megabyte write would make each
+/// *frame* expensive: if that shows up, unescape only from the last
+/// `STREAM_TAIL_LINES` newline escapes instead of the whole body. Line length
+/// is already bounded by `STREAM_MAX_LINE_CHARS`, without which minified
+/// content cost 650ms per delta at 53KB and grew from there.
 fn starting_call_lines(call: &mut StartingCall, frame: &str) -> Vec<Line<'static>> {
     call.refresh_preview();
     let Some(tail) = call.preview.tail.as_ref() else {
@@ -5648,6 +5703,84 @@ pub async fn run(
     res
 }
 
+/// Apply one event from the active run's stream, clearing `current` on a
+/// terminal one. `None` is a stream that closed without a terminal event (an
+/// aborted task).
+async fn apply_stream_event(
+    app: &mut App,
+    ev: Option<StreamEvent>,
+    current: &mut Option<CurrentRun>,
+) {
+    match ev {
+        Some(StreamEvent::Done { stop_reason, usage }) => {
+            app.on_done(stop_reason, usage);
+            *current = None;
+            // Auto-compact when approaching the context limit. Handed to
+            // the loop like `/compact` so the summarizing call runs off
+            // the render loop.
+            if app.should_auto_compact() && app.compacting.is_none() {
+                app.compact_request = Some(CompactKind::Auto);
+            }
+        }
+        Some(StreamEvent::Error { code, message }) => {
+            app.on_error(code, message);
+            *current = None;
+        }
+        // Each model roundtrip is one turn toward the finished-todo
+        // aging grace period. A single run can span many tool-call
+        // turns, so aging must count turns, not runs -- otherwise a
+        // finished plan lingers through the rest of a long run.
+        Some(ev @ StreamEvent::Step { .. }) => {
+            app.apply(ev);
+            age_closed_todos(app).await;
+        }
+        Some(other) => app.apply(other),
+        None => {
+            // Stream closed without a terminal event (aborted task).
+            // Keep any partial prose/tool calls already streamed.
+            app.pending_queue.clear();
+            if app.status == Status::Running {
+                app.flush_assistant();
+                app.abort_tool_rows();
+                // The task was killed without a natural stop, so the
+                // mid-turn `MessagesUpdated` that would have folded the
+                // completed tool calls never fired -- fold them here,
+                // exactly as the cancel/error paths do.
+                app.append_cancelled_turn_tools();
+                app.status = Status::Idle;
+                app.run_started = None;
+            }
+            // Auto-dequeue the next queued message
+            app.dequeue_next();
+            *current = None;
+        }
+    }
+}
+
+/// How many events one drain pass applies before handing control back to the
+/// render loop, so a run that emits faster than the loop can drain still
+/// yields to the keyboard poll.
+const EVENT_DRAIN_MAX: usize = 512;
+
+/// Apply every event already sitting in the run's channel, then return how many
+/// landed. A file-sized `write` streams its arguments in thousands of deltas
+/// (measured: 7000 for a 314KB file), and the loop draws once per iteration, so
+/// handling one event per pass means thousands of full repaints for a preview
+/// that only ever shows its last few lines. Draining first collapses a burst
+/// into a single frame. Stops early on a terminal event, which clears `current`
+/// -- nothing queued behind it belongs to a finished run.
+async fn drain_stream_events(app: &mut App, current: &mut Option<CurrentRun>) -> usize {
+    let mut applied = 0;
+    while applied < EVENT_DRAIN_MAX {
+        let Some(ev) = current.as_mut().and_then(|c| c.rx.try_recv().ok()) else {
+            break;
+        };
+        apply_stream_event(app, Some(ev), current).await;
+        applied += 1;
+    }
+    applied
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn chat_loop<B: Backend>(
     terminal: &mut Terminal<B>,
@@ -5910,50 +6043,10 @@ async fn chat_loop<B: Backend>(
                     (None, _) => {}
                 }
             }
-            ev = next_event(&mut current) => match ev {
-                Some(StreamEvent::Done { stop_reason, usage }) => {
-                    app.on_done(stop_reason, usage);
-                    current = None;
-                    // Auto-compact when approaching the context limit. Handed to
-                    // the loop like `/compact` so the summarizing call runs off
-                    // the render loop.
-                    if app.should_auto_compact() && app.compacting.is_none() {
-                        app.compact_request = Some(CompactKind::Auto);
-                    }
-                }
-                Some(StreamEvent::Error { code, message }) => {
-                    app.on_error(code, message);
-                    current = None;
-                }
-                // Each model roundtrip is one turn toward the finished-todo
-                // aging grace period. A single run can span many tool-call
-                // turns, so aging must count turns, not runs -- otherwise a
-                // finished plan lingers through the rest of a long run.
-                Some(ev @ StreamEvent::Step { .. }) => {
-                    app.apply(ev);
-                    age_closed_todos(app).await;
-                }
-                Some(other) => app.apply(other),
-                None => {
-                    // Stream closed without a terminal event (aborted task).
-                    // Keep any partial prose/tool calls already streamed.
-                    app.pending_queue.clear();
-                    if app.status == Status::Running {
-                        app.flush_assistant();
-                        app.abort_tool_rows();
-                        // The task was killed without a natural stop, so the
-                        // mid-turn `MessagesUpdated` that would have folded the
-                        // completed tool calls never fired -- fold them here,
-                        // exactly as the cancel/error paths do.
-                        app.append_cancelled_turn_tools();
-                        app.status = Status::Idle;
-                        app.run_started = None;
-                    }
-                    // Auto-dequeue the next queued message
-                    app.dequeue_next();
-                    current = None;
-                }
-            },
+            ev = next_event(&mut current) => {
+                apply_stream_event(app, ev, &mut current).await;
+                drain_stream_events(app, &mut current).await;
+            }
         }
     }
 
@@ -11816,7 +11909,7 @@ mod tests {
         McpPrompt, McpField, pairs_to_str,
         ProviderField,
         autoscroll_selection, selection_text, Selection, SelectionMode, COPY_NOTICE,
-        run_command, starting_call_lines, unescape_partial_json_string,
+        drain_stream_events, run_command, starting_call_lines, unescape_partial_json_string,
         running_group_rows, split_reasoning, strip_system_xml_tags, subagent_activity,
         answer_without_reasoning, assistant_runs, replay_display_log, thinking_open,
         without_think_tags, ReasoningSeg,
@@ -19256,6 +19349,135 @@ mod tests {
         let text: Vec<String> = starting_call_lines(&mut call, "⠋").iter().map(line_text).collect();
         assert_eq!(text.len(), 1);
         assert!(text[0].contains("Preparing bash"), "got {text:?}");
+    }
+
+    /// A `write` of minified or single-line content (a bundle, a JSON blob)
+    /// grows one preview line without bound. Unclamped that line is
+    /// re-highlighted in full on every argument delta -- syntect is linear in
+    /// line length -- and its wrapped row count floods the viewport the
+    /// preview lives in. Both are bounded by clamping the line itself.
+    #[test]
+    fn an_enormous_single_preview_line_is_clamped() {
+        let mut call = super::StartingCall::new("c1".into(), "write".into());
+        let body = "x".repeat(20_000);
+        call.args = format!(r#"{{"path":"bundle.js","content":"{body}"#);
+        let text: Vec<String> = starting_call_lines(&mut call, "\u{280b}")
+            .iter()
+            .map(line_text)
+            .collect();
+
+        let body_row = text
+            .iter()
+            .find(|l| l.contains("xxx"))
+            .unwrap_or_else(|| panic!("no body row in {text:?}"));
+        let xs = body_row.chars().filter(|&c| c == 'x').count();
+        assert!(
+            xs <= super::STREAM_MAX_LINE_CHARS,
+            "preview line kept {xs} chars of a 20000-char line"
+        );
+        assert!(
+            body_row.contains('\u{2026}'),
+            "clamped line is not marked as truncated: {body_row:?}"
+        );
+    }
+
+    /// Which end survives the clamp differs by line: a finished line reads
+    /// from its start, while the last one is still open and is where new bytes
+    /// land, so watching its tail is what shows the write progressing.
+    #[test]
+    fn a_clamped_line_keeps_its_head_unless_it_is_the_open_one() {
+        let mut call = super::StartingCall::new("c1".into(), "write".into());
+        let filler = "-".repeat(super::STREAM_MAX_LINE_CHARS * 2);
+        call.args = format!(
+            r#"{{"path":"a.txt","content":"HEAD1{filler}TAIL1\nHEAD2{filler}TAIL2"#
+        );
+        let text: Vec<String> = starting_call_lines(&mut call, "\u{280b}")
+            .iter()
+            .map(line_text)
+            .collect();
+        let joined = text.join("\n");
+
+        assert!(joined.contains("HEAD1"), "finished line lost its head: {joined}");
+        assert!(!joined.contains("TAIL1"), "finished line kept its tail: {joined}");
+        assert!(joined.contains("TAIL2"), "open line lost its tail: {joined}");
+        assert!(!joined.contains("HEAD2"), "open line kept its head: {joined}");
+    }
+
+    /// A file-sized `write` streams its arguments in thousands of deltas. One
+    /// repaint each is thousands of full frames for a preview that only ever
+    /// shows its last few lines, so a burst already sitting in the channel is
+    /// drained into a single frame.
+    #[tokio::test]
+    async fn a_burst_of_stream_events_is_drained_into_one_frame() {
+        let mut app = test_app();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut current = Some(CurrentRun {
+            rx,
+            handle: tokio::spawn(async {}),
+        });
+
+        tx.send(StreamEvent::ToolCallStarted {
+            id: "c1".into(),
+            name: "write".into(),
+        })
+        .expect("send");
+        for _ in 0..64 {
+            tx.send(StreamEvent::ToolCallArgsDelta {
+                id: "c1".into(),
+                delta: "ab".into(),
+            })
+            .expect("send");
+        }
+
+        let drained = drain_stream_events(&mut app, &mut current).await;
+        assert_eq!(drained, 65, "the whole burst must land in one pass");
+        assert_eq!(app.starting[0].args.len(), 128);
+        assert!(current.is_some(), "an unfinished run must stay live");
+
+        // Nothing left: draining an empty channel is a no-op, not a stall.
+        assert_eq!(drain_stream_events(&mut app, &mut current).await, 0);
+    }
+
+    /// The drain must not starve input handling: a run that emits faster than
+    /// the loop can drain still has to yield back to the keyboard poll.
+    #[tokio::test]
+    async fn the_drain_is_bounded() {
+        let mut app = test_app();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut current = Some(CurrentRun {
+            rx,
+            handle: tokio::spawn(async {}),
+        });
+        for _ in 0..(super::EVENT_DRAIN_MAX + 50) {
+            tx.send(StreamEvent::Token { text: "x".into() }).expect("send");
+        }
+        assert_eq!(
+            drain_stream_events(&mut app, &mut current).await,
+            super::EVENT_DRAIN_MAX
+        );
+    }
+
+    /// A terminal event inside a burst ends the run there and stops the drain,
+    /// so nothing queued behind it is applied to a finished run.
+    #[tokio::test]
+    async fn the_drain_stops_at_a_terminal_event() {
+        let mut app = test_app();
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut current = Some(CurrentRun {
+            rx,
+            handle: tokio::spawn(async {}),
+        });
+        tx.send(StreamEvent::Token { text: "hi".into() }).expect("send");
+        tx.send(StreamEvent::Done {
+            stop_reason: "stop".into(),
+            usage: None,
+        })
+        .expect("send");
+        tx.send(StreamEvent::Token { text: "late".into() }).expect("send");
+
+        let drained = drain_stream_events(&mut app, &mut current).await;
+        assert_eq!(drained, 2, "drain must stop on the terminal event");
+        assert!(current.is_none(), "the run was not cleared");
     }
 
     /// A path-carrying tool that isn't `write` must be named as itself.

--- a/src-tauri/src/core/cli/tui/markdown.rs
+++ b/src-tauri/src/core/cli/tui/markdown.rs
@@ -62,8 +62,7 @@ pub(super) fn live_assistant_lines(
             if i < last {
                 lines.push(reasoning_summary_row(body.len()));
             } else if stream_reasoning {
-                let tail = &body[body.len().saturating_sub(LIVE_REASONING_TAIL_LINES)..];
-                lines.extend(reasoning_detail_lines(&tail.join("\n")));
+                lines.extend(live_reasoning_tail(&body, width));
             }
             continue;
         }
@@ -74,16 +73,46 @@ pub(super) fn live_assistant_lines(
     lines
 }
 
+/// Columns the reasoning gutter takes. Subtracted from the width before the
+/// live tail wraps, so a pre-wrapped row still fits and the terminal re-wraps
+/// nothing.
+const REASONING_GUTTER_COLS: usize = 2;
+
+fn reasoning_row(body: Vec<Span<'static>>) -> Line<'static> {
+    let mut spans = vec![Span::styled("┊ ", Style::new().dark_gray())];
+    spans.extend(body);
+    Line::from(spans)
+}
+
+fn reasoning_body_span(text: String) -> Span<'static> {
+    Span::styled(text, Style::new().dim().italic())
+}
+
 /// A reasoning block's full dimmed lines (`┊ ` gutter, dim italic body).
 pub(super) fn reasoning_detail_lines(seg: &str) -> Vec<Line<'static>> {
     seg.lines()
         .filter(|l| !l.trim().is_empty())
-        .map(|l| {
-            Line::from(vec![
-                Span::styled("┊ ", Style::new().dark_gray()),
-                Span::styled(l.to_string(), Style::new().dim().italic()),
-            ])
-        })
+        .map(|l| reasoning_row(vec![reasoning_body_span(l.to_string())]))
+        .collect()
+}
+
+/// The open block's tail, bounded to [`LIVE_REASONING_TAIL_LINES`] *rendered*
+/// rows rather than source lines. Reasoning usually arrives as one long
+/// paragraph, so a source-line cap bounded nothing on screen: the block's
+/// height moved with however far the newest line had wrapped, jittering by a
+/// row or two as it grew. Wrapping here also gives every continuation its own
+/// gutter instead of letting it start under the margin.
+fn live_reasoning_tail(body: &[&str], width: u16) -> Vec<Line<'static>> {
+    let max = (width as usize)
+        .saturating_sub(REASONING_GUTTER_COLS)
+        .max(1);
+    let rows: Vec<Vec<Span<'static>>> = body
+        .iter()
+        .flat_map(|l| wrap_spans_at_words(vec![reasoning_body_span(l.to_string())], max))
+        .collect();
+    rows[rows.len().saturating_sub(LIVE_REASONING_TAIL_LINES)..]
+        .iter()
+        .map(|spans| reasoning_row(spans.clone()))
         .collect()
 }
 
@@ -94,10 +123,7 @@ pub(super) fn reasoning_summary_row(n: usize) -> Line<'static> {
     } else {
         format!("reasoning ({n} lines)")
     };
-    Line::from(vec![
-        Span::styled("┊ ", Style::new().dark_gray()),
-        Span::styled(label, Style::new().dim().italic()),
-    ])
+    reasoning_row(vec![reasoning_body_span(label)])
 }
 
 /// Render answer prose to styled lines. Every block -- prose, code fences,


### PR DESCRIPTION
## Describe Your Changes
Three fixes to what the `jan` CLI TUI shows while a turn is in flight. All in
`core::cli::tui` (CLI feature only; the desktop build is untouched).

### The TUI froze during a streaming `write` (4567c643e)

Not the upstream retry (that is a 250ms `tokio::time::sleep` on a task of its
own). Minified content -- a bundle, a JSON blob -- is *one* preview line that
grows for the whole write, and both costs it drives are linear in its length:
syntect re-highlighted the line on every delta, and its wrapped row count grew
until the preview owned the viewport. Measured 649 ms/delta at 53KB and ~1.2 s
at 99KB, against a 50ms frame budget.

- Preview lines are clamped to `STREAM_MAX_LINE_CHARS` (300, wider than any
  real terminal row) with a `…` marker: 1.08 ms at 99KB.
- The event arm now drains up to `EVENT_DRAIN_MAX` (512) queued events per
  frame, so a burst of deltas costs one derivation instead of one each.

### A backgrounded `bash` poll showed no command (bf8585fce)

A command that outlives its timeout keeps running and returns a `job_id`; the
model then calls `bash` with *only* that id, and the call blocks until the
command finishes. The label functions read only `command`, so such a row sat
live for minutes reading a bare "Executing command".

`App` now pairs a job with the command it was started from and the row reads
`Waiting for: cargo build --release`, resolving to `Collected: ...`. Labels are
built from the filled-in args; the journal keeps the args as they arrived, so
`/resume` rebuilds the pairing from the same events.

### The streaming thought block changed height between frames (36a8fe7a8)

`LIVE_REASONING_TAIL_LINES` (6) capped *source* lines while the terminal
wrapped them. Reasoning arrives as one long paragraph, so the cap bounded
nothing on screen and the block bounced between 5 and 6 rows as its last line
grew. The tail now word-wraps itself at `width - gutter` and keeps the last six
*wrapped* rows, so it grows monotonically to six and stays there -- and each
continuation carries its own gutter instead of starting under the margin.

## Fixes Issues

- Closes #8714
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
