### PR TITLE
fix(agent): drop malformed tool calls from history so a session can heal

### DIFF
--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -18,10 +18,10 @@ use crate::core::agent::events::{StreamEvent, Usage};
 use crate::core::agent::session::SessionBudget;
 use tauri_plugin_agent_tools::tools::gate::{DenyReason, PermissionDecision};
 use crate::core::agent::upstream::{
-    collect_mcp_openai_tools, copy_optional_chat_params, execute_mcp_tool_calls,
-    extract_choice_message, extract_tool_calls, load_assistant_config, parse_openai_messages,
-    repair_dangling_tool_calls, resolve_upstream_for_model, set_system_prompt,
-    stream_openai_chat_completions,
+    collect_mcp_openai_tools, copy_optional_chat_params, drop_malformed_tool_calls,
+    execute_mcp_tool_calls, extract_choice_message, extract_tool_calls, load_assistant_config,
+    parse_openai_messages, repair_dangling_tool_calls, resolve_upstream_for_model,
+    set_system_prompt, stream_openai_chat_completions,
 };
 #[cfg(not(feature = "cli"))]
 use crate::core::server::proxy::router_first_model;
@@ -1252,6 +1252,16 @@ async fn orchestrate_inner(
         .get("messages")
         .ok_or("Missing required field 'messages'")?;
     let mut conversation_messages = parse_openai_messages(messages_value)?;
+    // Drop tool calls a truncated stream left with unparsable arguments before
+    // anything else looks at the history. Such a call is persisted by the run
+    // that produced it and resent on every later turn, and an OpenAI-compatible
+    // upstream 422s the whole request over it -- so without this the session is
+    // wedged on its own history and cannot heal. Runs first so the dangling
+    // repair below sees the post-removal shape.
+    let poisoned = drop_malformed_tool_calls(&mut conversation_messages);
+    if poisoned > 0 {
+        log::warn!("agent: dropped {poisoned} tool call(s) with unparsable arguments from history");
+    }
     // Self-heal a conversation an earlier interrupted run may have left with a
     // tool_calls turn missing one of its results (e.g. the process was killed
     // while an `ask`/permission prompt was still pending). Providers like
@@ -2501,6 +2511,122 @@ mod tests {
         assert_eq!(content[1]["type"], "image_url");
         assert_eq!(content[1]["image_url"]["url"], "data:image/png;base64,QUJD");
         assert_eq!(content[1]["image_url"]["detail"], "auto");
+    }
+
+    /// End-to-end proof of the poisoned-history fix against an upstream that
+    /// behaves like the real one: a strict validator that rejects the whole
+    /// request (as a 422 does) when any tool call in the inbound history has
+    /// unparsable `function.arguments`.
+    ///
+    /// Without the sanitizer the session is wedged -- every turn resends the
+    /// truncated call and every turn is rejected, so the run can never make
+    /// progress. With it, the turn goes through.
+    #[tokio::test]
+    async fn poisoned_history_wedges_a_strict_upstream_until_sanitized() {
+        /// Rejects any request still carrying an unparsable tool-call argument.
+        struct StrictModel {
+            calls: std::sync::atomic::AtomicU32,
+        }
+        #[async_trait]
+        impl ModelInvoker for StrictModel {
+            async fn invoke(
+                &self,
+                request: &serde_json::Value,
+                _events: &mpsc::UnboundedSender<StreamEvent>,
+            ) -> Result<serde_json::Value, String> {
+                self.calls
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                for m in request["messages"].as_array().into_iter().flatten() {
+                    for tc in m["tool_calls"].as_array().into_iter().flatten() {
+                        if let Some(args) = tc["function"]["arguments"].as_str() {
+                            if !args.trim().is_empty()
+                                && serde_json::from_str::<serde_json::Value>(args).is_err()
+                            {
+                                return Err("HTTP 422: invalid tool call arguments".to_string());
+                            }
+                        }
+                    }
+                }
+                Ok(json!({
+                    "choices": [{ "message": { "content": "healed" }, "finish_reason": "stop" }]
+                }))
+            }
+        }
+
+        // The history a truncated stream leaves behind: `arguments` cut
+        // mid-JSON while the turn still claimed `finish_reason: "tool_calls"`.
+        let poisoned = vec![
+            json!({ "role": "user", "content": "write the file" }),
+            json!({
+                "role": "assistant",
+                "content": serde_json::Value::Null,
+                "tool_calls": [{
+                    "id": "call_trunc",
+                    "type": "function",
+                    "function": { "name": "write", "arguments": "{\"path\":\"a.rs\",\"content\":\"fn ma" }
+                }]
+            }),
+            json!({ "role": "tool", "tool_call_id": "call_trunc", "content": "(never ran)" }),
+            json!({ "role": "user", "content": "are you stuck?" }),
+        ];
+
+        // Before: the untouched history is rejected -- this is the wedge.
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let wedged = StrictModel {
+            calls: Default::default(),
+        };
+        let err = run_turn_cycle(
+            &tx,
+            &json!({}),
+            "m",
+            &[],
+            poisoned.clone(),
+            8,
+            &mut SessionBudget::new(None),
+            &wedged,
+            &MockTool::default(),
+            crate::core::agent::plan::RunMode::Normal,
+            None,
+            None,
+        )
+        .await;
+        assert!(
+            err.is_err_and(|e| e.contains("422")),
+            "unsanitized poisoned history must be rejected, reproducing the wedge"
+        );
+
+        // After: the same history, through the sanitizer the orchestrator runs
+        // on every inbound request, is accepted and the turn completes.
+        let mut healed_history = poisoned;
+        assert_eq!(drop_malformed_tool_calls(&mut healed_history), 1);
+        assert_eq!(repair_dangling_tool_calls(&mut healed_history), 0);
+
+        let (tx2, _rx2) = mpsc::unbounded_channel();
+        let healed = StrictModel {
+            calls: Default::default(),
+        };
+        let result = run_turn_cycle(
+            &tx2,
+            &json!({}),
+            "m",
+            &[],
+            healed_history,
+            8,
+            &mut SessionBudget::new(None),
+            &healed,
+            &MockTool::default(),
+            crate::core::agent::plan::RunMode::Normal,
+            None,
+            None,
+        )
+        .await
+        .expect("sanitized history must be accepted so the session can continue");
+        assert_eq!(result["choices"][0]["message"]["content"], "healed");
+        assert_eq!(
+            healed.calls.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "one clean round trip"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/core/agent/upstream.rs
+++ b/src-tauri/src/core/agent/upstream.rs
@@ -192,6 +192,99 @@ pub(crate) fn repair_dangling_tool_calls(messages: &mut Vec<serde_json::Value>) 
     repaired
 }
 
+/// Drops "poisoned" tool calls: an assistant `tool_calls` entry whose
+/// `function.arguments` is not parsable JSON. A model (observed with
+/// DeepSeek/vLLM) can end a stream mid-argument while still reporting
+/// `finish_reason: "tool_calls"`, so the truncated call is persisted into the
+/// thread. Every later turn resends it, and an OpenAI-compatible upstream
+/// rejects the whole request with 422 -- the session is wedged, because the
+/// poison is in the history the agent keeps replaying.
+///
+/// Removal, not reconstruction: a truncated argument cannot be recovered, and
+/// inventing one would run a tool the model never actually asked for. The call
+/// is dropped along with any `role: "tool"` reply carrying its `tool_call_id`,
+/// so no orphaned result is left behind. Valid sibling calls in the same turn
+/// survive; an assistant turn whose calls are ALL dropped keeps its text and
+/// loses only the `tool_calls` key (and is removed entirely if that leaves it
+/// empty, which would otherwise be a contentless assistant turn some providers
+/// reject). Returns the number of calls dropped.
+///
+/// Runs before [`repair_dangling_tool_calls`], so a surviving call that lost
+/// its result still gets the synthetic error reply from that pass.
+pub(crate) fn drop_malformed_tool_calls(messages: &mut Vec<serde_json::Value>) -> usize {
+    // A call is poison when arguments are present but unparsable. An absent or
+    // empty `arguments` is the well-formed "no arguments" spelling several
+    // providers use, and is left alone.
+    fn is_malformed(call: &serde_json::Value) -> bool {
+        let Some(args) = call
+            .get("function")
+            .and_then(|f| f.get("arguments"))
+            .and_then(|v| v.as_str())
+        else {
+            return false;
+        };
+        let args = args.trim();
+        !args.is_empty() && serde_json::from_str::<serde_json::Value>(args).is_err()
+    }
+
+    let mut dropped_ids: Vec<String> = Vec::new();
+    let mut dropped = 0;
+    for msg in messages.iter_mut() {
+        let Some(calls) = msg.get("tool_calls").and_then(|v| v.as_array()) else {
+            continue;
+        };
+        if !calls.iter().any(is_malformed) {
+            continue;
+        }
+        let mut kept: Vec<serde_json::Value> = Vec::with_capacity(calls.len());
+        for call in calls {
+            if is_malformed(call) {
+                if let Some(id) = call.get("id").and_then(|v| v.as_str()) {
+                    dropped_ids.push(id.to_string());
+                }
+                dropped += 1;
+            } else {
+                kept.push(call.clone());
+            }
+        }
+        let Some(obj) = msg.as_object_mut() else {
+            continue;
+        };
+        if kept.is_empty() {
+            obj.remove("tool_calls");
+        } else {
+            obj.insert("tool_calls".to_string(), serde_json::Value::Array(kept));
+        }
+    }
+    if dropped == 0 {
+        return 0;
+    }
+    // Drop the results that answered a dropped call, then any assistant turn
+    // left with neither text nor calls (content-null with no tool_calls is not
+    // a valid turn to resend).
+    messages.retain(|m| {
+        let role = m.get("role").and_then(|v| v.as_str()).unwrap_or_default();
+        if role == "tool" {
+            let id = m
+                .get("tool_call_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            return !dropped_ids.iter().any(|d| d == id);
+        }
+        if role != "assistant" || m.get("tool_calls").is_some() {
+            return true;
+        }
+        // Keep a turn that still says something; a content-null/empty one is
+        // now an empty shell left by the dropped call.
+        match m.get("content") {
+            Some(serde_json::Value::String(s)) => !s.trim().is_empty(),
+            Some(serde_json::Value::Array(a)) => !a.is_empty(),
+            _ => false,
+        }
+    });
+    dropped
+}
+
 pub(crate) fn set_system_prompt(messages: &mut Vec<serde_json::Value>, system_prompt: &str) {
     messages.retain(|m| m.get("role").and_then(|r| r.as_str()) != Some("system"));
     messages.insert(
@@ -1507,6 +1600,124 @@ mod tests {
         assert_eq!(messages.len(), 2);
         assert_eq!(messages[1]["role"], "tool");
         assert_eq!(messages[1]["tool_call_id"], "call_1");
+    }
+
+    #[test]
+    fn sanitize_leaves_valid_tool_calls_untouched() {
+        // Well-formed arguments, plus the empty-object and absent-arguments
+        // spellings providers use for a no-argument call.
+        let mut messages = vec![
+            json!({ "role": "user", "content": "hi" }),
+            json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [
+                    { "id": "c1", "type": "function", "function": { "name": "read", "arguments": "{\"path\":\"a.rs\"}" } },
+                    { "id": "c2", "type": "function", "function": { "name": "ls", "arguments": "{}" } },
+                    { "id": "c3", "type": "function", "function": { "name": "now" } },
+                ]
+            }),
+            json!({ "role": "tool", "tool_call_id": "c1", "content": "ok" }),
+        ];
+        let before = messages.clone();
+        assert_eq!(drop_malformed_tool_calls(&mut messages), 0);
+        assert_eq!(messages, before);
+    }
+
+    #[test]
+    fn sanitize_drops_a_truncated_call_and_its_result() {
+        // The wedging case: a stream cut mid-argument, persisted, then resent
+        // on every later turn and 422'd by the upstream.
+        let mut messages = vec![
+            json!({ "role": "user", "content": "write the file" }),
+            json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "id": "call_bad",
+                    "type": "function",
+                    "function": { "name": "write", "arguments": "{\"path\":\"a.rs\",\"content\":\"fn ma" }
+                }]
+            }),
+            json!({ "role": "tool", "tool_call_id": "call_bad", "content": "stale" }),
+            json!({ "role": "user", "content": "still there?" }),
+        ];
+        assert_eq!(drop_malformed_tool_calls(&mut messages), 1);
+        // The empty assistant shell and the orphaned result are both gone.
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0]["content"], "write the file");
+        assert_eq!(messages[1]["content"], "still there?");
+    }
+
+    #[test]
+    fn sanitize_keeps_valid_siblings_of_a_poisoned_call() {
+        let mut messages = vec![
+            json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [
+                    { "id": "ok", "type": "function", "function": { "name": "read", "arguments": "{\"path\":\"a\"}" } },
+                    { "id": "bad", "type": "function", "function": { "name": "write", "arguments": "{\"path\":\"b" } },
+                ]
+            }),
+            json!({ "role": "tool", "tool_call_id": "ok", "content": "contents" }),
+            json!({ "role": "tool", "tool_call_id": "bad", "content": "stale" }),
+        ];
+        assert_eq!(drop_malformed_tool_calls(&mut messages), 1);
+        let calls = messages[0]["tool_calls"].as_array().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0]["id"], "ok");
+        // Only the poisoned call's result was dropped.
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[1]["tool_call_id"], "ok");
+    }
+
+    #[test]
+    fn sanitize_preserves_assistant_text_when_all_calls_are_dropped() {
+        let mut messages = vec![json!({
+            "role": "assistant",
+            "content": "I'll write that file now.",
+            "tool_calls": [{
+                "id": "bad",
+                "type": "function",
+                "function": { "name": "write", "arguments": "{\"content\":\"trunc" }
+            }]
+        })];
+        assert_eq!(drop_malformed_tool_calls(&mut messages), 1);
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0]["content"], "I'll write that file now.");
+        assert!(messages[0].get("tool_calls").is_none());
+    }
+
+    #[test]
+    fn sanitize_then_dangling_repair_leaves_a_sendable_conversation() {
+        // The two passes compose the way the orchestrator runs them: the
+        // poisoned call goes away, and the surviving call that lost its result
+        // gets the synthetic error reply rather than being left dangling.
+        let mut messages = vec![
+            json!({ "role": "user", "content": "go" }),
+            json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [
+                    { "id": "keep", "type": "function", "function": { "name": "read", "arguments": "{}" } },
+                    { "id": "poison", "type": "function", "function": { "name": "write", "arguments": "{\"a\":" } },
+                ]
+            }),
+        ];
+        assert_eq!(drop_malformed_tool_calls(&mut messages), 1);
+        assert_eq!(repair_dangling_tool_calls(&mut messages), 1);
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[2]["role"], "tool");
+        assert_eq!(messages[2]["tool_call_id"], "keep");
+        // Every remaining call id has exactly one matching result.
+        let ids: Vec<&str> = messages[1]["tool_calls"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|c| c["id"].as_str().unwrap())
+            .collect();
+        assert_eq!(ids, vec!["keep"]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

A session could get permanently wedged by its own saved history. When a model ends a stream mid-argument while still reporting `finish_reason: "tool_calls"`, the truncated `function.arguments` string is persisted into the thread verbatim. Every subsequent turn resends it, and an OpenAI-compatible upstream rejects the **whole request** with a 422 - so the run can never make progress. Resuming the thread hits the same wall.

Nothing caught this before: the existing `repair_dangling_tool_calls` handles *missing results*, not *malformed arguments*.

## The fix

`drop_malformed_tool_calls` (`upstream.rs`) drops any tool call whose `function.arguments` is present but unparsable, plus the orphaned `role: "tool"` reply carrying its `tool_call_id`. It is wired at the same seam every outbound message array already passes through in `run_turn_cycle` (`loop.rs`), as a sibling of the established `repair_dangling_tool_calls` convention - so a surviving call that lost its result still gets that pass's synthetic error reply.

### Deliberate choices

- **Removal, not reconstruction.** A truncated argument is unrecoverable; inventing one would run a tool the model never actually requested.
- **Absent/empty `arguments` is left alone** - that is the valid "no arguments" spelling, not corruption.
- **Valid sibling calls survive.** An assistant turn keeps its text and loses only `tool_calls`, and is dropped entirely if that leaves it contentless (which some providers reject).

## Verification

`cargo test --locked --no-default-features --features cli --lib` - **1084 passed, 0 failed**. Clippy clean on both changed files; no new rustfmt noise (66 diffs in `loop.rs`, 12 in `upstream.rs` - byte-identical to `dev`).

Six new tests. The load-bearing one is `poisoned_history_wedges_a_strict_upstream_until_sanitized`, which drives the real `run_turn_cycle` against a strict model that rejects like the real upstream, and asserts **both directions**: the unsanitized history *is* rejected (wedge reproduced), then the same history is accepted and the turn completes.

### A/B on the actual `jan` binary

Beyond unit tests, this was verified end-to-end. A thread was planted at `<project>/.jan/agent/threads/` whose assistant turn carries `arguments = {"path":"src/a.rs","content":"fn ma` (verified unparsable) plus its orphaned `tool` result. The upstream is a fake that does what the real one does: 422 the whole request if any inbound tool call has unparsable arguments. Same thread, same command, only the sanitizer toggled.

**Baseline (sanitizer disabled, rebuilt):**
```
is_error: true, stop_reason: "error", num_turns: 1
upstream_error: HTTP 422 ... invalid tool call arguments for ['call_trunc']
upstream saw: REJECTED_422=True bad=['call_trunc']
```

**With the fix:**
```
WARN agent: dropped 1 tool call(s) with unparsable arguments from history
is_error: false, stop_reason: "stop", result: "healed: history is clean."
usage: 11 prompt / 5 completion / 16 total
upstream saw: REJECTED_422=False bad=[] (no tool_calls, no tool_call_id present)
```

The 422 becomes a clean completion, and the poisoned call never reaches the wire.
