### PR TITLE
fix(cli): make RepoRoot lazy so Windows irm|iex install works

### DIFF
--- a/scripts/install-jan-agent.ps1
+++ b/scripts/install-jan-agent.ps1
@@ -34,7 +34,6 @@ $ProgressPreference = 'SilentlyContinue'
 
 $BinaryName = 'jan.exe'
 $PlatformKey = 'windows-x86_64'
-$RepoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
 
 if (-not $Dir) {
   if ($env:JAN_INSTALL_DIR) {
@@ -101,6 +100,10 @@ function Install-Binary {
 }
 
 function Install-FromSource {
+  if (-not $PSCommandPath) {
+    throw '-Source requires running the script from a checkout; download scripts\install-jan-agent.ps1 and run it from the repo'
+  }
+  $RepoRoot = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
   if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) {
     throw 'cargo not found; install Rust first'
   }


### PR DESCRIPTION
Fixes #8796

## Problem

The documented Windows install one-liner `irm https://delta.jan.ai/jan-cli/install-jan-agent.ps1 | iex` fails immediately.

`scripts/install-jan-agent.ps1:37` computed `$RepoRoot` at script scope from `$PSCommandPath`. Under `irm | iex` there is no backing file, so `$PSCommandPath` is empty and `Split-Path` throws `Cannot bind argument to parameter 'Path' because it is an empty string` during setup, before any install logic runs.

`$RepoRoot` was referenced only inside `Install-FromSource` (lines 107/108/117), which runs only with `-Source`. The default published-build path (`Install-Published`) never used it, so the eager compute was pure collateral damage.

## Fix

Make `$RepoRoot` lazy: compute it inside `Install-FromSource` and throw an actionable error when the script was piped rather than run from a checkout.

## Audit

Read the whole script. No other script-scope statement assumes a file on disk; the default `irm | iex` path now runs clean through setup.

## Verification

Statically verified: `$RepoRoot` is now defined and used only inside `Install-FromSource`; no script-scope reference remains. Syntax check and execution could not be performed (no Windows machine / pwsh). Change is structurally identical to the existing `Install-FromSource` body.