### PR TITLE
ci: pass JAN_SIGNING_KEY to the agent CLI builds

### DIFF
--- a/.github/workflows/template-cli-build-linux-aarch64.yml
+++ b/.github/workflows/template-cli-build-linux-aarch64.yml
@@ -25,6 +25,11 @@ on:
         required: false
       DELTA_AWS_REGION:
         required: false
+      # Baked into the binary at compile time via option_env!; without it the
+      # released CLI falls back to the local-dev key and its signed requests
+      # are rejected.
+      JAN_SIGNING_KEY:
+        required: false
     outputs:
       FILE_NAME:
         value: ${{ jobs.build-linux-aarch64.outputs.FILE_NAME }}
@@ -79,6 +84,7 @@ jobs:
         env:
           JAN_CLI_UPDATE_CHANNEL: ${{ inputs.channel }}
           JAN_CLI_BUILD_VERSION: ${{ inputs.new_version }}
+          JAN_SIGNING_KEY: ${{ secrets.JAN_SIGNING_KEY }}
         run: |
           cd src-tauri
           cargo build --no-default-features --features cli --bin jan --release

--- a/.github/workflows/template-cli-build-linux-x64.yml
+++ b/.github/workflows/template-cli-build-linux-x64.yml
@@ -25,6 +25,11 @@ on:
         required: false
       DELTA_AWS_REGION:
         required: false
+      # Baked into the binary at compile time via option_env!; without it the
+      # released CLI falls back to the local-dev key and its signed requests
+      # are rejected.
+      JAN_SIGNING_KEY:
+        required: false
     outputs:
       FILE_NAME:
         value: ${{ jobs.build-linux-x64.outputs.FILE_NAME }}
@@ -88,6 +93,7 @@ jobs:
         env:
           JAN_CLI_UPDATE_CHANNEL: ${{ inputs.channel }}
           JAN_CLI_BUILD_VERSION: ${{ inputs.new_version }}
+          JAN_SIGNING_KEY: ${{ secrets.JAN_SIGNING_KEY }}
         run: |
           cd src-tauri
           cargo build --no-default-features --features cli --bin jan --release

--- a/.github/workflows/template-cli-build-macos.yml
+++ b/.github/workflows/template-cli-build-macos.yml
@@ -25,6 +25,11 @@ on:
         required: false
       DELTA_AWS_REGION:
         required: false
+      # Baked into the binary at compile time via option_env!; without it the
+      # released CLI falls back to the local-dev key and its signed requests
+      # are rejected.
+      JAN_SIGNING_KEY:
+        required: false
       # Optional code signing
       CODE_SIGN_P12_BASE64:
         required: false
@@ -67,6 +72,7 @@ jobs:
         env:
           JAN_CLI_UPDATE_CHANNEL: ${{ inputs.channel }}
           JAN_CLI_BUILD_VERSION: ${{ inputs.new_version }}
+          JAN_SIGNING_KEY: ${{ secrets.JAN_SIGNING_KEY }}
         run: |
           cd src-tauri
           cargo build --no-default-features --features cli --bin jan --release --target x86_64-apple-darwin
@@ -75,6 +81,7 @@ jobs:
         env:
           JAN_CLI_UPDATE_CHANNEL: ${{ inputs.channel }}
           JAN_CLI_BUILD_VERSION: ${{ inputs.new_version }}
+          JAN_SIGNING_KEY: ${{ secrets.JAN_SIGNING_KEY }}
         run: |
           cd src-tauri
           cargo build --no-default-features --features cli --bin jan --release --target aarch64-apple-darwin

--- a/.github/workflows/template-cli-build-windows-x64.yml
+++ b/.github/workflows/template-cli-build-windows-x64.yml
@@ -25,6 +25,11 @@ on:
         required: false
       DELTA_AWS_REGION:
         required: false
+      # Baked into the binary at compile time via option_env!; without it the
+      # released CLI falls back to the local-dev key and its signed requests
+      # are rejected.
+      JAN_SIGNING_KEY:
+        required: false
     outputs:
       FILE_NAME:
         value: ${{ jobs.build-windows-x64.outputs.FILE_NAME }}
@@ -55,6 +60,7 @@ jobs:
         env:
           JAN_CLI_UPDATE_CHANNEL: ${{ inputs.channel }}
           JAN_CLI_BUILD_VERSION: ${{ inputs.new_version }}
+          JAN_SIGNING_KEY: ${{ secrets.JAN_SIGNING_KEY }}
         run: |
           cd src-tauri
           cargo build --no-default-features --features cli --bin jan --release


### PR DESCRIPTION
## Problem

The CLI binary bakes the HMAC signing key in at compile time:

```rust
// src-tauri/src/core/updater/custom_updater.rs
pub(crate) const SECRET_KEY: &str = match option_env!("JAN_SIGNING_KEY") {
    Some(key) => key,
    None => "local-dev-test-key-not-for-production",
};
```

`core::cli::telemetry` signs its requests with that constant, but none of the four `template-cli-build-*` workflows set `JAN_SIGNING_KEY` on the `cargo build` step — so every released agent CLI shipped with the local-dev fallback baked in, and its signed requests get rejected.

The desktop templates (`template-tauri-build-{macos,windows-x64,linux-x64,linux-x64-flatpak}.yml`) already wire this correctly; the CLI templates were just missing it.

## Change

Same wiring as the desktop templates, applied to all four CLI templates:

- declare `JAN_SIGNING_KEY` (optional) under `on.workflow_call.secrets`
- set `JAN_SIGNING_KEY: ${{ secrets.JAN_SIGNING_KEY }}` on each `cargo build` step (macOS has two — x86_64 and aarch64)

Callers already use `secrets: inherit`, so `jan-tauri-build-agent-nightly.yaml` needs no change.

## Verification

- `yaml.safe_load` passes on all four files
- confirmed against `origin/dev`, where `src/core/cli/telemetry.rs:100` calls `SignedRequestHeaders::new(SECRET_KEY, ...)`

## Note

Opened against `main` per request; to be cherry-picked to `dev`. The commit touches only the four CLI templates, which are identical on both branches apart from `template-cli-build-linux-x64.yml` (main is ahead there) — the hunks are in the `secrets:` block and the build step's `env:`, so it should apply cleanly.