### PR TITLE
docs(agent): separate stable and nightly install instructions

### DIFF
--- a/docs/src/pages/docs/agent/index.mdx
+++ b/docs/src/pages/docs/agent/index.mdx
@@ -59,9 +59,12 @@ are all shared, so anything you set up in one is already there in the other.
 
 ## Install
 
+Stable Jan Agent installers will be added here.
+
+## Install nightly
+
 <Callout type="warning">
-Jan Agent is a preview. The installer on `dev` pulls from the `agent-nightly` channel - expect
-nightly-quality builds.
+Jan Agent is a preview. Nightly installs may include unfinished changes.
 </Callout>
 
 <Tabs items={['macOS / Linux', 'Windows']}>


### PR DESCRIPTION
## Summary
- Separates the stable install placeholder from the nightly install section.
- Keeps dedicated macOS/Linux and Windows nightly installation commands visible.

## Verification
- `yarn lint` - No ESLint warnings or errors.
- `yarn build` - Next.js production build completed successfully.