### PR TITLE
fix(mcp): cap tool-result size before it enters conversation history

### DIFF
--- a/src-tauri/src/core/agent/upstream.rs
+++ b/src-tauri/src/core/agent/upstream.rs
@@ -26,6 +26,7 @@ use crate::core::server::proxy::router_upstream;
 use crate::core::server::MlxBackendSession;
 use crate::core::{
     mcp::models::McpSettings,
+    mcp::truncate::truncate_tool_result,
     state::{ProviderConfig, SharedMcpServers},
 };
 
@@ -506,7 +507,13 @@ pub(crate) async fn execute_mcp_tool_calls(
     mcp_servers: &SharedMcpServers,
     mcp_settings: &Arc<Mutex<McpSettings>>,
 ) -> Vec<(String, String)> {
-    let timeout_duration = mcp_settings.lock().await.tool_call_timeout_duration();
+    let (timeout_duration, tool_output_cap) = {
+        let settings = mcp_settings.lock().await;
+        (
+            settings.tool_call_timeout_duration(),
+            settings.tool_output_cap(None),
+        )
+    };
     let servers = mcp_servers.lock().await;
 
     let mut results = Vec::with_capacity(tool_calls.len());
@@ -570,7 +577,9 @@ pub(crate) async fn execute_mcp_tool_calls(
         };
 
         let tool_result_string = match result {
-            Ok(res) => mcp_call_result_to_string(&res),
+            // Same cap as the desktop path: this string is appended to the agent's
+            // message history, so an unbounded result would blow the context here too.
+            Ok(res) => mcp_call_result_to_string(&truncate_tool_result(&res, tool_output_cap)),
             Err(e) => format!("ERROR: {e}"),
         };
 

--- a/src-tauri/src/core/mcp/commands.rs
+++ b/src-tauri/src/core/mcp/commands.rs
@@ -8,6 +8,7 @@ use tokio::time::timeout;
 use super::{
     constants::DEFAULT_MCP_CONFIG,
     helpers::{restart_active_mcp_servers, start_mcp_server, terminate_browser_mcp},
+    truncate::truncate_tool_result,
 };
 use crate::core::{
     app::commands::get_jan_data_folder_path,
@@ -389,6 +390,9 @@ pub async fn get_server_summaries(
 /// * `server_name` - Optional name of the server to call the tool from (for disambiguation)
 /// * `arguments` - Optional map of argument names to values
 /// * `cancellation_token` - Optional token to allow cancellation from JS side
+/// * `max_output_chars` - Optional caller-derived per-result character budget
+///   (the desktop chat derives one from the active model's context window);
+///   combined with the `maxToolOutputChars` setting, tighter wins
 ///
 /// # Returns
 /// * `Result<CallToolResult, String>` - Result of the tool call if successful, or error message if failed
@@ -407,8 +411,15 @@ pub async fn call_tool(
     server_name: Option<String>,
     arguments: Option<Map<String, Value>>,
     cancellation_token: Option<String>,
+    max_output_chars: Option<u64>,
 ) -> Result<CallToolResult, String> {
-    let timeout_duration = tool_call_timeout(&state).await;
+    let (timeout_duration, tool_output_cap) = {
+        let settings = state.mcp_settings.lock().await;
+        (
+            settings.tool_call_timeout_duration(),
+            settings.tool_output_cap(max_output_chars),
+        )
+    };
     // Set up cancellation if token is provided
     let (cancel_tx, cancel_rx) = oneshot::channel::<()>();
 
@@ -508,7 +519,10 @@ pub async fn call_tool(
         }
 
         cleanup_cancellation_token(&state, &cancellation_token).await;
-        return result;
+        // Cap here rather than at each caller: this is the single point every
+        // desktop MCP tool result passes through on its way into conversation
+        // history, so an unbounded result can never reach the model.
+        return result.map(|res| truncate_tool_result(&res, tool_output_cap));
     }
 
     // No server had the tool — check if it's because of transport errors

--- a/src-tauri/src/core/mcp/constants.rs
+++ b/src-tauri/src/core/mcp/constants.rs
@@ -1,6 +1,13 @@
 // Default MCP runtime settings
 pub const DEFAULT_MCP_TOOL_CALL_TIMEOUT_SECS: u64 = 30;
 
+/// Per-tool-result character cap applied before the result enters conversation
+/// history. A single unbounded result (a full browser page snapshot, say) can
+/// otherwise consume the whole model context. Roughly 12k tokens at ~3.5
+/// chars/token: large enough for a real page, small enough to leave room for
+/// the conversation. `0` disables the cap.
+pub const DEFAULT_MCP_MAX_TOOL_OUTPUT_CHARS: u64 = 40_000;
+
 // Browser MCP teardown: how long to wait for the port to free, and the poll cadence.
 pub const MCP_PORT_FREE_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(2000);
 pub const MCP_PORT_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
@@ -63,6 +70,7 @@ pub const DEFAULT_MCP_CONFIG: &str = r#"{
     "enableSmartToolRouting": true,
     "useLightweightRouterModel": false,
     "routerModelProvider": "",
-    "routerModelId": ""
+    "routerModelId": "",
+    "maxToolOutputChars": 40000
   }
 }"#;

--- a/src-tauri/src/core/mcp/mod.rs
+++ b/src-tauri/src/core/mcp/mod.rs
@@ -13,6 +13,7 @@ pub mod models;
 pub mod oauth;
 #[cfg(not(feature = "cli"))]
 pub mod progress;
+pub mod truncate;
 
 #[cfg(test)]
 #[cfg(not(feature = "cli"))]

--- a/src-tauri/src/core/mcp/models.rs
+++ b/src-tauri/src/core/mcp/models.rs
@@ -85,6 +85,10 @@ fn default_router_model_id() -> String {
     String::new()
 }
 
+fn default_max_tool_output_chars() -> u64 {
+    super::constants::DEFAULT_MCP_MAX_TOOL_OUTPUT_CHARS
+}
+
 /// Runtime MCP settings that can be adjusted via UI
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -105,6 +109,9 @@ pub struct McpSettings {
     pub router_model_provider: String,
     #[serde(default = "default_router_model_id")]
     pub router_model_id: String,
+    /// Per-tool-result character cap; `0` disables it.
+    #[serde(default = "default_max_tool_output_chars")]
+    pub max_tool_output_chars: u64,
 }
 
 impl Default for McpSettings {
@@ -118,6 +125,7 @@ impl Default for McpSettings {
             use_lightweight_router_model: false,
             router_model_provider: String::new(),
             router_model_id: String::new(),
+            max_tool_output_chars: super::constants::DEFAULT_MCP_MAX_TOOL_OUTPUT_CHARS,
         }
     }
 }
