### PR TITLE
fix: Increase Context Size works for custom OpenAI endpoints

### DIFF
--- a/web-app/src/containers/DropdownModelProvider.tsx
+++ b/web-app/src/containers/DropdownModelProvider.tsx
@@ -497,9 +497,7 @@ const DropdownModelProvider = memo(function DropdownModelProvider({
               </Tooltip>
               <ChevronsUpDown className="size-4 shrink-0 text-muted-foreground" />
             </button>
-          {currentModel?.settings &&
-            provider &&
-            provider.provider === 'llamacpp' && (
+          {currentModel && provider && (
               <div onClick={(e) => e.stopPropagation()}>
                 <ModelSetting
                   model={currentModel as Model}

--- a/web-app/src/containers/ModelSetting.tsx
+++ b/web-app/src/containers/ModelSetting.tsx
@@ -22,6 +22,11 @@ import { cn, getModelDisplayName } from '@/lib/utils'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { useAppState } from '@/hooks/useAppState'
 import { paramsSettings, samplerKeysForProvider } from '@/lib/predefinedParams'
+import {
+  createRemoteCtxLenSetting,
+  isLocalEngineProvider,
+  REMOTE_CTX_LEN_DESCRIPTION,
+} from '@/lib/model-context-size'
 
 type ModelSettingProps = {
   provider: ProviderObject
@@ -136,13 +141,19 @@ function useModelSettingControls(model: Model, provider: ProviderObject) {
     if (!provider) return
 
     // Create a copy of the model with updated settings
+    const remoteCtxTemplate =
+      key === 'ctx_len' && !isLocalEngineProvider(provider.provider)
+        ? createRemoteCtxLenSetting(typeof value === 'boolean' ? '' : value)
+        : undefined
     const updatedModel = {
       ...model,
       settings: {
         ...model.settings,
         [key]: {
+          ...(remoteCtxTemplate ?? {}),
           ...(model.settings?.[key] != null ? model.settings?.[key] : {}),
           controller_props: {
+            ...(remoteCtxTemplate?.controller_props ?? {}),
             ...(model.settings?.[key]?.controller_props ?? {}),
             value: value,
           },
@@ -165,17 +176,18 @@ function useModelSettingControls(model: Model, provider: ProviderObject) {
         models: updatedModels,
       })
 
-      // Call debounced stopModel only when updating settings that require restart,
-      // and only if the model is currently running
+      // Call debounced stopModel only when updating settings that require restart
+      // of a local engine. Remote/OpenAI-compatible endpoints have nothing to unload.
       if (
-        key === 'ctx_len' ||
-        key === 'ngl' ||
-        key === 'chat_template' ||
-        key === 'offload_mmproj' ||
-        key === 'batch_size' ||
-        key === 'cpu_moe' ||
-        key === 'n_cpu_moe' ||
-        key === 'n_cpu_ffn'
+        isLocalEngineProvider(provider.provider) &&
+        (key === 'ctx_len' ||
+          key === 'ngl' ||
+          key === 'chat_template' ||
+          key === 'offload_mmproj' ||
+          key === 'batch_size' ||
+          key === 'cpu_moe' ||
+          key === 'n_cpu_moe' ||
+          key === 'n_cpu_ffn')
       ) {
         // Check if model is running before stopping it
         serviceHub
@@ -315,7 +327,27 @@ export function ModelSettingFields({ model, provider }: ModelSettingProps) {
             </div>
           )}
           {(() => {
-            return Object.entries(model.settings || {})
+            const settings = model.settings || {}
+            const displaySettings =
+              !isLocalEngineProvider(provider.provider) && !settings.ctx_len
+                ? { ...settings, ctx_len: createRemoteCtxLenSetting('') }
+                : !isLocalEngineProvider(provider.provider) && settings.ctx_len
+                  ? {
+                      ...settings,
+                      ctx_len: {
+                        ...createRemoteCtxLenSetting(
+                          settings.ctx_len.controller_props?.value ?? ''
+                        ),
+                        ...settings.ctx_len,
+                        description: REMOTE_CTX_LEN_DESCRIPTION,
+                        controller_props: {
+                          ...createRemoteCtxLenSetting('').controller_props,
+                          ...settings.ctx_len.controller_props,
+                        },
+                      },
+                    }
+                  : settings
+            return Object.entries(displaySettings)
           .reduce<[string, unknown][]>((acc, entry) => {
             if (entry[0] === 'reasoning') return acc
             // Rendered by the dedicated ChatTemplateKwargs section above.

--- a/web-app/src/containers/dialogs/AddModel.tsx
+++ b/web-app/src/containers/dialogs/AddModel.tsx
@@ -17,6 +17,10 @@ import { getProviderTitle } from '@/lib/utils'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { getModelCapabilities } from '@/lib/models'
 import { toast } from 'sonner'
+import {
+  isLocalEngineProvider,
+  withRemoteCtxLen,
+} from '@/lib/model-context-size'
 
 type DialogAddModelProps = {
   provider: ModelProvider
@@ -46,7 +50,8 @@ export const DialogAddModel = ({ provider, trigger }: DialogAddModelProps) => {
       return // Don't submit if model ID already exists
     }
 
-    // Create the new model
+    // Create the new model. Remote/OpenAI-compatible models get a ctx_len
+    // setting so Context Size is editable and the overflow banner can persist it.
     const newModel = {
       id: modelId,
       model: modelId,
@@ -54,9 +59,12 @@ export const DialogAddModel = ({ provider, trigger }: DialogAddModelProps) => {
       capabilities: getModelCapabilities(provider.provider, modelId),
       version: '1.0',
     }
+    const seededModel = isLocalEngineProvider(provider.provider)
+      ? newModel
+      : withRemoteCtxLen(newModel)
 
     // Update the provider with the new model
-    const updatedModels = [...provider.models, newModel]
+    const updatedModels = [...provider.models, seededModel]
     updateProvider(provider.provider, {
       ...provider,
       models: updatedModels,

--- a/web-app/src/hooks/__tests__/useModelProvider.coverage.test.ts
+++ b/web-app/src/hooks/__tests__/useModelProvider.coverage.test.ts
@@ -379,6 +379,20 @@ describe('useModelProvider - coverage', () => {
         expect(migrated.providers[0].models[0].settings.cpu_moe).toBeDefined()
         expect(migrated.providers[0].models[0].settings.n_cpu_moe).toBeDefined()
       }],
+      [19, 'v20 seeds ctx_len on remote models, leaves llamacpp alone', {
+        providers: [
+          { provider: 'custom-ollama', models: [{ id: 'llama3', capabilities: [], settings: {} }], settings: [] },
+          { provider: 'llamacpp', models: [{ id: 'local', capabilities: [], settings: { ctx_len: { controller_props: { value: 4096 } } } }], settings: [] },
+        ],
+        deletedModels: [],
+      }, (migrated: any) => {
+        expect(
+          migrated.providers[0].models[0].settings.ctx_len.controller_props.value
+        ).toBe('')
+        expect(
+          migrated.providers[1].models[0].settings.ctx_len.controller_props.value
+        ).toBe(4096)
+      }],
     ])('handles version <= %i: %s', (version, _label, state, verify) => {
       const migrate = getMigrate()
       if (migrate) {

--- a/web-app/src/hooks/useModelProvider.ts
+++ b/web-app/src/hooks/useModelProvider.ts
@@ -7,6 +7,10 @@ import { modelSettings } from '@/lib/predefined'
 import { predefinedProviders } from '@/constants/providers'
 import { isLocalProvider } from '@/lib/utils'
 import { API_KEY_FALLBACKS_SETTING_KEY } from '@/lib/provider-api-keys'
+import {
+  isLocalEngineProvider,
+  seedRemoteModelsCtxLen,
+} from '@/lib/model-context-size'
 
 const API_KEY_SETTING_KEY = 'api-key'
 
@@ -795,9 +799,21 @@ export const useModelProvider = create<ModelProviderState>()(
           })
         }
 
+        if (version <= 19 && state?.providers) {
+          // Custom / OpenAI-compatible models had no ctx_len, so the overflow
+          // banner used a phantom 8k/32k cap and Increase Context Size was a
+          // no-op. Seed the existing ctx_len setting (empty = no client cap).
+          state.providers.forEach((provider) => {
+            if (isLocalEngineProvider(provider.provider) || !provider.models) {
+              return
+            }
+            provider.models = seedRemoteModelsCtxLen(provider.models) ?? []
+          })
+        }
+
         return state
       },
-      version: 19,
+      version: 20,
     }
   )
 )

--- a/web-app/src/lib/__tests__/model-context-size.test.ts
+++ b/web-app/src/lib/__tests__/model-context-size.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest'
+import { OUT_OF_CONTEXT_SIZE } from '@/utils/error'
+import {
+  applyCtxLenToModel,
+  contextOverflowMessage,
+  ctxLenMax,
+  findProviderModelIndex,
+  getModelCtxLen,
+  isLocalEngineProvider,
+  nextCtxLen,
+  parseCtxLen,
+  REMOTE_CTX_LEN_MAX,
+  seedRemoteModelsCtxLen,
+  withRemoteCtxLen,
+} from '../model-context-size'
+
+describe('parseCtxLen', () => {
+  it('reads positive numbers', () => {
+    expect(parseCtxLen(8192)).toBe(8192)
+    expect(parseCtxLen(0)).toBeUndefined()
+    expect(parseCtxLen(-1)).toBeUndefined()
+    expect(parseCtxLen(Number.NaN)).toBeUndefined()
+  })
+
+  it('reads numeric strings and treats empty as unset', () => {
+    expect(parseCtxLen('32768')).toBe(32768)
+    expect(parseCtxLen('')).toBeUndefined()
+    expect(parseCtxLen('  ')).toBeUndefined()
+    expect(parseCtxLen('nope')).toBeUndefined()
+  })
+})
+
+describe('getModelCtxLen', () => {
+  it('returns undefined when ctx_len is missing or empty', () => {
+    expect(getModelCtxLen(undefined)).toBeUndefined()
+    expect(getModelCtxLen({ id: 'm' } as Model)).toBeUndefined()
+    expect(
+      getModelCtxLen({
+        id: 'm',
+        settings: { ctx_len: { controller_props: { value: '' } } },
+      } as Model)
+    ).toBeUndefined()
+  })
+
+  it('reads the persisted controller value', () => {
+    expect(
+      getModelCtxLen({
+        id: 'm',
+        settings: { ctx_len: { controller_props: { value: 98304 } } },
+      } as Model)
+    ).toBe(98304)
+  })
+})
+
+describe('nextCtxLen', () => {
+  it('uses the local 8k → 32k → ×1.5 ladder', () => {
+    expect(nextCtxLen(4096, { max: 131072 })).toBe(8192)
+    expect(nextCtxLen(8192, { max: 131072 })).toBe(32768)
+    expect(nextCtxLen(32768, { max: 131072 })).toBe(49152)
+  })
+
+  it('caps at max so a fully-grown local window is a no-op', () => {
+    expect(nextCtxLen(131072, { max: 131072 })).toBe(131072)
+  })
+
+  it('jumps a remote 8k/32k default past a ~34k prompt in one click', () => {
+    expect(nextCtxLen(8192, { max: REMOTE_CTX_LEN_MAX, remote: true })).toBe(
+      65536
+    )
+    expect(nextCtxLen(32768, { max: REMOTE_CTX_LEN_MAX, remote: true })).toBe(
+      65536
+    )
+    const next = nextCtxLen(8192, {
+      max: REMOTE_CTX_LEN_MAX,
+      remote: true,
+      minNeeded: 34000,
+    })
+    expect(next).toBeGreaterThan(34000 / 0.9)
+    expect(next).toBe(65536)
+  })
+
+  it('honors minNeeded when the overflow is larger than the next step', () => {
+    const next = nextCtxLen(65536, {
+      max: REMOTE_CTX_LEN_MAX,
+      remote: true,
+      minNeeded: 200000,
+    })
+    expect(next).toBeGreaterThan(200000 / 0.9)
+  })
+})
+
+describe('withRemoteCtxLen / seedRemoteModelsCtxLen', () => {
+  it('seeds ctx_len without inventing a client cap', () => {
+    const seeded = withRemoteCtxLen({ id: 'llama3.1', model: 'llama3.1' })
+    expect(seeded.settings?.ctx_len?.key).toBe('ctx_len')
+    expect(seeded.settings?.ctx_len?.title).toBe('Context Size')
+    expect(seeded.settings?.ctx_len?.controller_props?.value).toBe('')
+    expect(getModelCtxLen(seeded as Model)).toBeUndefined()
+  })
+
+  it('does not overwrite an existing ctx_len', () => {
+    const existing = {
+      id: 'm',
+      settings: {
+        ctx_len: { controller_props: { value: 98304 } },
+      },
+    }
+    expect(withRemoteCtxLen(existing).settings?.ctx_len?.controller_props?.value).toBe(
+      98304
+    )
+  })
+
+  it('seeds every model that lacks ctx_len', () => {
+    const models = seedRemoteModelsCtxLen([
+      { id: 'a' },
+      { id: 'b', settings: { ctx_len: { controller_props: { value: 4096 } } } },
+    ])
+    expect(models?.[0].settings?.ctx_len?.controller_props?.value).toBe('')
+    expect(models?.[1].settings?.ctx_len?.controller_props?.value).toBe(4096)
+  })
+})
+
+describe('applyCtxLenToModel', () => {
+  it('writes a complete remote ctx_len setting so ModelSetting can render it', () => {
+    const updated = applyCtxLenToModel({ id: 'm' } as Model, 65536, true)
+    expect(updated.settings?.ctx_len?.key).toBe('ctx_len')
+    expect(updated.settings?.ctx_len?.controller_type).toBe('input')
+    expect(updated.settings?.ctx_len?.controller_props?.value).toBe(65536)
+    expect(updated.settings?.ctx_len?.title).toBe('Context Size')
+  })
+
+  it('preserves a local ctx_len max when raising the value', () => {
+    const updated = applyCtxLenToModel(
+      {
+        id: 'local',
+        settings: {
+          ctx_len: { controller_props: { value: 4096, max: 32768 } },
+        },
+      } as Model,
+      8192,
+      false
+    )
+    expect(updated.settings?.ctx_len?.controller_props?.value).toBe(8192)
+    expect(updated.settings?.ctx_len?.controller_props?.max).toBe(32768)
+  })
+})
+
+describe('Increase Context Size for a custom endpoint model', () => {
+  it('raises and persists ctx_len far enough that a ~34k prompt is no longer client-capped', () => {
+    const model = withRemoteCtxLen({
+      id: 'qwen3',
+      model: 'qwen3',
+    }) as Model
+    expect(getModelCtxLen(model)).toBeUndefined()
+
+    const raised = nextCtxLen(0, {
+      max: ctxLenMax(model, true),
+      remote: true,
+      minNeeded: 34000,
+    })
+    expect(raised).toBeGreaterThan(34000 / 0.9)
+
+    const persisted = applyCtxLenToModel(model, raised, true)
+    expect(getModelCtxLen(persisted)).toBe(raised)
+    expect(persisted.settings?.ctx_len?.key).toBe('ctx_len')
+    expect(34000 >= getModelCtxLen(persisted)! * 0.9).toBe(false)
+  })
+})
+
+describe('findProviderModelIndex', () => {
+  const models = [
+    { id: 'alpha', model: 'alpha' },
+    { id: 'beta-id', model: 'beta' },
+  ] as Model[]
+
+  it('matches by id, then model field', () => {
+    expect(findProviderModelIndex(models, { id: 'alpha' })).toBe(0)
+    expect(findProviderModelIndex(models, { id: 'missing', model: 'beta' })).toBe(
+      1
+    )
+    expect(findProviderModelIndex(models, { id: 'nope' })).toBe(-1)
+  })
+})
+
+describe('ctxLenMax / isLocalEngineProvider / contextOverflowMessage', () => {
+  it('uses a 1M remote max and 128k local max by default', () => {
+    expect(isLocalEngineProvider('llamacpp')).toBe(true)
+    expect(isLocalEngineProvider('mlx')).toBe(true)
+    expect(isLocalEngineProvider('ollama-custom')).toBe(false)
+    expect(ctxLenMax(undefined, true)).toBe(REMOTE_CTX_LEN_MAX)
+    expect(ctxLenMax(undefined, false)).toBe(131072)
+  })
+
+  it('embeds token counts so a later Increase click can clear the overflow', () => {
+    expect(contextOverflowMessage(34000, 8192)).toBe(
+      'request (34000 tokens) exceeds the available context size (8192 tokens)'
+    )
+    expect(contextOverflowMessage()).toBe(OUT_OF_CONTEXT_SIZE)
+  })
+})

--- a/web-app/src/lib/model-context-size.ts
+++ b/web-app/src/lib/model-context-size.ts
@@ -1,0 +1,183 @@
+import { modelSettings } from '@/lib/predefined'
+import { OUT_OF_CONTEXT_SIZE } from '@/utils/error'
+
+/** llama.cpp / MLX: ctx_len is an engine load parameter. */
+export function isLocalEngineProvider(providerName: string): boolean {
+  return providerName === 'llamacpp' || providerName === 'mlx'
+}
+
+export const REMOTE_CTX_LEN_DESCRIPTION =
+  "Client-side context budget used for overflow detection. Does not change the remote model's window. Leave empty to disable the client cap."
+
+export const REMOTE_CTX_LEN_MAX = 1_048_576
+export const LOCAL_CTX_LEN_MAX = 131_072
+
+export function parseCtxLen(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+    return value
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const n = Number(value)
+    if (Number.isFinite(n) && n > 0) return n
+  }
+  return undefined
+}
+
+export function getModelCtxLen(
+  model: Model | null | undefined
+): number | undefined {
+  return parseCtxLen(model?.settings?.ctx_len?.controller_props?.value)
+}
+
+/**
+ * Next context length after a manual "Increase Context Size" click.
+ *
+ * Local engines keep the historical 8k → 32k → ×1.5 ladder (VRAM-sensitive).
+ * Remote/OpenAI-compatible providers jump more aggressively so a ~34k prompt
+ * is not still blocked after the first click, and honor `minNeeded` when the
+ * overflow error includes a token count.
+ */
+export function nextCtxLen(
+  current: number,
+  options: {
+    max: number
+    minNeeded?: number
+    remote?: boolean
+  }
+): number {
+  const { max, minNeeded, remote } = options
+  const safeCurrent = Number.isFinite(current) && current > 0 ? current : 0
+
+  let next: number
+  if (remote) {
+    if (safeCurrent < 65536) next = 65536
+    else if (safeCurrent < 131072) next = 131072
+    else next = Math.round(safeCurrent * 1.5)
+  } else if (safeCurrent < 8192) {
+    next = 8192
+  } else if (safeCurrent < 32768) {
+    next = 32768
+  } else {
+    next = Math.round(safeCurrent * 1.5)
+  }
+
+  if (minNeeded != null && Number.isFinite(minNeeded) && minNeeded > 0) {
+    // Overflow heuristic is tokens >= ctx * 0.9, so the new cap must exceed that.
+    const required = Math.ceil(minNeeded / 0.9) + 1
+    const rounded = Math.ceil(required / 1024) * 1024
+    next = Math.max(next, rounded)
+  }
+
+  return Math.min(next, max)
+}
+
+export function ctxLenMax(
+  model: Model | null | undefined,
+  remote: boolean
+): number {
+  const configured = parseCtxLen(model?.settings?.ctx_len?.controller_props?.max)
+  if (configured) return configured
+  return remote ? REMOTE_CTX_LEN_MAX : LOCAL_CTX_LEN_MAX
+}
+
+export function createRemoteCtxLenSetting(
+  value: number | string = ''
+): ProviderSetting {
+  return {
+    ...modelSettings.ctx_len,
+    description: REMOTE_CTX_LEN_DESCRIPTION,
+    controller_props: {
+      ...modelSettings.ctx_len.controller_props,
+      value,
+      placeholder: '131072',
+      max: REMOTE_CTX_LEN_MAX,
+    },
+  }
+}
+
+export function withRemoteCtxLen<T extends { settings?: Model['settings'] }>(
+  model: T
+): T {
+  if (model.settings?.ctx_len) return model
+  return {
+    ...model,
+    settings: {
+      ...model.settings,
+      ctx_len: createRemoteCtxLenSetting(''),
+    },
+  }
+}
+
+export function seedRemoteModelsCtxLen<T extends { settings?: Model['settings'] }>(
+  models: T[] | undefined
+): T[] | undefined {
+  if (!models) return models
+  return models.map((model) => withRemoteCtxLen(model))
+}
+
+export function applyCtxLenToModel(
+  model: Model,
+  newValue: number,
+  remote: boolean
+): Model {
+  const existing = model.settings?.ctx_len
+  const base = remote
+    ? createRemoteCtxLenSetting(newValue)
+    : {
+        ...modelSettings.ctx_len,
+        ...(existing ?? {}),
+        controller_props: {
+          ...modelSettings.ctx_len.controller_props,
+          ...(existing?.controller_props ?? {}),
+          value: newValue,
+        },
+      }
+  return {
+    ...model,
+    settings: {
+      ...model.settings,
+      ctx_len: remote
+        ? {
+            ...base,
+            ...(existing ?? {}),
+            controller_props: {
+              ...base.controller_props,
+              ...(existing?.controller_props ?? {}),
+              value: newValue,
+              max: existing?.controller_props?.max ?? REMOTE_CTX_LEN_MAX,
+            },
+          }
+        : base,
+    },
+  }
+}
+
+export function findProviderModelIndex(
+  models: Model[],
+  selected: Pick<Model, 'id' | 'model'>
+): number {
+  const byId = models.findIndex((m) => m.id === selected.id)
+  if (byId !== -1) return byId
+  if (selected.model) {
+    const byModel = models.findIndex(
+      (m) => m.id === selected.model || m.model === selected.model
+    )
+    if (byModel !== -1) return byModel
+  }
+  return models.findIndex((m) => m.model === selected.id)
+}
+
+export function contextOverflowMessage(
+  promptTokens?: number,
+  ctxTokens?: number
+): string {
+  if (
+    promptTokens != null &&
+    ctxTokens != null &&
+    Number.isFinite(promptTokens) &&
+    Number.isFinite(ctxTokens)
+  ) {
+    return `request (${promptTokens} tokens) exceeds the available context size (${ctxTokens} tokens)`
+  }
+  return OUT_OF_CONTEXT_SIZE
+}

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -40,6 +40,10 @@ import { useAppState } from '@/hooks/useAppState'
 import { useShallow } from 'zustand/shallow'
 import { DialogAddModel } from '@/containers/dialogs/AddModel'
 import {
+  isLocalEngineProvider,
+  withRemoteCtxLen,
+} from '@/lib/model-context-size'
+import {
   providerHasRemoteApiKeys,
   providerRemoteApiKeyChain,
   API_KEY_FALLBACKS_SETTING_KEY,
@@ -505,6 +509,10 @@ function ProviderDetail() {
           capabilities: ['completion'],
           version: '1.0',
         }))
+      }
+
+      if (!isLocalEngineProvider(provider.provider)) {
+        newModels = newModels.map((m) => withRemoteCtxLen(m))
       }
 
       if (supportsRemoteCatalog(provider)) {
@@ -1115,8 +1123,7 @@ function ProviderDetail() {
                               provider={provider}
                               modelId={model.id}
                             />
-                            {model.settings && provider &&
-                              provider.provider === 'llamacpp' && (
+                            {provider && (
                               <ModelSetting provider={provider} model={model} />
                             )}
                             {((provider &&

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -71,6 +71,15 @@ import {
   isContextOverflowMessage,
   parseContextOverflow,
 } from '@/utils/error'
+import {
+  applyCtxLenToModel,
+  contextOverflowMessage,
+  ctxLenMax,
+  findProviderModelIndex,
+  getModelCtxLen,
+  isLocalEngineProvider,
+  nextCtxLen,
+} from '@/lib/model-context-size'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { Button } from '@/components/ui/button'
 import { IconAlertCircle, IconRefresh, IconLoader2 } from '@tabler/icons-react'
@@ -316,15 +325,22 @@ function ThreadDetail() {
       // of the new message, so the user sees the partial text immediately.
       if (!isAbort && finishReason === 'length') {
         const selectedModelState = useModelProvider.getState().selectedModel
+        const selectedProviderState =
+          useModelProvider.getState().selectedProvider
         const usage = msgMeta?.usage as
           | { inputTokens?: number; outputTokens?: number }
           | undefined
         const totalTokens =
           (usage?.inputTokens ?? 0) + (usage?.outputTokens ?? 0)
-        const ctxLen =
-          (selectedModelState?.settings?.ctx_len?.controller_props
-            ?.value as number) ?? 32768
-        const isContextLimit = totalTokens >= ctxLen * 0.9
+        const ctxLen = getModelCtxLen(selectedModelState)
+        // Remote/OpenAI-compatible models have no engine window. A missing
+        // ctx_len must not invent an 8k/32k client cap — that is what blocked
+        // long prompts that the backend would accept. Local engines keep the
+        // historical 32k fallback because llama.cpp always has a real n_ctx.
+        const remote = !isLocalEngineProvider(selectedProviderState)
+        const effectiveCtxLen = ctxLen ?? (remote ? undefined : 32768)
+        const isContextLimit =
+          effectiveCtxLen != null && totalTokens >= effectiveCtxLen * 0.9
 
         if (isContextLimit) {
           // Stash the partial so the manual "Increase Context Size" button can
@@ -337,8 +353,12 @@ function ThreadDetail() {
           if (partialText) {
             pendingContinuationRef.current = { message, text: partialText }
           }
-          stampContextErrorOnThread(threadId)
-          setContextLimitError(new Error(OUT_OF_CONTEXT_SIZE))
+          const overflowMsg = contextOverflowMessage(
+            totalTokens,
+            effectiveCtxLen
+          )
+          stampContextErrorOnThread(threadId, overflowMsg)
+          setContextLimitError(new Error(overflowMsg))
           return
         }
         // Non-context-limit length truncation: fall through and persist the
@@ -1467,51 +1487,32 @@ function ThreadDetail() {
     const provider = getProviderByName(selectedProvider)
     if (!provider) return
 
-    const modelIndex = provider.models.findIndex(
-      (m) => m.id === selectedModel.id
-    )
+    const modelIndex = findProviderModelIndex(provider.models, selectedModel)
     if (modelIndex === -1) return
 
     const model = provider.models[modelIndex]
+    const remote = !isLocalEngineProvider(provider.provider)
 
-    // Increase context length in steps: <8192 -> 8192 -> 32768 -> x1.5
-    const currentCtxLen =
-      (model.settings?.ctx_len?.controller_props?.value as number) ?? 8192
-    const maxCtxLen =
-      (model.settings?.ctx_len?.controller_props?.max as number) || 131072
+    const overflow = contextLimitError
+      ? parseContextOverflow(contextLimitError.message)
+      : null
+    const currentCtxLen = getModelCtxLen(model) ?? (remote ? 0 : 8192)
+    const maxCtxLen = ctxLenMax(model, remote)
+    const newCtxLen = nextCtxLen(currentCtxLen, {
+      max: maxCtxLen,
+      remote,
+      minNeeded: overflow?.requestTokens,
+    })
 
-    let newCtxLen: number
-    if (currentCtxLen < 8192) {
-      newCtxLen = 8192
-    } else if (currentCtxLen < 32768) {
-      newCtxLen = 32768
-    } else {
-      newCtxLen = Math.round(currentCtxLen * 1.5)
-    }
-
-    newCtxLen = Math.min(newCtxLen, maxCtxLen)
     if (newCtxLen <= currentCtxLen) {
       stampContextErrorOnThread(threadId)
       setContextLimitError(new Error(OUT_OF_CONTEXT_SIZE))
       return
     }
 
-    const updatedModel = {
-      ...model,
-      settings: {
-        ...model.settings,
-        ctx_len: {
-          ...(model.settings?.ctx_len ?? {}),
-          controller_props: {
-            ...(model.settings?.ctx_len?.controller_props ?? {}),
-            value: newCtxLen,
-          },
-        },
-      },
-    }
-
+    const updatedModel = applyCtxLenToModel(model, newCtxLen, remote)
     const updatedModels = [...provider.models]
-    updatedModels[modelIndex] = updatedModel as Model
+    updatedModels[modelIndex] = updatedModel
 
     updateProvider(provider.provider, {
       models: updatedModels,
@@ -1520,7 +1521,10 @@ function ThreadDetail() {
     // For llamacpp the router reads ctx-size from the preset, not from any
     // request param — so we must write model.yml and bounce the router before
     // the regenerate, otherwise the next load picks up the OLD context size.
-    // Other providers consume the new Zustand value directly on next load.
+    // Remote providers persist via Zustand (updateProvider) and consume the
+    // new value on the next request. Do not call stopModel — it defaults to
+    // the llamacpp engine and can throw, which aborted regenerate and made
+    // Increase Context Size look like a no-op.
     if (provider.provider === 'llamacpp') {
       try {
         await serviceHub
@@ -1535,8 +1539,6 @@ function ThreadDetail() {
         setContextLimitError(new Error(OUT_OF_CONTEXT_SIZE))
         return
       }
-    } else {
-      await serviceHub.models().stopModel(selectedModel.id)
     }
 
     // Consume any pending partial captured at the `finishReason === 'length'`
@@ -1549,9 +1551,13 @@ function ThreadDetail() {
       setPendingContinueMessage(pending.message)
     }
 
-    setTimeout(() => {
+    if (provider.provider === 'llamacpp') {
+      setTimeout(() => {
+        handleRegenerate()
+      }, 1000)
+    } else {
       handleRegenerate()
-    }, 1000)
+    }
   }, [
     selectedModel,
     selectedProvider,
@@ -1559,6 +1565,7 @@ function ThreadDetail() {
     serviceHub,
     handleRegenerate,
     threadId,
+    contextLimitError,
   ])
 
   // Keep refs in sync so onFinish always calls the latest versions


### PR DESCRIPTION
Fixes #8669

custom / openai-compatible models had no `ctx_len`, so the overflow banner used a fake 32k cap and the increase button either no-op'd (`stopModel` is llamacpp) or jumped 8k→32k and still blocked a ~34k prompt.

now those models get a persistable Context Size, increase skips `stopModel`, and a missing cap is not treated as 32k.

thx