### PR TITLE
fix(web): respect MCP ownership for web tool names

### DIFF
--- a/web-app/src/hooks/useToolOrigin.ts
+++ b/web-app/src/hooks/useToolOrigin.ts
@@ -16,14 +16,24 @@ export const useToolOrigin = (toolName: string): ToolOrigin | undefined => {
   const webSearchProviderLabel = useWebSearchConfig(
     (s) => getProviderMeta(s.searchProvider).label
   )
+  const nativeWebSearchEnabled = useWebSearchConfig(
+    (s) => s.webSearchEnabled
+  )
 
   return useMemo(
     () =>
       resolveToolOrigin(toolName, {
         mcpServer,
         isRagTool,
+        nativeWebSearchEnabled,
         webSearchProviderLabel,
       }),
-    [toolName, mcpServer, isRagTool, webSearchProviderLabel]
+    [
+      toolName,
+      mcpServer,
+      isRagTool,
+      nativeWebSearchEnabled,
+      webSearchProviderLabel,
+    ]
   )
 }

--- a/web-app/src/lib/__tests__/toolOrigin.test.ts
+++ b/web-app/src/lib/__tests__/toolOrigin.test.ts
@@ -3,6 +3,7 @@ import { resolveToolOrigin } from '../toolOrigin'
 
 const context = {
   isRagTool: false,
+  nativeWebSearchEnabled: true,
   webSearchProviderLabel: 'Exa',
 }
 