@@ -126,6 +134,22 @@ impl McpSettings {
     /// Returns the tool call timeout duration, enforcing a minimum of 1 second to avoid zero-duration timeouts.
     pub fn tool_call_timeout_duration(&self) -> std::time::Duration {
         std::time::Duration::from_secs(self.tool_call_timeout_seconds.max(1))
+    }
+
+    /// Effective per-tool-result character cap. `0` means uncapped.
+    ///
+    /// `override_chars` is the caller's own budget - the desktop chat derives one
+    /// from the active model's context window, which the backend cannot see. The
+    /// tighter of the two wins. A user setting of `0` disables capping outright,
+    /// and an absent or `0` override simply leaves the setting in charge.
+    pub fn tool_output_cap(&self, override_chars: Option<u64>) -> u64 {
+        if self.max_tool_output_chars == 0 {
+            return 0;
+        }
+        match override_chars {
+            Some(o) if o > 0 => o.min(self.max_tool_output_chars),
+            _ => self.max_tool_output_chars,
+        }
     }
 }
 

--- a/src-tauri/src/core/mcp/tests.rs
+++ b/src-tauri/src/core/mcp/tests.rs
@@ -655,6 +655,10 @@ fn test_mcp_settings_default_matches_constants() {
     assert!(!s.use_lightweight_router_model);
     assert!(s.router_model_provider.is_empty());
     assert!(s.router_model_id.is_empty());
+    assert_eq!(
+        s.max_tool_output_chars,
+        constants::DEFAULT_MCP_MAX_TOOL_OUTPUT_CHARS
+    );
 }
 
 #[test]
@@ -669,6 +673,40 @@ fn test_mcp_settings_tool_call_timeout_duration_enforces_minimum() {
     assert_eq!(s.tool_call_timeout_duration(), Duration::from_secs(5));
     s.tool_call_timeout_seconds = 600;
     assert_eq!(s.tool_call_timeout_duration(), Duration::from_secs(600));
+}
+
+#[test]
+fn test_mcp_settings_tool_output_cap_takes_the_tighter_of_setting_and_override() {
+    use super::models::McpSettings;
+    let s = McpSettings {
+        max_tool_output_chars: 40_000,
+        ..McpSettings::default()
+    };
+
+    // No caller budget: the user's setting governs.
+    assert_eq!(s.tool_output_cap(None), 40_000);
+    // A tighter model-derived budget wins.
+    assert_eq!(s.tool_output_cap(Some(8_000)), 8_000);
+    // A looser one cannot raise the user's ceiling.
+    assert_eq!(s.tool_output_cap(Some(500_000)), 40_000);
+    // A 0 override means "no derived budget", not "uncapped".
+    assert_eq!(s.tool_output_cap(Some(0)), 40_000);
+}
+
+#[test]
+fn test_mcp_settings_zero_max_tool_output_chars_disables_capping() {
+    use super::models::McpSettings;
+    let s = McpSettings {
+        max_tool_output_chars: 0,
+        ..McpSettings::default()
+    };
+
+    assert_eq!(s.tool_output_cap(None), 0);
+    assert_eq!(
+        s.tool_output_cap(Some(8_000)),
+        0,
+        "an explicit opt-out is not overridden by a derived budget"
+    );
 }
 
 #[test]
