### PR TITLE
docs(agent): update Jan CLI install links to delta.jan.ai

### DIFF
--- a/docs/src/pages/docs/agent/index.mdx
+++ b/docs/src/pages/docs/agent/index.mdx
@@ -67,12 +67,12 @@ nightly-quality builds.
 <Tabs items={['macOS / Linux', 'Windows']}>
   <Tabs.Tab>
 ```bash
-curl -fsSL https://raw.githubusercontent.com/janhq/jan/dev/scripts/install-jan-agent.sh | bash
+curl -fsSL https://delta.jan.ai/jan-cli/install-jan-agent.sh | bash
 ```
   </Tabs.Tab>
   <Tabs.Tab>
 ```powershell
-irm https://raw.githubusercontent.com/janhq/jan/dev/scripts/install-jan-agent.ps1 | iex
+irm https://delta.jan.ai/jan-cli/install-jan-agent.ps1 | iex
 ```
   </Tabs.Tab>
 </Tabs>

--- a/docs/src/pages/docs/agent/quickstart.mdx
+++ b/docs/src/pages/docs/agent/quickstart.mdx
@@ -36,7 +36,7 @@ nightly-quality builds.
 <Tabs items={['macOS / Linux', 'Windows']}>
   <Tabs.Tab>
 ```bash
-curl -fsSL https://raw.githubusercontent.com/janhq/jan/dev/scripts/install-jan-agent.sh | bash
+curl -fsSL https://delta.jan.ai/jan-cli/install-jan-agent.sh | bash
 ```
 
 Installs to `~/.local/bin` by default. Override it with `JAN_INSTALL_DIR=/usr/local/bin`, and make
@@ -44,7 +44,7 @@ sure the directory is on your `PATH`.
   </Tabs.Tab>
   <Tabs.Tab>
 ```powershell
-irm https://raw.githubusercontent.com/janhq/jan/dev/scripts/install-jan-agent.ps1 | iex
+irm https://delta.jan.ai/jan-cli/install-jan-agent.ps1 | iex
 ```
   </Tabs.Tab>
 </Tabs>


### PR DESCRIPTION
Update the Jan CLI install instructions on the docs site to the new download endpoints.

## Change
- `docs/src/pages/docs/agent/index.mdx`
- `docs/src/pages/docs/agent/quickstart.mdx`

Old (raw GitHub script on `dev`):
```bash
curl -fsSL https://raw.githubusercontent.com/janhq/jan/dev/scripts/install-jan-agent.sh | bash
irm https://raw.githubusercontent.com/janhq/jan/dev/scripts/install-jan-agent.ps1 | iex
```

New:
```bash
curl -fsSL https://delta.jan.ai/jan-cli/install-jan-agent.sh | bash
irm https://delta.jan.ai/jan-cli/install-jan-agent.ps1 | iex
```

## Notes
- Docs-only change; no code touched.
- The `--source` build-from-checkout note (quickstart.mdx:59) is unrelated and left as-is.