### PR TITLE
fix(agent-tools): make Unix sandbox limits platform-aware

### DIFF
--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/proc.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/proc.rs
@@ -190,10 +190,15 @@ const TEMP_ENV_KEYS: &[&str] = &["TMPDIR", "TMP", "TEMP"];
 /// Bound the resource exhaustion a sandboxed command could otherwise trigger on
 /// the host. `bwrap` 0.6.1 (and older) has no `--rlimit`, so instead we clamp the
 /// child's soft limits here, before exec, from the one choke point every backend
-/// funnels through. A fork-bomb is capped by `NPROC`, descriptor exhaustion by
-/// `NOFILE`, and disk fill through the unbounded workspace bind by `FSIZE`. The
-/// bwrap wrapper execs `bwrap` itself, which sets up the namespace and then
-/// execs the real shell, so the limits carry over to every descendant. Linux
+/// funnels through. Descriptor exhaustion is capped by `NOFILE`, and disk fill
+/// through the unbounded workspace bind by `FSIZE`. Linux `NPROC` constrains
+/// fork bombs, but the kernel accounts it per user rather than per shell tree.
+/// Keep it high enough at 8192 that ordinary workstation processes do not
+/// exhaust a tool shell's available process slots. macOS has its own UID-wide
+/// process ceiling (`kern.maxprocperuid`); an unprivileged Jan child cannot raise
+/// that ceiling, so the Linux-specific cap is not applied there. The bwrap
+/// wrapper execs `bwrap` itself, which sets up the namespace and then execs the
+/// real shell, so the remaining limits carry over to every descendant. Unix
 /// only; the Windows AppContainer child is limited by its token.
 #[cfg(unix)]
 fn confine_limits(cmd: &mut Command) {
@@ -206,7 +211,8 @@ fn confine_limits(cmd: &mut Command) {
     unsafe {
         cmd.pre_exec(|| {
             for (resource, limit) in [
-                (nix::libc::RLIMIT_NPROC, 4096_u64),
+                #[cfg(target_os = "linux")]
+                (nix::libc::RLIMIT_NPROC, 8192_u64),
                 (nix::libc::RLIMIT_NOFILE, 1024_u64),
                 (nix::libc::RLIMIT_FSIZE, 1024_u64 * 1024_u64 * 1024_u64),
             ] {
@@ -473,21 +479,31 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn confine_limits_caps_the_child_process_count() {
-        // The rlimit mounting must actually reach the spawned child: with NPROC
-        // clamped we still run up to the cap, but a fork-bomb past it fails.
-        let child = spawn(shell(), "exit 0", &tmp(), None).await.unwrap();
-        let pid = child.id().unwrap();
-        child.wait_with_output().await.unwrap();
-        unregister(pid);
-
-        // Spawn a shell that reports its own soft NOFILE limit; confine_limits
-        // sets it to 1024, which should be visible inside the sandbox.
+    async fn confine_limits_caps_child_file_descriptors() {
+        // The rlimit mounting must actually reach the spawned child: NOFILE is
+        // set to 1024, which should be visible inside the sandbox.
         let child = spawn(shell(), "ulimit -n", &tmp(), None).await.unwrap();
         let pid = child.id().unwrap();
         let out = child.wait_with_output().await.unwrap();
         unregister(pid);
         let val = String::from_utf8_lossy(&out.stdout).trim().to_string();
         assert_eq!(val, "1024", "NOFILE soft limit should be capped, got: {val}");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn confine_limits_caps_child_processes() {
+        // NPROC is a per-user Linux limit, so use a higher 8192 ceiling to
+        // preserve the fork-bomb guard without making ordinary workstation
+        // process counts exhaust the child shell's process slots.
+        let child = spawn(shell(), "ulimit -u", &tmp(), None).await.unwrap();
+        let pid = child.id().unwrap();
+        let out = child.wait_with_output().await.unwrap();
+        unregister(pid);
+        let actual = String::from_utf8_lossy(&out.stdout).trim().to_string();
+        assert_eq!(
+            actual, "8192",
+            "NPROC soft limit should be capped at 8192, got: {actual}"
+        );
     }
 }

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/proc.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/proc.rs
@@ -213,7 +213,7 @@ fn confine_limits(cmd: &mut Command) {
             for (resource, limit) in [
                 #[cfg(target_os = "linux")]
                 (nix::libc::RLIMIT_NPROC, 8192_u64),
-                (nix::libc::RLIMIT_NOFILE, 1024_u64),
+                (nix::libc::RLIMIT_NOFILE, 2048_u64),
                 (nix::libc::RLIMIT_FSIZE, 1024_u64 * 1024_u64 * 1024_u64),
             ] {
                 let r = nix::libc::rlimit {
@@ -481,13 +481,13 @@ mod tests {
     #[tokio::test]
     async fn confine_limits_caps_child_file_descriptors() {
         // The rlimit mounting must actually reach the spawned child: NOFILE is
-        // set to 1024, which should be visible inside the sandbox.
+        // set to 2048, which should be visible inside the sandbox.
         let child = spawn(shell(), "ulimit -n", &tmp(), None).await.unwrap();
         let pid = child.id().unwrap();
         let out = child.wait_with_output().await.unwrap();
         unregister(pid);
         let val = String::from_utf8_lossy(&out.stdout).trim().to_string();
-        assert_eq!(val, "1024", "NOFILE soft limit should be capped, got: {val}");
+        assert_eq!(val, "2048", "NOFILE soft limit should be capped, got: {val}");
     }
 
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
## Summary

Jan applies Unix resource limits immediately before it starts an agent-tool shell. The old process cap (`RLIMIT_NPROC=4096`) is charged to the whole Unix user, not one Jan tool run. On a busy workstation, unrelated processes can consume that shared allowance and cause a normal tool command to fail at `fork()`.

<img width="50%" alt="Linux fork failure under the shared process limit" src="https://github.com/user-attachments/assets/0910cdc0-e84d-40cb-aa04-1f3d5e54ef7c" />

## Change

- **Linux:** raise `RLIMIT_NPROC` from `4096` to `8192`.
- **macOS:** do not set `RLIMIT_NPROC`; inherit the host session limit.
- **Unix:** raise `RLIMIT_NOFILE` from `1024` to `2048`.
- Keep the existing `RLIMIT_FSIZE=1 GiB` guard.

## Why the platform split

Linux keeps a finite process ceiling, but at `8192` it no longer creates the tight shared-account limit that caused the observed fork failure.

macOS has the same UID-wide accounting problem. In a controlled Jan child-shell test, setting `NPROC=8` succeeded and the child's first background fork failed. That proves a Jan-set value is an account-wide constraint, not a per-tool budget, so the macOS build leaves process count to the host.

Codex local macOS is useful precedent: its sandbox constrains filesystem and network authority, but does not assign a per-run PID budget. Skipping Jan's macOS `NPROC` setting therefore does not remove a per-run boundary; this primitive never provided one.

## Verification

- Linux child-shell limit test: `NPROC=8192`.
- Linux and macOS child-shell limit test: `NOFILE=2048`.
- macOS reproduction: a Jan child with test-only `NPROC=8` inherited `8` and its first fork was rejected.
- Rebuilt and smoke-tested the Linux CLI and the universal macOS CLI.

## Scope

This is a compatibility fix, not per-run fork-bomb isolation. `RLIMIT_NPROC` is UID-scoped. A real Linux per-run process budget needs a delegated cgroup-v2 `pids.max` (or equivalent supervisor) created before Bubblewrap starts; macOS needs its own platform-specific containment design.
