### PR TITLE
fix(agent-tui): add a repaint path so foreign TTY writes cannot persist

### DIFF
--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/commands.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/commands.rs
@@ -593,7 +593,6 @@ fn output_sink(
 mod tests {
     use super::*;
     use serde_json::json;
-
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/commands.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/commands.rs
@@ -460,12 +460,14 @@ async fn execute_tool_inner(
     match gate::resolve_decision(
         tool,
         &args,
-        &root,
-        Some(&scratch),
-        &read_roots,
+        &gate::GateContext {
+            project_root: &root,
+            scratch: Some(&scratch),
+            read_roots: &read_roots,
+            hide_jan: true,
+        },
         &ToolPermissions::default(),
         &SessionGrants::default(),
-        true,
     ) {
         Decision::Allow => {}
         Decision::HardDeny(gate::DenyReason::Hidden) => {
@@ -591,13 +593,15 @@ fn output_sink(
 mod tests {
     use super::*;
     use serde_json::json;
+
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 
-    /// The output sink test's shared ledger: what was sent, tagged with call id.
-    type Seen = Arc<Mutex<Vec<(u64, Option<String>, String)>>>;
 
     static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    /// Chunks recorded by [`test_sink`]: monotonic `(seq, call_id, text)`.
+    type SeenChunks = Arc<Mutex<Vec<(u64, Option<String>, String)>>>;
 
     /// A temp dir standing in for the Jan data folder.
     fn unique_data_folder() -> PathBuf {
@@ -798,7 +802,7 @@ mod tests {
         // "No change" instead of "Created".
         // The sweep test collects every scratch in the shared temp dir; without
         // this it can delete ours between the write and the assertion.
-        let _guard = crate::workspace::lock_scratch_namespace();
+        let _guard = crate::workspace::lock_scratch_namespace().await;
         let scratch = crate::workspace::ensure_scratch_dir(T_SCRATCH)
             .await
             .unwrap();
@@ -1452,7 +1456,7 @@ mod tests {
     /// and what matters here is the ordering, correlation and the byte budget.
     #[test]
     fn the_output_sink_numbers_chunks_and_tags_them_with_the_call() {
-        let seen: Seen = Arc::new(Mutex::new(Vec::new()));
+        let seen: SeenChunks = Arc::new(Mutex::new(Vec::new()));
         let sink = test_sink(seen.clone(), Some("call-7".into()));
 
         sink("one".into());
@@ -1471,7 +1475,7 @@ mod tests {
     /// tool result.
     #[test]
     fn the_output_sink_stops_at_the_byte_cap_and_says_so() {
-        let seen: Seen = Arc::new(Mutex::new(Vec::new()));
+        let seen: SeenChunks = Arc::new(Mutex::new(Vec::new()));
         let sink = test_sink(seen.clone(), None);
 
         sink("x".repeat(MAX_STREAMED_BYTES + 1));
@@ -1485,7 +1489,7 @@ mod tests {
 
     /// Mirrors `output_sink`'s accounting without a `Channel`, which cannot be
     /// constructed outside a webview.
-    fn test_sink(seen: Seen, call_id: Option<String>) -> crate::tools::OutputSink {
+    fn test_sink(seen: SeenChunks, call_id: Option<String>) -> crate::tools::OutputSink {
         use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
         use std::sync::Arc;
         let seq = Arc::new(AtomicU64::new(0));

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/commands.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/commands.rs
@@ -768,7 +768,6 @@ mod tests {
     /// spelled `/tmp/...` where it is bound over the sandbox's `/tmp` and by its
     /// real path where nothing is mounted there.
     #[tokio::test]
-    #[allow(clippy::await_holding_lock)]
     async fn escaping_writes_are_refused() {
         let data = unique_data_folder();
         let df = data.to_string_lossy().to_string();
@@ -799,9 +798,6 @@ mod tests {
         // spelling reaches the scratch on this platform. The scratch outlives the
         // test process, so the name is per-run: a leftover file would answer
         // "No change" instead of "Created".
-        // The sweep test collects every scratch in the shared temp dir; without
-        // this it can delete ours between the write and the assertion.
-        let _guard = crate::workspace::lock_scratch_namespace().await;
         let scratch = crate::workspace::ensure_scratch_dir(T_SCRATCH)
             .await
             .unwrap();
@@ -991,10 +987,8 @@ mod tests {
         let _ = std::fs::remove_dir_all(&data);
     }
 
-    /// Thread isolation: each conversation gets its own sandbox, and neither a
-    /// relative climb-out nor a sibling-thread absolute path reaches the other's
-    /// scratch files. `/tmp` is the agent's own (per-thread) scratch, so a read
-    /// of `/tmp` from a different thread resolves to that thread's empty scratch.
+    /// Thread isolation: a relative climb-out cannot reach another thread's
+    /// workspace, and each thread sees only its own scratch files.
     #[tokio::test]
     async fn one_thread_cannot_read_another_threads_files() {
         let data = unique_data_folder();
@@ -1031,16 +1025,21 @@ mod tests {
             err.message
         );
 
-        // `/tmp` is the per-thread scratch: t1's scratch (written by its shell)
-        // is not visible to t2, whose own scratch is empty.
+        // The tool-visible scratch path follows the shell: `/tmp` on Linux,
+        // the real per-thread directory on macOS and Windows.
         let one_scratch = crate::workspace::ensure_scratch_dir(t1).await.unwrap();
         std::fs::write(one_scratch.join("secret.txt"), b"classified").unwrap();
+        let two_scratch = crate::workspace::ensure_scratch_dir(t2).await.unwrap();
+        let requested = crate::tools::sandbox::scratch_display_path(
+            Some(&two_scratch),
+            &two_scratch.join("secret.txt"),
+        );
         let out = execute_tool(
             df.clone(),
             t2.into(),
             None,
             "read".into(),
-            json!({"path": "/tmp/secret.txt"}),
+            json!({"path": requested}),
             None,
             None,
             None,

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/gate.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/gate.rs
@@ -176,7 +176,6 @@ pub fn resolve_decision(
             .and_then(|v| v.as_str())
             .map(|c| command_touches_hidden_jan_path(ctx.project_root, c))
             .unwrap_or(false);
-
     if hits_hidden || exec_hits_hidden {
         return Decision::HardDeny(DenyReason::Hidden);
     }
@@ -1011,7 +1010,6 @@ mod tests {
     #[test]
     fn an_escaping_read_still_prompts_when_no_root_covers_it() {
         let root = unique_root();
-
         let repo = unique_root();
         let elsewhere = unique_root();
         let roots = vec![repo.clone()];
@@ -1027,7 +1025,6 @@ mod tests {
             &ToolPermissions::new(PermissionDefault::ReadOnly, &[], &[], &[]),
             &SessionGrants::default(),
         );
-
         assert_eq!(d, Decision::Prompt(PromptKind::ReadEscape));
         for d in [&root, &repo, &elsewhere] {
             let _ = std::fs::remove_dir_all(d);

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/gate.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/gate.rs
@@ -131,16 +131,28 @@ pub enum Decision {
 /// session grant > capability rules. Reads inside the project are silently
 /// allowed; reads that escape the project, and all writes/exec, prompt (unless
 /// already granted this session or pre-approved in agent.toml).
-#[allow(clippy::too_many_arguments)]
+///
+/// The sandbox geometry is bundled in [`GateContext`] so callers describe the
+/// filesystem and hiding policy once instead of repeating four trailing args.
+
+#[derive(Debug, Clone, Copy)]
+pub struct GateContext<'a> {
+    /// The project root: paths inside it are the agent's own workspace.
+    pub project_root: &'a Path,
+    /// The session scratch, bound over `/tmp` in the sandbox where it is mounted.
+    pub scratch: Option<&'a Path>,
+    /// Folders the user attached read-only: reads may reach them, writes may not.
+    pub read_roots: &'a [PathBuf],
+    /// Hide the agent's own `.jan` state (skills/memory/config) from general tools.
+    pub hide_jan: bool,
+}
+
 pub fn resolve_decision(
     tool: &BuiltinTool,
     args: &serde_json::Value,
-    project_root: &Path,
-    scratch: Option<&Path>,
-    read_roots: &[PathBuf],
+    ctx: &GateContext,
     perms: &ToolPermissions,
     grants: &SessionGrants,
-    hide_jan: bool,
 ) -> Decision {
     if perms.is_denied(tool.name) {
         return Decision::HardDeny(DenyReason::Policy);
@@ -150,20 +162,21 @@ pub fn resolve_decision(
     // Checked ahead of allow rules so an allowed tool name cannot bypass it.
     // The whole check is skipped when not hiding, so an unconfined CLI run can
     // read and edit its own `.jan` like any other project state.
-    let hits_hidden = hide_jan
+    let hits_hidden = ctx.hide_jan
         && tool.path_args.iter().any(|key| {
             args.get(key)
                 .and_then(|v| v.as_str())
-                .map(|p| is_hidden_jan_path(project_root, p))
+                .map(|p| is_hidden_jan_path(ctx.project_root, p))
                 .unwrap_or(false)
         });
-    let exec_hits_hidden = hide_jan
+    let exec_hits_hidden = ctx.hide_jan
         && tool.capability == Capability::Exec
         && args
             .get("command")
             .and_then(|v| v.as_str())
-            .map(|c| command_touches_hidden_jan_path(project_root, c))
+            .map(|c| command_touches_hidden_jan_path(ctx.project_root, c))
             .unwrap_or(false);
+
     if hits_hidden || exec_hits_hidden {
         return Decision::HardDeny(DenyReason::Hidden);
     }
@@ -184,7 +197,8 @@ pub fn resolve_decision(
                 args.get(key)
                     .and_then(|v| v.as_str())
                     .map(|p| {
-                        escapes_read_roots(project_root, scratch, read_roots, p).unwrap_or(true)
+                        escapes_read_roots(ctx.project_root, ctx.scratch, ctx.read_roots, p)
+                            .unwrap_or(true)
                     })
                     .unwrap_or(false)
             });
@@ -207,7 +221,7 @@ pub fn resolve_decision(
             let escapes = tool.path_args.iter().any(|key| {
                 args.get(key)
                     .and_then(|v| v.as_str())
-                    .map(|p| escapes_project(project_root, scratch, p).unwrap_or(true))
+                    .map(|p| escapes_project(ctx.project_root, ctx.scratch, p).unwrap_or(true))
                     .unwrap_or(false)
             });
             if escapes {
@@ -282,12 +296,14 @@ mod tests {
         let d = resolve_decision(
             lookup("read").unwrap(),
             &json!({"path": "inner.txt"}),
-            &root,
-            None,
-            &[],
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &[],
+                hide_jan: true,
+            },
             &perms,
             &grants,
-            true,
         );
         assert_eq!(d, Decision::Allow);
         let _ = std::fs::remove_dir_all(&root);
@@ -301,12 +317,14 @@ mod tests {
         let d = resolve_decision(
             lookup("read").unwrap(),
             &json!({"path": "../x"}),
-            &root,
-            None,
-            &[],
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &[],
+                hide_jan: true,
+            },
             &perms,
             &grants,
-            true,
         );
         assert_eq!(d, Decision::Prompt(PromptKind::ReadEscape));
         let _ = std::fs::remove_dir_all(&root);
@@ -321,12 +339,14 @@ mod tests {
             let d = resolve_decision(
                 lookup(tool).unwrap(),
                 &json!({}),
-                &root,
-                None,
-                &[],
+                &GateContext {
+                    project_root: &root,
+                    scratch: None,
+                    read_roots: &[],
+                    hide_jan: true,
+                },
                 &perms,
                 &grants,
-                true,
             );
             assert_eq!(d, Decision::Allow, "{tool} should be auto-allowed");
         }
@@ -342,12 +362,14 @@ mod tests {
         let d = resolve_decision(
             lookup("web_search").unwrap(),
             &json!({}),
-            &root,
-            None,
-            &[],
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &[],
+                hide_jan: true,
+            },
             &perms,
             &grants,
-            true,
         );
         assert_eq!(
             d,
@@ -369,12 +391,14 @@ mod tests {
             let d = resolve_decision(
                 lookup(tool).unwrap(),
                 &json!({ "path": ".jan/agent/agent.toml" }),
-                &root,
-                None,
-                &[],
+                &GateContext {
+                    project_root: &root,
+                    scratch: None,
+                    read_roots: &[],
+                    hide_jan: true,
+                },
                 &perms,
                 &grants,
-                true,
             );
             assert_eq!(
                 d,
@@ -386,12 +410,14 @@ mod tests {
         let d = resolve_decision(
             lookup("bash").unwrap(),
             &json!({"command": "cat .jan/agent/agent.toml"}),
-            &root,
-            None,
-            &[],
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &[],
+                hide_jan: true,
+            },
             &perms,
             &grants,
-            true,
         );
         assert_eq!(d, Decision::HardDeny(DenyReason::Hidden));
         // The instructions file is an ordinary project file at the root.
@@ -399,12 +425,14 @@ mod tests {
         let d = resolve_decision(
             lookup("read").unwrap(),
             &json!({"path": "JAN.md"}),
-            &root,
-            None,
-            &[],
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &[],
+                hide_jan: true,
+            },
             &perms,
             &grants,
-            true,
         );
         assert_eq!(d, Decision::Allow);
         let _ = std::fs::remove_dir_all(&root);
@@ -424,12 +452,14 @@ mod tests {
             let d = resolve_decision(
                 lookup(tool).unwrap(),
                 &json!({ "path": ".jan/agent/agent.toml" }),
-                &root,
-                None,
-                &[],
+                &GateContext {
+                    project_root: &root,
+                    scratch: None,
+                    read_roots: &[],
+                    hide_jan: false,
+                },
                 &perms,
                 &grants,
-                false,
             );
             assert_ne!(
                 d,
@@ -441,12 +471,14 @@ mod tests {
         let d = resolve_decision(
             lookup("bash").unwrap(),
             &json!({"command": "cat .jan/agent/agent.toml"}),
-            &root,
-            None,
-            &[],
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &[],
+                hide_jan: false,
+            },
             &perms,
             &grants,
-            false,
         );
         assert_ne!(d, Decision::HardDeny(DenyReason::Hidden));
         let _ = std::fs::remove_dir_all(&root);
@@ -460,12 +492,14 @@ mod tests {
         let d = resolve_decision(
             lookup("write").unwrap(),
             &json!({"path": "out.txt"}),
-            &root,
-            None,
-            &[],
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &[],
+                hide_jan: true,
+            },
             &perms,
             &grants,
-            true,
         );
         assert_eq!(d, Decision::Prompt(PromptKind::Write));
         let _ = std::fs::remove_dir_all(&root);
@@ -479,12 +513,14 @@ mod tests {
         let d = resolve_decision(
             lookup("bash").unwrap(),
             &json!({"command": "ls"}),
-            &root,
-            None,
-            &[],
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &[],
+                hide_jan: true,
+            },
             &perms,
             &grants,
-            true,
         );
         assert_eq!(d, Decision::Prompt(PromptKind::Exec));
         let _ = std::fs::remove_dir_all(&root);
@@ -499,12 +535,14 @@ mod tests {
             let d = resolve_decision(
                 lookup("bash").unwrap(),
                 &json!({"command": "ls", "job_id": job_id}),
-                &root,
-                None,
-                &[],
+                &GateContext {
+                    project_root: &root,
+                    scratch: None,
+                    read_roots: &[],
+                    hide_jan: true,
+                },
                 &perms,
                 &grants,
-                true,
             );
             assert_eq!(d, Decision::Prompt(PromptKind::Exec), "job_id {job_id:?}");
         }
@@ -519,12 +557,14 @@ mod tests {
         let d = resolve_decision(
             lookup("bash").unwrap(),
             &json!({"job_id": "bash-0"}),
-            &root,
-            None,
-            &[],
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &[],
+                hide_jan: true,
+            },
             &perms,
             &grants,
-            true,
         );
         assert_eq!(d, Decision::Allow);
         let _ = std::fs::remove_dir_all(&root);
@@ -550,12 +590,14 @@ mod tests {
         let d = resolve_decision(
             lookup("bash").unwrap(),
             &json!({"command": "git push"}),
-            &root,
-            None,
-            &[],
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &[],
+                hide_jan: true,
+            },
             &perms,
             &grants,
-            true,
         );
         assert_eq!(d, Decision::Allow);
 
@@ -563,12 +605,14 @@ mod tests {
         let d = resolve_decision(
             lookup("bash").unwrap(),
             &json!({"command": "rm -rf /"}),
-            &root,
-            None,
-            &[],
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &[],
+                hide_jan: true,
+            },
             &perms,
             &grants,
-            true,
         );
         assert_eq!(d, Decision::Prompt(PromptKind::Exec));
         let _ = std::fs::remove_dir_all(&root);
@@ -590,12 +634,14 @@ mod tests {
             let d = resolve_decision(
                 lookup("bash").unwrap(),
                 &json!({ "command": cmd }),
-                &root,
-                None,
-                &[],
+                &GateContext {
+                    project_root: &root,
+                    scratch: None,
+                    read_roots: &[],
+                    hide_jan: true,
+                },
                 &perms,
                 &grants,
-                true,
             );
             assert_eq!(
                 d,
@@ -617,12 +663,14 @@ mod tests {
             let d = resolve_decision(
                 lookup("bash").unwrap(),
                 &json!({ "command": cmd }),
-                &root,
-                None,
-                &[],
+                &GateContext {
+                    project_root: &root,
+                    scratch: None,
+                    read_roots: &[],
+                    hide_jan: true,
+                },
                 &perms,
                 &grants,
-                true,
             );
             assert_eq!(d, Decision::Allow, "should be covered: {cmd}");
         }
@@ -640,12 +688,14 @@ mod tests {
         let d = resolve_decision(
             lookup("bash").unwrap(),
             &json!({"command": "sudo   systemctl restart nginx"}),
-            &root,
-            None,
-            &[],
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &[],
+                hide_jan: true,
+            },
             &perms,
             &grants,
-            true,
         );
         assert_eq!(d, Decision::Allow);
 
@@ -653,12 +703,14 @@ mod tests {
         let d = resolve_decision(
             lookup("bash").unwrap(),
             &json!({"command": "sudo rm -rf /"}),
-            &root,
-            None,
-            &[],
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &[],
+                hide_jan: true,
+            },
             &perms,
             &grants,
-            true,
         );
         assert_eq!(d, Decision::Prompt(PromptKind::Exec));
         let _ = std::fs::remove_dir_all(&root);
@@ -681,12 +733,14 @@ mod tests {
                 let d = resolve_decision(
                     lookup(tool).unwrap(),
                     &json!({ "path": path }),
-                    &root,
-                    None,
-                    &[],
+                    &GateContext {
+                        project_root: &root,
+                        scratch: None,
+                        read_roots: &[],
+                        hide_jan: true,
+                    },
                     &perms,
                     &grants,
-                    true,
                 );
                 assert_eq!(
                     d,
@@ -707,12 +761,14 @@ mod tests {
             let d = resolve_decision(
                 lookup(name).unwrap(),
                 &json!({"name": "x", "content": "y"}),
-                &root,
-                None,
-                &[],
+                &GateContext {
+                    project_root: &root,
+                    scratch: None,
+                    read_roots: &[],
+                    hide_jan: true,
+                },
                 &perms,
                 &grants,
-                true,
             );
             assert_eq!(d, Decision::Allow, "{name} should auto-allow");
         }
@@ -722,12 +778,14 @@ mod tests {
         let d = resolve_decision(
             lookup("memory_write").unwrap(),
             &json!({"name": "x", "content": "y"}),
-            &root,
-            None,
-            &[],
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &[],
+                hide_jan: true,
+            },
             &denied,
             &grants,
-            true,
         );
         assert_eq!(d, Decision::HardDeny(DenyReason::Policy));
         let _ = std::fs::remove_dir_all(&root);
@@ -741,12 +799,14 @@ mod tests {
         let d = resolve_decision(
             lookup("write").unwrap(),
             &json!({"path": "out.txt"}),
-            &root,
-            None,
-            &[],
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &[],
+                hide_jan: true,
+            },
             &perms,
             &grants,
-            true,
         );
         assert_eq!(d, Decision::HardDeny(DenyReason::Policy));
         let _ = std::fs::remove_dir_all(&root);
@@ -760,12 +820,14 @@ mod tests {
         let d = resolve_decision(
             lookup("write").unwrap(),
             &json!({"path": "out.txt"}),
-            &root,
-            None,
-            &[],
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &[],
+                hide_jan: true,
+            },
             &perms,
             &grants,
-            true,
         );
         assert_eq!(d, Decision::Allow);
         let _ = std::fs::remove_dir_all(&root);
@@ -780,12 +842,14 @@ mod tests {
         let d = resolve_decision(
             lookup("write").unwrap(),
             &json!({"path": "out.txt"}),
-            &root,
-            None,
-            &[],
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &[],
+                hide_jan: true,
+            },
             &perms,
             &grants,
-            true,
         );
         assert_eq!(d, Decision::Allow);
         let _ = std::fs::remove_dir_all(&root);
@@ -800,12 +864,14 @@ mod tests {
         let d = resolve_decision(
             lookup("read").unwrap(),
             &json!({"path": "../x"}),
-            &root,
-            None,
-            &[],
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &[],
+                hide_jan: true,
+            },
             &perms,
             &grants,
-            true,
         );
         assert_eq!(d, Decision::Allow);
         let _ = std::fs::remove_dir_all(&root);
@@ -819,12 +885,14 @@ mod tests {
         let d = resolve_decision(
             lookup("write").unwrap(),
             &json!({"path": "sub/new.txt"}),
-            &root,
-            None,
-            &[],
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &[],
+                hide_jan: true,
+            },
             &perms,
             &grants,
-            true,
         );
         assert_eq!(d, Decision::Prompt(PromptKind::Write));
         let _ = std::fs::remove_dir_all(&root);
@@ -840,12 +908,14 @@ mod tests {
             let d = resolve_decision(
                 lookup("write").unwrap(),
                 &json!({"path": path}),
-                &root,
-                None,
-                &[],
+                &GateContext {
+                    project_root: &root,
+                    scratch: None,
+                    read_roots: &[],
+                    hide_jan: true,
+                },
                 &perms,
                 &grants,
-                true,
             );
             assert_eq!(d, Decision::Prompt(PromptKind::WriteEscape), "{}", path);
         }
@@ -861,12 +931,14 @@ mod tests {
         let d = resolve_decision(
             lookup("write").unwrap(),
             &json!({"path": "../x"}),
-            &root,
-            None,
-            &[],
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &[],
+                hide_jan: true,
+            },
             &perms,
             &grants,
-            true,
         );
         assert_eq!(d, Decision::Allow);
         let _ = std::fs::remove_dir_all(&root);
@@ -880,12 +952,14 @@ mod tests {
         let d = resolve_decision(
             lookup("read").unwrap(),
             &json!({"path": "../x"}),
-            &root,
-            None,
-            &[],
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &[],
+                hide_jan: true,
+            },
             &perms,
             &grants,
-            true,
         );
         assert_eq!(d, Decision::Prompt(PromptKind::ReadEscape));
         let _ = std::fs::remove_dir_all(&root);
@@ -905,24 +979,28 @@ mod tests {
         let read = resolve_decision(
             lookup("read").unwrap(),
             &json!({"path": target}),
-            &root,
-            None,
-            &roots,
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &roots,
+                hide_jan: true,
+            },
             &perms,
             &grants,
-            true,
         );
         assert_eq!(read, Decision::Allow);
 
         let write = resolve_decision(
             lookup("write").unwrap(),
             &json!({"path": repo.join("new.txt").to_string_lossy(), "content": "y"}),
-            &root,
-            None,
-            &roots,
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &roots,
+                hide_jan: true,
+            },
             &ToolPermissions::new(PermissionDefault::ReadOnly, &[], &[], &[]),
             &grants,
-            true,
         );
         assert_eq!(write, Decision::Prompt(PromptKind::WriteEscape));
 
@@ -933,19 +1011,23 @@ mod tests {
     #[test]
     fn an_escaping_read_still_prompts_when_no_root_covers_it() {
         let root = unique_root();
+
         let repo = unique_root();
         let elsewhere = unique_root();
         let roots = vec![repo.clone()];
         let d = resolve_decision(
             lookup("read").unwrap(),
             &json!({"path": elsewhere.join("secret").to_string_lossy()}),
-            &root,
-            None,
-            &roots,
+            &GateContext {
+                project_root: &root,
+                scratch: None,
+                read_roots: &roots,
+                hide_jan: true,
+            },
             &ToolPermissions::new(PermissionDefault::ReadOnly, &[], &[], &[]),
             &SessionGrants::default(),
-            true,
         );
+
         assert_eq!(d, Decision::Prompt(PromptKind::ReadEscape));
         for d in [&root, &repo, &elsewhere] {
             let _ = std::fs::remove_dir_all(d);

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/gate.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/gate.rs
@@ -124,17 +124,7 @@ pub enum Decision {
     Prompt(PromptKind),
 }
 
-/// Decide how a built-in tool call should be gated, combining the static
-/// agent.toml policy, capability class, sandbox escape, and session grants.
-///
-/// Precedence: deny (agent.toml) > explicit allow/allow_write (agent.toml) >
-/// session grant > capability rules. Reads inside the project are silently
-/// allowed; reads that escape the project, and all writes/exec, prompt (unless
-/// already granted this session or pre-approved in agent.toml).
-///
-/// The sandbox geometry is bundled in [`GateContext`] so callers describe the
-/// filesystem and hiding policy once instead of repeating four trailing args.
-
+/// Filesystem roots and hiding policy used when gating a tool call.
 #[derive(Debug, Clone, Copy)]
 pub struct GateContext<'a> {
     /// The project root: paths inside it are the agent's own workspace.
@@ -147,6 +137,13 @@ pub struct GateContext<'a> {
     pub hide_jan: bool,
 }
 
+/// Decide how a built-in tool call should be gated, combining the static
+/// agent.toml policy, capability class, sandbox escape, and session grants.
+///
+/// Precedence: deny (agent.toml) > explicit allow/allow_write (agent.toml) >
+/// session grant > capability rules. Reads inside the project are silently
+/// allowed; reads that escape the project, and all writes/exec, prompt (unless
+/// already granted this session or pre-approved in agent.toml).
 pub fn resolve_decision(
     tool: &BuiltinTool,
     args: &serde_json::Value,

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/handlers.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/handlers.rs
@@ -2563,12 +2563,14 @@ mod tests {
         let d = crate::tools::gate::resolve_decision(
             lookup("write").unwrap(),
             &json!({"path": "/tmp/x.txt", "content": "y"}),
-            &root,
-            Some(&scratch),
-            &[],
+            &crate::tools::gate::GateContext {
+                project_root: &root,
+                scratch: Some(&scratch),
+                read_roots: &[],
+                hide_jan: true,
+            },
             &crate::permissions::ToolPermissions::default(),
             &crate::tools::gate::SessionGrants::default(),
-            true,
         );
         assert_eq!(
             d,
@@ -2592,12 +2594,14 @@ mod tests {
         let d = crate::tools::gate::resolve_decision(
             lookup("write").unwrap(),
             &json!({"path": "/tmp/esc/x.txt", "content": "y"}),
-            &root,
-            Some(&scratch),
-            &[],
+            &crate::tools::gate::GateContext {
+                project_root: &root,
+                scratch: Some(&scratch),
+                read_roots: &[],
+                hide_jan: true,
+            },
             &crate::permissions::ToolPermissions::default(),
             &crate::tools::gate::SessionGrants::default(),
-            true,
         );
         assert_eq!(
             d,
@@ -3487,8 +3491,10 @@ mod tests {
     // ---- screenshot ---------------------------------------------------------
 
     /// Two headless Chromes racing for the same profile dir collide, so the
-    /// tests that actually launch one are serialised.
-    static CHROME_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    /// tests that actually launch one are serialised. An async mutex so the test
+    /// can hold it across the awaited screenshot without `await_holding_lock`.
+    static CHROME_TEST_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
+        std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
 
     #[tokio::test]
     async fn screenshot_rejects_a_non_html_file() {
@@ -3542,7 +3548,7 @@ mod tests {
         if chrome_binary().is_none() {
             return;
         }
-        let _guard = CHROME_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = CHROME_TEST_LOCK.lock().await;
         let root = unique_root();
         std::fs::write(
             root.join("page.html"),

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/jail.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/jail.rs
@@ -1069,8 +1069,13 @@ mod enforcement_tests {
     fn temp_dir() -> PathBuf {
         let tmp = std::env::temp_dir();
         #[cfg(target_os = "macos")]
-        let tmp = tmp.canonicalize().unwrap_or(tmp);
-        tmp
+        {
+            tmp.canonicalize().unwrap_or(tmp)
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            tmp
+        }
     }
 
     fn workspace() -> PathBuf {

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/workspace.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/workspace.rs
@@ -245,13 +245,12 @@ const SCRATCH_STALE_AFTER: std::time::Duration = std::time::Duration::from_secs(
 /// Failures are silent per entry: another user's `jan-agent-*` in a shared
 /// `/tmp` is not ours to delete and simply fails the unlink.
 pub async fn sweep_stale_scratch_dirs() -> usize {
-    sweep_scratch_older_than(SCRATCH_STALE_AFTER).await
+    sweep_scratch_older_than(&std::env::temp_dir(), SCRATCH_STALE_AFTER).await
 }
 
-/// [`sweep_stale_scratch_dirs`] with an explicit age, so a test can collect a
-/// scratch it just created instead of waiting a day.
-async fn sweep_scratch_older_than(max_age: std::time::Duration) -> usize {
-    let Ok(mut entries) = tokio::fs::read_dir(std::env::temp_dir()).await else {
+/// Sweep an explicit directory so tests never collect another session's scratch.
+async fn sweep_scratch_older_than(root: &Path, max_age: std::time::Duration) -> usize {
+    let Ok(mut entries) = tokio::fs::read_dir(root).await else {
         return 0;
     };
     let mut removed = 0;
@@ -457,25 +456,6 @@ pub fn workspace_filename(name: &str) -> Result<String, String> {
     Ok(format!("{stem}.md"))
 }
 
-/// Serialises tests that touch the *global* scratch namespace.
-///
-/// `sweep_scratch_older_than` collects every scratch dir in the shared host temp
-/// dir, so running it beside a test that needs its own scratch alive is a race:
-/// the sweep deletes the directory the other test is mid-way through using. Any
-/// test that either sweeps or depends on a live scratch takes this first.
-#[cfg(test)]
-pub(crate) static SCRATCH_NAMESPACE_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
-    std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
-
-/// Take [`SCRATCH_NAMESPACE_LOCK`], awaiting the mutex like the tests that use
-/// it. The guard is held across the async body on purpose: these tests serialise
-/// against the sweep that otherwise races them, and [`tokio::sync::Mutex`] drops
-/// the guard if a task is cancelled, so it cannot deadlock.
-#[cfg(test)]
-pub(crate) async fn lock_scratch_namespace() -> tokio::sync::MutexGuard<'static, ()> {
-    SCRATCH_NAMESPACE_LOCK.lock().await
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -545,30 +525,32 @@ mod tests {
     /// by age. Nothing else in the temp dir is touched, and a fresh scratch
     /// survives the real 24h threshold.
     #[tokio::test]
-    #[allow(clippy::await_holding_lock)]
     async fn stale_scratch_dirs_are_swept_and_fresh_ones_are_not() {
-        let session = format!("sweep-stale-{}", std::process::id());
-        let _guard = lock_scratch_namespace().await;
-        let orphan = ensure_scratch_dir(&session).await.unwrap();
+        let root = tmp_root("scratch_sweep");
+        let orphan = root.join("jan-agent-orphan");
+        ensure_scratch_dir_path(&orphan).await.unwrap();
         std::fs::write(orphan.join("spill.txt"), b"leaked").unwrap();
-        let bystander = std::env::temp_dir().join(format!("not-a-scratch-{session}"));
+        let bystander = root.join("not-a-scratch");
         std::fs::create_dir_all(&bystander).unwrap();
 
         assert_eq!(
-            sweep_stale_scratch_dirs().await,
+            sweep_scratch_older_than(&root, SCRATCH_STALE_AFTER).await,
             0,
             "a fresh scratch is live"
         );
         assert!(orphan.is_dir());
 
-        assert!(sweep_scratch_older_than(std::time::Duration::ZERO).await >= 1);
+        assert_eq!(
+            sweep_scratch_older_than(&root, std::time::Duration::ZERO).await,
+            1
+        );
         assert!(!orphan.exists(), "an abandoned scratch must be collected");
         assert!(
             bystander.is_dir(),
             "swept a directory that is not a scratch"
         );
 
-        let _ = std::fs::remove_dir_all(&bystander);
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     /// The scratch root must never be a pre-planted symlink to another

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/workspace.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/workspace.rs
@@ -464,15 +464,16 @@ pub fn workspace_filename(name: &str) -> Result<String, String> {
 /// the sweep deletes the directory the other test is mid-way through using. Any
 /// test that either sweeps or depends on a live scratch takes this first.
 #[cfg(test)]
-pub(crate) static SCRATCH_NAMESPACE_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+pub(crate) static SCRATCH_NAMESPACE_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
 
-/// Take [`SCRATCH_NAMESPACE_LOCK`], ignoring poisoning: a panic in one test must
-/// not cascade into unrelated failures in every other one.
+/// Take [`SCRATCH_NAMESPACE_LOCK`], awaiting the mutex like the tests that use
+/// it. The guard is held across the async body on purpose: these tests serialise
+/// against the sweep that otherwise races them, and [`tokio::sync::Mutex`] drops
+/// the guard if a task is cancelled, so it cannot deadlock.
 #[cfg(test)]
-pub(crate) fn lock_scratch_namespace() -> std::sync::MutexGuard<'static, ()> {
-    SCRATCH_NAMESPACE_LOCK
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
+pub(crate) async fn lock_scratch_namespace() -> tokio::sync::MutexGuard<'static, ()> {
+    SCRATCH_NAMESPACE_LOCK.lock().await
 }
 
 #[cfg(test)]
@@ -547,7 +548,7 @@ mod tests {
     #[allow(clippy::await_holding_lock)]
     async fn stale_scratch_dirs_are_swept_and_fresh_ones_are_not() {
         let session = format!("sweep-stale-{}", std::process::id());
-        let _guard = lock_scratch_namespace();
+        let _guard = lock_scratch_namespace().await;
         let orphan = ensure_scratch_dir(&session).await.unwrap();
         std::fs::write(orphan.join("spill.txt"), b"leaked").unwrap();
         let bystander = std::env::temp_dir().join(format!("not-a-scratch-{session}"));

--- a/src-tauri/src/core/agent/loop.rs
+++ b/src-tauri/src/core/agent/loop.rs
@@ -956,14 +956,16 @@ impl ToolInvoker for CompositeToolInvoker {
             let decision = resolve_decision(
                 tool,
                 &args,
-                &self.project_root,
-                Some(self.scratch_root.as_path()),
-                // The CLI works *in* the project, so it has no separate
-                // read-only root to attach.
-                &[],
+                &tauri_plugin_agent_tools::tools::gate::GateContext {
+                    project_root: &self.project_root,
+                    scratch: Some(self.scratch_root.as_path()),
+                    // The CLI works *in* the project, so it has no separate
+                    // read-only root to attach.
+                    read_roots: &[],
+                    hide_jan: self.sandbox,
+                },
                 &self.permissions,
                 &snapshot,
-                self.sandbox,
             );
             // Auto-approval suppresses every prompt (sandbox escape, write, exec) but
             // still honors HardDeny, so the hidden `.jan` invariant (while the shell

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -1891,14 +1891,9 @@ struct App {
     /// Lines scrolled back from the tail; 0 pins the view to the bottom so new
     /// content follows. Non-zero survives streaming so scroll-back stays usable.
     scrollback: u16,
-    /// A full repaint is owed before the next frame: `apply_repaint` clears the
-    /// screen and resets ratatui's diff baseline so the following draw re-emits
-    /// every cell. A
-    /// foreign write to the TTY (a `wall(1)` broadcast) damages the physical
-    /// screen without touching either buffer, so the diff alone sees no change
-    /// and would leave that damage on screen for the rest of the session. Set
-    /// by Ctrl-L and by `Event::Resize`, never per frame -- an unconditional
-    /// clear would flicker and undo the synchronized-update work.
+    /// Ctrl-L or a resize requests a full repaint before the next frame.
+    /// Foreign TTY writes bypass ratatui's buffers, so ordinary diffs cannot
+    /// repair them. Clear only on request, never on every frame.
     repaint: bool,
     /// Set when the user submits a message; the loop spawns a run next tick.
     want_start: bool,
@@ -7958,15 +7953,6 @@ async fn chat_loop<B: Backend>(
             }
         }
 
-        // A repaint was asked for (Ctrl-L, or a resize): invalidate the frame
-        // so the draw below re-emits every cell rather than diffing against
-        // buffers that no longer describe the screen. See `apply_repaint`.
-        // Kept outside the synchronized block below: the clear is its own
-        // screen operation, not part of the frame that block flips atomically.
-        if app.take_repaint() {
-            apply_repaint(terminal);
-        }
-
         // Wrap the repaint in synchronized-output (`\x1b[?2026h/l`) so the
         // terminal buffers the whole frame and flips it atomically, eliminating
         // tearing. Written straight to stdout (not the generic `Backend`) for the
@@ -7977,6 +7963,12 @@ async fn chat_loop<B: Backend>(
         // frame (see `use_synchronized_output`).
         if sync_output {
             let _ = execute!(io::stdout(), BeginSynchronizedUpdate);
+        }
+        // Clear inside the synchronized frame too, so the terminal never
+        // presents an empty screen between clearing and repainting. Kitty
+        // still skips synchronized output, as it does for ordinary draws.
+        if app.take_repaint() {
+            apply_repaint(terminal);
         }
         let draw_result = terminal.draw(|f| draw(f, app)).map_err(|e| e.to_string());
         if sync_output {
@@ -8458,10 +8450,9 @@ fn route_paste_event(app: &mut App, event: Event) {
     }
 }
 
-/// Route a terminal resize to a full repaint. Diffing the next frame against a
-/// buffer laid out for the old geometry leaves debris on screen, so the whole
-/// frame is re-emitted against the new size instead. Purely a display concern:
-/// the draft, scroll position, and any running turn are untouched.
+/// Request a repaint even when a resize event reports the current geometry.
+/// Ratatui already handles size changes during `draw`, but a resize can damage
+/// the screen and return to the old size before the next frame is drawn.
 fn route_resize_event(app: &mut App, event: Event) {
     if !matches!(event, Event::Resize(_, _)) {
         return;
@@ -16379,7 +16370,7 @@ mod tests {
         message_text, note_update, open_config_screen, open_rewind_picker, pairs_to_str,
         parse_command, partial_json_field, provider_label_for_model, rebuild_recall,
         replay_display_log, restore_goal, restore_run_mode, restore_todos, resume_hint,
-        rewind_to, route_paste_event, route_resize_event, row_width, run_command,
+        rewind_to, route_paste_event, row_width, run_command,
         running_group_rows, selection_text, spans_width, spawn_branch_poll, split_reasoning,
         starting_call_lines, startup_modes, strip_system_xml_tags, subagent_activity,
         subagent_name_from_run_id, summarize_result, sync_output_for, thinking_open,
@@ -25543,49 +25534,6 @@ mod tests {
         );
     }
 
-    /// Ctrl-L is the repaint key, in ordinary composing and while a docked ask
-    /// owns the keyboard (`handle_ask_key` runs first and would otherwise
-    /// swallow it). It is a display operation: it must not type into the
-    /// composer or answer.
-    #[tokio::test]
-    async fn ctrl_l_routes_to_a_repaint() {
-        let mut app = test_app();
-        let registry: PermissionRegistry = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-        let mcp_servers: crate::core::state::SharedMcpServers =
-            Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-        let mut current: Option<CurrentRun> = None;
-        let ctrl_l = KeyEvent::new(KeyCode::Char('l'), KeyModifiers::CONTROL);
-
-        handle_key(&mut app, ctrl_l, &registry, &mut current, &mcp_servers).await;
-        assert!(app.take_repaint(), "Ctrl-L must request a full repaint");
-        assert!(app.input.is_empty(), "got: {:?}", app.input);
-
-        // A plain `l` is ordinary text, not a repaint.
-        let plain_l = KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE);
-        handle_key(&mut app, plain_l, &registry, &mut current, &mcp_servers).await;
-        assert!(!app.take_repaint(), "only Ctrl-L may repaint");
-        assert_eq!(app.input, "l");
-
-        assert!(
-            KEY_BINDINGS.iter().any(|(k, _)| k.contains("Ctrl-L")),
-            "the repaint key needs advertising"
-        );
-    }
-
-    /// A resize is a repaint trigger in its own right: the next frame must not
-    /// be diffed against a buffer laid out for the old geometry.
-    #[test]
-    fn resize_routes_to_a_repaint() {
-        let mut app = test_app();
-        route_resize_event(&mut app, Event::Resize(100, 40));
-        assert!(app.take_repaint(), "a resize must request a full repaint");
-
-        // Other events leave the flag alone -- the repaint is triggered, never
-        // unconditional (a per-frame clear would flicker).
-        route_resize_event(&mut app, Event::Paste("hi".into()));
-        assert!(!app.take_repaint());
-    }
-
     /// A backend that counts cursor-position queries and otherwise behaves
     /// exactly like `TestBackend`. `Terminal::clear` issues one; on crossterm
     /// that is a DSR (`\x1b[6n`) round trip, which `read_position_raw` waits
@@ -25751,6 +25699,9 @@ mod tests {
             request: ask_request(false, false),
             timeout_secs: None,
         });
+        let ask = app.ask_queue.front_mut().unwrap();
+        ask.editing_custom = true;
+        ask.custom_input = "answer in progress".into();
 
         let ctrl_l = KeyEvent::new(KeyCode::Char('l'), KeyModifiers::CONTROL);
         assert!(
@@ -25762,9 +25713,10 @@ mod tests {
             !app.ask_queue.is_empty(),
             "a repaint must not answer or dismiss the question"
         );
-        assert!(
-            app.ask_queue.front().unwrap().custom_input.is_empty(),
-            "the repaint key must not be typed into the answer"
+        assert_eq!(
+            app.ask_queue.front().unwrap().custom_input,
+            "answer in progress",
+            "a repaint must preserve the answer being edited"
         );
     }
 

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -1891,6 +1891,15 @@ struct App {
     /// Lines scrolled back from the tail; 0 pins the view to the bottom so new
     /// content follows. Non-zero survives streaming so scroll-back stays usable.
     scrollback: u16,
+    /// A full repaint is owed before the next frame: `apply_repaint` clears the
+    /// screen and resets ratatui's diff baseline so the following draw re-emits
+    /// every cell. A
+    /// foreign write to the TTY (a `wall(1)` broadcast) damages the physical
+    /// screen without touching either buffer, so the diff alone sees no change
+    /// and would leave that damage on screen for the rest of the session. Set
+    /// by Ctrl-L and by `Event::Resize`, never per frame -- an unconditional
+    /// clear would flicker and undo the synchronized-update work.
+    repaint: bool,
     /// Set when the user submits a message; the loop spawns a run next tick.
     want_start: bool,
     /// Turns (model roundtrips, plus the submission that kicked off a run)
@@ -2347,6 +2356,7 @@ impl App {
             retry_after_compact: false,
             overflow_retries: 0,
             scrollback: 0,
+            repaint: false,
             want_start: false,
             turns_since_todos_closed: 0,
             todos_closed_at: None,
@@ -2487,6 +2497,18 @@ impl App {
     fn clear_selection(&mut self) {
         self.selection = None;
         self.copy_armed = false;
+    }
+
+    /// Owe a full repaint on the next frame. A pure display operation: it
+    /// leaves the draft, scroll position, and run state alone, so it is safe
+    /// to request from any mode, mid-turn included.
+    fn request_repaint(&mut self) {
+        self.repaint = true;
+    }
+
+    /// Take the pending full-repaint request, if there is one.
+    fn take_repaint(&mut self) -> bool {
+        std::mem::take(&mut self.repaint)
     }
 
     /// Line count of a copy recent enough to still advertise, if any.
@@ -7936,6 +7958,15 @@ async fn chat_loop<B: Backend>(
             }
         }
 
+        // A repaint was asked for (Ctrl-L, or a resize): invalidate the frame
+        // so the draw below re-emits every cell rather than diffing against
+        // buffers that no longer describe the screen. See `apply_repaint`.
+        // Kept outside the synchronized block below: the clear is its own
+        // screen operation, not part of the frame that block flips atomically.
+        if app.take_repaint() {
+            apply_repaint(terminal);
+        }
+
         // Wrap the repaint in synchronized-output (`\x1b[?2026h/l`) so the
         // terminal buffers the whole frame and flips it atomically, eliminating
         // tearing. Written straight to stdout (not the generic `Backend`) for the
@@ -7982,6 +8013,7 @@ async fn chat_loop<B: Backend>(
                                 handle_mouse(app, mouse);
                             }
                         }
+                        Ok(event @ Event::Resize(_, _)) => route_resize_event(app, event),
                         _ => {}
                     }
                 }
@@ -8346,6 +8378,14 @@ async fn handle_ask_key(
         return true;
     }
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    // A docked ask owns the keyboard, and runs before `handle_key`, so the
+    // repaint key has to be honoured here too -- otherwise a broadcast that
+    // lands during a question stays on screen until the question is answered.
+    // Consumed rather than typed into a custom answer.
+    if ctrl && key.code == KeyCode::Char('l') {
+        app.request_repaint();
+        return true;
+    }
     if ctrl && matches!(key.code, KeyCode::Char('c') | KeyCode::Char('d')) {
         crate::core::agent::interaction::cancel_all(registry).await;
         app.ask_queue.clear();
@@ -8415,6 +8455,41 @@ fn route_paste_event(app: &mut App, event: Event) {
         for c in text.chars() {
             app.input_insert(c);
         }
+    }
+}
+
+/// Route a terminal resize to a full repaint. Diffing the next frame against a
+/// buffer laid out for the old geometry leaves debris on screen, so the whole
+/// frame is re-emitted against the new size instead. Purely a display concern:
+/// the draft, scroll position, and any running turn are untouched.
+fn route_resize_event(app: &mut App, event: Event) {
+    if !matches!(event, Event::Resize(_, _)) {
+        return;
+    }
+    app.request_repaint();
+}
+
+/// Clear the screen and reset ratatui's diff baseline, so the next `draw`
+/// re-emits every cell instead of only the ones its buffers say changed. This
+/// is what actually erases a foreign write: a `wall(1)` broadcast paints over
+/// the frame without touching either buffer, so the diff alone considers those
+/// cells already correct and would leave the damage there for the session.
+///
+/// `Terminal::resize` rather than `Terminal::clear`: both clear and reset the
+/// baseline, but `clear` first asks the backend for the cursor position, which
+/// on crossterm is a DSR (`\x1b[6n`) round trip -- a *blocking* read of up to
+/// two seconds. A terminal that never answers (a pipe, a multiplexer that
+/// swallows it, or one whose reply our own event reader already consumed)
+/// would stall streaming and input for that long and then skip the clear
+/// anyway, which is the frozen-UI failure this key exists to fix. `size` is a
+/// `TIOCGWINSZ` ioctl with no round trip, so the repaint stays immediate.
+///
+/// Best-effort like the synchronized-update markers: a terminal that refuses
+/// its size is not reason enough to end the session, and the next frame still
+/// draws.
+fn apply_repaint<B: Backend>(terminal: &mut Terminal<B>) {
+    if let Ok(size) = terminal.size() {
+        let _ = terminal.resize(size.into());
     }
 }
 
@@ -8723,6 +8798,17 @@ async fn handle_key(
     }
 
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+
+    // Ctrl-L is the readline/less spelling of "redraw", and it is deliberately
+    // ahead of every mode guard below: the screen can be damaged by a foreign
+    // write (a `wall(1)` broadcast) at any moment, including while a prompt or
+    // picker owns the keyboard, so the recovery key has to work in all of them.
+    // Repainting touches nothing but the display -- the draft, scroll position,
+    // and any in-flight turn are left exactly as they were.
+    if ctrl && key.code == KeyCode::Char('l') {
+        app.request_repaint();
+        return;
+    }
     let alt = key.modifiers.contains(KeyModifiers::ALT);
     let sup = key.modifiers.contains(KeyModifiers::SUPER);
     // A modified Enter is a newline, never a submit or a completion, so the
@@ -9908,6 +9994,7 @@ const KEY_BINDINGS: &[(&str, &str)] = &[
     ("PgUp/PgDn", "Scroll the transcript"),
     ("Ctrl-O", "Expand or collapse all tool calls"),
     ("Ctrl-V", "Paste an image from the clipboard"),
+    ("Ctrl-L", "Redraw the screen (repairs a broadcast over it)"),
     ("Shift+Tab", "Cycle reasoning effort (low/medium/high)"),
     ("Alt+T", "Toggle reasoning effort (low / last)"),
     (
@@ -16281,23 +16368,24 @@ mod tests {
     use super::SessionLimits;
     use super::{
         age_closed_todos, alt_scroll_restore, alt_scroll_save_off, answer_without_reasoning,
-        apply_resume, apply_stream_event, assistant_is_awaiting_user_answer, assistant_runs,
-        autoscroll_selection, await_branch_poll, backgrounded_job_id, brand, build_user_message,
-        clipboard_path, compact_tokens, context_lines, diff_lines, drain_stream_events,
-        estimate_token_count, finish_account_login, finish_compaction, finish_context_report,
-        finish_login, finish_plugin_install, finish_tokamak_login, finish_update_install,
-        format_tokens, group_detail_lines, group_summary, handle_ask_key, handle_ask_mouse,
-        handle_key, handle_mouse, header_spans, image_mime, image_mime_of, input_content_lines,
-        load_first_file_image, load_image_file, message_text, note_update, open_config_screen,
-        open_rewind_picker, pairs_to_str, parse_command, partial_json_field,
-        provider_label_for_model, rebuild_recall, replay_display_log, restore_goal,
-        restore_run_mode, restore_todos, resume_hint, rewind_to, route_paste_event, row_width,
-        run_command, running_group_rows, selection_text, spans_width, spawn_branch_poll,
-        split_reasoning, starting_call_lines, startup_modes, strip_system_xml_tags,
-        subagent_activity, subagent_name_from_run_id, summarize_result, sync_output_for,
-        thinking_open, tilde_path, tokens_per_second, tool_activity, tool_finished,
-        transcript_top_padding, unescape_partial_json_string, user_content_parts, wave_sweep_line,
-        with_wave_glyph, without_think_tags, App, CompactKind, ContextReport, ContextSegment,
+        apply_repaint, apply_resume, apply_stream_event, assistant_is_awaiting_user_answer,
+        assistant_runs, autoscroll_selection, await_branch_poll, backgrounded_job_id, brand,
+        build_user_message, clipboard_path, compact_tokens, context_lines, diff_lines,
+        drain_stream_events, estimate_token_count, finish_account_login, finish_compaction,
+        finish_context_report, finish_login, finish_plugin_install, finish_tokamak_login,
+        finish_update_install, format_tokens, group_detail_lines, group_summary,
+        handle_ask_key, handle_ask_mouse, handle_key, handle_mouse, header_spans, image_mime,
+        image_mime_of, input_content_lines, load_first_file_image, load_image_file,
+        message_text, note_update, open_config_screen, open_rewind_picker, pairs_to_str,
+        parse_command, partial_json_field, provider_label_for_model, rebuild_recall,
+        replay_display_log, restore_goal, restore_run_mode, restore_todos, resume_hint,
+        rewind_to, route_paste_event, route_resize_event, row_width, run_command,
+        running_group_rows, selection_text, spans_width, spawn_branch_poll, split_reasoning,
+        starting_call_lines, startup_modes, strip_system_xml_tags, subagent_activity,
+        subagent_name_from_run_id, summarize_result, sync_output_for, thinking_open,
+        tilde_path, tokens_per_second, tool_activity, tool_finished, transcript_top_padding,
+        unescape_partial_json_string, user_content_parts, wave_sweep_line, with_wave_glyph,
+        without_think_tags, App, CompactKind, ContextReport, ContextSegment,
         ContextView, CurrentRun, McpField, McpPrompt, Pending, PendingImage, PickerKind,
         ProviderField, ReasoningSeg, ResumeTarget, Row, RowKind, Selection, SelectionMode,
         SnapshotJob, Status, AGENT_SETTINGS, ALT_SCROLL_RESTORE, ALT_SCROLL_SAVE_OFF, COPY_NOTICE,
@@ -25392,6 +25480,292 @@ mod tests {
         assert_eq!(app.copy_notice(), Some(3));
         app.copied = Some((Instant::now() - COPY_NOTICE - Duration::from_millis(1), 3));
         assert_eq!(app.copy_notice(), None);
+    }
+
+    /// The bug this exists for: a foreign write to the TTY (`wall(1)`) damages
+    /// the physical screen without touching either of ratatui's buffers, so the
+    /// per-cell diff considers those cells already correct and never repaints
+    /// them -- the damage is permanent for the session. Simulated by writing
+    /// straight to the backend (`Backend::draw` is what the real terminal write
+    /// amounts to: it changes the screen, not the buffers). First half asserts
+    /// the bug is real under a plain redraw; second half asserts the repaint
+    /// path repairs it.
+    #[test]
+    fn repaint_restores_cells_a_foreign_write_corrupted() {
+        use ratatui::backend::Backend as _;
+        use ratatui::buffer::Cell;
+        use ratatui::{backend::TestBackend, Terminal};
+
+        let mut app = test_app();
+        app.submit_user("what does this project do".to_string());
+        let mut terminal = Terminal::new(TestBackend::new(60, 30)).unwrap();
+        terminal.draw(|f| super::draw(f, &mut app)).unwrap();
+        let clean = terminal.backend().buffer().clone();
+
+        // Pick a cell the frame actually painted, so a restored value is
+        // distinguishable from an incidentally blank one.
+        let (cx, cy) = (0..clean.area.height)
+            .flat_map(|y| (0..clean.area.width).map(move |x| (x, y)))
+            .find(|&(x, y)| clean[(x, y)].symbol().trim() != "")
+            .expect("the frame must paint something");
+
+        let mut broadcast = Cell::EMPTY;
+        broadcast.set_symbol("W");
+        terminal
+            .backend_mut()
+            .draw(std::iter::once((cx, cy, &broadcast)))
+            .unwrap();
+        assert_eq!(
+            terminal.backend().buffer()[(cx, cy)].symbol(),
+            "W",
+            "the simulated broadcast must actually land on the screen"
+        );
+
+        // The bug: an ordinary redraw diffs identical buffers, emits nothing,
+        // and leaves the broadcast sitting on the frame.
+        terminal.draw(|f| super::draw(f, &mut app)).unwrap();
+        assert_eq!(
+            terminal.backend().buffer()[(cx, cy)].symbol(),
+            "W",
+            "a plain redraw is expected to leave foreign damage in place"
+        );
+
+        // The fix: the repaint resets the diff baseline, so the next frame
+        // re-emits every cell and the damage is gone.
+        app.request_repaint();
+        assert!(app.take_repaint());
+        apply_repaint(&mut terminal);
+        terminal.draw(|f| super::draw(f, &mut app)).unwrap();
+        assert_eq!(
+            terminal.backend().buffer(),
+            &clean,
+            "a repaint must restore the frame the broadcast damaged"
+        );
+    }
+
+    /// Ctrl-L is the repaint key, in ordinary composing and while a docked ask
+    /// owns the keyboard (`handle_ask_key` runs first and would otherwise
+    /// swallow it). It is a display operation: it must not type into the
+    /// composer or answer.
+    #[tokio::test]
+    async fn ctrl_l_routes_to_a_repaint() {
+        let mut app = test_app();
+        let registry: PermissionRegistry = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let mcp_servers: crate::core::state::SharedMcpServers =
+            Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let mut current: Option<CurrentRun> = None;
+        let ctrl_l = KeyEvent::new(KeyCode::Char('l'), KeyModifiers::CONTROL);
+
+        handle_key(&mut app, ctrl_l, &registry, &mut current, &mcp_servers).await;
+        assert!(app.take_repaint(), "Ctrl-L must request a full repaint");
+        assert!(app.input.is_empty(), "got: {:?}", app.input);
+
+        // A plain `l` is ordinary text, not a repaint.
+        let plain_l = KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE);
+        handle_key(&mut app, plain_l, &registry, &mut current, &mcp_servers).await;
+        assert!(!app.take_repaint(), "only Ctrl-L may repaint");
+        assert_eq!(app.input, "l");
+
+        assert!(
+            KEY_BINDINGS.iter().any(|(k, _)| k.contains("Ctrl-L")),
+            "the repaint key needs advertising"
+        );
+    }
+
+    /// A resize is a repaint trigger in its own right: the next frame must not
+    /// be diffed against a buffer laid out for the old geometry.
+    #[test]
+    fn resize_routes_to_a_repaint() {
+        let mut app = test_app();
+        route_resize_event(&mut app, Event::Resize(100, 40));
+        assert!(app.take_repaint(), "a resize must request a full repaint");
+
+        // Other events leave the flag alone -- the repaint is triggered, never
+        // unconditional (a per-frame clear would flicker).
+        route_resize_event(&mut app, Event::Paste("hi".into()));
+        assert!(!app.take_repaint());
+    }
+
+    /// A backend that counts cursor-position queries and otherwise behaves
+    /// exactly like `TestBackend`. `Terminal::clear` issues one; on crossterm
+    /// that is a DSR (`\x1b[6n`) round trip, which `read_position_raw` waits
+    /// on for up to two seconds.
+    struct CountingBackend {
+        inner: ratatui::backend::TestBackend,
+        cursor_queries: std::cell::Cell<usize>,
+    }
+
+    impl ratatui::backend::Backend for CountingBackend {
+        type Error = <ratatui::backend::TestBackend as ratatui::backend::Backend>::Error;
+
+        fn draw<'a, I>(&mut self, content: I) -> Result<(), Self::Error>
+        where
+            I: Iterator<Item = (u16, u16, &'a ratatui::buffer::Cell)>,
+        {
+            self.inner.draw(content)
+        }
+
+        fn get_cursor_position(&mut self) -> Result<ratatui::layout::Position, Self::Error> {
+            self.cursor_queries.set(self.cursor_queries.get() + 1);
+            self.inner.get_cursor_position()
+        }
+
+        fn set_cursor_position<P: Into<ratatui::layout::Position>>(
+            &mut self,
+            position: P,
+        ) -> Result<(), Self::Error> {
+            self.inner.set_cursor_position(position)
+        }
+
+        fn hide_cursor(&mut self) -> Result<(), Self::Error> {
+            self.inner.hide_cursor()
+        }
+
+        fn show_cursor(&mut self) -> Result<(), Self::Error> {
+            self.inner.show_cursor()
+        }
+
+        fn clear(&mut self) -> Result<(), Self::Error> {
+            self.inner.clear()
+        }
+
+        fn clear_region(
+            &mut self,
+            clear_type: ratatui::backend::ClearType,
+        ) -> Result<(), Self::Error> {
+            self.inner.clear_region(clear_type)
+        }
+
+        fn size(&self) -> Result<ratatui::layout::Size, Self::Error> {
+            self.inner.size()
+        }
+
+        fn window_size(&mut self) -> Result<ratatui::backend::WindowSize, Self::Error> {
+            self.inner.window_size()
+        }
+
+        fn flush(&mut self) -> Result<(), Self::Error> {
+            self.inner.flush()
+        }
+    }
+
+    /// `apply_repaint` must never ask the backend where the cursor is.
+    /// `Terminal::clear` does, and on crossterm that DSR round trip blocks this
+    /// single-threaded loop for up to two seconds against a terminal that does
+    /// not answer -- freezing streaming and input, and then skipping the clear
+    /// anyway. Measured at 2.04s against an unresponsive PTY before this was
+    /// switched to the size-based path, versus 0.06s once it was.
+    #[test]
+    fn repaint_never_blocks_on_a_cursor_query() {
+        use ratatui::backend::Backend as _;
+        use ratatui::Terminal;
+
+        let mut app = test_app();
+        let backend = CountingBackend {
+            inner: ratatui::backend::TestBackend::new(60, 30),
+            cursor_queries: std::cell::Cell::new(0),
+        };
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| super::draw(f, &mut app)).unwrap();
+        let clean = terminal.backend().inner.buffer().clone();
+
+        // Damage the screen the way a `wall(1)` broadcast does.
+        let (cx, cy) = (0..clean.area.height)
+            .flat_map(|y| (0..clean.area.width).map(move |x| (x, y)))
+            .find(|&(x, y)| clean[(x, y)].symbol().trim() != "")
+            .expect("the frame must paint something");
+        let mut broadcast = ratatui::buffer::Cell::EMPTY;
+        broadcast.set_symbol("W");
+        terminal
+            .backend_mut()
+            .draw(std::iter::once((cx, cy, &broadcast)))
+            .unwrap();
+
+        let before = terminal.backend().cursor_queries.get();
+        apply_repaint(&mut terminal);
+        terminal.draw(|f| super::draw(f, &mut app)).unwrap();
+        let asked = terminal.backend().cursor_queries.get() - before;
+
+        assert_eq!(
+            asked, 0,
+            "the repaint must not issue a cursor-position query: on crossterm \
+             that is a blocking DSR round trip on the render loop"
+        );
+        assert_eq!(
+            terminal.backend().inner.buffer(),
+            &clean,
+            "and it must still restore the frame the broadcast damaged"
+        );
+    }
+
+    /// A repaint is a display operation and nothing more: a user pressing
+    /// Ctrl-L mid-draft must not lose the draft or have the transcript jump.
+    #[tokio::test]
+    async fn composer_draft_and_scroll_survive_a_repaint() {
+        use ratatui::{backend::TestBackend, Terminal};
+
+        let mut app = test_app();
+        for i in 0..40 {
+            app.submit_user(format!("message {i}"));
+        }
+        app.input = "a draft mid-sentence".to_string();
+        app.scrollback = 7;
+
+        let mut terminal = Terminal::new(TestBackend::new(60, 30)).unwrap();
+        terminal.draw(|f| super::draw(f, &mut app)).unwrap();
+        let before = terminal.backend().buffer().clone();
+
+        let registry: PermissionRegistry = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let mcp_servers: crate::core::state::SharedMcpServers =
+            Arc::new(tokio::sync::Mutex::new(HashMap::new()));
+        let mut current: Option<CurrentRun> = None;
+        let ctrl_l = KeyEvent::new(KeyCode::Char('l'), KeyModifiers::CONTROL);
+        handle_key(&mut app, ctrl_l, &registry, &mut current, &mcp_servers).await;
+
+        assert_eq!(app.input, "a draft mid-sentence", "the draft must survive");
+        assert_eq!(app.scrollback, 7, "the scroll position must survive");
+
+        // And the repainted frame is the same frame, redrawn -- not a scrolled
+        // or emptied one.
+        assert!(app.take_repaint());
+        apply_repaint(&mut terminal);
+        terminal.draw(|f| super::draw(f, &mut app)).unwrap();
+        assert_eq!(
+            terminal.backend().buffer(),
+            &before,
+            "a repaint must reproduce the same frame"
+        );
+    }
+
+    /// A docked ask owns the keyboard and runs before `handle_key`, so it has
+    /// to honour the repaint key itself -- a broadcast landing during a
+    /// question would otherwise stay on screen until it is answered. The key is
+    /// consumed, never typed into a custom answer, and the question survives.
+    #[tokio::test]
+    async fn ctrl_l_repaints_while_an_ask_owns_the_keyboard() {
+        let mut app = test_app();
+        let registry = crate::core::agent::interaction::new_registry();
+        let (request_id, _receiver) = crate::core::agent::interaction::register(&registry).await;
+        app.apply(StreamEvent::AskRequest {
+            request_id,
+            request: ask_request(false, false),
+            timeout_secs: None,
+        });
+
+        let ctrl_l = KeyEvent::new(KeyCode::Char('l'), KeyModifiers::CONTROL);
+        assert!(
+            handle_ask_key(&mut app, ctrl_l, &registry).await,
+            "the ask must consume Ctrl-L rather than pass it on"
+        );
+        assert!(app.take_repaint(), "Ctrl-L must repaint during an ask");
+        assert!(
+            !app.ask_queue.is_empty(),
+            "a repaint must not answer or dismiss the question"
+        );
+        assert!(
+            app.ask_queue.front().unwrap().custom_input.is_empty(),
+            "the repaint key must not be typed into the answer"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Ctrl-L and terminal resize restore TUI frames damaged by foreign terminal writes without blocking on cursor queries or losing the draft and scroll position. Full clears stay inside synchronized output; the existing kitty exception remains unchanged.
- Preserve tool permission boundaries while grouping sandbox context, using async screenshot-test locking, and isolating scratch cleanup tests from other tests and live Jan sessions. Scratch isolation coverage now uses the correct path on each platform.

Fixes #8804

## Verification
- `cargo test --locked --lib --no-default-features --features cli` - 1,380 passed.
- `cargo test --locked -p tauri-plugin-agent-tools --lib` - 293 passed, 1 ignored; run with a private temporary directory.
- `cargo clippy --locked --no-default-features --features cli --lib --bin jan --tests -- -D warnings` - passed.
- `cargo clippy --locked -p tauri-plugin-agent-tools --lib --tests -- -D warnings` - passed.
- `cargo build --locked --bin jan --no-default-features --features cli` - passed.
- Real CLI PTY smoke checks with a terminal emulator - injected foreign TTY writes survive ordinary draws and disappear after Ctrl-L; the frame and draft are preserved, resize recovers, and no cursor-position query is emitted. Recovery took about 56 ms. Synchronized mode encloses every clear; kitty-mode output retains the synchronization opt-out. These checks do not exercise actual WezTerm/kitty applications or a multi-user `wall` broadcast.
- Isolated scratch-sweep reproduction - before the fix, the test deleted an unrelated live-session sentinel; after the fix, both the targeted test and the plugin suite preserve it.