@@ -696,6 +734,7 @@ impl PartialEq for super::models::McpSettings {
             && self.use_lightweight_router_model == other.use_lightweight_router_model
             && self.router_model_provider == other.router_model_provider
             && self.router_model_id == other.router_model_id
+            && self.max_tool_output_chars == other.max_tool_output_chars
     }
 }
 

--- a/src-tauri/src/core/mcp/truncate.rs
+++ b/src-tauri/src/core/mcp/truncate.rs
@@ -1,0 +1,240 @@
+//! Size cap for MCP tool results.
+//!
+//! A tool result is injected verbatim into conversation history, so one call to
+//! a tool that dumps a whole page (Jan Browser MCP's snapshot, for instance) can
+//! exhaust the model's context on its own, regardless of how large that context
+//! is. Everything that hands an MCP result to a model funnels through here first
+//! so the payload is bounded and the clipping is announced rather than silent.
+
+use rmcp::model::{CallToolResult, Content};
+
+/// Total text characters carried by a result, across every text block.
+fn total_text_chars(result: &CallToolResult) -> usize {
+    result
+        .content
+        .iter()
+        .filter_map(|c| c.as_text())
+        .map(|t| t.text.chars().count())
+        .sum()
+}
+
+fn truncation_marker(retained: usize, total: usize) -> String {
+    format!(
+        "[Tool output truncated: {retained} of {total} characters retained. \
+Increase \"Max tool output characters\" in Settings > MCP Servers to retain more.]"
+    )
+}
+
+/// Cap the combined text of `result` at `max_chars`, appending a marker block
+/// that reports how much was kept.
+///
+/// The budget spans all text blocks rather than each block individually, since
+/// the model receives their concatenation. Blocks are filled in order: earlier
+/// ones survive intact, the block that crosses the budget is cut mid-way, and
+/// later ones are dropped. Non-text blocks (images, resources, audio) are never
+/// counted or altered - they aren't the payload that blows up, and clipping
+/// their base64 would corrupt them.
+///
+/// `max_chars == 0` disables the cap, which is how a user opts out.
+pub fn truncate_tool_result(result: &CallToolResult, max_chars: u64) -> CallToolResult {
+    if max_chars == 0 {
+        return result.clone();
+    }
+    let max_chars = max_chars as usize;
+
+    let total = total_text_chars(result);
+    if total <= max_chars {
+        return result.clone();
+    }
+
+    let mut used = 0usize;
+    let mut new_content: Vec<Content> = Vec::with_capacity(result.content.len() + 1);
+
+    for block in &result.content {
+        let Some(text) = block.as_text() else {
+            // Non-text block: pass through untouched.
+            new_content.push(block.clone());
+            continue;
+        };
+
+        if used >= max_chars {
+            continue; // Budget spent; this block and the rest are dropped.
+        }
+
+        let len = text.text.chars().count();
+        let keep = len.min(max_chars - used);
+        used += keep;
+
+        if keep == len {
+            new_content.push(block.clone());
+        } else {
+            new_content.push(Content::text(
+                text.text.chars().take(keep).collect::<String>(),
+            ));
+        }
+    }
+
+    new_content.push(Content::text(truncation_marker(used, total)));
+
+    CallToolResult {
+        content: new_content,
+        structured_content: result.structured_content.clone(),
+        is_error: result.is_error,
+        meta: result.meta.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text_result(parts: &[&str]) -> CallToolResult {
+        CallToolResult::success(parts.iter().map(|p| Content::text(*p)).collect())
+    }
+
+    fn texts(result: &CallToolResult) -> Vec<String> {
+        result
+            .content
+            .iter()
+            .filter_map(|c| c.as_text())
+            .map(|t| t.text.clone())
+            .collect()
+    }
+
+    /// The web layer reads `content[].text` off the serialized result and feeds
+    /// it straight into conversation history, so the cap has to hold on the wire,
+    /// not just in the struct.
+    #[test]
+    fn serialized_result_the_web_layer_receives_is_bounded() {
+        // Stand-in for a Jan Browser MCP page snapshot: one enormous text block.
+        let snapshot = CallToolResult::success(vec![Content::text(
+            "<div>page</div>".repeat(100_000),
+        )]);
+
+        let capped = truncate_tool_result(&snapshot, 40_000);
+        let wire = serde_json::to_value(&capped).expect("serializes");
+
+        let blocks = wire["content"].as_array().expect("content array");
+        let wire_chars: usize = blocks
+            .iter()
+            .filter_map(|b| b["text"].as_str())
+            .map(|t| t.chars().count())
+            .sum();
+
+        assert!(
+            wire_chars < 41_000,
+            "1.5M-char snapshot reached the model as {wire_chars} chars"
+        );
+        assert!(blocks
+            .last()
+            .and_then(|b| b["text"].as_str())
+            .is_some_and(|t| t.contains("truncated")));
+    }
+
+    #[test]
+    fn small_output_passes_through_untouched() {
+        let result = text_result(&["hello world"]);
+        let capped = truncate_tool_result(&result, 100);
+
+        assert_eq!(texts(&capped), vec!["hello world".to_string()]);
+        assert_eq!(capped.content.len(), 1, "no marker on untruncated output");
+    }
+
+    #[test]
+    fn output_exactly_at_cap_is_not_truncated() {
+        let result = text_result(&["0123456789"]);
+        let capped = truncate_tool_result(&result, 10);
+
+        assert_eq!(texts(&capped), vec!["0123456789".to_string()]);
+        assert_eq!(capped.content.len(), 1);
+    }
+
+    #[test]
+    fn oversized_output_is_capped_to_max_chars() {
+        let result = text_result(&["x".repeat(5_000).as_str()]);
+        let capped = truncate_tool_result(&result, 100);
+
+        let retained: usize = capped
+            .content
+            .iter()
+            .take(capped.content.len() - 1)
+            .filter_map(|c| c.as_text())
+            .map(|t| t.text.chars().count())
+            .sum();
+        assert_eq!(retained, 100);
+    }
+
+    #[test]
+    fn truncation_marker_reports_retained_and_total() {
+        let result = text_result(&["y".repeat(5_000).as_str()]);
+        let capped = truncate_tool_result(&result, 100);
+
+        let marker = texts(&capped).pop().expect("marker block");
+        assert!(marker.contains("truncated"), "marker text: {marker}");
+        assert!(marker.contains("100 of 5000"), "marker text: {marker}");
+        assert!(
+            marker.contains("Max tool output characters"),
+            "marker points the user at the setting: {marker}"
+        );
+    }
+
+    #[test]
+    fn multi_block_budget_spans_all_text_blocks() {
+        let result = text_result(&["aaaa", "bbbb", "cccc"]);
+        let capped = truncate_tool_result(&result, 6);
+
+        let blocks = texts(&capped);
+        // First block intact, second cut mid-way, third dropped, marker appended.
+        assert_eq!(blocks[0], "aaaa");
+        assert_eq!(blocks[1], "bb");
+        assert_eq!(blocks.len(), 3, "third block dropped, marker added: {blocks:?}");
+        assert!(blocks[2].contains("6 of 12"), "marker text: {}", blocks[2]);
+    }
+
+    #[test]
+    fn non_text_blocks_survive_truncation() {
+        let result = CallToolResult::success(vec![
+            Content::text("z".repeat(1_000)),
+            Content::image("ZmFrZQ==".to_string(), "image/png".to_string()),
+        ]);
+        let capped = truncate_tool_result(&result, 10);
+
+        assert!(
+            capped.content.iter().any(|c| c.as_image().is_some()),
+            "image block must not be dropped by the text cap"
+        );
+        assert_eq!(texts(&capped)[0].chars().count(), 10);
+    }
+
+    #[test]
+    fn zero_max_chars_disables_the_cap() {
+        let result = text_result(&["w".repeat(10_000).as_str()]);
+        let capped = truncate_tool_result(&result, 0);
+
+        assert_eq!(texts(&capped)[0].chars().count(), 10_000);
+        assert_eq!(capped.content.len(), 1);
+    }
+
+    #[test]
+    fn error_flag_and_structured_content_are_preserved() {
+        let mut result = text_result(&["e".repeat(500).as_str()]);
+        result.is_error = Some(true);
+        result.structured_content = Some(serde_json::json!({ "code": 42 }));
+
+        let capped = truncate_tool_result(&result, 10);
+
+        assert_eq!(capped.is_error, Some(true));
+        assert_eq!(
+            capped.structured_content,
+            Some(serde_json::json!({ "code": 42 }))
+        );
+    }
+
+    #[test]
+    fn multibyte_text_is_cut_on_char_boundaries() {
+        let result = text_result(&["日本語テキスト".repeat(100).as_str()]);
+        let capped = truncate_tool_result(&result, 5);
+
+        assert_eq!(texts(&capped)[0], "日本語テキ");
+    }
+}

--- a/web-app/src/hooks/useMCPServers.ts
+++ b/web-app/src/hooks/useMCPServers.ts
@@ -33,6 +33,12 @@ export type MCPSettings = {
   useLightweightRouterModel: boolean
   routerModelProvider: string
   routerModelId: string
+  /**
+   * Per-tool-result character cap applied before the result enters conversation
+   * history, so one oversized result cannot exhaust the model's context. `0`
+   * disables the cap.
+   */
+  maxToolOutputChars: number
 }
 
 export const DEFAULT_MCP_SETTINGS: MCPSettings = {
@@ -44,6 +50,7 @@ export const DEFAULT_MCP_SETTINGS: MCPSettings = {
   useLightweightRouterModel: false,
   routerModelProvider: '',
   routerModelId: '',
+  maxToolOutputChars: 40000,
 }
 
 type MCPServerStoreState = {

--- a/web-app/src/lib/__tests__/context-manager.test.ts
+++ b/web-app/src/lib/__tests__/context-manager.test.ts
@@ -5,6 +5,7 @@ import {
   estimateMessageTokens,
   trimMessages,
   compactMessages,
+  deriveToolOutputCap,
   type ContextManagerConfig,
 } from '../context-manager'
 
@@ -227,5 +228,35 @@ describe('compactMessages', () => {
     expect(result.messages.length).toBeGreaterThan(0)
     // No summary generated on fallback
     expect(result.compactedSummary).toBeUndefined()
+  })
+})
+
+describe('deriveToolOutputCap', () => {
+  it('scales the budget with the model context window', () => {
+    const small = deriveToolOutputCap(8_192)
+    const large = deriveToolOutputCap(1_000_000)
+
+    expect(small).toBeGreaterThan(0)
+    expect(large).toBeGreaterThan(small!)
+  })
+
+  it('leaves most of the window for the conversation itself', () => {
+    // A single tool result must not be allowed to fill the context it lives in.
+    const ctxTokens = 100_000
+    const cap = deriveToolOutputCap(ctxTokens)!
+
+    expect(estimateTokens('x'.repeat(cap))).toBeLessThan(ctxTokens / 2)
+  })
+
+  it('returns undefined when the context window is unknown', () => {
+    // Remote providers often report no window; the user's setting then governs
+    // alone rather than a fabricated budget taking over.
+    expect(deriveToolOutputCap(undefined)).toBeUndefined()
+    expect(deriveToolOutputCap(0)).toBeUndefined()
+    expect(deriveToolOutputCap(-1)).toBeUndefined()
+  })
+
+  it('returns a whole number of characters', () => {
+    expect(Number.isInteger(deriveToolOutputCap(8_191))).toBe(true)
   })
 })

--- a/web-app/src/lib/context-manager.ts
+++ b/web-app/src/lib/context-manager.ts
@@ -15,6 +15,32 @@ export function estimateTokens(text: string): number {
   return Math.ceil(text.length / CHARS_PER_TOKEN)
 }
 
+/**
+ * Share of the model's context window a single tool result may occupy.
+ *
+ * One result should never crowd out the conversation that gives it meaning, so
+ * this is deliberately a minority of the window: enough for a substantial page
+ * or file, far short of the whole budget.
+ */
+const TOOL_OUTPUT_FRACTION_OF_CONTEXT = 0.25
+
+/**
+ * Per-tool-result character budget derived from the active model's context
+ * window, so a bigger window earns a proportionally bigger allowance instead of
+ * being held to one hardcoded number.
+ *
+ * Returns `undefined` when the window is unknown - remote providers often don't
+ * report one - leaving the user's configured cap in sole charge.
+ */
+export function deriveToolOutputCap(
+  contextWindowTokens: number | undefined
+): number | undefined {
+  if (!contextWindowTokens || contextWindowTokens <= 0) return undefined
+  return Math.floor(
+    contextWindowTokens * CHARS_PER_TOKEN * TOOL_OUTPUT_FRACTION_OF_CONTEXT
+  )
+}
+
 function messageToText(message: UIMessage): string {
   const parts: string[] = []
   for (const part of message.parts) {

--- a/web-app/src/locales/en/mcp-servers.json
+++ b/web-app/src/locales/en/mcp-servers.json
@@ -59,6 +59,8 @@
     "description": "Configure how Jan manages and retries MCP servers.",
     "toolCallTimeout": "Tool call timeout (seconds)",
     "toolCallTimeoutDesc": "Maximum time to wait for an MCP tool response before timing out.",
+    "maxToolOutputChars": "Max tool output characters",
+    "maxToolOutputCharsDesc": "Longest tool result kept in the conversation. Anything past this is trimmed and marked as truncated, so one large result cannot exhaust the model's context. Set to 0 to keep results whole.",
     "smartToolRouting": "Smart MCP tool routing",
     "smartToolRoutingDesc": "When enabled, Jan selects relevant MCP servers before loading tools. Disable to always load the full MCP tool list.",
     "useLightweightRouterModel": "Use a dedicated model for routing",

--- a/web-app/src/routes/settings/__tests__/mcp-servers.error.test.tsx
+++ b/web-app/src/routes/settings/__tests__/mcp-servers.error.test.tsx
@@ -6,6 +6,7 @@ import { useAppState } from '@/hooks/useAppState'
 const activateMCPServer = vi.fn()
 const deactivateMCPServer = vi.fn()
 const getConnectedServers = vi.fn().mockResolvedValue([])
+const updateSettings = vi.fn()
 
 vi.mock('@/containers/SettingsMenu', () => ({
   default: () => <div data-testid="settings-menu">Settings Menu</div>,
@@ -121,6 +122,7 @@ vi.mock('@/hooks/useMCPServers', () => ({
     useLightweightRouterModel: false,
     routerModelProvider: '',
     routerModelId: '',
+    maxToolOutputChars: 40000,
   },
   useMCPServers: () => ({
     mcpServers: {
@@ -138,6 +140,7 @@ vi.mock('@/hooks/useMCPServers', () => ({
       useLightweightRouterModel: false,
       routerModelProvider: '',
       routerModelId: '',
+      maxToolOutputChars: 40000,
     },
     addServer: vi.fn(),
     editServer: vi.fn(),
@@ -153,7 +156,7 @@ vi.mock('@/hooks/useMCPServers', () => ({
       active: false,
     }),
     setSettings: vi.fn(),
-    updateSettings: vi.fn(),
+    updateSettings,
   }),
 }))
 
@@ -235,5 +238,54 @@ describe('MCP servers route error handling', () => {
     await waitFor(() => {
       expect(useAppState.getState().errorMessage?.message).toBe('wrapped startup failed')
     })
+  })
+})
+
+// #8557: users had no way to bound an MCP result before it filled the context.
+describe('max tool output characters control', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getConnectedServers.mockResolvedValue([])
+  })
+
+  const capInput = (): HTMLInputElement => {
+    const inputs = screen.getAllByRole<HTMLInputElement>('spinbutton')
+    const found = inputs.find((i) => i.value === '40000')
+    if (!found) throw new Error('cap input not rendered')
+    return found
+  }
+
+  it('shows the configured cap and saves an edited one', async () => {
+    const Component = McpServersRoute.component as React.ComponentType
+    await act(async () => {
+      render(<Component />)
+    })
+
+    fireEvent.change(capInput(), { target: { value: '12000' } })
+
+    expect(updateSettings).toHaveBeenCalledWith({ maxToolOutputChars: 12000 })
+  })
+
+  it('accepts 0 as an explicit opt-out rather than rejecting it', async () => {
+    const Component = McpServersRoute.component as React.ComponentType
+    await act(async () => {
+      render(<Component />)
+    })
+
+    fireEvent.change(capInput(), { target: { value: '0' } })
+
+    expect(updateSettings).toHaveBeenCalledWith({ maxToolOutputChars: 0 })
+  })
+
+  it('restores the default when the field is cleared', async () => {
+    // An empty box must not persist as "0 characters of tool output".
+    const Component = McpServersRoute.component as React.ComponentType
+    await act(async () => {
+      render(<Component />)
+    })
+
+    fireEvent.change(capInput(), { target: { value: '' } })
+
+    expect(updateSettings).toHaveBeenCalledWith({ maxToolOutputChars: 40000 })
   })
 })

--- a/web-app/src/routes/settings/mcp-servers.tsx
+++ b/web-app/src/routes/settings/mcp-servers.tsx
@@ -174,6 +174,20 @@ function MCPServersDesktop() {
     }
   }
 
+  const updateMaxToolOutputChars = (rawValue: string) => {
+    if (rawValue === '') {
+      updateSettings({
+        maxToolOutputChars: DEFAULT_MCP_SETTINGS.maxToolOutputChars,
+      })
+      return
+    }
+
+    const numericValue = Number(rawValue)
+    if (!Number.isNaN(numericValue) && numericValue >= 0) {
+      updateSettings({ maxToolOutputChars: numericValue })
+    }
+  }
+
   const modelProviders = useModelProvider((state) => state.providers)
 
   const routerPickerDisabled =
@@ -569,6 +583,27 @@ function MCPServersDesktop() {
                       value={settings.toolCallTimeoutSeconds}
                       onChange={(event) =>
                         updateToolCallTimeout(event.target.value)
+                      }
+                      onBlur={() => {
+                        void syncServers()
+                      }}
+                      className="w-28"
+                    />
+                  }
+                />
+                <CardItem
+                  title={t('mcp-servers:runtimeSettings.maxToolOutputChars')}
+                  description={t(
+                    'mcp-servers:runtimeSettings.maxToolOutputCharsDesc'
+                  )}
+                  actions={
+                    <Input
+                      type="number"
+                      min={0}
+                      step={1000}
+                      value={settings.maxToolOutputChars}
+                      onChange={(event) =>
+                        updateMaxToolOutputChars(event.target.value)
                       }
                       onBlur={() => {
                         void syncServers()

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -18,6 +18,7 @@ import { SESSION_STORAGE_PREFIX } from '@/constants/chat'
 import { useChat } from '@/hooks/use-chat'
 import { useModelProvider } from '@/hooks/useModelProvider'
 import { useInterfaceSettings } from '@/hooks/useInterfaceSettings'
+import { deriveToolOutputCap } from '@/lib/context-manager'
 import { renderInstructions } from '@/lib/instructionTemplate'
 import {
   Conversation,
@@ -556,9 +557,18 @@ function ThreadDetail() {
                 scope: projectId ? 'project' : 'thread',
               })
             } else if (mcpToolNames.has(toolName)) {
+              // An MCP result is injected into conversation history verbatim, so
+              // a page-sized one can exhaust the context on its own. Give the
+              // backend a budget scaled to the window this model actually has;
+              // it narrows that against the user's configured ceiling.
+              const ctxLen = useModelProvider.getState().selectedModel?.settings
+                ?.ctx_len?.controller_props?.value
               result = await serviceHub.mcp().callTool({
                 toolName,
                 arguments: toolCall.input,
+                maxOutputChars: deriveToolOutputCap(
+                  typeof ctxLen === 'number' ? ctxLen : undefined
+                ),
               })
             } else {
               result = {

--- a/web-app/src/routes/threads/__tests__/$threadId.test.tsx
+++ b/web-app/src/routes/threads/__tests__/$threadId.test.tsx
@@ -815,6 +815,60 @@ describe('ThreadDetail route', () => {
       expect(h.toolApprovalState.requestApproval).toHaveBeenCalledTimes(1)
     })
 
+    // A tool result is injected into conversation history verbatim, so an
+    // uncapped one can exhaust the context on its own (#8557). The budget the
+    // model's own window affords is handed to the backend, which enforces it.
+    it('caps the tool result against the active model context window', async () => {
+      h.appStateState.mcpToolNames = new Set(['fetch'])
+      h.toolApprovalState.requestApproval = vi.fn().mockResolvedValue(true)
+      const callTool = vi.fn().mockResolvedValue({ error: '', content: [] })
+      hub.mcp = () => ({ callTool }) as never
+      renderComponent()
+
+      const onToolCall = (
+        h as { capturedOnToolCall: (arg: unknown) => Promise<void> }
+      ).capturedOnToolCall
+      await act(async () => {
+        await onToolCall(toolCall('tc5'))
+      })
+      await act(async () => {
+        await finishWithToolCalls()
+      })
+
+      const { maxOutputChars } = callTool.mock.calls[0][0]
+      // 4096-token window in the harness: a fraction of it, not the whole thing.
+      expect(maxOutputChars).toBeGreaterThan(0)
+      expect(maxOutputChars).toBeLessThan(4096 * 3.5)
+    })
+
+    it('omits the cap when the model reports no context window', async () => {
+      // Remote providers often don't; the user's configured ceiling then governs
+      // alone rather than an invented budget silently clipping output.
+      h.appStateState.mcpToolNames = new Set(['fetch'])
+      h.toolApprovalState.requestApproval = vi.fn().mockResolvedValue(true)
+      const previousSettings = h.modelProviderState.selectedModel.settings
+      h.modelProviderState.selectedModel.settings = {}
+      const callTool = vi.fn().mockResolvedValue({ error: '', content: [] })
+      hub.mcp = () => ({ callTool }) as never
+
+      try {
+        renderComponent()
+        const onToolCall = (
+          h as { capturedOnToolCall: (arg: unknown) => Promise<void> }
+        ).capturedOnToolCall
+        await act(async () => {
+          await onToolCall(toolCall('tc6'))
+        })
+        await act(async () => {
+          await finishWithToolCalls()
+        })
+
+        expect(callTool.mock.calls[0][0].maxOutputChars).toBeUndefined()
+      } finally {
+        h.modelProviderState.selectedModel.settings = previousSettings
+      }
+    })
+
     // A model can request several tools in one turn. They arrive together but
     // are executed one at a time, which is what the queue display depends on.
     describe('several tool calls in one turn', () => {

--- a/web-app/src/services/mcp/default.ts
+++ b/web-app/src/services/mcp/default.ts
@@ -43,7 +43,11 @@ export class DefaultMCPService implements MCPService {
     return []
   }
 
-  async callTool(args: { toolName: string; arguments: object }): Promise<MCPToolCallResult> {
+  async callTool(args: {
+    toolName: string
+    arguments: object
+    maxOutputChars?: number
+  }): Promise<MCPToolCallResult> {
     console.log('callTool called with args:', args)
     return {
       error: '',

--- a/web-app/src/services/mcp/tauri.ts
+++ b/web-app/src/services/mcp/tauri.ts
@@ -83,6 +83,7 @@ export class TauriMCPService extends DefaultMCPService {
     toolName: string
     serverName?: string
     arguments: object
+    maxOutputChars?: number
   }): Promise<{ error: string; content: { text: string }[] }> {
     return window.core?.api?.callTool(args)
   }

--- a/web-app/src/services/mcp/types.ts
+++ b/web-app/src/services/mcp/types.ts
@@ -60,7 +60,17 @@ export interface MCPService {
   /** Return name/capabilities/description for all connected servers. */
   getServerSummaries(): Promise<ServerSummary[]>
   getConnectedServers(): Promise<string[]>
-  callTool(args: { toolName: string; serverName?: string; arguments: object }): Promise<MCPToolCallResult>
+  /**
+   * `maxOutputChars` is a per-result character budget derived from the active
+   * model's context window; the backend narrows its own configured cap to it so
+   * one oversized result cannot exhaust the context.
+   */
+  callTool(args: {
+    toolName: string
+    serverName?: string
+    arguments: object
+    maxOutputChars?: number
+  }): Promise<MCPToolCallResult>
   callToolWithCancellation(args: {
     toolName: string
     serverName?: string


### PR DESCRIPTION
Closes #8557

## The bug

A user with Jan Browser MCP hit "Prompt is too long" on Anthropic - with a 1M-token context window. The maintainer guessed "probably a bug in the tool output," which turned out to be right, though not as malformed output.

An MCP tool result was injected into conversation history verbatim, with no size cap anywhere in the chain:

- `call_tool` (`src-tauri/src/core/mcp/commands.rs:404`) returned the raw `CallToolResult`, every content block intact.
- The desktop chat fed it straight in at `web-app/src/routes/threads/$threadId.tsx:580`: `addToolOutput({ ..., output: result.content })`, which becomes a `tool-result` part and is serialized into the model request by `convertToModelMessages`.

`browser_snapshot` returns a whole-page dump as one text block. Once it is in the history it is re-sent on every subsequent turn, so a single call can exhaust the context no matter how large that context is. The cap that mattered was the absence of one, not the model's window.

On the specific "duplicated or malformed blocks" theory: the output is not malformed, just enormous. `get_result_text` (commands.rs:748) does read only `content[0]`, but it is used solely by the ping/connectivity checks, never on the path to the model - so it is not the leak, and it is left alone here. The real multi-block gap was that nothing bounded the blocks at all, which the cap now covers as a combined budget.

## The fix

`truncate_tool_result` caps the combined text of a result and appends a marker saying how much was kept:

```
[Tool output truncated: 40000 of 1500000 characters retained. Increase "Max tool output characters" in Settings > MCP Servers to retain more.]
```

Nothing is dropped silently, and the message tells both the model and the user what happened and where to change it.

Details that matter:

- The budget spans all text blocks, since the model sees their concatenation. Earlier blocks survive intact, the block crossing the budget is cut, later ones are dropped.
- Non-text blocks (images, resources) pass through untouched - clipping mid-base64 would corrupt them.
- Cutting is on `char` boundaries, so multibyte text is not mangled.
- `is_error`, `structured_content` and `_meta` are preserved.

Enforced at both points where an MCP result reaches a model: `call_tool` (every desktop tool call) and `execute_mcp_tool_calls` (the agent loop's own history).

## The control the user asked for

The reporter asked for "some control over it," so the cap is a setting rather than a constant: **Max tool output characters** in Settings > MCP Servers, defaulting to 40,000 chars (~12k tokens). `0` keeps results whole for anyone who wants the old behavior.

The chat path additionally derives a budget from the active model's context window (25% of it, in chars) and passes it to `callTool`, so a 1M-token model gets a proportionally larger allowance than an 8k one. The backend takes the tighter of the two. When a provider reports no context window - remote ones often don't - the derived budget is omitted and the user's setting governs alone.

## Tests

Backend, `cargo test --lib core::mcp` - 75 passed:

- cap enforcement, truncation marker contents, small-output passthrough, exact-boundary passthrough
- multi-block budget spanning, non-text block survival, multibyte char boundaries
- `0` disabling the cap, error/structured-content preservation
- a serialized-result test asserting the JSON the web layer actually receives is bounded, using a 1.5M-char stand-in for a page snapshot
- `tool_output_cap` precedence: user setting vs derived override, and opt-out precedence

Web-app, vitest - 137 passed across the touched files:

- `deriveToolOutputCap` scaling, conversation headroom, unknown-window `undefined`, integer output
- `$threadId` passes the derived cap to `callTool`, and omits it when the model reports no window
- the settings control renders the configured value, saves edits, accepts `0`, and restores the default when cleared

`tsc -b` and eslint are clean on the touched files. `cargo fmt` was deliberately not run; the repo's Rust diff-noise guard passes.
