### PR TITLE
fix(ci): scope rust-check caches to main

### DIFF
--- a/.github/workflows/rust-check.yml
+++ b/.github/workflows/rust-check.yml
@@ -1,8 +1,15 @@
 name: Rust Check
 on:
   workflow_dispatch:
-  pull_request:
+  # Caches are branch-scoped and only the default branch's are readable from
+  # anywhere, so main has to run this to leave anything worth restoring.
+  push:
     branches:
+      - main
+  pull_request:
+    # PRs open against main; the dev-only filter left this to manual dispatch.
+    branches:
+      - main
       - dev
 
 concurrency:
@@ -44,6 +51,9 @@ jobs:
         with:
           workspaces: src-tauri
           key: ${{ matrix.name }}
+          # Branches restore but never save: one 3.5GB cache set on main
+          # rather than one per branch, which is what breached the 10GB cap.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install Tauri dependencies
         if: matrix.tauri
@@ -95,6 +105,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: src-tauri/${{ matrix.crate }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install Tauri dependencies
         run: |


### PR DESCRIPTION
## Describe Your Changes

This pull request updates the `.github/workflows/rust-check.yml` workflow to improve caching efficiency and control when caches are saved, addressing issues with GitHub Actions cache limits. The main focus is to ensure that cache is only saved from the `main` branch, preventing excessive cache usage across multiple branches.

Workflow caching improvements:

* Updated the workflow triggers so that pushes and pull requests to the `main` branch run the workflow, ensuring that only the default branch's cache is used and shared.
* Modified the `Swatinem/rust-cache` steps to only save caches when running on the `main` branch, preventing each branch from creating its own cache and breaching the 10GB cap. [[1]](diffhunk://#diff-67fd9c4ad522b117ffa69f7d15f6a0030be162d66da6f756de886c667c6902ceR54-R56) [[2]](diffhunk://#diff-67fd9c4ad522b117ffa69f7d15f6a0030be162d66da6f756de886c667c6902ceR108)

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