@@ -47,6 +48,16 @@ describe('resolveToolOrigin', () => {
     expect(
       resolveToolOrigin('web_search', { ...context, mcpServer: 'someserver' })
     ).toEqual({ kind: 'web-search', detail: 'Exa' })
+  })
+
+  it('attributes a same-named tool to MCP when native web search is disabled', () => {
+    expect(
+      resolveToolOrigin('web_search', {
+        ...context,
+        mcpServer: 'donsetch',
+        nativeWebSearchEnabled: false,
+      })
+    ).toEqual({ kind: 'mcp', detail: 'donsetch' })
   })
 
   it('prefers RAG over MCP when both somehow match', () => {

--- a/web-app/src/lib/__tests__/webToolRouting.test.ts
+++ b/web-app/src/lib/__tests__/webToolRouting.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { isNativeWebTool } from '../webToolRouting'
+
+describe('isNativeWebTool', () => {
+  it.each(['web_search', 'web_fetch'])(
+    'recognises the enabled native %s tool',
+    (toolName) => {
+      expect(isNativeWebTool(toolName, true)).toBe(true)
+    }
+  )
+
+  it.each(['web_search', 'web_fetch'])(
+    'does not claim a same-named MCP %s tool while native web search is disabled',
+    (toolName) => {
+      expect(isNativeWebTool(toolName, false)).toBe(false)
+    }
+  )
+
+  it('does not claim unrelated tools', () => {
+    expect(isNativeWebTool('search_documents', true)).toBe(false)
+  })
+})

--- a/web-app/src/lib/toolOrigin.ts
+++ b/web-app/src/lib/toolOrigin.ts
@@ -1,3 +1,9 @@
+import {
+  isNativeWebTool,
+  WEB_FETCH_TOOL,
+  WEB_SEARCH_TOOL,
+} from './webToolRouting'
+
 /**
  * Where a tool call came from. Jan runs three families of tools -- the native
  * web tools, the built-in RAG tools, and MCP server tools -- and a collapsed
@@ -13,12 +19,11 @@ export type ToolOriginContext = {
   /** MCP server owning this tool, when it is an MCP tool. */
   mcpServer?: string
   isRagTool: boolean
+  /** Whether Jan's native web-search tools are currently advertised. */
+  nativeWebSearchEnabled: boolean
   /** Display name of the configured web search provider, e.g. "Exa". */
   webSearchProviderLabel: string
 }
-
-export const WEB_SEARCH_TOOL = 'web_search'
-export const WEB_FETCH_TOOL = 'web_fetch'
 
 /**
  * Resolution order mirrors the execution order in the thread route: native web
@@ -27,12 +32,20 @@ export const WEB_FETCH_TOOL = 'web_fetch'
  */
 export function resolveToolOrigin(
   toolName: string,
-  { mcpServer, isRagTool, webSearchProviderLabel }: ToolOriginContext
+  {
+    mcpServer,
+    isRagTool,
+    nativeWebSearchEnabled,
+    webSearchProviderLabel,
+  }: ToolOriginContext
 ): ToolOrigin | undefined {
-  if (toolName === WEB_SEARCH_TOOL) {
+  const isNativeWeb = isNativeWebTool(toolName, nativeWebSearchEnabled)
+  if (isNativeWeb && toolName === WEB_SEARCH_TOOL) {
     return { kind: 'web-search', detail: webSearchProviderLabel }
   }
-  if (toolName === WEB_FETCH_TOOL) return { kind: 'web-fetch' }
+  if (isNativeWeb && toolName === WEB_FETCH_TOOL) {
+    return { kind: 'web-fetch' }
+  }
   if (isRagTool) return { kind: 'rag' }
   if (mcpServer) return { kind: 'mcp', detail: mcpServer }
   return undefined

--- a/web-app/src/lib/webSearchTool.ts
+++ b/web-app/src/lib/webSearchTool.ts
@@ -1,8 +1,6 @@
 import { webSearch, webFetch } from '@janhq/tauri-plugin-websearch-api'
 import { useWebSearchConfig } from '@/hooks/useWebSearchConfig'
 
-export const WEB_TOOL_NAMES = new Set(['web_search', 'web_fetch'])
-
 export const WEB_SEARCH_DESCRIPTION =
   'Search the web and return a ranked list of results (title, URL, snippet, and optional publish date). Use this to find current information, documentation, or sources you can then read with web_fetch. Cite the URLs you rely on.'
 

--- a/web-app/src/lib/webToolRouting.ts
+++ b/web-app/src/lib/webToolRouting.ts
@@ -1,0 +1,16 @@
+export const WEB_SEARCH_TOOL = 'web_search'
+export const WEB_FETCH_TOOL = 'web_fetch'
+
+export const WEB_TOOL_NAMES = new Set([WEB_SEARCH_TOOL, WEB_FETCH_TOOL])
+
+/**
+ * A same-named MCP tool is still an MCP tool when Jan's native web search is
+ * disabled. Keep dispatch in sync with refreshTools(), which only advertises
+ * the native tools while this setting is enabled.
+ */
+export function isNativeWebTool(
+  toolName: string,
+  webSearchEnabled: boolean
+): boolean {
+  return webSearchEnabled && WEB_TOOL_NAMES.has(toolName)
+}

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -76,7 +76,9 @@ import { IconAlertCircle, IconRefresh, IconLoader2 } from '@tabler/icons-react'
 import { useToolApproval } from '@/hooks/useToolApproval'
 import { useToolApprovalRequests } from '@/hooks/useToolApprovalRequests'
 import { useToolCallRuntime } from '@/hooks/useToolCallRuntime'
-import { WEB_TOOL_NAMES, executeWebTool } from '@/lib/webSearchTool'
+import { executeWebTool } from '@/lib/webSearchTool'
+import { isNativeWebTool } from '@/lib/webToolRouting'
+import { useWebSearchConfig } from '@/hooks/useWebSearchConfig'
 import DropdownModelProvider from '@/containers/DropdownModelProvider'
 import { ExtensionTypeEnum, VectorDBExtension } from '@janhq/core'
 import { ExtensionManager } from '@/lib/extension'
@@ -487,10 +489,13 @@ function ThreadDetail() {
 
           try {
             const toolName = toolCall.toolName
+            const isWebTool = isNativeWebTool(
+              toolName,
+              useWebSearchConfig.getState().webSearchEnabled
+            )
 
             // Built-in RAG and native web tools are internal and auto-allowed.
-            const approved = ragToolNames.has(toolName) ||
-              WEB_TOOL_NAMES.has(toolName)
+            const approved = ragToolNames.has(toolName) || isWebTool
               ? true
               : await (toolApprovalPromises.current.get(toolCall.toolCallId) ??
                   useToolApprovalRequests
@@ -519,7 +524,7 @@ function ThreadDetail() {
 
             let result
 
-            if (WEB_TOOL_NAMES.has(toolName)) {
+            if (isWebTool) {
               result = await executeWebTool(toolName, toolCall.input)
             } else if (ragToolNames.has(toolName)) {
               result = await serviceHub.rag().callTool({
@@ -663,7 +668,10 @@ function ThreadDetail() {
       const ragToolNames = useAppState.getState().ragToolNames
       if (
         !ragToolNames.has(toolCall.toolName) &&
-        !WEB_TOOL_NAMES.has(toolCall.toolName) &&
+        !isNativeWebTool(
+          toolCall.toolName,
+          useWebSearchConfig.getState().webSearchEnabled
+        ) &&
         !toolApprovalPromises.current.has(toolCall.toolCallId)
       ) {
         toolApprovalPromises.current.set(


### PR DESCRIPTION
## Describe Your Changes

- Route `web_search` and `web_fetch` through Jan's native adapter only while built-in Web Search is enabled.
- Preserve MCP approval and execution for servers that expose the same tool names when built-in Web Search is disabled.
- Keep tool-origin labels consistent with the actual dispatcher.
- Add regression coverage for enabled native tools and disabled same-named MCP tools.

### Root cause

Tool advertisement already respected `webSearchEnabled`, but the thread execution path classified tools with a static name set. An MCP-owned `web_search` call was therefore auto-approved and sent to Exa even when Jan's native Web Search was disabled.

## Fixes Issues

- Closes #8777

## Verification

- `yarn test:web web-app/src/lib/__tests__/toolOrigin.test.ts web-app/src/lib/__tests__/webToolRouting.test.ts` — 14 passed
- `yarn workspace @janhq/web-app lint`
- `yarn workspace @janhq/web-app build`
- `git diff --check`

## Demonstration

The reporter's before-state is captured in #8777. The regression now proves that `web_search` / `web_fetch` are native only when the feature is enabled, and that a disabled same-named tool resolves to its MCP server (`donsetch`) instead of Exa.

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [x] Updated behavior tests for the bug fix
- [x] No documentation or follow-up refactor is needed for this focused routing change
