### PR TITLE
feat(agent): improve skills/plugins ux

### DIFF
--- a/.omp
+++ b/.omp
@@ -1,0 +1,1 @@
+/Users/thinhlpg/code/jan/.omp

--- a/.omp
+++ b/.omp
@@ -1,1 +1,0 @@
-/Users/thinhlpg/code/jan/.omp

--- a/AGENT-TUI.md
+++ b/AGENT-TUI.md
@@ -247,6 +247,7 @@ Defined in the `SLASH_COMMANDS` const array and handled by `run_command()`:
 | `/resume [id]` | Resume a thread |
 | `/model [id]` | Switch model |
 | `/mcp` | Manage MCP servers |
+| `/reload [plugin\|skills\|system-prompt]` | Re-scan skills/plugins from disk and rebuild the catalog mid-session (bare: plugin), reporting what changed |
 | `/cancel [N]` | Cancel queued messages |
 | `/config` | View provider config |
 | `/quit` | Exit the TUI |

--- a/docs/src/pages/docs/agent/plugins.mdx
+++ b/docs/src/pages/docs/agent/plugins.mdx
@@ -87,8 +87,13 @@ Imported MCP servers use names such as `figma:figma` to avoid collisions. Existi
 servers with different settings are not overwritten; review them in `/mcp`.
 Stored key references such as `${API_KEY}` and `${CLAUDE_PLUGIN_ROOT}` are resolved
 from the plugin's key store and installed directory. Key files and generated MCP
-configuration are owner-only (`0600`) on Unix. Provider-side OAuth client
-restrictions still apply.
+configuration are owner-only (`0600`) on Unix.
+
+OAuth browser sign-in requires successful client registration. If the provider
+rejects registration, Jan shows the endpoint, HTTP status, and rejection detail
+in the TUI instead of opening a consent page with a placeholder client ID.
+[Figma restricts its remote MCP server to approved clients](https://developers.figma.com/docs/figma-mcp-server/remote-server-installation/);
+installing its plugin does not grant Jan that approval.
 
 ## Invoking plugin skills
 

--- a/docs/src/pages/docs/agent/plugins.mdx
+++ b/docs/src/pages/docs/agent/plugins.mdx
@@ -73,6 +73,23 @@ The plugin is cloned (`--depth 1`), validated to contain a plugin manifest, `ski
 Reinstalling an existing plugin is refused (remove it first). Specs with shell metacharacters are
 rejected outright - a plugin name is a name, not a command.
 
+In the TUI, installation continues directly into setup. Jan reads the plugin's
+`.mcp.json` or inline `mcpServers` declarations, collects required keys in a masked
+field, and offers **Enable and connect** for each server. Nothing is enabled or
+executed until you confirm. Remote servers that require OAuth continue into
+browser sign-in and reconnect automatically afterward.
+
+Choose **Not now** or press Esc to keep the plugin installed without completing
+its connections. Resume with `/plugin setup <name>`; no separate terminal command
+or Jan restart is needed. Plugins without keys or MCP servers are ready immediately.
+
+Imported MCP servers use names such as `figma:figma` to avoid collisions. Existing
+servers with different settings are not overwritten; review them in `/mcp`.
+Stored key references such as `${API_KEY}` and `${CLAUDE_PLUGIN_ROOT}` are resolved
+from the plugin's key store and installed directory. Key files and generated MCP
+configuration are owner-only (`0600`) on Unix. Provider-side OAuth client
+restrictions still apply.
+
 ## Invoking plugin skills
 
 Plugin skills are qualified with their plugin name: `release-tools:prepare`.
@@ -135,6 +152,7 @@ Interactive commands:
 /plugin list                  # one compact summary line per plugin
 /plugin list release-tools    # description and skill names for one plugin
 /plugin remove release-tools  # uninstall
+/plugin setup release-tools   # resume API-key or MCP connection setup
 /plugin search prepare        # search the marketplace (name/description)
 ```
 

--- a/docs/src/pages/docs/agent/plugins.mdx
+++ b/docs/src/pages/docs/agent/plugins.mdx
@@ -8,10 +8,10 @@ import { Callout } from 'nextra/components'
 
 # Plugins
 
-A plugin is a set of [skills](/docs/agent/skills) installed from a git repository. Any repo that
-looks like a skill collection - or is a single skill - can be installed with one command, without
-copying files by hand or trusting a download step. Installing a plugin never runs its code: a
-plugin carries instructions plus optional metadata, nothing executable.
+A plugin packages skills, commands, agent definitions, and optional MCP server
+declarations from a git repository. Installing it copies those files without
+running its scripts or starting its MCP servers. Enabling a declared MCP server
+is a separate, explicit setup action that can run local code or contact a remote service.
 
 ## Where they live
 
@@ -38,8 +38,9 @@ A plugin's payload is discovered conventionally, so a repo needs no manifest to 
   and `repo`. The directory name is the plugin's identity; the manifest's `name` is what
   `plugin list` shows when present.
 
-This is the same layout Claude Code and Codex plugins use, so existing plugins install and work
-unchanged: `anthropics/claude-plugins-official` and similar marketplaces are drop-in compatible.
+Jan discovers these conventional directories in Claude Code-style plugin repositories,
+including `anthropics/claude-plugins-official`. Installation does not guarantee runtime
+compatibility: external commands, credentials, and provider approval may still be required.
 
 ## Installing
 
@@ -76,24 +77,38 @@ rejected outright - a plugin name is a name, not a command.
 In the TUI, installation continues directly into setup. Jan reads the plugin's
 `.mcp.json` or inline `mcpServers` declarations, collects required keys in a masked
 field, and offers **Enable and connect** for each server. Nothing is enabled or
-executed until you confirm. Remote servers that require OAuth continue into
-browser sign-in and reconnect automatically afterward.
+executed until you confirm. For providers that accept Jan's OAuth client registration,
+setup offers browser sign-in and reconnects after successful authorization.
 
 Choose **Not now** or press Esc to keep the plugin installed without completing
-its connections. Resume with `/plugin setup <name>`; no separate terminal command
-or Jan restart is needed. Plugins without keys or MCP servers are ready immediately.
+its connections. Resume with `/plugin setup <name>`, or use `/plugin setup` to
+choose one installed plugin. Type or paste to filter by name and description
+(case-insensitive); Backspace edits the search, Up/Down selects, Enter opens setup,
+and Esc cancels. Rows identify the installation directory and also show the manifest
+name when it differs. Opening the picker does not run setup for every plugin or enable
+any servers. No separate terminal command or Jan restart is needed. Plugins without
+keys or MCP servers need no connection setup.
 
 Imported MCP servers use names such as `figma:figma` to avoid collisions. Existing
 servers with different settings are not overwritten; review them in `/mcp`.
 Stored key references such as `${API_KEY}` and `${CLAUDE_PLUGIN_ROOT}` are resolved
 from the plugin's key store and installed directory. Key files and generated MCP
 configuration are owner-only (`0600`) on Unix.
+Shell credential injection is scoped to the project that registered the keys;
+starting a run in another project does not replace that project's shell credentials.
 
 OAuth browser sign-in requires successful client registration. If the provider
 rejects registration, Jan shows the endpoint, HTTP status, and rejection detail
 in the TUI instead of opening a consent page with a placeholder client ID.
-[Figma restricts its remote MCP server to approved clients](https://developers.figma.com/docs/figma-mcp-server/remote-server-installation/);
-installing its plugin does not grant Jan that approval.
+[Figma restricts its remote MCP server to approved clients](https://developers.figma.com/docs/figma-mcp-server/remote-server-installation/).
+**Remote Figma sign-in is currently blocked for Jan:** registration returns HTTP 403.
+Installing the Figma plugin does not grant approval, and retrying setup does not remove
+that restriction. Jan does not currently accept pre-registered OAuth client credentials.
+
+MCP connections already enabled in Jan remain in its user-owned configuration.
+Skipping setup does not disable them, and removing a plugin does not remove its imported
+MCP entries. Use `/mcp`, select the server, then **Disable** or **Remove server**.
+This also applies to placeholder servers declared by example plugins.
 
 ## Invoking plugin skills
 

--- a/docs/src/pages/docs/agent/slash-commands.mdx
+++ b/docs/src/pages/docs/agent/slash-commands.mdx
@@ -59,7 +59,7 @@ See [Run modes](/docs/agent/run-modes), [Goals and todos](/docs/agent/goals-and-
 | `/model [id]` | Switch model. Bare: pick interactively |
 | `/effort [low\|medium\|high]` | Set reasoning effort. Bare: show current; `low` is faster, `high` thinks deeper |
 | `/mcp` | List, toggle, add, edit, and remove MCP servers; Enter opens a server's detail screen, where you can list its tools and sign in to it |
-| `/plugin [list\|install <spec>\|remove <name>\|search [query]\|setup <name>]` | Manage plugins: install from a git URL or the marketplace, list/remove installed, search the marketplace. `setup` collects a plugin's required API keys (masked paste; keys land in `~/.jan/agent/plugin-env/` 0600 and reach the sandboxed shell on the next run) |
+| `/plugin [list\|install <spec>\|remove <name>\|search [query]\|setup <name>]` | Install and manage plugins. Installation opens setup automatically: masked API-key entry, then confirmation to enable declared MCP servers and sign in when required. `setup <name>` resumes setup without manual MCP configuration or restarting Jan |
 | `/reload [plugin\|skills\|system-prompt]` | Re-scan skills/plugins from disk and rebuild the catalog mid-session (bare: `plugin`), reporting added/removed/changed entries. `system-prompt` re-reads `JAN.md` and applies on the next run |
 | `/login` | Sign in to Tokamak and save the API key |
 | `/config` | View provider config (`~/.jan/config.toml`) |

--- a/docs/src/pages/docs/agent/slash-commands.mdx
+++ b/docs/src/pages/docs/agent/slash-commands.mdx
@@ -60,6 +60,7 @@ See [Run modes](/docs/agent/run-modes), [Goals and todos](/docs/agent/goals-and-
 | `/effort [low\|medium\|high]` | Set reasoning effort. Bare: show current; `low` is faster, `high` thinks deeper |
 | `/mcp` | List, toggle, add, edit, and remove MCP servers; Enter opens a server's detail screen, where you can list its tools and sign in to it |
 | `/plugin [list\|install <spec>\|remove <name>\|search [query]]` | Manage plugins: install from a git URL or the marketplace, list/remove installed, search the marketplace |
+| `/reload [plugin\|skills\|system-prompt]` | Re-scan skills/plugins from disk and rebuild the catalog mid-session (bare: `plugin`), reporting added/removed/changed entries. `system-prompt` re-reads `JAN.md` and applies on the next run |
 | `/login` | Sign in to Tokamak and save the API key |
 | `/config` | View provider config (`~/.jan/config.toml`) |
 | `/terminal-setup` | Configure this terminal so <kbd>Shift</kbd>+<kbd>Enter</kbd> inserts a newline and, on macOS, <kbd>Option</kbd>+<kbd>Delete</kbd> deletes a word. Writes the terminal's own config where it can (VS Code, kitty, Ghostty, tmux) and prints the manual step where it cannot. Idempotent |

--- a/docs/src/pages/docs/agent/slash-commands.mdx
+++ b/docs/src/pages/docs/agent/slash-commands.mdx
@@ -59,7 +59,7 @@ See [Run modes](/docs/agent/run-modes), [Goals and todos](/docs/agent/goals-and-
 | `/model [id]` | Switch model. Bare: pick interactively |
 | `/effort [low\|medium\|high]` | Set reasoning effort. Bare: show current; `low` is faster, `high` thinks deeper |
 | `/mcp` | List, toggle, add, edit, and remove MCP servers; Enter opens a server's detail screen, where you can list its tools and sign in to it |
-| `/plugin [list\|install <spec>\|remove <name>\|search [query]]` | Manage plugins: install from a git URL or the marketplace, list/remove installed, search the marketplace |
+| `/plugin [list\|install <spec>\|remove <name>\|search [query]\|setup <name>]` | Manage plugins: install from a git URL or the marketplace, list/remove installed, search the marketplace. `setup` collects a plugin's required API keys (masked paste; keys land in `~/.jan/agent/plugin-env/` 0600 and reach the sandboxed shell on the next run) |
 | `/reload [plugin\|skills\|system-prompt]` | Re-scan skills/plugins from disk and rebuild the catalog mid-session (bare: `plugin`), reporting added/removed/changed entries. `system-prompt` re-reads `JAN.md` and applies on the next run |
 | `/login` | Sign in to Tokamak and save the API key |
 | `/config` | View provider config (`~/.jan/config.toml`) |

--- a/docs/src/pages/docs/agent/slash-commands.mdx
+++ b/docs/src/pages/docs/agent/slash-commands.mdx
@@ -59,7 +59,7 @@ See [Run modes](/docs/agent/run-modes), [Goals and todos](/docs/agent/goals-and-
 | `/model [id]` | Switch model. Bare: pick interactively |
 | `/effort [low\|medium\|high]` | Set reasoning effort. Bare: show current; `low` is faster, `high` thinks deeper |
 | `/mcp` | List, toggle, add, edit, and remove MCP servers; Enter opens a server's detail screen, where you can list its tools and sign in to it |
-| `/plugin [list\|install <spec>\|remove <name>\|search [query]\|setup <name>]` | Install and manage plugins. Installation opens setup automatically: masked API-key entry, then confirmation to enable declared MCP servers and sign in when required. `setup <name>` resumes setup without manual MCP configuration or restarting Jan |
+| `/plugin [list\|install <spec>\|remove <name>\|search [query]\|setup [name]]` | Install and manage plugins. Installation opens setup automatically: masked API-key entry, then confirmation to enable declared MCP servers and sign in when required. Bare `setup` opens a single-plugin picker; `setup <name>` resumes that plugin directly without manual MCP configuration or restarting Jan |
 | `/reload [plugin\|skills\|system-prompt]` | Re-scan skills/plugins from disk and rebuild the catalog mid-session (bare: `plugin`), reporting added/removed/changed entries. `system-prompt` re-reads `JAN.md` and applies on the next run |
 | `/login` | Sign in to Tokamak and save the API key |
 | `/config` | View provider config (`~/.jan/config.toml`) |

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/proc.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/proc.rs
@@ -7,9 +7,39 @@
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::{Mutex, OnceLock};
+use std::sync::{Mutex, OnceLock, RwLock};
 
 use tokio::process::{Child, Command};
+
+/// Plugin-declared environment values, injected into every sandboxed shell on
+/// top of [`SANDBOX_ENV_ALLOW`]. The allowlist is static and minimal exactly
+/// so host secrets cannot leak into a `bash` call; plugin keys are the
+/// deliberate exception — a plugin's skills/commands cannot call the service
+/// they integrate with without their credentials. Only variables an installed
+/// plugin's manifest *declares* (see the host's `plugins::required_env`) may
+/// land here, and only with a value the user typed into the masked setup
+/// prompt; the map is replaced wholesale by the host on every run start.
+static PLUGIN_ENV: OnceLock<RwLock<std::collections::BTreeMap<String, String>>> = OnceLock::new();
+
+/// Replace the plugin-declared environment values handed to sandboxed shells.
+pub fn set_plugin_env(vars: std::collections::BTreeMap<String, String>) {
+    let lock = PLUGIN_ENV.get_or_init(|| RwLock::new(Default::default()));
+    *lock.write().unwrap() = vars;
+}
+
+/// A snapshot of the current plugin-declared environment values.
+fn plugin_env() -> std::collections::BTreeMap<String, String> {
+    PLUGIN_ENV
+        .get()
+        .map(|lock| lock.read().unwrap().clone())
+        .unwrap_or_default()
+}
+
+/// Read back the current plugin env values (tests / diagnostics).
+#[doc(hidden)]
+pub fn plugin_env_snapshot() -> std::collections::BTreeMap<String, String> {
+    plugin_env()
+}
 
 /// How to invoke the host shell. `program` + `args` are fixed; the command
 /// string is appended as the final argv element, or piped to stdin when
@@ -242,6 +272,11 @@ pub async fn spawn(
         if let Some(val) = std::env::var_os(key) {
             cmd.env(key, val);
         }
+    }
+    // Plugin-declared credentials come last so they always win over an
+    // allowlist key of the same name.
+    for (key, val) in plugin_env() {
+        cmd.env(key, val);
     }
     // Point the shell's temp env at the session scratch, overriding the host
     // values the allowlist just copied in. Without this a command that writes

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/proc.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/proc.rs
@@ -7,38 +7,24 @@
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::{Mutex, OnceLock, RwLock};
+use std::sync::{LazyLock, Mutex, OnceLock, RwLock};
 
 use tokio::process::{Child, Command};
 
-/// Plugin-declared environment values, injected into every sandboxed shell on
-/// top of [`SANDBOX_ENV_ALLOW`]. The allowlist is static and minimal exactly
-/// so host secrets cannot leak into a `bash` call; plugin keys are the
-/// deliberate exception — a plugin's skills/commands cannot call the service
-/// they integrate with without their credentials. Only variables an installed
-/// plugin's manifest *declares* (see the host's `plugins::required_env`) may
-/// land here, and only with a value the user typed into the masked setup
-/// prompt; the map is replaced wholesale by the host on every run start.
-static PLUGIN_ENV: OnceLock<RwLock<BTreeMap<String, String>>> = OnceLock::new();
+/// User-supplied, plugin-declared credentials, scoped to the project that
+/// registered them. Concurrent projects must never replace each other's keys.
+static PLUGIN_ENV: LazyLock<RwLock<BTreeMap<PathBuf, BTreeMap<String, String>>>> =
+    LazyLock::new(|| RwLock::new(BTreeMap::new()));
 
-/// Replace the plugin-declared environment values handed to sandboxed shells.
-pub fn set_plugin_env(vars: BTreeMap<String, String>) {
-    let lock = PLUGIN_ENV.get_or_init(|| RwLock::new(Default::default()));
-    *lock.write().unwrap() = vars;
-}
-
-/// A snapshot of the current plugin-declared environment values.
-fn plugin_env() -> BTreeMap<String, String> {
-    PLUGIN_ENV
-        .get()
-        .map(|lock| lock.read().unwrap().clone())
-        .unwrap_or_default()
-}
-
-/// Read back the current plugin env values (tests / diagnostics).
-#[doc(hidden)]
-pub fn plugin_env_snapshot() -> BTreeMap<String, String> {
-    plugin_env()
+/// Replace one project's plugin credentials, or revoke them with an empty map.
+pub fn set_plugin_env(root: &Path, vars: BTreeMap<String, String>) {
+    let root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let mut projects = PLUGIN_ENV.write().unwrap();
+    if vars.is_empty() {
+        projects.remove(&root);
+    } else {
+        projects.insert(root, vars);
+    }
 }
 
 /// True for variable names the sandbox owns itself: the static allowlist, the
@@ -286,11 +272,14 @@ pub async fn spawn(
             cmd.env(key, val);
         }
     }
-    // Plugin-declared credentials come last so they always win over an
-    // allowlist key of the same name (reserved names never get this far --
-    // see `is_reserved_env_key`).
-    for (key, val) in plugin_env() {
-        cmd.env(key, val);
+    // `cwd` is the tool context's project root, not a shell-selected subdirectory.
+    // Borrow the matching map instead of copying all registered credentials.
+    {
+        let root = std::fs::canonicalize(cwd).unwrap_or_else(|_| cwd.to_path_buf());
+        let projects = PLUGIN_ENV.read().unwrap();
+        if let Some(vars) = projects.get(&root) {
+            cmd.envs(vars);
+        }
     }
     // Point the shell's temp env at the session scratch, overriding the host
     // values the allowlist just copied in. Without this a command that writes

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/proc.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/proc.rs
@@ -4,7 +4,7 @@
 //! top-level shell. Without this, any command that spawns children (a build, a
 //! `foo &`, a pipeline) leaks orphans when the run is torn down.
 
-use std::collections::HashSet;
+use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::{Mutex, OnceLock, RwLock};
@@ -19,16 +19,16 @@ use tokio::process::{Child, Command};
 /// plugin's manifest *declares* (see the host's `plugins::required_env`) may
 /// land here, and only with a value the user typed into the masked setup
 /// prompt; the map is replaced wholesale by the host on every run start.
-static PLUGIN_ENV: OnceLock<RwLock<std::collections::BTreeMap<String, String>>> = OnceLock::new();
+static PLUGIN_ENV: OnceLock<RwLock<BTreeMap<String, String>>> = OnceLock::new();
 
 /// Replace the plugin-declared environment values handed to sandboxed shells.
-pub fn set_plugin_env(vars: std::collections::BTreeMap<String, String>) {
+pub fn set_plugin_env(vars: BTreeMap<String, String>) {
     let lock = PLUGIN_ENV.get_or_init(|| RwLock::new(Default::default()));
     *lock.write().unwrap() = vars;
 }
 
 /// A snapshot of the current plugin-declared environment values.
-fn plugin_env() -> std::collections::BTreeMap<String, String> {
+fn plugin_env() -> BTreeMap<String, String> {
     PLUGIN_ENV
         .get()
         .map(|lock| lock.read().unwrap().clone())
@@ -37,8 +37,21 @@ fn plugin_env() -> std::collections::BTreeMap<String, String> {
 
 /// Read back the current plugin env values (tests / diagnostics).
 #[doc(hidden)]
-pub fn plugin_env_snapshot() -> std::collections::BTreeMap<String, String> {
+pub fn plugin_env_snapshot() -> BTreeMap<String, String> {
     plugin_env()
+}
+
+/// True for variable names the sandbox owns itself: the static allowlist, the
+/// scratch temp keys, and the classic dynamic-linker/loader injection
+/// prefixes. The host refuses to store or inject plugin-declared values under
+/// these names -- a plugin declaring `PATH` or `LD_PRELOAD` would otherwise
+/// let one pasted value clobber (or escape) the sandbox environment wholesale.
+pub fn is_reserved_env_key(key: &str) -> bool {
+    SANDBOX_ENV_ALLOW.contains(&key)
+        || TEMP_ENV_KEYS.contains(&key)
+        || key.starts_with("LD_")
+        || key.starts_with("DYLD_")
+        || key.starts_with("SUDO_")
 }
 
 /// How to invoke the host shell. `program` + `args` are fixed; the command
@@ -274,7 +287,8 @@ pub async fn spawn(
         }
     }
     // Plugin-declared credentials come last so they always win over an
-    // allowlist key of the same name.
+    // allowlist key of the same name (reserved names never get this far --
+    // see `is_reserved_env_key`).
     for (key, val) in plugin_env() {
         cmd.env(key, val);
     }

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/proc.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/tools/proc.rs
@@ -7,14 +7,14 @@
 use std::collections::{BTreeMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
-use std::sync::{LazyLock, Mutex, OnceLock, RwLock};
+use std::sync::{Mutex, OnceLock, RwLock};
 
 use tokio::process::{Child, Command};
 
 /// User-supplied, plugin-declared credentials, scoped to the project that
 /// registered them. Concurrent projects must never replace each other's keys.
-static PLUGIN_ENV: LazyLock<RwLock<BTreeMap<PathBuf, BTreeMap<String, String>>>> =
-    LazyLock::new(|| RwLock::new(BTreeMap::new()));
+static PLUGIN_ENV: RwLock<BTreeMap<PathBuf, BTreeMap<String, String>>> =
+    RwLock::new(BTreeMap::new());
 
 /// Replace one project's plugin credentials, or revoke them with an empty map.
 pub fn set_plugin_env(root: &Path, vars: BTreeMap<String, String>) {

--- a/src-tauri/src/core/agent/context.rs
+++ b/src-tauri/src/core/agent/context.rs
@@ -30,10 +30,11 @@ its absence means you have everything. A command's `[exit N]` line is the author
 /// by hand or through `/init` -- becomes authoritative project context.
 const CONTEXT_FILE_NAME: &str = "JAN.md";
 
-/// Ingest `JAN.md` from the project root and its ancestors, wrapped in a
-/// `<project_context>` block so the model treats them as authoritative project
-/// instructions. Returns None when none exist.
-pub(crate) fn load_context_files(project_root: &Path) -> Option<String> {
+/// Read every non-empty `JAN.md` from the project root up to the filesystem
+/// root, nearest-first. Shared by the system-prompt builder and the CLI's
+/// `/reload system-prompt` report (which needs paths and sizes, not the
+/// wrapped block).
+pub(crate) fn context_files(project_root: &Path) -> Vec<(std::path::PathBuf, String)> {
     let mut files: Vec<(std::path::PathBuf, String)> = Vec::new();
     let mut dir = Some(project_root);
     while let Some(current) = dir {
@@ -45,12 +46,20 @@ pub(crate) fn load_context_files(project_root: &Path) -> Option<String> {
         }
         dir = current.parent();
     }
-    if files.is_empty() {
-        return None;
-    }
     // Ancestors are collected nearest-first; reverse so the nearest (most
     // specific) instructions appear last and take precedence.
     files.reverse();
+    files
+}
+
+/// Ingest `JAN.md` from the project root and its ancestors, wrapped in a
+/// `<project_context>` block so the model treats them as authoritative project
+/// instructions. Returns None when none exist.
+pub(crate) fn load_context_files(project_root: &Path) -> Option<String> {
+    let files = context_files(project_root);
+    if files.is_empty() {
+        return None;
+    }
     let mut block = String::from(
         "<project_context>\n\nProject-specific instructions and guidelines:\n\n",
     );

--- a/src-tauri/src/core/agent/git.rs
+++ b/src-tauri/src/core/agent/git.rs
@@ -120,6 +120,37 @@ pub(crate) fn current_branch(path: &Path) -> Option<String> {
         .filter(|s| !s.is_empty() && s != "HEAD")
 }
 
+/// The main worktree's root when `path` sits in a *linked* worktree, `None`
+/// when `path` is the main worktree itself (or not a git repo at all). Skills
+/// and plugins are installed under `<repo>/.jan/agent` in whatever checkout ran
+/// the install; a linked worktree has its own working tree but shares the
+/// repository, so agent setup should follow the repo, not the checkout.
+/// `--git-common-dir` points at the shared `<main>/.git`; the main worktree
+/// root is its parent. `--path-format=absolute` (git 2.31+) keeps the answer
+/// usable no matter which cwd git would otherwise resolve against.
+pub(crate) fn worktree_primary_root(path: &Path) -> Option<PathBuf> {
+    let p = path.to_string_lossy();
+    let common = git(&[
+        "-C",
+        &p,
+        "rev-parse",
+        "--path-format=absolute",
+        "--git-common-dir",
+    ])
+    .ok()
+    .map(|s| s.trim().to_string())
+    .filter(|s| !s.is_empty())?;
+    let primary = PathBuf::from(&common).parent()?.to_path_buf();
+    // Only a linked worktree shares: the main worktree's common dir lives
+    // *inside* its own root, so this filter also keeps callers from merging a
+    // directory with itself (duplicate entries).
+    if primary == path {
+        None
+    } else {
+        Some(primary)
+    }
+}
+
 /// The canonical empty tree object every git repo has, without needing a
 /// commit to hash it from -- used as the base tree when `HEAD` is unborn.
 #[cfg(feature = "cli")]
@@ -413,6 +444,25 @@ mod tests {
         assert_eq!(second.as_deref(), Some("feature/other"));
         assert_ne!(first, second, "the branch must change after an external checkout");
 
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A linked worktree shares the repo's common dir but has its own working
+    /// tree: `worktree_primary_root` must resolve to the main checkout there,
+    /// and to `None` in the main checkout itself (no self-merge).
+    #[test]
+    fn worktree_primary_root_resolves_linked_worktrees() {
+        let Some(root) = init_repo() else { return };
+        assert_eq!(worktree_primary_root(&root), None, "main worktree has no primary");
+
+        let linked = std::env::temp_dir().join(format!("jan_wt_linked_{}", COUNTER.fetch_add(1, Ordering::SeqCst)));
+        let r = root.to_string_lossy().to_string();
+        let l = linked.to_string_lossy().to_string();
+        git(&["-C", &r, "worktree", "add", &l, "-b", "jan-test-linked"])
+            .expect("add worktree");
+        assert_eq!(worktree_primary_root(&linked).as_deref(), Some(root.as_path()));
+
+        let _ = std::fs::remove_dir_all(&linked);
         let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/src-tauri/src/core/agent/git.rs
+++ b/src-tauri/src/core/agent/git.rs
@@ -17,9 +17,7 @@
 //! ref. The user's `git status`, current branch, and staged changes are never
 //! touched. Shelling out keeps us free of a libgit2 dependency.
 
-use std::path::Path;
-#[cfg(feature = "cli")]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 
@@ -128,7 +126,7 @@ pub(crate) fn current_branch(path: &Path) -> Option<String> {
 /// `--git-common-dir` points at the shared `<main>/.git`; the main worktree
 /// root is its parent. `--path-format=absolute` (git 2.31+) keeps the answer
 /// usable no matter which cwd git would otherwise resolve against.
-pub(crate) fn worktree_primary_root(path: &Path) -> Option<PathBuf> {
+pub(crate) fn worktree_primary_root(path: &Path) -> Option<std::path::PathBuf> {
     let p = path.to_string_lossy();
     let common = git(&[
         "-C",

--- a/src-tauri/src/core/agent/plugin_commands.rs
+++ b/src-tauri/src/core/agent/plugin_commands.rs
@@ -32,39 +32,47 @@ pub(crate) struct ParsedCommand {
 
 /// Every command shipped by installed plugins, sorted by plugin then name.
 /// Discovery is recursive (`commands/**/*.md`), skips `README.md` and
-/// dotfiles, and ignores interrupted `.installing-*` staging directories.
+/// dotfiles, and ignores interrupted `.installing-*` staging directories. A
+/// linked git worktree also sees the main worktree's plugins, project-local
+/// shadowing shared ones (see `skills::discovery_roots`).
 pub(crate) fn discover(root: &Path) -> Vec<CommandEntry> {
-    let dir = crate::core::agent::skills::plugins_dir(root);
-    let Ok(rd) = std::fs::read_dir(&dir) else {
-        return Vec::new();
-    };
+    let mut seen = std::collections::HashSet::new();
     let mut out = Vec::new();
-    for entry in rd.flatten() {
-        let path = entry.path();
-        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
-            continue;
-        }
-        let Some(plugin) = path.file_name().and_then(|s| s.to_str()) else {
+    for r in crate::core::agent::skills::discovery_roots(root) {
+        let dir = crate::core::agent::skills::plugins_dir(&r);
+        let Ok(rd) = std::fs::read_dir(&dir) else {
             continue;
         };
-        if plugin.starts_with(".installing-") {
-            continue;
-        }
-        crate::core::agent::skills::walk_markdown_files(&path.join("commands"), &mut |path| {
-            let raw = std::fs::read_to_string(path).unwrap_or_default();
-            let name = path
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or_default();
-            let parsed = parse_command(&raw);
-            out.push(CommandEntry {
-                name: name.to_string(),
-                plugin: plugin.to_string(),
-                description: parsed.description,
-                file: path.to_path_buf(),
-                hints: template_hints(&parsed.body),
+        for entry in rd.flatten() {
+            let path = entry.path();
+            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            let Some(plugin) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if plugin.starts_with(".installing-") {
+                continue;
+            }
+            if !seen.insert(plugin.to_string()) {
+                continue;
+            }
+            crate::core::agent::skills::walk_markdown_files(&path.join("commands"), &mut |path| {
+                let raw = std::fs::read_to_string(path).unwrap_or_default();
+                let name = path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or_default();
+                let parsed = parse_command(&raw);
+                out.push(CommandEntry {
+                    name: name.to_string(),
+                    plugin: plugin.to_string(),
+                    description: parsed.description,
+                    file: path.to_path_buf(),
+                    hints: template_hints(&parsed.body),
+                });
             });
-        });
+        }
     }
     out.sort_by(|a, b| (&a.plugin, &a.name).cmp(&(&b.plugin, &b.name)));
     out

--- a/src-tauri/src/core/agent/plugin_commands.rs
+++ b/src-tauri/src/core/agent/plugin_commands.rs
@@ -36,44 +36,24 @@ pub(crate) struct ParsedCommand {
 /// linked git worktree also sees the main worktree's plugins, project-local
 /// shadowing shared ones (see `skills::discovery_roots`).
 pub(crate) fn discover(root: &Path) -> Vec<CommandEntry> {
-    let mut seen = std::collections::HashSet::new();
     let mut out = Vec::new();
-    for r in crate::core::agent::skills::discovery_roots(root) {
-        let dir = crate::core::agent::skills::plugins_dir(&r);
-        let Ok(rd) = std::fs::read_dir(&dir) else {
-            continue;
-        };
-        for entry in rd.flatten() {
-            let path = entry.path();
-            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
-                continue;
-            }
-            let Some(plugin) = path.file_name().and_then(|s| s.to_str()) else {
-                continue;
-            };
-            if plugin.starts_with(".installing-") {
-                continue;
-            }
-            if !seen.insert(plugin.to_string()) {
-                continue;
-            }
-            crate::core::agent::skills::walk_markdown_files(&path.join("commands"), &mut |path| {
-                let raw = std::fs::read_to_string(path).unwrap_or_default();
-                let name = path
-                    .file_stem()
-                    .and_then(|s| s.to_str())
-                    .unwrap_or_default();
-                let parsed = parse_command(&raw);
-                out.push(CommandEntry {
-                    name: name.to_string(),
-                    plugin: plugin.to_string(),
-                    description: parsed.description,
-                    file: path.to_path_buf(),
-                    hints: template_hints(&parsed.body),
-                });
+    crate::core::agent::skills::plugin_dirs_across_roots(root, |plugin, path| {
+        crate::core::agent::skills::walk_markdown_files(&path.join("commands"), &mut |path| {
+            let raw = std::fs::read_to_string(path).unwrap_or_default();
+            let name = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or_default();
+            let parsed = parse_command(&raw);
+            out.push(CommandEntry {
+                name: name.to_string(),
+                plugin: plugin.to_string(),
+                description: parsed.description,
+                file: path.to_path_buf(),
+                hints: template_hints(&parsed.body),
             });
-        }
-    }
+        });
+    });
     out.sort_by(|a, b| (&a.plugin, &a.name).cmp(&(&b.plugin, &b.name)));
     out
 }

--- a/src-tauri/src/core/agent/plugins.rs
+++ b/src-tauri/src/core/agent/plugins.rs
@@ -258,16 +258,9 @@ fn plugin_env_path(dir: &Path, plugin: &str) -> Result<PathBuf, String> {
     Ok(dir.join(format!("{stem}.toml")))
 }
 
-/// The stored env values for one plugin. Missing or malformed file -> empty.
-#[cfg(feature = "cli")]
-pub(crate) fn stored_plugin_env(plugin: &str) -> std::collections::BTreeMap<String, String> {
-    match plugin_env_dir() {
-        Ok(dir) => stored_plugin_env_in(&dir, plugin),
-        Err(_) => Default::default(),
-    }
-}
-
-/// [`stored_plugin_env`] against an explicit directory (tests).
+/// The stored env values for one plugin, resolved against the real plugin-env
+/// store directory. Missing or malformed file -> empty.
+/// [`stored_plugin_env_in`] is the variant taking an explicit directory (tests).
 pub(crate) fn stored_plugin_env_in(
     dir: &Path,
     plugin: &str,

--- a/src-tauri/src/core/agent/plugins.rs
+++ b/src-tauri/src/core/agent/plugins.rs
@@ -124,6 +124,88 @@ struct Manifest {
     version: Option<String>,
     #[serde(default)]
     repo: Option<String>,
+    /// Optional setup requirements: environment variables the plugin needs
+    /// (typically API keys). `plugin.toml`:
+    ///
+    /// ```toml
+    /// [setup.env]
+    /// GITHUB_TOKEN = "https://github.com/settings/tokens"
+    /// ```
+    ///
+    /// The value is the URL the user can obtain the key from (empty when the
+    /// plugin author has no link to share).
+    #[serde(default)]
+    setup: Option<SetupSection>,
+    /// Claude-convention manifests declare their needs indirectly: an
+    /// `.claude-plugin/plugin.json` `mcpServers` block whose env values
+    /// reference `${VAR}`. Those references are collected as required
+    /// variables without a URL.
+    #[serde(default, rename = "mcpServers")]
+    mcp_servers: Option<std::collections::BTreeMap<String, McpServerDecl>>,
+}
+
+/// The `[setup]` manifest section.
+#[derive(Debug, Default, Deserialize)]
+struct SetupSection {
+    #[serde(default)]
+    env: Option<std::collections::BTreeMap<String, String>>,
+}
+
+/// One Claude `mcpServers` entry: only its env block matters here.
+#[derive(Debug, Default, Deserialize)]
+struct McpServerDecl {
+    #[serde(default)]
+    env: Option<std::collections::BTreeMap<String, String>>,
+}
+
+impl Manifest {
+    /// Environment variables this plugin requires, as `(var, url)` pairs —
+    /// the URL the user can obtain the value from, empty when unknown.
+    fn required_env(&self) -> std::collections::BTreeMap<String, String> {
+        let mut out = std::collections::BTreeMap::new();
+        if let Some(setup) = &self.setup {
+            for (key, url) in setup.env.iter().flatten() {
+                if is_env_name(key) {
+                    out.insert(key.clone(), url.trim().to_string());
+                }
+            }
+        }
+        for server in self.mcp_servers.iter().flat_map(|m| m.values()) {
+            for value in server.env.iter().flatten().map(|(_, v)| v) {
+                for var in template_refs(value) {
+                    if is_env_name(&var) {
+                        out.entry(var).or_default();
+                    }
+                }
+            }
+        }
+        out
+    }
+}
+
+/// A plausible environment-variable name (used as a file stem and registry
+/// key, so it must not contain path separators or control characters).
+fn is_env_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_')
+        && !name.chars().next().unwrap().is_ascii_digit()
+}
+
+/// Every `${VAR}` reference in a manifest value.
+fn template_refs(value: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = value;
+    while let Some(start) = rest.find("${") {
+        if let Some(len) = rest[start + 2..].find('}') {
+            out.push(rest[start + 2..start + 2 + len].to_string());
+            rest = &rest[start + 2 + len + 1..];
+        } else {
+            break;
+        }
+    }
+    out
 }
 
 fn client() -> Result<reqwest::Client, String> {
@@ -159,6 +241,159 @@ pub(crate) fn find_installed(root: &Path, query: &str) -> Option<(String, Instal
     installed_entries(root)
         .into_iter()
         .find(|(directory, plugin)| directory == &query || plugin.name == query)
+}
+
+/// `~/.jan/agent/plugin-env/` — where the setup prompt stores plugin API keys.
+/// Resolved from the home directory directly (not the cli-gated global config
+/// helpers) so the desktop run path syncs the same registry.
+fn plugin_env_dir() -> Result<PathBuf, String> {
+    dirs::home_dir()
+        .map(|home| home.join(".jan").join("agent").join("plugin-env"))
+        .ok_or_else(|| "could not resolve the user's home directory".to_string())
+}
+
+/// `plugin-env/<plugin>.toml` under `dir`.
+fn plugin_env_path(dir: &Path, plugin: &str) -> Result<PathBuf, String> {
+    let stem = crate::core::agent::skills::safe_stem(plugin)?;
+    Ok(dir.join(format!("{stem}.toml")))
+}
+
+/// The stored env values for one plugin. Missing or malformed file -> empty.
+#[cfg(feature = "cli")]
+pub(crate) fn stored_plugin_env(plugin: &str) -> std::collections::BTreeMap<String, String> {
+    match plugin_env_dir() {
+        Ok(dir) => stored_plugin_env_in(&dir, plugin),
+        Err(_) => Default::default(),
+    }
+}
+
+/// [`stored_plugin_env`] against an explicit directory (tests).
+pub(crate) fn stored_plugin_env_in(
+    dir: &Path,
+    plugin: &str,
+) -> std::collections::BTreeMap<String, String> {
+    plugin_env_path(dir, plugin)
+        .ok()
+        .and_then(|p| std::fs::read_to_string(p).ok())
+        .and_then(|raw| toml::from_str(&raw).ok())
+        .unwrap_or_default()
+}
+
+/// Persist one env value for a plugin, merging with what is already stored.
+#[cfg(feature = "cli")]
+pub(crate) fn save_plugin_env(plugin: &str, key: &str, value: &str) -> Result<(), String> {
+    save_plugin_env_in(&plugin_env_dir()?, plugin, key, value)
+}
+
+/// [`save_plugin_env`] against an explicit directory (tests).
+#[cfg(any(feature = "cli", test))]
+pub(crate) fn save_plugin_env_in(
+    dir: &Path,
+    plugin: &str,
+    key: &str,
+    value: &str,
+) -> Result<(), String> {
+    if !is_env_name(key) {
+        return Err(format!("invalid environment variable name '{key}'"));
+    }
+    let path = plugin_env_path(dir, plugin)?;
+    let mut values: std::collections::BTreeMap<String, String> = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|raw| toml::from_str(&raw).ok())
+        .unwrap_or_default();
+    values.insert(key.to_string(), value.to_string());
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("could not create {parent:?}: {e}"))?;
+    }
+    let serialized = toml::to_string(&values).map_err(|e| e.to_string())?;
+    #[cfg(unix)]
+    let perms = {
+        use std::os::unix::fs::OpenOptionsExt;
+        std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)
+    };
+    #[cfg(not(unix))]
+    let perms = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(&path);
+    perms
+        .and_then(|mut f| f.write_all(serialized.as_bytes()))
+        .map_err(|e| format!("could not write {}: {e}", path.display()))
+}
+
+/// Every env variable one plugin declares as required, as `(var, url)` in
+/// manifest order. Unlike [`missing_plugin_env`] this includes satisfied
+/// entries: an explicit `/plugin setup <name>` re-runs the whole prompt.
+#[cfg(feature = "cli")]
+pub(crate) fn declared_plugin_env(root: &Path, plugin: &str) -> Vec<(String, String)> {
+    skills::find_plugin_dir(root, plugin)
+        .map(|dir| read_manifest(&dir).required_env().into_iter().collect())
+        .unwrap_or_default()
+}
+
+/// Setup requirements that are not yet satisfied: `(plugin, var, url)` in
+/// scan order. A var is satisfied when the user stored a value or the process
+/// environment already provides one (CI, shells, direnv...).
+#[cfg(feature = "cli")]
+pub(crate) fn missing_plugin_env(root: &Path) -> Vec<(String, String, String)> {
+    match plugin_env_dir() {
+        Ok(dir) => missing_plugin_env_in(root, &dir),
+        Err(_) => Vec::new(),
+    }
+}
+
+/// [`missing_plugin_env`] against an explicit store directory (tests).
+#[cfg(any(feature = "cli", test))]
+fn missing_plugin_env_in(root: &Path, env_dir: &Path) -> Vec<(String, String, String)> {
+    let mut out = Vec::new();
+    for (directory, _) in installed_entries(root) {
+        let Some(dir) = skills::find_plugin_dir(root, &directory) else {
+            continue;
+        };
+        let stored = stored_plugin_env_in(env_dir, &directory);
+        for (var, url) in read_manifest(&dir).required_env() {
+            let in_store = stored.get(&var).is_some_and(|v| !v.is_empty());
+            let in_host = std::env::var_os(&var).is_some_and(|v| !v.is_empty());
+            if !in_store && !in_host {
+                out.push((directory.clone(), var, url));
+            }
+        }
+    }
+    out
+}
+
+/// Hand the sandboxed shells their plugin-declared credentials: values stored
+/// via the setup prompt, intersected with the variables the installed
+/// plugins' manifests still declare (a plugin that dropped a requirement
+/// stops receiving it). Runs on every run start via `ensure_project` and
+/// after `/reload`, so install/remove/setup changes are picked up live.
+pub(crate) fn sync_env_registry(root: &Path) {
+    if let Ok(dir) = plugin_env_dir() {
+        sync_env_registry_in(root, &dir);
+    }
+}
+
+/// [`sync_env_registry`] against an explicit store directory (tests).
+fn sync_env_registry_in(root: &Path, env_dir: &Path) {
+    let mut values: std::collections::BTreeMap<String, String> = Default::default();
+    for (directory, _) in installed_entries(root) {
+        let Some(dir) = skills::find_plugin_dir(root, &directory) else {
+            continue;
+        };
+        let stored = stored_plugin_env_in(env_dir, &directory);
+        for var in read_manifest(&dir).required_env().into_keys() {
+            if let Some(value) = stored.get(&var).filter(|v| !v.is_empty()) {
+                values.insert(var, value.clone());
+            }
+        }
+    }
+    tauri_plugin_agent_tools::tools::proc::set_plugin_env(values);
 }
 
 fn installed_entries(root: &Path) -> Vec<(String, InstalledPlugin)> {
@@ -1637,5 +1872,88 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&root);
         let _ = std::fs::remove_dir_all(repo);
+    }
+
+    /// An installed plugin (by directory convention) whose manifest declares
+    /// one required env var, plus the store dir tests use instead of `~/.jan`.
+    fn plugin_with_env_requirement(tag: &str, var: &str, url: &str) -> (PathBuf, PathBuf) {
+        let root = unique_root(tag);
+        let dir = root.join(".jan/agent/plugins/acme");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("plugin.toml"),
+            format!("name = \"acme\"\n\n[setup.env]\n{var} = \"{url}\"\n"),
+        )
+        .unwrap();
+        let env_dir = root.join("plugin-env-store");
+        std::fs::create_dir_all(&env_dir).unwrap();
+        (root, env_dir)
+    }
+
+    #[test]
+    fn required_env_reads_setup_section_and_claude_mcp_refs() {
+        let root = unique_root("reqenv");
+        std::fs::create_dir_all(root.join("acme")).unwrap();
+        std::fs::write(
+            root.join("acme/plugin.toml"),
+            "name = \"acme\"\n\n[setup.env]\nACME_TOKEN = \"https://example.com/keys\"\n",
+        )
+        .unwrap();
+        let req = read_manifest(&root.join("acme")).required_env();
+        assert_eq!(
+            req.get("ACME_TOKEN").map(String::as_str),
+            Some("https://example.com/keys")
+        );
+
+        // The Claude convention declares needs indirectly: ${VAR} references
+        // inside an mcpServers env block, with no URL to show.
+        std::fs::create_dir_all(root.join("claude").join(".claude-plugin")).unwrap();
+        std::fs::write(
+            root.join("claude/.claude-plugin/plugin.json"),
+            r#"{"name":"claude","mcpServers":{"gh":{"command":"x","env":{"GITHUB_TOKEN":"${GITHUB_TOKEN}"}}}}"#,
+        )
+        .unwrap();
+        let req = read_manifest(&root.join("claude")).required_env();
+        assert_eq!(req.get("GITHUB_TOKEN").map(String::as_str), Some(""));
+
+        // Malformed names are filtered, not propagated.
+        std::fs::create_dir_all(root.join("bad")).unwrap();
+        std::fs::write(
+            root.join("bad/plugin.toml"),
+            "[setup.env]\n\"../evil\" = \"https://x\"\n\"HAS SPACE\" = \"https://y\"\n",
+        )
+        .unwrap();
+        let req = read_manifest(&root.join("bad")).required_env();
+        assert!(req.is_empty(), "{req:?}");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn save_store_and_missing_report_roundtrip() {
+        let (root, env_dir) = plugin_with_env_requirement("envstore", "ACME_TOKEN", "https://x");
+
+        // Nothing stored: the requirement is reported as missing.
+        let missing = missing_plugin_env_in(&root, &env_dir);
+        assert_eq!(
+            missing,
+            vec![("acme".to_string(), "ACME_TOKEN".to_string(), "https://x".to_string())]
+        );
+
+        // Store a value: the requirement is satisfied.
+        save_plugin_env_in(&env_dir, "acme", "ACME_TOKEN", "secret").unwrap();
+        assert_eq!(
+            stored_plugin_env_in(&env_dir, "acme").get("ACME_TOKEN"),
+            Some(&"secret".to_string())
+        );
+        assert!(missing_plugin_env_in(&root, &env_dir).is_empty());
+        assert!(plugin_env_path(&env_dir, "acme").unwrap().exists());
+
+        // Sync registers exactly the declared+stored variable.
+        sync_env_registry_in(&root, &env_dir);
+        let snapshot =
+            tauri_plugin_agent_tools::tools::proc::plugin_env_snapshot();
+        assert_eq!(snapshot.get("ACME_TOKEN").map(String::as_str), Some("secret"));
+
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/src-tauri/src/core/agent/plugins.rs
+++ b/src-tauri/src/core/agent/plugins.rs
@@ -162,48 +162,57 @@ pub(crate) fn find_installed(root: &Path, query: &str) -> Option<(String, Instal
 }
 
 fn installed_entries(root: &Path) -> Vec<(String, InstalledPlugin)> {
-    let dir = skills::plugins_dir(root);
-    let Ok(rd) = std::fs::read_dir(&dir) else {
-        return Vec::new();
-    };
-    // Scan each artifact kind once; per-plugin counts filter the shared lists
-    // rather than re-walking the whole plugin tree per plugin.
+    // A linked git worktree also sees the main worktree's plugins, the
+    // project-local one shadowing a same-named shared one. Counts come from
+    // the merged discovery above, so shared plugins report real payloads.
+    let mut seen = std::collections::HashSet::new();
     let all_skills = skills::discover_plugins(root);
     let all_commands = crate::core::agent::plugin_commands::discover(root);
     let mut out = Vec::new();
-    for entry in rd.flatten() {
-        let path = entry.path();
-        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
-            continue;
-        }
-        let Some(directory) = path.file_name().and_then(|s| s.to_str()) else {
+    for r in skills::discovery_roots(root) {
+        let dir = skills::plugins_dir(&r);
+        let Ok(rd) = std::fs::read_dir(&dir) else {
             continue;
         };
-        if directory.starts_with(".installing-") {
-            continue;
+        // Scan each artifact kind once; per-plugin counts filter the shared
+        // lists rather than re-walking the whole plugin tree per plugin.
+        for entry in rd.flatten() {
+            let path = entry.path();
+            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            let Some(directory) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if directory.starts_with(".installing-") {
+                continue;
+            }
+            if !seen.insert(directory.to_string()) {
+                continue;
+            }
+            let manifest = read_manifest(&path);
+            let plugin_skills = all_skills
+                .iter()
+                .filter(|e| e.plugin.as_deref() == Some(directory))
+                .count();
+            let plugin_commands = all_commands
+                .iter()
+                .filter(|e| e.plugin == directory)
+                .count();
+            let plugin_agents = crate::core::agent::subagent::count_plugin_agents(root, directory);
+            out.push((
+                directory.to_string(),
+                InstalledPlugin {
+                    name: manifest.name.unwrap_or_else(|| directory.to_string()),
+                    description: manifest.description.unwrap_or_default(),
+                    version: manifest.version.unwrap_or_else(|| "0.0.0".to_string()),
+                    repo: manifest.repo.unwrap_or_default(),
+                    skills: plugin_skills,
+                    commands: plugin_commands,
+                    agents: plugin_agents,
+                },
+            ));
         }
-        let manifest = read_manifest(&path);
-        let plugin_skills = all_skills
-            .iter()
-            .filter(|e| e.plugin.as_deref() == Some(directory))
-            .count();
-        let plugin_commands = all_commands
-            .iter()
-            .filter(|e| e.plugin == directory)
-            .count();
-        let plugin_agents = crate::core::agent::subagent::count_plugin_agents(root, directory);
-        out.push((
-            directory.to_string(),
-            InstalledPlugin {
-                name: manifest.name.unwrap_or_else(|| directory.to_string()),
-                description: manifest.description.unwrap_or_default(),
-                version: manifest.version.unwrap_or_else(|| "0.0.0".to_string()),
-                repo: manifest.repo.unwrap_or_default(),
-                skills: plugin_skills,
-                commands: plugin_commands,
-                agents: plugin_agents,
-            },
-        ));
     }
     out.sort_by(|a, b| a.1.name.cmp(&b.1.name));
     out

--- a/src-tauri/src/core/agent/plugins.rs
+++ b/src-tauri/src/core/agent/plugins.rs
@@ -225,19 +225,22 @@ pub(crate) fn installed(root: &Path) -> Vec<InstalledPlugin> {
         .collect()
 }
 
-/// Find an installed plugin by directory name or manifest name. Used by the
-/// cli `/plugin` popup; the desktop lists plugins through `installed`.
+/// Find an installed plugin by directory name, falling back to manifest name.
+/// Directory identity wins when another plugin uses it as a display name.
 #[cfg(feature = "cli")]
 pub(crate) fn find_installed(root: &Path, query: &str) -> Option<(String, InstalledPlugin)> {
     let query = skills::safe_stem(query).ok()?;
-    installed_entries(root)
-        .into_iter()
-        .find(|(directory, plugin)| directory == &query || plugin.name == query)
+    let mut entries = installed_entries(root);
+    let index = entries.iter().position(|(directory, _)| directory == &query)
+        .or_else(|| entries.iter().position(|(_, plugin)| plugin.name == query))?;
+    Some(entries.swap_remove(index))
 }
 
-/// `~/.jan/agent/plugin-env/` — where the setup prompt stores plugin API keys.
+/// `~/.jan/agent/plugin-env/`, shared by CLI setup and desktop discovery.
 fn plugin_env_dir() -> Result<PathBuf, String> {
-    crate::core::agent::global_config::global_jan_dir().map(|jan| jan.join("agent").join("plugin-env"))
+    dirs::home_dir()
+        .map(|home| home.join(".jan").join("agent").join("plugin-env"))
+        .ok_or_else(|| "could not resolve the user's home directory".to_string())
 }
 
 /// `plugin-env/<plugin>.toml` under `dir`.
@@ -318,7 +321,14 @@ pub(crate) fn save_plugin_env_in(
         .truncate(true)
         .open(&path);
     perms
-        .and_then(|mut f| f.write_all(serialized.as_bytes()))
+        .and_then(|mut f| {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                f.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+            }
+            f.write_all(serialized.as_bytes())
+        })
         .map_err(|e| format!("could not write {}: {e}", path.display()))
 }
 
@@ -372,6 +382,8 @@ fn missing_plugin_env_in(root: &Path, env_dir: &Path) -> Vec<(String, String, St
 pub(crate) fn sync_env_registry(root: &Path) {
     if let Ok(dir) = plugin_env_dir() {
         sync_env_registry_in(root, &dir);
+    } else {
+        tauri_plugin_agent_tools::tools::proc::set_plugin_env(root, Default::default());
     }
 }
 
@@ -389,10 +401,10 @@ fn sync_env_registry_in(root: &Path, env_dir: &Path) {
             }
         }
     }
-    tauri_plugin_agent_tools::tools::proc::set_plugin_env(values);
+    tauri_plugin_agent_tools::tools::proc::set_plugin_env(root, values);
 }
 
-fn installed_entries(root: &Path) -> Vec<(String, InstalledPlugin)> {
+pub(crate) fn installed_entries(root: &Path) -> Vec<(String, InstalledPlugin)> {
     // A linked git worktree also sees the main worktree's plugins, the
     // project-local one shadowing a same-named shared one. Counts come from
     // the merged discovery above, so shared plugins report real payloads.
@@ -2056,6 +2068,71 @@ mod tests {
         std::fs::remove_dir_all(root).unwrap();
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn saving_plugin_keys_restricts_existing_files_and_preserves_other_keys() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("acme.toml");
+        std::fs::write(&path, "OTHER_TOKEN = \"keep\"\n").unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        save_plugin_env_in(dir.path(), "acme", "ACME_TOKEN", "secret").unwrap();
+
+        assert_eq!(std::fs::metadata(&path).unwrap().permissions().mode() & 0o777, 0o600);
+        let values = stored_plugin_env_in(dir.path(), "acme");
+        assert_eq!(values.get("OTHER_TOKEN").map(String::as_str), Some("keep"));
+        assert_eq!(values.get("ACME_TOKEN").map(String::as_str), Some("secret"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn plugin_keys_do_not_cross_project_boundaries() {
+        use tauri_plugin_agent_tools::tools::proc;
+
+        let temp = tempfile::tempdir().unwrap();
+        let first = temp.path().join("first");
+        let second = temp.path().join("second");
+        let unrelated = temp.path().join("unrelated");
+        std::fs::create_dir_all(&unrelated).unwrap();
+        for (root, value) in [(&first, "first-secret"), (&second, "second-secret")] {
+            let plugin = root.join(".jan/agent/plugins/acme");
+            std::fs::create_dir_all(&plugin).unwrap();
+            std::fs::write(
+                plugin.join("plugin.toml"),
+                "[setup.env]\nJAN_PLUGIN_ISOLATION_TOKEN = \"\"\n",
+            ).unwrap();
+            let store = root.join("key-store");
+            save_plugin_env_in(&store, "acme", "JAN_PLUGIN_ISOLATION_TOKEN", value).unwrap();
+            sync_env_registry_in(root, &store);
+        }
+        // Both projects are registered before either launches a shell.
+        for (root, expected) in [
+            (&first, "first-secret"), (&second, "second-secret"), (&unrelated, "unset"),
+        ] {
+            let child = proc::spawn(
+                proc::shell(), "printf '%s' \"${JAN_PLUGIN_ISOLATION_TOKEN-unset}\"", root, None,
+            ).await.unwrap();
+            let pid = child.id().unwrap();
+            let output = child.wait_with_output().await.unwrap();
+            proc::unregister(pid);
+            assert!(output.status.success());
+            assert_eq!(String::from_utf8(output.stdout).unwrap(), expected);
+        }
+        // Dropping a manifest requirement must revoke the next shell's key.
+        std::fs::write(first.join(".jan/agent/plugins/acme/plugin.toml"), "name = \"acme\"\n").unwrap();
+        sync_env_registry_in(&first, &first.join("key-store"));
+        let child = proc::spawn(
+            proc::shell(), "printf '%s' \"${JAN_PLUGIN_ISOLATION_TOKEN-unset}\"", &first, None,
+        ).await.unwrap();
+        let pid = child.id().unwrap();
+        let output = child.wait_with_output().await.unwrap();
+        proc::unregister(pid);
+        assert!(output.status.success());
+        assert_eq!(String::from_utf8(output.stdout).unwrap(), "unset");
+    }
+
     #[test]
     fn save_store_and_missing_report_roundtrip() {
         let (root, env_dir) = plugin_with_env_requirement("envstore", "ACME_TOKEN", "https://x");
@@ -2075,12 +2152,6 @@ mod tests {
         );
         assert!(missing_plugin_env_in(&root, &env_dir).is_empty());
         assert!(plugin_env_path(&env_dir, "acme").unwrap().exists());
-
-        // Sync registers exactly the declared+stored variable.
-        sync_env_registry_in(&root, &env_dir);
-        let snapshot =
-            tauri_plugin_agent_tools::tools::proc::plugin_env_snapshot();
-        assert_eq!(snapshot.get("ACME_TOKEN").map(String::as_str), Some("secret"));
 
         let _ = std::fs::remove_dir_all(&root);
     }

--- a/src-tauri/src/core/agent/plugins.rs
+++ b/src-tauri/src/core/agent/plugins.rs
@@ -269,7 +269,7 @@ pub(crate) fn save_plugin_env(plugin: &str, key: &str, value: &str) -> Result<()
 }
 
 /// [`save_plugin_env`] against an explicit directory (tests).
-#[cfg(any(feature = "cli", test))]
+#[cfg(feature = "cli")]
 pub(crate) fn save_plugin_env_in(
     dir: &Path,
     plugin: &str,
@@ -357,7 +357,7 @@ pub(crate) fn missing_plugin_env(root: &Path) -> Vec<(String, String, String)> {
 }
 
 /// [`missing_plugin_env`] against an explicit store directory (tests).
-#[cfg(any(feature = "cli", test))]
+#[cfg(feature = "cli")]
 fn missing_plugin_env_in(root: &Path, env_dir: &Path) -> Vec<(String, String, String)> {
     let mut out = Vec::new();
     for (directory, _) in installed_entries(root) {
@@ -506,7 +506,7 @@ pub(crate) fn plugin_mcp_servers(
     resolved_mcp_servers(&dir, &stored)
 }
 
-#[cfg(any(feature = "cli", test))]
+#[cfg(feature = "cli")]
 fn resolved_mcp_servers(
     dir: &Path,
     stored: &std::collections::BTreeMap<String, String>,

--- a/src-tauri/src/core/agent/plugins.rs
+++ b/src-tauri/src/core/agent/plugins.rs
@@ -161,11 +161,15 @@ struct McpServerDecl {
 impl Manifest {
     /// Environment variables this plugin requires, as `(var, url)` pairs —
     /// the URL the user can obtain the value from, empty when unknown.
+    /// Variables the sandbox owns (`PATH`, temp keys, loader injection
+    /// prefixes) are refused: a pasted value under one of those names could
+    /// clobber or escape the sandbox environment wholesale.
     fn required_env(&self) -> std::collections::BTreeMap<String, String> {
+        use tauri_plugin_agent_tools::tools::proc::is_reserved_env_key;
         let mut out = std::collections::BTreeMap::new();
         if let Some(setup) = &self.setup {
             for (key, url) in setup.env.iter().flatten() {
-                if is_env_name(key) {
+                if is_env_name(key) && !is_reserved_env_key(key) {
                     out.insert(key.clone(), url.trim().to_string());
                 }
             }
@@ -173,7 +177,7 @@ impl Manifest {
         for server in self.mcp_servers.iter().flat_map(|m| m.values()) {
             for value in server.env.iter().flatten().map(|(_, v)| v) {
                 for var in template_refs(value) {
-                    if is_env_name(&var) {
+                    if is_env_name(&var) && !is_reserved_env_key(&var) {
                         out.entry(var).or_default();
                     }
                 }
@@ -244,12 +248,8 @@ pub(crate) fn find_installed(root: &Path, query: &str) -> Option<(String, Instal
 }
 
 /// `~/.jan/agent/plugin-env/` — where the setup prompt stores plugin API keys.
-/// Resolved from the home directory directly (not the cli-gated global config
-/// helpers) so the desktop run path syncs the same registry.
 fn plugin_env_dir() -> Result<PathBuf, String> {
-    dirs::home_dir()
-        .map(|home| home.join(".jan").join("agent").join("plugin-env"))
-        .ok_or_else(|| "could not resolve the user's home directory".to_string())
+    crate::core::agent::global_config::global_jan_dir().map(|jan| jan.join("agent").join("plugin-env"))
 }
 
 /// `plugin-env/<plugin>.toml` under `dir`.
@@ -260,8 +260,7 @@ fn plugin_env_path(dir: &Path, plugin: &str) -> Result<PathBuf, String> {
 
 /// The stored env values for one plugin, resolved against the real plugin-env
 /// store directory. Missing or malformed file -> empty.
-/// [`stored_plugin_env_in`] is the variant taking an explicit directory (tests).
-pub(crate) fn stored_plugin_env_in(
+fn stored_plugin_env_in(
     dir: &Path,
     plugin: &str,
 ) -> std::collections::BTreeMap<String, String> {
@@ -289,11 +288,26 @@ pub(crate) fn save_plugin_env_in(
     if !is_env_name(key) {
         return Err(format!("invalid environment variable name '{key}'"));
     }
+    if tauri_plugin_agent_tools::tools::proc::is_reserved_env_key(key) {
+        return Err(format!("'{key}' is reserved by the sandbox and cannot be set for a plugin"));
+    }
     let path = plugin_env_path(dir, plugin)?;
-    let mut values: std::collections::BTreeMap<String, String> = std::fs::read_to_string(&path)
-        .ok()
-        .and_then(|raw| toml::from_str(&raw).ok())
-        .unwrap_or_default();
+    let mut values: std::collections::BTreeMap<String, String> = match
+        std::fs::read_to_string(&path)
+    {
+        Ok(raw) => match toml::from_str(&raw) {
+            Ok(v) => v,
+            // Refuse to merge into a file we cannot parse: saving would
+            // silently destroy the other stored keys for this plugin.
+            Err(_) => {
+                return Err(format!(
+                    "stored env file {} is malformed - delete it and re-run setup",
+                    path.display()
+                ))
+            }
+        },
+        Err(_) => Default::default(),
+    };
     values.insert(key.to_string(), value.to_string());
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).map_err(|e| format!("could not create {parent:?}: {e}"))?;
@@ -331,8 +345,11 @@ pub(crate) fn declared_plugin_env(root: &Path, plugin: &str) -> Vec<(String, Str
 }
 
 /// Setup requirements that are not yet satisfied: `(plugin, var, url)` in
-/// scan order. A var is satisfied when the user stored a value or the process
-/// environment already provides one (CI, shells, direnv...).
+/// scan order. A var is satisfied only when the user stored a value via the
+/// setup prompt: the sandboxed shell drops every host variable except the
+/// static allowlist, so a var provided by the host environment would never
+/// reach the plugin's commands even though the prompt claimed it was
+/// satisfied.
 #[cfg(feature = "cli")]
 pub(crate) fn missing_plugin_env(root: &Path) -> Vec<(String, String, String)> {
     match plugin_env_dir() {
@@ -351,9 +368,7 @@ fn missing_plugin_env_in(root: &Path, env_dir: &Path) -> Vec<(String, String, St
         };
         let stored = stored_plugin_env_in(env_dir, &directory);
         for (var, url) in read_manifest(&dir).required_env() {
-            let in_store = stored.get(&var).is_some_and(|v| !v.is_empty());
-            let in_host = std::env::var_os(&var).is_some_and(|v| !v.is_empty());
-            if !in_store && !in_host {
+            if stored.get(&var).is_none_or(|v| v.is_empty()) {
                 out.push((directory.clone(), var, url));
             }
         }
@@ -393,32 +408,11 @@ fn installed_entries(root: &Path) -> Vec<(String, InstalledPlugin)> {
     // A linked git worktree also sees the main worktree's plugins, the
     // project-local one shadowing a same-named shared one. Counts come from
     // the merged discovery above, so shared plugins report real payloads.
-    let mut seen = std::collections::HashSet::new();
     let all_skills = skills::discover_plugins(root);
     let all_commands = crate::core::agent::plugin_commands::discover(root);
     let mut out = Vec::new();
-    for r in skills::discovery_roots(root) {
-        let dir = skills::plugins_dir(&r);
-        let Ok(rd) = std::fs::read_dir(&dir) else {
-            continue;
-        };
-        // Scan each artifact kind once; per-plugin counts filter the shared
-        // lists rather than re-walking the whole plugin tree per plugin.
-        for entry in rd.flatten() {
-            let path = entry.path();
-            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
-                continue;
-            }
-            let Some(directory) = path.file_name().and_then(|s| s.to_str()) else {
-                continue;
-            };
-            if directory.starts_with(".installing-") {
-                continue;
-            }
-            if !seen.insert(directory.to_string()) {
-                continue;
-            }
-            let manifest = read_manifest(&path);
+    skills::plugin_dirs_across_roots(root, |directory, path| {
+        let manifest = read_manifest(path);
             let plugin_skills = all_skills
                 .iter()
                 .filter(|e| e.plugin.as_deref() == Some(directory))
@@ -440,8 +434,7 @@ fn installed_entries(root: &Path) -> Vec<(String, InstalledPlugin)> {
                     agents: plugin_agents,
                 },
             ));
-        }
-    }
+    });
     out.sort_by(|a, b| a.1.name.cmp(&b.1.name));
     out
 }
@@ -1092,7 +1085,18 @@ pub(crate) fn remove(root: &Path, name: &str) -> Result<(), String> {
     if !target.is_dir() {
         return Err(format!("ERROR: plugin '{name}' is not installed"));
     }
-    std::fs::remove_dir_all(&target).map_err(|e| format!("ERROR: {e}"))
+    std::fs::remove_dir_all(&target).map_err(|e| format!("ERROR: {e}"))?;
+    // Drop the stored credentials too: they live outside the plugin
+    // directory (a reinstall must not silently reactivate them), so removing
+    // the plugin has to clean them up here. Then refresh the live registry so
+    // the sandboxed shells of the current session stop receiving the values.
+    if let Ok(dir) = plugin_env_dir() {
+        if let Ok(path) = plugin_env_path(&dir, name) {
+            let _ = std::fs::remove_file(path);
+        }
+    }
+    sync_env_registry(root);
+    Ok(())
 }
 
 /// List marketplace plugins matching `query` (name or description, case

--- a/src-tauri/src/core/agent/plugins.rs
+++ b/src-tauri/src/core/agent/plugins.rs
@@ -136,24 +136,14 @@ struct Manifest {
     /// plugin author has no link to share).
     #[serde(default)]
     setup: Option<SetupSection>,
-    /// Claude-convention manifests declare their needs indirectly: an
-    /// `.claude-plugin/plugin.json` `mcpServers` block whose env values
-    /// reference `${VAR}`. Those references are collected as required
-    /// variables without a URL.
+    /// Inline MCP declarations; `.mcp.json` declarations are merged on read.
     #[serde(default, rename = "mcpServers")]
-    mcp_servers: Option<std::collections::BTreeMap<String, McpServerDecl>>,
+    mcp_servers: Option<std::collections::BTreeMap<String, serde_json::Value>>,
 }
 
 /// The `[setup]` manifest section.
 #[derive(Debug, Default, Deserialize)]
 struct SetupSection {
-    #[serde(default)]
-    env: Option<std::collections::BTreeMap<String, String>>,
-}
-
-/// One Claude `mcpServers` entry: only its env block matters here.
-#[derive(Debug, Default, Deserialize)]
-struct McpServerDecl {
     #[serde(default)]
     env: Option<std::collections::BTreeMap<String, String>>,
 }
@@ -175,11 +165,9 @@ impl Manifest {
             }
         }
         for server in self.mcp_servers.iter().flat_map(|m| m.values()) {
-            for value in server.env.iter().flatten().map(|(_, v)| v) {
-                for var in template_refs(value) {
-                    if is_env_name(&var) && !is_reserved_env_key(&var) {
-                        out.entry(var).or_default();
-                    }
+            for var in mcp_template_refs(server) {
+                if var != "CLAUDE_PLUGIN_ROOT" && is_env_name(&var) && !is_reserved_env_key(&var) {
+                    out.entry(var).or_default();
                 }
             }
         }
@@ -440,6 +428,14 @@ fn installed_entries(root: &Path) -> Vec<(String, InstalledPlugin)> {
 }
 
 fn read_manifest(root: &Path) -> Manifest {
+    let mut manifest = read_manifest_metadata(root);
+    if let Ok(servers) = read_mcp_declarations(root, manifest.mcp_servers.take()) {
+        manifest.mcp_servers = Some(servers);
+    }
+    manifest
+}
+
+fn read_manifest_metadata(root: &Path) -> Manifest {
     std::fs::read_to_string(root.join("plugin.toml"))
         .ok()
         .and_then(|raw| toml::from_str::<Manifest>(&raw).ok())
@@ -449,6 +445,115 @@ fn read_manifest(root: &Path) -> Manifest {
                 .and_then(|raw| serde_json::from_str::<Manifest>(&raw).ok())
         })
         .unwrap_or_default()
+}
+
+fn read_mcp_declarations(
+    root: &Path,
+    inline: Option<std::collections::BTreeMap<String, serde_json::Value>>,
+) -> Result<std::collections::BTreeMap<String, serde_json::Value>, String> {
+    let mut servers = inline.unwrap_or_default();
+    let path = root.join(".mcp.json");
+    match std::fs::read_to_string(&path) {
+        Ok(raw) => {
+            let mut document: serde_json::Value = serde_json::from_str(&raw)
+                .map_err(|_| format!("invalid MCP JSON in {}", path.display()))?;
+            let entries = document.get_mut("mcpServers")
+                .map(serde_json::Value::take)
+                .unwrap_or(document);
+            let entries: std::collections::BTreeMap<String, serde_json::Value> =
+                serde_json::from_value(entries)
+                    .map_err(|_| format!("{} must contain an MCP server map", path.display()))?;
+            servers.extend(entries);
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => return Err(format!("could not read {}: {e}", path.display())),
+    }
+    Ok(servers)
+}
+
+fn mcp_template_refs(value: &serde_json::Value) -> Vec<String> {
+    match value {
+        serde_json::Value::String(text) => template_refs(text),
+        serde_json::Value::Array(items) => items.iter().flat_map(mcp_template_refs).collect(),
+        serde_json::Value::Object(fields) => fields.values().flat_map(mcp_template_refs).collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Installed MCP declarations, ready for the user to review before activation.
+/// Reads the plugin's own key store, never unrelated host credentials.
+#[cfg(feature = "cli")]
+pub(crate) fn plugin_mcp_servers(
+    root: &Path,
+    plugin: &str,
+) -> Result<Vec<(String, serde_json::Value)>, String> {
+    let plugin = skills::safe_stem(plugin)?;
+    let dir = skills::find_plugin_dir(root, &plugin)
+        .ok_or_else(|| format!("plugin '{plugin}' is not installed"))?;
+    let stored = stored_plugin_env_in(&plugin_env_dir()?, &plugin);
+    resolved_mcp_servers(&dir, &stored)
+}
+
+#[cfg(any(feature = "cli", test))]
+fn resolved_mcp_servers(
+    dir: &Path,
+    stored: &std::collections::BTreeMap<String, String>,
+) -> Result<Vec<(String, serde_json::Value)>, String> {
+    fn expand(
+        value: &mut serde_json::Value,
+        dir: &Path,
+        stored: &std::collections::BTreeMap<String, String>,
+    ) -> Result<(), String> {
+        match value {
+            serde_json::Value::String(text) => {
+                let original = std::mem::take(text);
+                let mut rest = original.as_str();
+                while let Some(start) = rest.find("${") {
+                    text.push_str(&rest[..start]);
+                    let end = rest[start + 2..].find('}')
+                        .ok_or("unterminated variable in plugin MCP configuration")? + start + 2;
+                    let var = &rest[start + 2..end];
+                    if var == "CLAUDE_PLUGIN_ROOT" {
+                        text.push_str(&dir.to_string_lossy());
+                    } else {
+                        let value = stored.get(var).filter(|v| !v.is_empty())
+                            .ok_or_else(|| format!("missing plugin key '{var}' - complete plugin setup first"))?;
+                        text.push_str(value);
+                    }
+                    rest = &rest[end + 1..];
+                }
+                text.push_str(rest);
+            }
+            serde_json::Value::Array(items) => {
+                for item in items {
+                    expand(item, dir, stored)?;
+                }
+            }
+            serde_json::Value::Object(fields) => {
+                for item in fields.values_mut() {
+                    expand(item, dir, stored)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+    let metadata = read_manifest_metadata(dir);
+    let declarations = read_mcp_declarations(dir, metadata.mcp_servers)?;
+    let mut out = Vec::new();
+    for (name, mut config) in declarations {
+        let fields = config.as_object_mut()
+            .ok_or_else(|| format!("MCP server '{name}' must be an object"))?;
+        // Claude permits URL-only remote entries and omitted stdio args.
+        let transport = if fields.contains_key("url") { "http" } else { "stdio" };
+        fields.entry("type").or_insert_with(|| transport.into());
+        if fields.get("type").and_then(serde_json::Value::as_str) == Some("stdio") {
+            fields.entry("args").or_insert_with(|| serde_json::json!([]));
+        }
+        expand(&mut config, dir, stored)?;
+        out.push((name, config));
+    }
+    Ok(out)
 }
 
 /// Reject specs that could inject shell commands. The spec is later passed as
@@ -1923,6 +2028,32 @@ mod tests {
         let req = read_manifest(&root.join("bad")).required_env();
         assert!(req.is_empty(), "{req:?}");
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn required_env_reads_mcp_file_headers_without_prompting_for_plugin_root() {
+        let root = unique_root("mcp-env");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(
+            root.join(".mcp.json"),
+            r#"{"mcpServers":{"remote":{"url":"https://example.com/mcp","headers":{"Authorization":"Bearer ${ACME_TOKEN}"}},"local":{"command":"node","args":["${CLAUDE_PLUGIN_ROOT}/server.js"]}}}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            read_manifest(&root).required_env(),
+            std::collections::BTreeMap::from([("ACME_TOKEN".to_string(), String::new())])
+        );
+        assert!(resolved_mcp_servers(&root, &Default::default()).is_err());
+        let stored = std::collections::BTreeMap::from([
+            ("ACME_TOKEN".to_string(), "secret-${NOT_A_TEMPLATE}".to_string()),
+        ]);
+        let servers: std::collections::BTreeMap<_, _> =
+            resolved_mcp_servers(&root, &stored).unwrap().into_iter().collect();
+        assert_eq!(servers["remote"]["headers"]["Authorization"], "Bearer secret-${NOT_A_TEMPLATE}");
+        assert_eq!(servers["local"]["args"][0], format!("{}/server.js", root.display()));
+        std::fs::write(root.join(".mcp.json"), "{broken").unwrap();
+        assert!(resolved_mcp_servers(&root, &stored).is_err());
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/src-tauri/src/core/agent/project.rs
+++ b/src-tauri/src/core/agent/project.rs
@@ -294,6 +294,10 @@ pub(crate) fn permissions_from(cfg: &AgentToml) -> ToolPermissions {
 /// scaffolded: an empty placeholder costs prompt space and teaches nothing, so
 /// it is written by `/init` or by hand.
 pub(crate) fn ensure_project(project_root: &Path) -> Result<PathBuf, String> {
+    // Refresh the plugin env registry first: this is the one choke point
+    // every run path calls, so a stored API key reaches the sandboxed shells
+    // of the run about to start.
+    super::plugins::sync_env_registry(project_root);
     if !project_root.is_dir() {
         return Err(format!(
             "project directory does not exist: {}. Pass --project with a path to an existing directory (paths are case-sensitive).",

--- a/src-tauri/src/core/agent/skills.rs
+++ b/src-tauri/src/core/agent/skills.rs
@@ -542,6 +542,7 @@ pub(crate) fn user_catalog(root: &Path, enabled: &[String]) -> Vec<SkillMeta> {
 /// the enabled whitelist — the full disk truth. This is what `/reload skills`
 /// diffs against the previous scan, so an edit or install shows up as an
 /// added/removed/changed entry regardless of who may invoke it.
+#[cfg(feature = "cli")]
 pub(crate) fn full_catalog(root: &Path) -> Vec<SkillMeta> {
     side_catalog(root, &[], |_| true)
 }

--- a/src-tauri/src/core/agent/skills.rs
+++ b/src-tauri/src/core/agent/skills.rs
@@ -538,12 +538,20 @@ pub(crate) fn user_catalog(root: &Path, enabled: &[String]) -> Vec<SkillMeta> {
     side_catalog(root, enabled, |p| p.user_invocable)
 }
 
+/// Every discovered skill (project + plugin), both invocation sides, ignoring
+/// the enabled whitelist — the full disk truth. This is what `/reload skills`
+/// diffs against the previous scan, so an edit or install shows up as an
+/// added/removed/changed entry regardless of who may invoke it.
+pub(crate) fn full_catalog(root: &Path) -> Vec<SkillMeta> {
+    side_catalog(root, &[], |_| true)
+}
+
 /// Metadata for every skill one plugin ships (both invocation sides), for the
 /// `/plugin list` view. The enabled whitelist is intentionally ignored here:
 /// the management view shows what the plugin contributes, not what is active.
 #[cfg(feature = "cli")]
 pub(crate) fn plugin_skill_metas(root: &Path, plugin: &str) -> Vec<SkillMeta> {
-    let mut metas = side_catalog(root, &[], |_| true);
+    let mut metas = full_catalog(root);
     metas.retain(|m| m.plugin.as_deref() == Some(plugin));
     metas
 }

--- a/src-tauri/src/core/agent/skills.rs
+++ b/src-tauri/src/core/agent/skills.rs
@@ -203,14 +203,48 @@ pub(crate) fn scan_skill_dir(dir: &Path) -> Vec<SkillEntry> {
     out
 }
 
-/// All project skills (`.jan/agent/skills`), sorted by name.
+/// All project skills (`.jan/agent/skills`), sorted by name. A linked git
+/// worktree also sees the main worktree's skills: installs land in the
+/// checkout that ran them, but agent setup follows the repository, not the
+/// checkout. Project-local skills shadow same-named shared ones.
 pub(crate) fn discover(root: &Path) -> Vec<SkillEntry> {
-    scan_skill_dir(&skills_dir(root))
+    let mut seen = std::collections::HashSet::new();
+    let mut out: Vec<SkillEntry> = Vec::new();
+    for r in discovery_roots(root) {
+        for e in scan_skill_dir(&skills_dir(&r)) {
+            if seen.insert(e.name.clone()) {
+                out.push(e);
+            }
+        }
+    }
+    out.sort_by(|a, b| a.name.cmp(&b.name));
+    out
 }
 
 /// The plugins directory `.jan/agent/plugins`.
 pub(crate) fn plugins_dir(root: &Path) -> PathBuf {
     root.join(".jan").join("agent").join("plugins")
+}
+
+/// Roots whose `.jan/agent` payload this project sees, in shadowing order:
+/// the project root first, then the main worktree root when the project is a
+/// linked git worktree. Skills and plugins install into whichever checkout ran
+/// the install; a linked worktree shares the repository but not the working
+/// tree, so discovery follows the repo, not the checkout. Earlier roots win:
+/// a project-local entry shadows a same-named shared one.
+pub(crate) fn discovery_roots(root: &Path) -> Vec<PathBuf> {
+    let mut roots = vec![root.to_path_buf()];
+    roots.extend(crate::core::agent::git::worktree_primary_root(root));
+    roots
+}
+
+/// Locate an installed plugin's directory by name across the discovery roots
+/// (project-local first). `None` when no root has it.
+pub(crate) fn find_plugin_dir(root: &Path, plugin: &str) -> Option<PathBuf> {
+    discovery_roots(root)
+        .iter()
+        .map(|r| plugins_dir(r).join(plugin))
+        .find(|p| p.is_dir())
 }
 
 /// Recursively yield every `*.md` file under `dir`, skipping dotfiles and
@@ -263,42 +297,50 @@ pub(crate) fn invocation_wrapper(name: &str, kind: &str) -> String {
 /// (folder and flat forms, same rules as project skills) plus an optional
 /// single `SKILL.md` at the plugin root (a repo that is itself one skill).
 pub(crate) fn discover_plugins(root: &Path) -> Vec<SkillEntry> {
-    let dir = plugins_dir(root);
-    let Ok(rd) = std::fs::read_dir(&dir) else {
-        return Vec::new();
-    };
+    let mut seen = std::collections::HashSet::new();
     let mut out: Vec<SkillEntry> = Vec::new();
-    for entry in rd.flatten() {
-        let path = entry.path();
-        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
-            continue;
-        }
-        let Some(plugin) = path.file_name().and_then(|s| s.to_str()) else {
+    for r in discovery_roots(root) {
+        let dir = plugins_dir(&r);
+        let Ok(rd) = std::fs::read_dir(&dir) else {
             continue;
         };
-        // Ignore interrupted `.installing-*` staging directories, matching the
-        // command/agent loaders: a partially-copied plugin must not leak its
-        // skills into the catalog during an install.
-        if plugin.starts_with(".installing-") {
-            continue;
+        for entry in rd.flatten() {
+            let path = entry.path();
+            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            let Some(plugin) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            // Ignore interrupted `.installing-*` staging directories, matching
+            // the command/agent loaders: a partially-copied plugin must not
+            // leak its skills into the catalog during an install.
+            if plugin.starts_with(".installing-") {
+                continue;
+            }
+            // Earlier roots shadow: a plugin installed in this checkout hides
+            // a same-named one shared from the main worktree.
+            if !seen.insert(plugin.to_string()) {
+                continue;
+            }
+            let mut tagged = Vec::new();
+            for e in scan_skill_dir(&path.join("skills")) {
+                tagged.push(SkillEntry {
+                    plugin: Some(plugin.to_string()),
+                    ..e
+                });
+            }
+            let root_md = path.join("SKILL.md");
+            if root_md.is_file() {
+                tagged.push(SkillEntry {
+                    name: plugin.to_string(),
+                    file: root_md,
+                    is_folder: false,
+                    plugin: Some(plugin.to_string()),
+                });
+            }
+            out.extend(tagged);
         }
-        let mut tagged = Vec::new();
-        for e in scan_skill_dir(&path.join("skills")) {
-            tagged.push(SkillEntry {
-                plugin: Some(plugin.to_string()),
-                ..e
-            });
-        }
-        let root_md = path.join("SKILL.md");
-        if root_md.is_file() {
-            tagged.push(SkillEntry {
-                name: plugin.to_string(),
-                file: root_md,
-                is_folder: false,
-                plugin: Some(plugin.to_string()),
-            });
-        }
-        out.extend(tagged);
     }
     out.sort_by(|a, b| a.name.cmp(&b.name));
     out
@@ -355,7 +397,7 @@ fn resolve_in_plugin(root: &Path, plugin: &str, plain: &str) -> Option<SkillEntr
     if safe_stem(plugin).ok()? != plugin || safe_stem(plain).ok()? != plain {
         return None;
     }
-    let base = plugins_dir(root).join(plugin);
+    let base = find_plugin_dir(root, plugin)?;
     let folder = base.join("skills").join(plain).join("SKILL.md");
     if folder.is_file() {
         return Some(SkillEntry {
@@ -1220,5 +1262,81 @@ mod tests {
         // Unknown skill errors.
         assert!(build_invocation_message(&root, "nope", "").is_err());
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A repo with one commit plus a linked worktree, or skip when git is
+    /// unavailable. Returns `(main_root, linked_root)`.
+    fn repo_with_linked_worktree(tag: &str) -> Option<(std::path::PathBuf, std::path::PathBuf)> {
+        if std::process::Command::new("git").arg("--version").output().is_err() {
+            return None;
+        }
+        let n = std::time::SystemTime::UNIX_EPOCH
+            .elapsed()
+            .unwrap()
+            .as_nanos();
+        let main = std::env::temp_dir().join(format!("jan_wt_main_{tag}_{n}"));
+        std::fs::create_dir_all(&main).unwrap();
+        let run = |args: &[&str]| -> bool {
+            std::process::Command::new("git")
+                .args(args)
+                .current_dir(&main)
+                .status()
+                .map(|s| s.success())
+                .unwrap_or(false)
+        };
+        if !run(&["init", "-q", "."])
+            || !run(&["commit", "--allow-empty", "-q", "-m", "init"])
+        {
+            return None;
+        }
+        let linked = std::env::temp_dir().join(format!("jan_wt_link_{tag}_{n}"));
+        let l = linked.to_string_lossy().to_string();
+        if !run(&["worktree", "add", &l]) {
+            return None;
+        }
+        Some((main, linked))
+    }
+
+    /// Skills and plugins installed in the main worktree are visible from a
+    /// linked worktree (agent setup follows the repo, not the checkout), and a
+    /// project-local skill shadows a same-named shared one.
+    #[test]
+    fn linked_worktree_sees_main_worktree_skills_and_plugins() {
+        let Some((main, linked)) = repo_with_linked_worktree("discover") else {
+            return;
+        };
+        // git resolves paths through realpath, and on macOS /var is a symlink
+        // to /private/var: canonicalize so prefix comparisons hold.
+        let main = std::fs::canonicalize(&main).unwrap();
+        let linked = std::fs::canonicalize(&linked).unwrap();
+        project_skill(&main, "shared", "shared\n");
+        plugin_skill(&main, "shared-plugin", "prep", "plugin\n");
+
+        // Both the shared skill and the shared plugin's skills are visible
+        // from the linked worktree, under the linked root.
+        let names: Vec<String> = discover(&linked).iter().map(|e| e.name.clone()).collect();
+        assert!(names.contains(&"shared".to_string()), "{names:?}");
+        let plugins = discover_plugins(&linked);
+        assert_eq!(
+            plugins.iter().map(qualified_name).collect::<Vec<_>>(),
+            vec!["shared-plugin:prep".to_string()]
+        );
+        // Reading a shared plugin skill resolves through the linked root too.
+        let entry = resolve_readable(&linked, "shared-plugin:prep").unwrap();
+        assert!(entry.file.starts_with(&main));
+
+        // Project-local shadows shared: the linked worktree's own copy wins.
+        project_skill(&linked, "shared", "local\n");
+        let entry = discover(&linked)
+            .into_iter()
+            .find(|e| e.name == "shared")
+            .unwrap();
+        assert!(entry.file.starts_with(&linked), "local must win");
+
+        // The main worktree does not merge with itself (no duplicates).
+        assert_eq!(discover(&main).iter().filter(|e| e.name == "shared").count(), 1);
+
+        let _ = std::fs::remove_dir_all(&main);
+        let _ = std::fs::remove_dir_all(&linked);
     }
 }

--- a/src-tauri/src/core/agent/skills.rs
+++ b/src-tauri/src/core/agent/skills.rs
@@ -247,6 +247,34 @@ pub(crate) fn find_plugin_dir(root: &Path, plugin: &str) -> Option<PathBuf> {
         .find(|p| p.is_dir())
 }
 
+/// Visit every installed plugin directory across the discovery roots, with
+/// first-root-wins shadowing: a project-local plugin hides a same-named one
+/// shared from the main worktree. Skips non-directories and interrupted
+/// `.installing-*` staging directories (a partially-copied plugin must not
+/// leak its payload mid-install). Shared by the skill, command, agent, and
+/// plugin-listing discovery passes so they all agree on what is installed.
+pub(crate) fn plugin_dirs_across_roots(root: &Path, mut visit: impl FnMut(&str, &Path)) {
+    let mut seen = std::collections::HashSet::new();
+    for r in discovery_roots(root) {
+        let Ok(rd) = std::fs::read_dir(plugins_dir(&r)) else {
+            continue;
+        };
+        for entry in rd.flatten() {
+            let path = entry.path();
+            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            let Some(plugin) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if plugin.starts_with(".installing-") || !seen.insert(plugin.to_string()) {
+                continue;
+            }
+            visit(plugin, &path);
+        }
+    }
+}
+
 /// Recursively yield every `*.md` file under `dir`, skipping dotfiles and
 /// `README` files (any case). Callers read each file themselves so read-failure
 /// handling stays with them. Shared by plugin command and plugin agent
@@ -297,33 +325,9 @@ pub(crate) fn invocation_wrapper(name: &str, kind: &str) -> String {
 /// (folder and flat forms, same rules as project skills) plus an optional
 /// single `SKILL.md` at the plugin root (a repo that is itself one skill).
 pub(crate) fn discover_plugins(root: &Path) -> Vec<SkillEntry> {
-    let mut seen = std::collections::HashSet::new();
     let mut out: Vec<SkillEntry> = Vec::new();
-    for r in discovery_roots(root) {
-        let dir = plugins_dir(&r);
-        let Ok(rd) = std::fs::read_dir(&dir) else {
-            continue;
-        };
-        for entry in rd.flatten() {
-            let path = entry.path();
-            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
-                continue;
-            }
-            let Some(plugin) = path.file_name().and_then(|s| s.to_str()) else {
-                continue;
-            };
-            // Ignore interrupted `.installing-*` staging directories, matching
-            // the command/agent loaders: a partially-copied plugin must not
-            // leak its skills into the catalog during an install.
-            if plugin.starts_with(".installing-") {
-                continue;
-            }
-            // Earlier roots shadow: a plugin installed in this checkout hides
-            // a same-named one shared from the main worktree.
-            if !seen.insert(plugin.to_string()) {
-                continue;
-            }
-            let mut tagged = Vec::new();
+    plugin_dirs_across_roots(root, |plugin, path| {
+        let mut tagged = Vec::new();
             for e in scan_skill_dir(&path.join("skills")) {
                 tagged.push(SkillEntry {
                     plugin: Some(plugin.to_string()),
@@ -340,8 +344,7 @@ pub(crate) fn discover_plugins(root: &Path) -> Vec<SkillEntry> {
                 });
             }
             out.extend(tagged);
-        }
-    }
+    });
     out.sort_by(|a, b| a.name.cmp(&b.name));
     out
 }

--- a/src-tauri/src/core/agent/subagent.rs
+++ b/src-tauri/src/core/agent/subagent.rs
@@ -282,10 +282,9 @@ fn load_plugin_agents(project_root: &Path, out: &mut Vec<SubagentDefinition>) {
 /// skipping READMEs and dotfiles.
 pub(crate) fn count_plugin_agents(root: &Path, plugin: &str) -> usize {
     let mut count = 0;
-    let base = crate::core::agent::skills::plugins_dir(root)
-        .join(plugin)
-        .join("agents");
-    scan_agent_files(&base, &mut |_, _| count += 1);
+    if let Some(dir) = crate::core::agent::skills::find_plugin_dir(root, plugin) {
+        scan_agent_files(&dir.join("agents"), &mut |_, _| count += 1);
+    }
     count
 }
 
@@ -381,9 +380,10 @@ fn map_claude_tools(tools: &[String]) -> Option<Vec<String>> {
 #[cfg(feature = "cli")]
 pub(crate) fn plugin_agent_metas(root: &Path, plugin: &str) -> Vec<(String, String)> {
     let mut out = Vec::new();
-    let base = crate::core::agent::skills::plugins_dir(root)
-        .join(plugin)
-        .join("agents");
+    let Some(base) = crate::core::agent::skills::find_plugin_dir(root, plugin) else {
+        return out;
+    };
+    let base = base.join("agents");
     scan_agent_files(&base, &mut |_, raw| {
         if let Some((name, description, _, _)) = parse_plugin_agent(raw) {
             out.push((name, description));

--- a/src-tauri/src/core/agent/subagent.rs
+++ b/src-tauri/src/core/agent/subagent.rs
@@ -258,23 +258,9 @@ impl SubagentRegistry {
 /// metadata and ignored (the parent's model runs the child); `tools` maps
 /// Claude tool names onto Jan tool names, dropping names with no equivalent.
 fn load_plugin_agents(project_root: &Path, out: &mut Vec<SubagentDefinition>) {
-    let dir = crate::core::agent::skills::plugins_dir(project_root);
-    let Ok(rd) = std::fs::read_dir(&dir) else {
-        return;
-    };
-    for entry in rd.flatten() {
-        let path = entry.path();
-        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
-            continue;
-        }
-        let Some(plugin) = path.file_name().and_then(|s| s.to_str()) else {
-            continue;
-        };
-        if plugin.starts_with(".installing-") {
-            continue;
-        }
+    crate::core::agent::skills::plugin_dirs_across_roots(project_root, |_, path| {
         scan_agent_dir(&path.join("agents"), out);
-    }
+    });
 }
 
 /// Number of agent markdown files one plugin ships, for the plugin listing.

--- a/src-tauri/src/core/cli/mcp.rs
+++ b/src-tauri/src/core/cli/mcp.rs
@@ -78,7 +78,23 @@ fn write_config(data_folder: &std::path::Path, cfg: &Value) -> Result<(), String
 
     let body = serde_json::to_string_pretty(&doc).map_err(|e| e.to_string())?;
     let tmp = path.with_extension("json.tmp");
-    std::fs::write(&tmp, body).map_err(|e| e.to_string())?;
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(&tmp).map_err(|e| e.to_string())?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))
+            .map_err(|e| e.to_string())?;
+    }
+    // MCP env/header fields can contain keys entered during plugin setup.
+    std::io::Write::write_all(&mut file, body.as_bytes()).map_err(|e| e.to_string())?;
+    drop(file);
     std::fs::rename(&tmp, &path).map_err(|e| e.to_string())?;
     Ok(())
 }

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -854,7 +854,7 @@ impl PluginSetupPrompt {
         self.input.push_str(super::secret_input::pasted(text));
     }
 
-    /// Advance past the current entry; `None` once every entry is done.
+    /// Advance past the current entry, clearing the field and any error.
     fn advance(&mut self) {
         self.current += 1;
         self.input.clear();
@@ -8555,18 +8555,7 @@ fn handle_account_login_key(app: &mut App, key: KeyEvent, ctrl: bool) {
         return;
     }
     if ctrl && key.code == KeyCode::Char('v') {
-        match clipboard_text() {
-            Ok(text) => {
-                if let Some(prompt) = app.account_login.as_mut() {
-                    prompt.paste(&text);
-                }
-            }
-            Err(e) => {
-                if let Some(prompt) = app.account_login.as_mut() {
-                    prompt.error = Some(format!("could not read the clipboard: {e}"));
-                }
-            }
-        }
+        paste_clipboard_into(app, |app| &mut app.account_login);
         return;
     }
 
@@ -8651,18 +8640,7 @@ fn handle_login_key(app: &mut App, key: KeyEvent, ctrl: bool) {
         if !app.login.as_ref().is_some_and(LoginPrompt::editable) {
             return;
         }
-        match super::secret_input::clipboard_text() {
-            Ok(text) => {
-                if let Some(prompt) = app.login.as_mut() {
-                    prompt.paste(&text);
-                }
-            }
-            Err(e) => {
-                if let Some(prompt) = app.login.as_mut() {
-                    prompt.error = Some(format!("could not read the clipboard: {e}"));
-                }
-            }
-        }
+        paste_clipboard_into(app, |app| &mut app.login);
         return;
     }
 
@@ -8698,6 +8676,62 @@ fn handle_login_key(app: &mut App, key: KeyEvent, ctrl: bool) {
 /// image path is `clipboard_image`).
 fn clipboard_text() -> Result<String, String> {
     super::secret_input::clipboard_text()
+}
+
+/// Input handling the three masked prompts (`/login`, account login,
+/// `/plugin setup`) share for Ctrl-V routing.
+trait MaskedPrompt {
+    /// Store the pasted text (each impl applies its own masking/editability
+    /// rules).
+    fn paste_text(&mut self, text: &str);
+    /// Surface a failure on the prompt's error line.
+    fn set_error(&mut self, message: String);
+}
+
+/// Some terminals deliver a paste as a key rather than an `Event::Paste`, so
+/// the masked prompts' key handlers route Ctrl-V here: read the clipboard,
+/// feed the text to the prompt, or record the failure on its error line.
+/// `prompt` selects the docked prompt from the app state.
+fn paste_clipboard_into<P: MaskedPrompt>(app: &mut App, prompt: fn(&mut App) -> &mut Option<P>) {
+    match clipboard_text() {
+        Ok(text) => {
+            if let Some(p) = prompt(app) {
+                p.paste_text(&text);
+            }
+        }
+        Err(e) => {
+            if let Some(p) = prompt(app) {
+                p.set_error(format!("could not read the clipboard: {e}"));
+            }
+        }
+    }
+}
+
+impl MaskedPrompt for LoginPrompt {
+    fn paste_text(&mut self, text: &str) {
+        self.paste(text);
+    }
+    fn set_error(&mut self, message: String) {
+        self.error = Some(message);
+    }
+}
+
+impl MaskedPrompt for AccountLoginPrompt {
+    fn paste_text(&mut self, text: &str) {
+        self.paste(text);
+    }
+    fn set_error(&mut self, message: String) {
+        self.error = Some(message);
+    }
+}
+
+impl MaskedPrompt for PluginSetupPrompt {
+    fn paste_text(&mut self, text: &str) {
+        self.paste(text);
+    }
+    fn set_error(&mut self, message: String) {
+        self.error = Some(message);
+    }
 }
 
 /// Open `/plugin setup` for the first installed plugin whose declared env
@@ -8749,8 +8783,9 @@ fn start_plugin_setup(app: &mut App, plugin: &str, entries: Vec<PluginEnvEntry>)
 }
 
 /// Keys for the `/plugin setup` prompt: Enter saves the value and advances,
-/// `s` skips an entry, Esc/Ctrl-C abandons the rest. Same masked-entry rules
-/// as the `/login` paste field.
+/// `s` skips the current entry when the field is still empty (once something
+/// is typed, `s` is just a character of the secret), Esc/Ctrl-C abandons the
+/// rest. Same masked-entry rules as the `/login` paste field.
 fn handle_plugin_setup_key(app: &mut App, key: KeyEvent, ctrl: bool) {
     let cancel = key.code == KeyCode::Esc
         || (ctrl && matches!(key.code, KeyCode::Char('c') | KeyCode::Char('d')));
@@ -8761,25 +8796,12 @@ fn handle_plugin_setup_key(app: &mut App, key: KeyEvent, ctrl: bool) {
     }
     // Ctrl-V: some terminals send a paste as a key rather than Event::Paste.
     if ctrl && key.code == KeyCode::Char('v') {
-        match super::secret_input::clipboard_text() {
-            Ok(text) => {
-                if let Some(prompt) = app.plugin_setup.as_mut() {
-                    prompt.paste(&text);
-                }
-            }
-            Err(e) => {
-                if let Some(prompt) = app.plugin_setup.as_mut() {
-                    prompt.error = Some(format!("could not read the clipboard: {e}"));
-                }
-            }
-        }
+        paste_clipboard_into(app, |app| &mut app.plugin_setup);
         return;
     }
-    let Some(prompt) = app.plugin_setup.as_mut() else {
-        return;
-    };
     match key.code {
         KeyCode::Enter => {
+            let Some(prompt) = app.plugin_setup.as_mut() else { return };
             let plugin = prompt.plugin.clone();
             let Some(entry) = prompt.entry() else { return };
             let value = prompt.input.trim().to_string();
@@ -8793,40 +8815,53 @@ fn handle_plugin_setup_key(app: &mut App, key: KeyEvent, ctrl: bool) {
                 return;
             }
             let key_name = entry.key.clone();
-            prompt.advance();
-            if prompt.done() {
+            // Advance and test completion inside a block so the `prompt` borrow
+            // ends before the app-level calls below (which re-borrow `app`).
+            let done = {
+                prompt.advance();
+                prompt.done()
+            };
+            // Sync on every save, not just at completion: a cancel after key
+            // 1 must still leave the live registry holding key 1.
+            crate::core::agent::plugins::sync_env_registry(&app.project_root);
+            app.note(&format!("plugin setup · {plugin} · {key_name} saved"));
+            if done {
                 app.plugin_setup = None;
-                crate::core::agent::plugins::sync_env_registry(&app.project_root);
-                app.note(&format!("plugin setup · {plugin} · {key_name} saved"));
                 // Chain into the next plugin that still needs keys.
                 open_plugin_setup(app);
-            } else {
-                app.note(&format!(
-                    "plugin setup · {plugin} · {key_name} saved"
-                ));
             }
         }
         KeyCode::Char('s') | KeyCode::Char('S') if !ctrl => {
+            let Some(prompt) = app.plugin_setup.as_mut() else { return };
+            if !prompt.input.is_empty() {
+                return;
+            }
             let plugin = prompt.plugin.clone();
             let key_name = prompt
                 .entry()
                 .map(|e| e.key.clone())
                 .unwrap_or_default();
-            prompt.advance();
-            if prompt.done() {
+            let done = {
+                prompt.advance();
+                prompt.done()
+            };
+            if done {
                 app.plugin_setup = None;
                 app.note(&format!("plugin setup · {plugin} · skipped {key_name}"));
                 open_plugin_setup(app);
             }
         }
         KeyCode::Backspace => {
+            let Some(prompt) = app.plugin_setup.as_mut() else { return };
             prompt.input.pop();
         }
-        KeyCode::Char(ch) if !ctrl => prompt.input.push(ch),
+        KeyCode::Char(ch) if !ctrl => {
+            let Some(prompt) = app.plugin_setup.as_mut() else { return };
+            prompt.input.push(ch);
+        }
         _ => {}
     }
 }
-
 fn handle_model_picker_key(app: &mut App, key: KeyEvent, ctrl: bool) {
     if key.code == KeyCode::Esc
         || (ctrl && matches!(key.code, KeyCode::Char('c') | KeyCode::Char('d')))

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -425,6 +425,8 @@ enum PickerKind {
     /// `/plugin install <collection>`: choose which plugins inside a collection
     /// repo to install. Space toggles a row, Enter installs everything checked.
     PluginSelect,
+    /// `/plugin setup`: choose one installed plugin without starting setup.
+    PluginSetup,
     /// Review a plugin-provided MCP server before enabling or executing it.
     PluginConnect,
     /// One MCP server's detail screen: the info block plus the actions that
@@ -438,13 +440,40 @@ struct Picker {
     kind: PickerKind,
     items: Vec<PickerItem>,
     selected: usize,
+    search: Option<PickerSearch>,
     /// Index of the provider row a first `d` armed for deletion, so a second
     /// `d` on the same row confirms it. `None` = nothing armed. Resets on
     /// navigation so an unrelated keypress can never delete by accident.
     armed_delete: Option<usize>,
 }
 
+/// Preserve the source rows while typing narrows the visible selection.
+struct PickerSearch {
+    all_items: Vec<PickerItem>,
+    query: String,
+}
+
 impl Picker {
+    fn with_search(mut self) -> Self {
+        self.search = Some(PickerSearch {
+            all_items: self.items.clone(),
+            query: String::new(),
+        });
+        self
+    }
+
+    fn refresh_search(&mut self) {
+        let Some(search) = &self.search else { return };
+        let query = search.query.to_lowercase();
+        let terms: Vec<&str> = query.split_whitespace().collect();
+        self.items = search.all_items.iter().filter(|item| {
+            let searchable = format!("{} {}", item.label, item.hint.as_deref().unwrap_or(""))
+                .to_lowercase();
+            terms.iter().all(|term| searchable.contains(term))
+        }).cloned().collect();
+        self.selected = 0;
+    }
+
     fn title(&self) -> &'static str {
         match self.kind {
             PickerKind::ResumeThread => " resume thread ",
@@ -457,6 +486,7 @@ impl Picker {
             PickerKind::ProviderSettings => " providers ",
             PickerKind::Todo => " todo ",
             PickerKind::PluginSelect => " install plugins ",
+            PickerKind::PluginSetup => " set up plugin ",
             PickerKind::PluginConnect => " plugin connection ",
             PickerKind::McpServer => " mcp server ",
         }
@@ -478,6 +508,7 @@ impl Picker {
             }
             PickerKind::Todo => " ↑/↓ select   d done   x abandon   r remove   Esc close",
             PickerKind::PluginSelect => " ↑/↓ select   Space toggle   Enter install   Esc cancel",
+            PickerKind::PluginSetup => " Type to search   Up/Down select   Enter set up   Esc cancel",
             PickerKind::PluginConnect => " Up/Down select   Enter confirm   Esc cancel setup",
             PickerKind::McpServer => " ↑/↓ select   Enter run   Esc back",
         }
@@ -7414,6 +7445,7 @@ fn finish_plugin_install(
             ));
             app.picker = Some(Picker {
                 kind: PickerKind::PluginSelect,
+                search: None,
                 items: candidates
                     .into_iter()
                     .map(|c| PickerItem {
@@ -8476,6 +8508,11 @@ fn route_paste_event(app: &mut App, event: Event) {
     } else if let Some(prompt) = app.plugin_setup.as_mut() {
         // A pasted plugin API key belongs to the setup field.
         prompt.paste(&text);
+    } else if let Some(picker) = app.picker.as_mut().filter(|picker| picker.search.is_some()) {
+        if let Some(search) = picker.search.as_mut() {
+            search.query.extend(text.chars().filter(|c| !c.is_control()));
+        }
+        picker.refresh_search();
     } else if let Some(prompt) = app.settings_prompt.as_mut() {
         prompt.paste(&text);
     } else if let Some(prompt) = app.mcp_prompt.as_mut() {
@@ -8749,11 +8786,30 @@ impl MaskedPrompt for PluginSetupPrompt {
     }
 }
 
-/// Set up installed plugins without leaving the TUI.
+/// Choose one installed plugin; opening setup must not run the whole catalog.
 fn open_plugin_setup(app: &mut App) -> bool {
-    app.plugin_setup_queue = crate::core::agent::plugins::installed(&app.project_root)
-        .into_iter().map(|p| p.name).collect();
-    next_plugin_setup(app)
+    let plugins = crate::core::agent::plugins::installed_entries(&app.project_root);
+    if plugins.is_empty() {
+        app.note("no plugins installed - use /plugin install <git-url> first");
+        return false;
+    }
+    app.picker = Some(Picker {
+        kind: PickerKind::PluginSetup,
+        search: None,
+        items: plugins.into_iter().map(|(directory, plugin)| PickerItem {
+            label: if directory == plugin.name {
+                directory.clone()
+            } else {
+                format!("{directory} ({})", plugin.name)
+            },
+            value: directory,
+            hint: (!plugin.description.is_empty()).then_some(plugin.description),
+            checkbox: None,
+        }).collect(),
+        selected: 0,
+        armed_delete: None,
+    }.with_search());
+    true
 }
 
 fn next_plugin_setup(app: &mut App) -> bool {
@@ -8815,6 +8871,7 @@ fn show_next_plugin_connection(app: &mut App) {
     };
     app.picker = Some(Picker {
         kind: PickerKind::PluginConnect,
+        search: None,
         items: vec![
             PickerItem {
                 value: "connect".into(),
@@ -9198,6 +9255,19 @@ async fn handle_key(
     // act and close; the `/mcp` picker toggles the selected row in place.
     if let Some(picker) = app.picker.as_mut() {
         match key.code {
+            KeyCode::Char(ch) if picker.search.is_some() && !ctrl && !alt && !sup => {
+                if let Some(search) = picker.search.as_mut() {
+                    search.query.push(ch);
+                }
+                picker.refresh_search();
+            }
+            KeyCode::Backspace if picker.search.is_some() => {
+                if let Some(search) = picker.search.as_mut() {
+                    search.query.pop();
+                }
+                picker.refresh_search();
+            }
+            KeyCode::Enter if picker.items.is_empty() => {}
             KeyCode::Up | KeyCode::Char('k') => {
                 picker.armed_delete = None;
                 picker.selected = picker.selected.saturating_sub(1);
@@ -9496,6 +9566,9 @@ async fn handle_key(
                     PickerKind::Todo => {}
                     // PluginSelect Enter is handled by the guarded arm above.
                     PickerKind::PluginSelect => {}
+                    PickerKind::PluginSetup => {
+                        open_plugin_setup_for(app, &value);
+                    }
                     // McpServer Enter is handled by the guarded arm above.
                     PickerKind::McpServer => {}
                     PickerKind::PluginConnect => {}
@@ -10122,8 +10195,8 @@ const SLASH_COMMANDS: &[SlashCommand] = &[
     },
     SlashCommand {
         name: "/plugin",
-        hint: "[list|install <spec>|remove <name>|search [query]|setup <name>]",
-        description: "Manage plugins: install from a git URL or the marketplace, list/remove installed, search the marketplace, set up required API keys",
+        hint: "[list|install <spec>|remove <name>|search [query]|setup [name]]",
+        description: "Manage plugins: install, list/remove, search, or choose a plugin to set up its API keys and MCP connections",
         alias_of: None,
     },
     SlashCommand {
@@ -11389,6 +11462,7 @@ fn open_settings_screen(app: &mut App) {
     let toml_path = app.agent_dir.join("agent.toml");
     app.picker = Some(Picker {
         kind: PickerKind::AgentSettings,
+        search: None,
         items: build_agent_settings_items(&toml_path),
         selected: 0,
         armed_delete: None,
@@ -11435,6 +11509,7 @@ fn open_provider_settings(app: &mut App) {
     };
     app.picker = Some(Picker {
         kind: PickerKind::ProviderSettings,
+        search: None,
         items,
         selected: 0,
         armed_delete: None,
@@ -11949,6 +12024,7 @@ fn open_todo_picker(app: &mut App) {
     }
     app.picker = Some(Picker {
         kind: PickerKind::Todo,
+        search: None,
         items: build_todo_items(&app.todos),
         selected: 0,
         armed_delete: None,
@@ -12468,6 +12544,7 @@ fn open_thread_picker(app: &mut App) {
             } else {
                 app.picker = Some(Picker {
                     kind: PickerKind::ResumeThread,
+                    search: None,
                     items,
                     selected: 0,
                     armed_delete: None,
@@ -12567,6 +12644,7 @@ async fn open_mcp_picker(app: &mut App, mcp_servers: &crate::core::state::Shared
     app.mcp_detail = None;
     app.picker = Some(Picker {
         kind: PickerKind::ToggleMcp,
+        search: None,
         items,
         selected: 0,
         armed_delete: None,
@@ -12597,6 +12675,7 @@ async fn open_mcp_detail(
     };
     app.picker = Some(Picker {
         kind: PickerKind::McpServer,
+        search: None,
         items: mcp_action_items(&server),
         selected: 0,
         armed_delete: None,
@@ -12858,6 +12937,7 @@ fn open_login_picker_at(app: &mut App, selected_provider: Option<&str>) {
         .unwrap_or(0);
     app.picker = Some(Picker {
         kind: PickerKind::LoginProvider,
+        search: None,
         items,
         selected,
         armed_delete: None,
@@ -13312,6 +13392,7 @@ fn open_config_screen(app: &mut App) {
     };
     app.picker = Some(Picker {
         kind: PickerKind::ViewConfig,
+        search: None,
         items,
         selected: 0,
         armed_delete: None,
@@ -13727,6 +13808,7 @@ fn open_rewind_picker(app: &mut App) {
     let selected = items.len() - 1;
     app.picker = Some(Picker {
         kind: PickerKind::RewindMessage,
+        search: None,
         items,
         selected,
         armed_delete: None,
@@ -13753,6 +13835,7 @@ fn open_rewind_scope(app: &mut App, user_index: usize) {
     }
     app.picker = Some(Picker {
         kind: PickerKind::RewindScope,
+        search: None,
         items,
         selected: 0,
         armed_delete: None,
@@ -15874,10 +15957,17 @@ fn draw_picker(
                 };
                 spans.push(Span::styled(mark, style));
             }
-            if let Some(hint) = &it.hint {
-                spans.push(Span::styled(format!("{hint}  "), Style::new().dark_gray()));
+            if picker.kind == PickerKind::PluginSetup {
+                spans.push(Span::raw(it.label.clone()));
+                if let Some(hint) = &it.hint {
+                    spans.push(Span::styled(format!("  {hint}"), Style::new().dark_gray()));
+                }
+            } else {
+                if let Some(hint) = &it.hint {
+                    spans.push(Span::styled(format!("{hint}  "), Style::new().dark_gray()));
+                }
+                spans.push(Span::raw(it.label.clone()));
             }
-            spans.push(Span::raw(it.label.clone()));
             ListItem::new(Line::from(spans))
         })
         .collect();
@@ -15892,7 +15982,27 @@ fn draw_picker(
     // setting's description, default, valid range, and current value - the
     // rows themselves stay terse (`key  = value`) because the detail footer
     // explains what each knob does.
-    if picker.kind == PickerKind::AgentSettings {
+    if let Some(search) = &picker.search {
+        let block = Block::default().borders(Borders::ALL).title(picker.title());
+        let inner = block.inner(area);
+        f.render_widget(block, area);
+        let rows = Layout::vertical([Constraint::Length(1), Constraint::Min(0)]).split(inner);
+        f.render_widget(
+            Paragraph::new(truncate(
+                &format!(" Search: {}|", search.query),
+                rows[0].width as usize,
+            )),
+            rows[0],
+        );
+        if picker.items.is_empty() {
+            f.render_widget(
+                Paragraph::new(" No plugins match").style(Style::new().dark_gray()),
+                rows[1],
+            );
+        } else {
+            f.render_stateful_widget(list.block(Block::default()), rows[1], &mut state);
+        }
+    } else if picker.kind == PickerKind::AgentSettings {
         let list_area = Rect {
             height: area.height.saturating_sub(2),
             ..area
@@ -30130,6 +30240,145 @@ mod tests {
             format!("name = \"acme\"\n\n[setup.env]\n{var} = \"{url}\"\n"),
         )
         .unwrap();
+    }
+    #[tokio::test]
+    async fn plugin_setup_selection_preserves_directory_identity() {
+        let (mut app, root) = skill_test_app("deploy", "How to deploy.");
+        for (directory, name, description) in [
+            ("alpha", "shared", "First"),
+            ("beta", "shared", "Second"),
+            ("gamma", "beta", "Third"),
+        ] {
+            let dir = root.join(".jan/agent/plugins").join(directory);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(
+                dir.join("plugin.toml"),
+                format!("name = \"{name}\"\ndescription = \"{description}\"\n"),
+            ).unwrap();
+        }
+        for (directory, query) in [("alpha", "First"), ("beta", "Second"), ("gamma", "Third")] {
+            run_command(&mut app, "plugin setup", &no_mcp()).await;
+            route_paste_event(&mut app, Event::Paste(query.into()));
+            handle_key(
+                &mut app, key(KeyCode::Enter), &PermissionRegistry::default(), &mut None, &no_mcp(),
+            ).await;
+            let last = transcript_text(&app);
+            assert!(
+                last.ends_with(&format!("plugin '{directory}' is ready - no connection required")),
+                "selection must use the installation directory: {last}",
+            );
+        }
+        run_command(&mut app, "plugin setup beta", &no_mcp()).await;
+        assert!(transcript_text(&app).ends_with("plugin 'beta' is ready - no connection required"));
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+    #[tokio::test]
+    async fn plugin_setup_search_filters_without_leaking_or_selecting_empty_results() {
+        let (mut app, root) = skill_test_app("deploy", "How to deploy.");
+        for (name, description) in [
+            ("alpha", "General development tools"),
+            ("figma", "Canvas design tools with a long description that must not hide the plugin name"),
+            ("qjk-tools", "Keyboard tools"),
+        ] {
+            let dir = root.join(".jan/agent/plugins").join(name);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(
+                dir.join("plugin.toml"),
+                format!("name = \"{name}\"\ndescription = \"{description}\"\n"),
+            ).unwrap();
+        }
+        run_command(&mut app, "plugin setup", &no_mcp()).await;
+        let screen = render_rows(&mut app, 50, 20).join("\n");
+        assert!(screen.contains("figma"), "name must remain visible: {screen}");
+
+        // q/j/k are search text here, not the generic picker's shortcuts.
+        for ch in "qjk".chars() {
+            handle_key(
+                &mut app, key(KeyCode::Char(ch)), &PermissionRegistry::default(), &mut None, &no_mcp(),
+            ).await;
+        }
+        let screen = render_rows(&mut app, 70, 20).join("\n");
+        assert!(screen.contains("qjk-tools") && !screen.contains("alpha"), "{screen}");
+        handle_key(
+            &mut app, key(KeyCode::Esc), &PermissionRegistry::default(), &mut None, &no_mcp(),
+        ).await;
+        run_command(&mut app, "plugin setup", &no_mcp()).await;
+
+        // Paste matches descriptions case-insensitively and stays out of chat.
+        route_paste_event(&mut app, Event::Paste("CANVAS".into()));
+        assert!(app.input.is_empty(), "search paste leaked into chat");
+        let screen = render_rows(&mut app, 70, 20).join("\n");
+        assert!(screen.contains("figma") && !screen.contains("alpha"), "{screen}");
+        handle_key(
+            &mut app, key(KeyCode::Char('é')), &PermissionRegistry::default(), &mut None, &no_mcp(),
+        ).await;
+        let screen = render_rows(&mut app, 70, 20).join("\n");
+        assert!(screen.contains("No plugins match"), "{screen}");
+        handle_key(
+            &mut app, key(KeyCode::Enter), &PermissionRegistry::default(), &mut None, &no_mcp(),
+        ).await;
+        assert!(app.picker.is_some(), "Enter with no matches must keep search open");
+        handle_key(
+            &mut app, key(KeyCode::Backspace), &PermissionRegistry::default(), &mut None, &no_mcp(),
+        ).await;
+        handle_key(
+            &mut app, key(KeyCode::Enter), &PermissionRegistry::default(), &mut None, &no_mcp(),
+        ).await;
+        assert!(app.picker.is_none());
+        let transcript = transcript_text(&app);
+        assert!(transcript.contains("plugin 'figma' is ready"), "{transcript}");
+        assert!(!transcript.contains("alpha") && !transcript.contains("qjk-tools"), "{transcript}");
+        std::fs::remove_dir_all(root).unwrap();
+    }
+
+
+    #[tokio::test]
+    async fn plugin_setup_without_name_waits_for_one_selection() {
+        let (mut app, root) = skill_test_app("deploy", "How to deploy.");
+        for name in ["alpha", "example-plugin", "figma"] {
+            let dir = root.join(".jan/agent/plugins").join(name);
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("plugin.toml"), format!("name = \"{name}\"\n")).unwrap();
+            if name != "alpha" {
+                std::fs::write(
+                    dir.join(".mcp.json"),
+                    r#"{"mcpServers":{"remote":{"url":"https://mcp.example.com/api"}}}"#,
+                ).unwrap();
+            }
+        }
+        let before = transcript_text(&app);
+        run_command(&mut app, "plugin setup", &no_mcp()).await;
+        assert_eq!(transcript_text(&app), before, "opening setup must not run every plugin");
+        let screen = render_rows(&mut app, 100, 30).join("\n");
+        assert!(screen.contains("alpha") && screen.contains("figma"), "{screen}");
+        assert!(!screen.contains("Enable and connect"), "{screen}");
+        handle_key(
+            &mut app, key(KeyCode::Esc), &PermissionRegistry::default(), &mut None, &no_mcp(),
+        ).await;
+        assert!(app.picker.is_none());
+        assert!(app.mcp_job_request.is_none());
+        assert_eq!(transcript_text(&app), before);
+
+        run_command(&mut app, "plugin setup", &no_mcp()).await;
+        let picker = app.picker.as_mut().unwrap();
+        picker.selected = picker.items.iter().position(|p| p.value == "figma").unwrap();
+        handle_key(
+            &mut app, key(KeyCode::Enter), &PermissionRegistry::default(), &mut None, &no_mcp(),
+        ).await;
+        let screen = render_rows(&mut app, 100, 30).join("\n");
+        assert!(screen.contains("Enable and connect figma:remote"), "{screen}");
+        assert!(app.mcp_job_request.is_none(), "selection still requires connection consent");
+        handle_key(
+            &mut app, key(KeyCode::Down), &PermissionRegistry::default(), &mut None, &no_mcp(),
+        ).await;
+        handle_key(
+            &mut app, key(KeyCode::Enter), &PermissionRegistry::default(), &mut None, &no_mcp(),
+        ).await;
+        assert!(app.picker.is_none(), "skipping the selected plugin must not start another");
+        assert!(app.mcp_job_request.is_none());
+        assert_eq!(transcript_text(&app), before);
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[tokio::test]

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -425,6 +425,8 @@ enum PickerKind {
     /// `/plugin install <collection>`: choose which plugins inside a collection
     /// repo to install. Space toggles a row, Enter installs everything checked.
     PluginSelect,
+    /// Review a plugin-provided MCP server before enabling or executing it.
+    PluginConnect,
     /// One MCP server's detail screen: the info block plus the actions that
     /// apply to it (see `open_mcp_detail`). Reached with Enter from `ToggleMcp`.
     McpServer,
@@ -455,6 +457,7 @@ impl Picker {
             PickerKind::ProviderSettings => " providers ",
             PickerKind::Todo => " todo ",
             PickerKind::PluginSelect => " install plugins ",
+            PickerKind::PluginConnect => " plugin connection ",
             PickerKind::McpServer => " mcp server ",
         }
     }
@@ -475,6 +478,7 @@ impl Picker {
             }
             PickerKind::Todo => " ↑/↓ select   d done   x abandon   r remove   Esc close",
             PickerKind::PluginSelect => " ↑/↓ select   Space toggle   Enter install   Esc cancel",
+            PickerKind::PluginConnect => " Up/Down select   Enter confirm   Esc cancel setup",
             PickerKind::McpServer => " ↑/↓ select   Enter run   Esc back",
         }
     }
@@ -674,6 +678,8 @@ enum McpJob {
     /// screen is open, so the screen refreshes when the connect lands instead of
     /// sitting on `not connected` until the user navigates away and back.
     Connect(String),
+    /// First connection during plugin setup; an OAuth challenge starts sign-in.
+    PluginConnect(String),
 }
 
 /// What an `McpJob` came back with.
@@ -693,6 +699,10 @@ enum McpJobDone {
     Connected {
         server: String,
         result: Result<(), String>,
+    },
+    PluginConnected {
+        server: String,
+        result: Result<(), super::mcp::ConnectError>,
     },
 }
 
@@ -1865,6 +1875,10 @@ struct App {
     /// Active `/plugin setup` prompt (docked like `/login`); owns the keyboard
     /// while open and collects the plugin's required API keys, masked.
     plugin_setup: Option<PluginSetupPrompt>,
+    /// Remaining plugins/connections in the current install or setup flow.
+    plugin_setup_queue: std::collections::VecDeque<String>,
+    plugin_mcp_pending: std::collections::VecDeque<(String, serde_json::Value)>,
+    plugin_mcp_connecting: Option<String>,
     /// Active `/settings` edit prompt (docked like `/login`); owns the
     /// keyboard while open. Holds the setting being edited and any validation
     /// error; writes go straight to agent.toml on Enter.
@@ -2380,6 +2394,9 @@ impl App {
             probed_models: std::collections::HashSet::new(),
             login_submit: None,
             plugin_setup: None,
+            plugin_setup_queue: Default::default(),
+            plugin_mcp_pending: Default::default(),
+            plugin_mcp_connecting: None,
             account_login: None,
             account_login_submit: None,
             account_login_manual_tx: None,
@@ -7382,10 +7399,8 @@ fn finish_plugin_install(
                     p.name, p.skills
                 ));
             }
-            // A plugin that declares required API keys opens its setup dock
-            // right away: the link to obtain each key plus a masked paste
-            // field, so the user never has to edit env files by hand.
-            open_plugin_setup(app);
+            app.plugin_setup_queue = plugins.into_iter().map(|p| p.name).collect();
+            next_plugin_setup(app);
         }
         Ok(GitInstall::Collection(candidates)) => {
             let Some(url) = url else {
@@ -8734,34 +8749,128 @@ impl MaskedPrompt for PluginSetupPrompt {
     }
 }
 
-/// Open `/plugin setup` for the first installed plugin whose declared env
-/// variables are not yet satisfied. Returns whether a dock opened.
+/// Set up installed plugins without leaving the TUI.
 fn open_plugin_setup(app: &mut App) -> bool {
-    let missing = crate::core::agent::plugins::missing_plugin_env(&app.project_root);
-    let Some((plugin, _, _)) = missing.first() else {
-        return false;
-    };
-    let plugin = plugin.clone();
-    let entries = missing
-        .into_iter()
-        .filter(|(p, _, _)| p == &plugin)
-        .map(|(_, key, url)| PluginEnvEntry { key, url })
-        .collect::<Vec<_>>();
-    start_plugin_setup(app, &plugin, entries)
+    app.plugin_setup_queue = crate::core::agent::plugins::installed(&app.project_root)
+        .into_iter().map(|p| p.name).collect();
+    next_plugin_setup(app)
 }
 
-/// Open `/plugin setup` for a named plugin, offering every variable it
-/// declares (even satisfied ones, so a value can be replaced). Returns whether
-/// a dock opened.
+fn next_plugin_setup(app: &mut App) -> bool {
+    while let Some(plugin) = app.plugin_setup_queue.pop_front() {
+        if open_plugin_setup_for(app, &plugin) {
+            return true;
+        }
+    }
+    false
+}
+
 fn open_plugin_setup_for(app: &mut App, plugin: &str) -> bool {
-    let entries = crate::core::agent::plugins::declared_plugin_env(&app.project_root, plugin)
+    let Some((directory, _)) = crate::core::agent::plugins::find_installed(&app.project_root, plugin) else {
+        app.note(&format!("plugin '{plugin}' is not installed - use /plugin install <git-url> first"));
+        return false;
+    };
+    let entries = crate::core::agent::plugins::declared_plugin_env(&app.project_root, &directory)
         .into_iter()
         .map(|(key, url)| PluginEnvEntry { key, url })
         .collect::<Vec<_>>();
     if entries.is_empty() {
-        return false;
+        return open_plugin_mcp_setup(app, &directory);
     }
-    start_plugin_setup(app, plugin, entries)
+    start_plugin_setup(app, &directory, entries)
+}
+
+fn open_plugin_mcp_setup(app: &mut App, plugin: &str) -> bool {
+    match crate::core::agent::plugins::plugin_mcp_servers(&app.project_root, plugin) {
+        Ok(servers) if servers.is_empty() => {
+            app.note(&format!("plugin '{plugin}' is ready - no connection required"));
+            false
+        }
+        Ok(servers) => {
+            app.plugin_mcp_pending = servers.into_iter()
+                .map(|(name, config)| (format!("{plugin}:{name}"), config)).collect();
+            show_next_plugin_connection(app);
+            true
+        }
+        Err(e) => {
+            app.note(&format!("plugin '{plugin}' setup: {e}"));
+            false
+        }
+    }
+}
+
+fn show_next_plugin_connection(app: &mut App) {
+    let Some((name, config)) = app.plugin_mcp_pending.front() else {
+        next_plugin_setup(app);
+        return;
+    };
+    let target = if let Some(url) = config.get("url").and_then(serde_json::Value::as_str) {
+        // Do not put URL credentials, query strings or headers in the transcript.
+        reqwest::Url::parse(url).ok()
+            .and_then(|u| u.host_str().map(str::to_owned))
+            .unwrap_or_else(|| "remote MCP server".to_string())
+    } else {
+        config.get("command").and_then(serde_json::Value::as_str)
+            .unwrap_or("local MCP process").to_string()
+    };
+    app.picker = Some(Picker {
+        kind: PickerKind::PluginConnect,
+        items: vec![
+            PickerItem {
+                value: "connect".into(),
+                label: format!("Enable and connect {name}"),
+                hint: Some(format!("{target} - allow this plugin's MCP server")),
+                checkbox: None,
+            },
+            PickerItem {
+                value: "skip".into(),
+                label: "Not now".into(),
+                hint: Some("Keep installed; resume with /plugin setup <name>".into()),
+                checkbox: None,
+            },
+        ],
+        selected: 0,
+        armed_delete: None,
+    });
+}
+
+fn confirm_plugin_connection(app: &mut App, connect: bool) {
+    app.picker = None;
+    let Some((name, mut config)) = app.plugin_mcp_pending.pop_front() else { return };
+    if !connect {
+        show_next_plugin_connection(app);
+        return;
+    }
+    // The shared MCP config is user-owned. Never replace an unrelated server.
+    let result = (|| {
+        super::mcp::validate_server_name(&name)?;
+        super::mcp::validate_config(&config)?;
+        if let Some(existing) = super::mcp::get_server(&name) {
+            let mut existing = existing.config;
+            existing.as_object_mut().map(|o| o.remove("active"));
+            config.as_object_mut().map(|o| o.remove("active"));
+            if existing != config {
+                return Err(format!("MCP server '{name}' already has different settings; review it in /mcp"));
+            }
+        }
+        config["active"] = true.into();
+        super::mcp::upsert_server(&name, &config)
+    })();
+    if let Err(e) = result {
+        app.note(&e);
+        show_next_plugin_connection(app);
+        return;
+    }
+    app.note(&format!("connecting '{name}' - sign-in will open if required..."));
+    app.plugin_mcp_connecting = Some(name.clone());
+    app.mcp_job_request = Some(McpJob::PluginConnect(name));
+}
+
+fn finish_plugin_connection(app: &mut App, server: &str) {
+    if app.plugin_mcp_connecting.as_deref() == Some(server) {
+        app.plugin_mcp_connecting = None;
+        show_next_plugin_connection(app);
+    }
 }
 
 /// Install the dock state for `plugin` with `entries`, after announcing it.
@@ -8791,6 +8900,8 @@ fn handle_plugin_setup_key(app: &mut App, key: KeyEvent, ctrl: bool) {
         || (ctrl && matches!(key.code, KeyCode::Char('c') | KeyCode::Char('d')));
     if cancel {
         app.plugin_setup = None;
+        app.plugin_setup_queue.clear();
+        app.plugin_mcp_pending.clear();
         app.note("plugin setup cancelled - resume with /plugin setup <name>");
         return;
     }
@@ -8825,8 +8936,9 @@ fn handle_plugin_setup_key(app: &mut App, key: KeyEvent, ctrl: bool) {
             app.note(&format!("plugin setup · {plugin} · {key_name} saved"));
             if done {
                 app.plugin_setup = None;
-                // Chain into the next plugin that still needs keys.
-                open_plugin_setup(app);
+                if !open_plugin_mcp_setup(app, &plugin) {
+                    next_plugin_setup(app);
+                }
             }
         }
         KeyCode::Char('s') | KeyCode::Char('S') if !ctrl && prompt.input.is_empty() => {
@@ -8840,7 +8952,9 @@ fn handle_plugin_setup_key(app: &mut App, key: KeyEvent, ctrl: bool) {
             if done {
                 app.plugin_setup = None;
                 app.note(&format!("plugin setup · {plugin} · skipped {key_name}"));
-                open_plugin_setup(app);
+                if !open_plugin_mcp_setup(app, &plugin) {
+                    next_plugin_setup(app);
+                }
             }
         }
         KeyCode::Backspace => {
@@ -9123,6 +9237,10 @@ async fn handle_key(
                 let action = picker.items[picker.selected].value.clone();
                 run_mcp_action(app, &action, mcp_servers).await;
             }
+            KeyCode::Enter if picker.kind == PickerKind::PluginConnect => {
+                let connect = picker.items[picker.selected].value == "connect";
+                confirm_plugin_connection(app, connect);
+            }
             // `/mcp` picker: `a` opens the add wizard, `e` opens the edit
             // wizard prefilled from the selected row, `d` removes the selected
             // server. All act through the shared config layer.
@@ -9380,6 +9498,7 @@ async fn handle_key(
                     PickerKind::PluginSelect => {}
                     // McpServer Enter is handled by the guarded arm above.
                     PickerKind::McpServer => {}
+                    PickerKind::PluginConnect => {}
                 }
             }
             // Esc on the detail screen steps back to the server list rather
@@ -9389,11 +9508,15 @@ async fn handle_key(
                 open_mcp_picker(app, mcp_servers).await;
             }
             KeyCode::Esc | KeyCode::Char('q') if !ctrl => {
+                app.plugin_setup_queue.clear();
+                app.plugin_mcp_pending.clear();
                 app.plugin_collection_url = None;
                 app.picker = None;
                 app.mcp_detail = None;
             }
             _ if ctrl_c || ctrl_d => {
+                app.plugin_setup_queue.clear();
+                app.plugin_mcp_pending.clear();
                 app.plugin_collection_url = None;
                 app.picker = None;
                 app.mcp_detail = None;
@@ -12038,16 +12161,16 @@ async fn plugin_command(app: &mut App, arg: &str) {
             app.note("installing plugin...");
         }
         "setup" => {
+            if app.plugin_mcp_connecting.is_some() {
+                app.note("plugin connection is in progress");
+                return;
+            }
+            app.plugin_setup_queue.clear();
+            app.plugin_mcp_pending.clear();
             if rest.is_empty() {
-                if !open_plugin_setup(app) {
-                    app.note(
-                        "no plugin is missing keys (usage: /plugin setup <name>)",
-                    );
-                }
-            } else if !open_plugin_setup_for(app, &rest) {
-                app.note(&format!(
-                    "plugin '{rest}' declares no setup keys (declare [setup.env] in its plugin.toml)"
-                ));
+                open_plugin_setup(app);
+            } else {
+                open_plugin_setup_for(app, &rest);
             }
         }
         "remove" => {
@@ -13212,8 +13335,13 @@ async fn run_mcp_job(job: McpJob, servers: crate::core::state::SharedMcpServers)
             McpJobDone::Authorized { server, result }
         }
         McpJob::Connect(server) => {
-            let result = connect_mcp_server(&server, &servers).await;
+            let result = connect_mcp_server(&server, &servers).await.map_err(|e| e.to_string());
             McpJobDone::Connected { server, result }
+        }
+        McpJob::PluginConnect(server) => {
+            super::mcp::disconnect(&server, &servers).await;
+            let result = connect_mcp_server(&server, &servers).await;
+            McpJobDone::PluginConnected { server, result }
         }
     }
 }
@@ -13266,7 +13394,10 @@ async fn finish_mcp_job(
                     servers,
                 )));
             }
-            Err(e) => app.note(&format!("could not start sign-in for '{server}': {e}")),
+            Err(e) => {
+                app.note(&format!("could not start sign-in for '{server}': {e}"));
+                finish_plugin_connection(app, &server);
+            }
         },
         McpJobDone::Authorized { server, result } => match result {
             Ok(()) => {
@@ -13282,6 +13413,7 @@ async fn finish_mcp_job(
             Err(e) => {
                 app.browser_confirm = None;
                 app.note(&format!("sign-in for '{server}' failed: {e}"));
+                finish_plugin_connection(app, &server);
             }
         },
         McpJobDone::Connected { server, result } => {
@@ -13289,12 +13421,30 @@ async fn finish_mcp_job(
                 Ok(()) => app.note(&format!("'{server}' connected")),
                 Err(e) => app.note(&format!("MCP: {e}")),
             }
+            finish_plugin_connection(app, &server);
             if app
                 .mcp_detail
                 .as_ref()
                 .is_some_and(|d| d.server.name == server)
             {
                 open_mcp_detail(app, &server, mcp_servers).await;
+            }
+        }
+        McpJobDone::PluginConnected { server, result } => {
+            match result {
+                Err(super::mcp::ConnectError::NeedsAuth { .. }) => {
+                    app.note(&format!("'{server}' requires sign-in - preparing authorization..."));
+                    *job = Some(tokio::spawn(run_mcp_job(
+                        McpJob::BeginAuth(server), mcp_servers.clone(),
+                    )));
+                }
+                result => {
+                    match result {
+                        Ok(()) => app.note(&format!("'{server}' connected - tools are ready")),
+                        Err(e) => app.note(&format!("could not connect '{server}': {e}; retry from /plugin setup")),
+                    }
+                    finish_plugin_connection(app, &server);
+                }
             }
         }
     }
@@ -13430,7 +13580,7 @@ fn show_mcp_tools(app: &mut App) {
 async fn connect_mcp_server(
     name: &str,
     servers: &crate::core::state::SharedMcpServers,
-) -> Result<(), String> {
+) -> Result<(), super::mcp::ConnectError> {
     let cfg = super::mcp::list_servers()
         .into_iter()
         .find(|s| s.name == name)
@@ -13438,7 +13588,6 @@ async fn connect_mcp_server(
         .ok_or_else(|| format!("'{name}' is no longer in mcp_config.json"))?;
     super::mcp::connect(name, &cfg, servers)
         .await
-        .map_err(|e| e.to_string())
 }
 
 /// `connect_mcp_server`, detached: for the paths with no screen waiting on the
@@ -30012,6 +30161,67 @@ mod tests {
         assert!(app.plugin_setup.is_none());
         assert!(transcript_text(&app).contains("plugin setup cancelled"));
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn plugin_setup_offers_mcp_connection_without_manual_configuration() {
+        crate::core::app::commands::with_temp_data_folder(|_| {
+            let (mut app, root) = skill_test_app("deploy", "How to deploy.");
+            rt().block_on(run_command(&mut app, "plugin setup design", &no_mcp()));
+            assert!(transcript_text(&app).contains("is not installed"));
+            assert!(app.plugin_setup.is_none());
+            let dir = root.join(".jan/agent/plugins/design");
+            std::fs::create_dir_all(&dir).unwrap();
+            std::fs::write(dir.join("plugin.toml"), "name = \"design\"\n").unwrap();
+            std::fs::write(
+                dir.join(".mcp.json"),
+                r#"{"mcpServers":{"remote":{"url":"https://example.com/mcp"}}}"#,
+            )
+            .unwrap();
+            finish_plugin_install(
+                &mut app,
+                None,
+                Ok(crate::core::agent::plugins::GitInstall::Installed(
+                    crate::core::agent::plugins::installed(&root),
+                )),
+            );
+            let screen = render_rows(&mut app, 100, 30).join("\n");
+            assert!(screen.contains("Enable and connect"), "{screen}");
+            assert!(screen.contains("example.com"), "{screen}");
+            assert!(super::super::mcp::get_server("design:remote").is_none());
+            rt().block_on(handle_key(
+                &mut app, key(KeyCode::Esc), &PermissionRegistry::default(), &mut None, &no_mcp(),
+            ));
+            assert!(super::super::mcp::get_server("design:remote").is_none());
+            rt().block_on(run_command(&mut app, "plugin setup design", &no_mcp()));
+            rt().block_on(handle_key(
+                &mut app, key(KeyCode::Enter), &PermissionRegistry::default(), &mut None, &no_mcp(),
+            ));
+            let configured = super::super::mcp::get_server("design:remote").unwrap();
+            assert!(configured.active);
+            assert_eq!(configured.config["url"], "https://example.com/mcp");
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let mode = std::fs::metadata(super::super::mcp::config_file_path())
+                    .unwrap().permissions().mode();
+                assert_eq!(mode & 0o777, 0o600);
+            }
+            // An existing user-owned server must not be silently replaced.
+            app.plugin_mcp_connecting = None;
+            super::super::mcp::upsert_server("design:remote", &serde_json::json!({
+                "type": "http", "url": "https://other.example/mcp",
+            })).unwrap();
+            rt().block_on(run_command(&mut app, "plugin setup design", &no_mcp()));
+            rt().block_on(handle_key(
+                &mut app, key(KeyCode::Enter), &PermissionRegistry::default(), &mut None, &no_mcp(),
+            ));
+            assert_eq!(
+                super::super::mcp::get_server("design:remote").unwrap().config["url"],
+                "https://other.example/mcp",
+            );
+            std::fs::remove_dir_all(root).unwrap();
+        });
     }
 
     #[tokio::test]

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -9460,10 +9460,18 @@ struct SlashCommand {
 }
 
 /// Slash popup metadata is intentionally loaded outside the render path.
-/// Plugin installation and removal explicitly refresh this snapshot.
+/// Plugin installation and removal explicitly refresh this snapshot — as does
+/// `/reload`, which diffs a fresh scan against it to report what changed.
 struct SlashCatalog {
     commands: Vec<crate::core::agent::plugin_commands::CommandEntry>,
     skills: Vec<crate::core::agent::skills::SkillMeta>,
+    /// Installed plugin summaries from the same scan, for `/reload plugin`'s
+    /// added/removed/updated report.
+    plugins: Vec<crate::core::agent::plugins::InstalledPlugin>,
+    /// Every discovered skill, both invocation sides — the full disk truth
+    /// `/reload skills` diffs against (the popup list above is only the
+    /// user-invocable subset).
+    all_skills: Vec<crate::core::agent::skills::SkillMeta>,
 }
 
 impl SlashCatalog {
@@ -9473,6 +9481,8 @@ impl SlashCatalog {
             // Keep every user-invocable skill here. The enabled whitelist is
             // re-read below so edits to agent.toml take effect immediately.
             skills: crate::core::agent::skills::user_catalog(root, &[]),
+            plugins: crate::core::agent::plugins::installed(root),
+            all_skills: crate::core::agent::skills::full_catalog(root),
         }
     }
 
@@ -9778,6 +9788,12 @@ const SLASH_COMMANDS: &[SlashCommand] = &[
         alias_of: None,
     },
     SlashCommand {
+        name: "/reload",
+        hint: "[plugin|skills|system-prompt]",
+        description: "Re-scan skills/plugins from disk and rebuild the catalog mid-session (bare: plugin)",
+        alias_of: None,
+    },
+    SlashCommand {
         name: "/cancel",
         hint: "[N]",
         description: "Cancel queued messages (bare: all, or index)",
@@ -10006,6 +10022,7 @@ async fn run_command(
         }
         "mcp" => open_mcp_picker(app, mcp_servers).await,
         "plugin" => plugin_command(app, arg).await,
+        "reload" => reload_command(app, arg),
         "login" => login_command(app, arg),
         "logout" => logout_command(app, arg),
         "update" => update_command(app),
@@ -11831,6 +11848,152 @@ async fn plugin_command(app: &mut App, arg: &str) {
         other => app.note(&format!(
             "unknown /plugin subcommand '{other}' (try list|install|remove|search)"
         )),
+    }
+}
+
+/// One diffable catalog entry for `/reload`: `key` is the stable identity,
+/// `label` the display line, `state` everything whose change marks the entry
+/// as updated (version/description/counts for plugins, description and
+/// invocation flags for skills).
+struct ReloadEntry {
+    key: String,
+    label: String,
+    state: String,
+}
+
+/// Snapshot the installed-plugin summaries for `/reload plugin`'s diff.
+fn reload_plugin_entries(plugins: &[crate::core::agent::plugins::InstalledPlugin]) -> Vec<ReloadEntry> {
+    plugins
+        .iter()
+        .map(|p| ReloadEntry {
+            key: p.name.clone(),
+            label: format!("plugin {} (v{})", p.name, p.version),
+            state: format!(
+                "v{} · {} skill(s) · {} command(s) · {} agent(s) · {}",
+                p.version, p.skills, p.commands, p.agents, p.description
+            ),
+        })
+        .collect()
+}
+
+/// Snapshot the full skill catalog for `/reload skills`'s diff, keyed by
+/// qualified name (`<plugin>:<skill>` for plugin skills).
+fn reload_skill_entries(skills: &[crate::core::agent::skills::SkillMeta]) -> Vec<ReloadEntry> {
+    skills
+        .iter()
+        .map(|m| {
+            let name = m
+                .plugin
+                .as_ref()
+                .map_or_else(|| m.name.clone(), |p| format!("{p}:{}", m.name));
+            ReloadEntry {
+                key: name.clone(),
+                label: name,
+                state: format!(
+                    "{} [user:{} model:{}]",
+                    m.description, m.user_invocable, m.model_invocable
+                ),
+            }
+        })
+        .collect()
+}
+
+/// Diff two catalog snapshots by identity, returning display lines for
+/// added, removed, and updated entries in scan order.
+fn diff_reload_entries(
+    before: &[ReloadEntry],
+    after: &[ReloadEntry],
+) -> (Vec<String>, Vec<String>, Vec<String>) {
+    fn keyed(items: &[ReloadEntry]) -> std::collections::BTreeMap<String, &ReloadEntry> {
+        items.iter().map(|e| (e.key.clone(), e)).collect()
+    }
+    let (old, new) = (keyed(before), keyed(after));
+    let mut added = Vec::new();
+    let mut removed = Vec::new();
+    let mut updated = Vec::new();
+    for (key, entry) in &new {
+        match old.get(key) {
+            None => added.push(entry.label.clone()),
+            Some(prev) if prev.state != entry.state => updated.push(format!(
+                "{} ({} → {})",
+                entry.label, prev.state, entry.state
+            )),
+            Some(_) => {}
+        }
+    }
+    for (key, entry) in &old {
+        if !new.contains_key(key) {
+            removed.push(entry.label.clone());
+        }
+    }
+    (added, removed, updated)
+}
+
+/// `/reload [plugin|skills|system-prompt]`: re-run skill/plugin discovery and
+/// rebuild the slash catalog mid-session, reporting added/removed/changed
+/// entries. Bare `/reload` targets plugins — the payload an install most
+/// often changes. The model-facing system prompt (JAN.md instructions, the
+/// skills catalog) is rebuilt from disk on every run, so the `system-prompt`
+/// target re-reads and reports what the next run picks up.
+fn reload_command(app: &mut App, arg: &str) {
+    let root = app.project_root.clone();
+    match arg.trim() {
+        "" | "plugin" | "plugins" => {
+            let before = reload_plugin_entries(&app.slash_catalog.plugins);
+            app.refresh_slash_catalog();
+            let after = reload_plugin_entries(&app.slash_catalog.plugins);
+            app.note("◈ reload · plugin · re-scanned installed plugins");
+            report_reload_diff(app, diff_reload_entries(&before, &after));
+        }
+        "skill" | "skills" => {
+            let before = reload_skill_entries(&app.slash_catalog.all_skills);
+            app.refresh_slash_catalog();
+            let after = reload_skill_entries(&app.slash_catalog.all_skills);
+            app.note("◈ reload · skills · re-scanned project and plugin skills");
+            report_reload_diff(app, diff_reload_entries(&before, &after));
+        }
+        "system-prompt" => {
+            // Nothing caches the instructions across runs: the system prompt
+            // (including this block and the skills catalog) is rebuilt from
+            // disk at the start of every run. Re-read now to confirm what the
+            // next run will pick up.
+            let files = crate::core::agent::context::context_files(&root);
+            if files.is_empty() {
+                app.note("◈ reload · system-prompt · no JAN.md in this project or its ancestors");
+                return;
+            }
+            app.note("◈ reload · system-prompt · re-read project instructions (applies next run)");
+            for (path, content) in &files {
+                app.system_detail_text(&format!(
+                    "  {} ({} bytes)",
+                    path.display(),
+                    content.len()
+                ));
+            }
+        }
+        other => app.note(&format!(
+            "unknown /reload target '{other}' (try plugin | skills | system-prompt)"
+        )),
+    }
+}
+
+/// Print a reload diff, or the unchanged note when the scan found nothing new.
+fn report_reload_diff(
+    app: &mut App,
+    (added, removed, updated): (Vec<String>, Vec<String>, Vec<String>),
+) {
+    if added.is_empty() && removed.is_empty() && updated.is_empty() {
+        app.system_detail_text("  no changes since the last scan");
+        return;
+    }
+    for line in added {
+        app.system_detail_text(&format!("  + {line}"));
+    }
+    for line in removed {
+        app.system_detail_text(&format!("  - {line}"));
+    }
+    for line in updated {
+        app.system_detail_text(&format!("  ~ {line}"));
     }
 }
 
@@ -28843,11 +29006,15 @@ mod tests {
     fn slash_prefix_narrows_and_unmatched_hides() {
         let mut app = test_app();
         app.input = "/re".into();
-        // Both `/resume` and `/reasoning` start with `re`; catalog order
-        // (stable sort on equal prefix score) keeps resume first.
+        // `/resume`, `/reasoning`, and `/reload` start with `re`; catalog
+        // order (stable sort on equal prefix score) keeps resume first.
         assert_eq!(
             names(&app),
-            vec!["/resume".to_string(), "/reasoning".to_string()]
+            vec![
+                "/resume".to_string(),
+                "/reasoning".to_string(),
+                "/reload".to_string()
+            ]
         );
         app.input = "/xyz".into();
         assert!(app.slash_matches().is_empty());
@@ -29343,6 +29510,140 @@ mod tests {
         app.input = "/skill:rel".into();
         assert!(names(&app).contains(&"/skill:release:prepare".to_string()));
         let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// A plugin summary manifest on disk, so `/reload plugin` has a version
+    /// to report.
+    fn plugin_manifest_in_app(root: &std::path::Path, plugin: &str, version: &str) {
+        std::fs::write(
+            root.join(".jan/agent/plugins")
+                .join(plugin)
+                .join("plugin.toml"),
+            format!("name = \"{plugin}\"\nversion = \"{version}\"\n"),
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn reload_bare_defaults_to_plugin_and_reports_changes() {
+        let (mut app, root) = skill_test_app("deploy", "How to deploy.");
+        // Bare /reload targets plugins; nothing installed, nothing changed.
+        run_command(&mut app, "reload", &no_mcp()).await;
+        let out = transcript_text(&app);
+        assert!(
+            out.contains("re-scanned installed plugins"),
+            "note: {out}"
+        );
+        assert!(
+            out.contains("no changes since the last scan"),
+            "diff: {out}"
+        );
+
+        // Install a plugin payload on disk; the next reload reports it and
+        // the rebuilt catalog serves its command immediately.
+        plugin_command_in_app(&root, "acme", "ship", "---\ndescription: Ship it\n---\nGo");
+        plugin_manifest_in_app(&root, "acme", "1.0.0");
+        run_command(&mut app, "reload", &no_mcp()).await;
+        let out = transcript_text(&app);
+        assert!(out.contains("+ plugin acme (v1.0.0)"), "diff: {out}");
+        assert!(
+            app.slash_catalog
+                .commands
+                .iter()
+                .any(|c| c.plugin == "acme" && c.name == "ship"),
+            "command must be live after reload"
+        );
+
+        // A second reload has an up-to-date snapshot: nothing changed.
+        run_command(&mut app, "reload plugin", &no_mcp()).await;
+        assert!(transcript_text(&app).contains("no changes since the last scan"));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn reload_skills_reports_added_changed_and_removed() {
+        let (mut app, root) = skill_test_app("deploy", "How to deploy.");
+        run_command(&mut app, "reload skills", &no_mcp()).await;
+        assert!(transcript_text(&app).contains("no changes since the last scan"));
+
+        let skills = root.join(".jan/agent/skills");
+
+        // Added: a new skill shows up and joins the popup catalog.
+        std::fs::create_dir_all(skills.join("audit")).unwrap();
+        std::fs::write(
+            skills.join("audit").join("SKILL.md"),
+            "---\ndescription: Audit deps\n---\n\nBody.\n",
+        )
+        .unwrap();
+        run_command(&mut app, "reload skills", &no_mcp()).await;
+        let out = transcript_text(&app);
+        assert!(out.contains("+ audit"), "diff: {out}");
+        assert!(
+            app.slash_catalog
+                .skills
+                .iter()
+                .any(|m| m.name == "audit"),
+            "skill must be live after reload"
+        );
+
+        // Changed: an edited description is reported as an update.
+        std::fs::write(
+            skills.join("deploy").join("SKILL.md"),
+            "---\ndescription: How to ship\n---\n\nBody.\n",
+        )
+        .unwrap();
+        run_command(&mut app, "reload skills", &no_mcp()).await;
+        let out = transcript_text(&app);
+        assert!(
+            out.contains("~ deploy (How to deploy."),
+            "diff: {out}"
+        );
+        assert!(out.contains("→ How to ship"), "diff: {out}");
+
+        // Removed: a deleted skill leaves the catalog.
+        std::fs::remove_dir_all(skills.join("audit")).unwrap();
+        run_command(&mut app, "reload skills", &no_mcp()).await;
+        let out = transcript_text(&app);
+        assert!(out.contains("- audit"), "diff: {out}");
+        assert!(
+            !app.slash_catalog.skills.iter().any(|m| m.name == "audit"),
+            "removed skill must drop from the catalog"
+        );
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[tokio::test]
+    async fn reload_system_prompt_reads_jan_md() {
+        let (mut app, root) = skill_test_app("deploy", "How to deploy.");
+        run_command(&mut app, "reload system-prompt", &no_mcp()).await;
+        assert!(
+            transcript_text(&app).contains("no JAN.md in this project"),
+            "empty project: {}",
+            transcript_text(&app)
+        );
+
+        std::fs::write(root.join("JAN.md"), "# Rules\n\nRun the tests.\n").unwrap();
+        run_command(&mut app, "reload system-prompt", &no_mcp()).await;
+        let out = transcript_text(&app);
+        assert!(out.contains("re-read project instructions"), "{out}");
+        assert!(out.contains("JAN.md"), "{out}");
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn slash_commands_include_reload() {
+        assert!(SLASH_COMMANDS.iter().any(|c| c.name == "/reload"));
+    }
+
+    #[tokio::test]
+    async fn reload_unknown_target_notes_usage() {
+        let mut app = test_app();
+        run_command(&mut app, "reload bogus", &no_mcp()).await;
+        assert!(
+            transcript_text(&app).contains("unknown /reload target 'bogus'"),
+            "{}",
+            transcript_text(&app)
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -8799,9 +8799,11 @@ fn handle_plugin_setup_key(app: &mut App, key: KeyEvent, ctrl: bool) {
         paste_clipboard_into(app, |app| &mut app.plugin_setup);
         return;
     }
+    let Some(prompt) = app.plugin_setup.as_mut() else {
+        return;
+    };
     match key.code {
         KeyCode::Enter => {
-            let Some(prompt) = app.plugin_setup.as_mut() else { return };
             let plugin = prompt.plugin.clone();
             let Some(entry) = prompt.entry() else { return };
             let value = prompt.input.trim().to_string();
@@ -8815,12 +8817,8 @@ fn handle_plugin_setup_key(app: &mut App, key: KeyEvent, ctrl: bool) {
                 return;
             }
             let key_name = entry.key.clone();
-            // Advance and test completion inside a block so the `prompt` borrow
-            // ends before the app-level calls below (which re-borrow `app`).
-            let done = {
-                prompt.advance();
-                prompt.done()
-            };
+            prompt.advance();
+            let done = prompt.done();
             // Sync on every save, not just at completion: a cancel after key
             // 1 must still leave the live registry holding key 1.
             crate::core::agent::plugins::sync_env_registry(&app.project_root);
@@ -8831,20 +8829,14 @@ fn handle_plugin_setup_key(app: &mut App, key: KeyEvent, ctrl: bool) {
                 open_plugin_setup(app);
             }
         }
-        KeyCode::Char('s') | KeyCode::Char('S') if !ctrl => {
-            let Some(prompt) = app.plugin_setup.as_mut() else { return };
-            if !prompt.input.is_empty() {
-                return;
-            }
+        KeyCode::Char('s') | KeyCode::Char('S') if !ctrl && prompt.input.is_empty() => {
             let plugin = prompt.plugin.clone();
             let key_name = prompt
                 .entry()
                 .map(|e| e.key.clone())
                 .unwrap_or_default();
-            let done = {
-                prompt.advance();
-                prompt.done()
-            };
+            prompt.advance();
+            let done = prompt.done();
             if done {
                 app.plugin_setup = None;
                 app.note(&format!("plugin setup · {plugin} · skipped {key_name}"));
@@ -8852,11 +8844,9 @@ fn handle_plugin_setup_key(app: &mut App, key: KeyEvent, ctrl: bool) {
             }
         }
         KeyCode::Backspace => {
-            let Some(prompt) = app.plugin_setup.as_mut() else { return };
             prompt.input.pop();
         }
         KeyCode::Char(ch) if !ctrl => {
-            let Some(prompt) = app.plugin_setup.as_mut() else { return };
             prompt.input.push(ch);
         }
         _ => {}
@@ -30007,14 +29997,14 @@ mod tests {
         assert!(rendered.contains("ACME_TOKEN"), "{rendered}");
         assert!(rendered.contains("https://example.com/keys"), "{rendered}");
 
-        // Typed characters render masked, never verbatim. Simulate the paste
-        // path directly: the typed secret must not appear in the frame.
-        if let Some(prompt) = app.plugin_setup.as_mut() {
-            prompt.paste("supersecret123");
+        // Once input starts, s/S are secret characters, not skip shortcuts.
+        for ch in "a-superSecret123".chars() {
+            handle_plugin_setup_key(&mut app, key(KeyCode::Char(ch)), false);
         }
+        assert_eq!(app.plugin_setup.as_ref().unwrap().input, "a-superSecret123");
         let rows = render_rows(&mut app, 100, 30);
         let rendered = rows.join("\n");
-        assert!(!rendered.contains("supersecret123"), "{rendered}");
+        assert!(!rendered.contains("a-superSecret123"), "{rendered}");
         assert!(rendered.contains('*'), "mask row: {rendered}");
 
         // Esc cancels the dock.

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -820,6 +820,53 @@ impl LoginPrompt {
     }
 }
 
+/// One required environment variable of a plugin: its name and, when the
+/// manifest declares it, the URL the user can obtain the value from.
+struct PluginEnvEntry {
+    key: String,
+    url: String,
+}
+
+/// `/plugin setup`: a docked, `/login`-styled prompt collecting the API keys a
+/// plugin declares it needs. One entry per variable; the field is masked (the
+/// value never reaches the screen, scrollback, or transcript), Enter saves and
+/// advances, `s` skips, Esc abandons the remaining entries. Values go to
+/// `~/.jan/agent/plugin-env/<plugin>.toml` (0600) and are injected into the
+/// sandboxed shell on the next run.
+struct PluginSetupPrompt {
+    plugin: String,
+    entries: Vec<PluginEnvEntry>,
+    current: usize,
+    input: String,
+    error: Option<String>,
+}
+
+impl PluginSetupPrompt {
+    fn entry(&self) -> Option<&PluginEnvEntry> {
+        self.entries.get(self.current)
+    }
+
+    fn masked(&self) -> String {
+        super::secret_input::mask(self.input.chars().count())
+    }
+
+    fn paste(&mut self, text: &str) {
+        self.input.push_str(super::secret_input::pasted(text));
+    }
+
+    /// Advance past the current entry; `None` once every entry is done.
+    fn advance(&mut self) {
+        self.current += 1;
+        self.input.clear();
+        self.error = None;
+    }
+
+    /// Whether every entry has been visited.
+    fn done(&self) -> bool {
+        self.current >= self.entries.len()
+    }
+}
+
 /// `/login` account entry: owns an OAuth descriptor while the browser callback
 /// task races the loopback callback with a manually pasted redirect URL/code.
 struct AccountLoginPrompt {
@@ -1815,6 +1862,9 @@ struct App {
     model_picker: Option<ModelPicker>,
     /// Active `/login` prompt; owns the keyboard while open.
     login: Option<LoginPrompt>,
+    /// Active `/plugin setup` prompt (docked like `/login`); owns the keyboard
+    /// while open and collects the plugin's required API keys, masked.
+    plugin_setup: Option<PluginSetupPrompt>,
     /// Active `/settings` edit prompt (docked like `/login`); owns the
     /// keyboard while open. Holds the setting being edited and any validation
     /// error; writes go straight to agent.toml on Enter.
@@ -2329,6 +2379,7 @@ impl App {
             provider_prompt: None,
             probed_models: std::collections::HashSet::new(),
             login_submit: None,
+            plugin_setup: None,
             account_login: None,
             account_login_submit: None,
             account_login_manual_tx: None,
@@ -7325,12 +7376,16 @@ fn finish_plugin_install(
             if plugins.is_empty() {
                 app.note("nothing installed");
             }
-            for p in plugins {
+            for p in &plugins {
                 app.note(&format!(
                     "installed plugin '{}' ({} skills)",
                     p.name, p.skills
                 ));
             }
+            // A plugin that declares required API keys opens its setup dock
+            // right away: the link to obtain each key plus a masked paste
+            // field, so the user never has to edit env files by hand.
+            open_plugin_setup(app);
         }
         Ok(GitInstall::Collection(candidates)) => {
             let Some(url) = url else {
@@ -8403,6 +8458,9 @@ fn route_paste_event(app: &mut App, event: Event) {
         // A pasted API key belongs to the login field, not the chat composer
         // (where it would echo).
         prompt.paste(&text);
+    } else if let Some(prompt) = app.plugin_setup.as_mut() {
+        // A pasted plugin API key belongs to the setup field.
+        prompt.paste(&text);
     } else if let Some(prompt) = app.settings_prompt.as_mut() {
         prompt.paste(&text);
     } else if let Some(prompt) = app.mcp_prompt.as_mut() {
@@ -8642,6 +8700,133 @@ fn clipboard_text() -> Result<String, String> {
     super::secret_input::clipboard_text()
 }
 
+/// Open `/plugin setup` for the first installed plugin whose declared env
+/// variables are not yet satisfied. Returns whether a dock opened.
+fn open_plugin_setup(app: &mut App) -> bool {
+    let missing = crate::core::agent::plugins::missing_plugin_env(&app.project_root);
+    let Some((plugin, _, _)) = missing.first() else {
+        return false;
+    };
+    let plugin = plugin.clone();
+    let entries = missing
+        .into_iter()
+        .filter(|(p, _, _)| p == &plugin)
+        .map(|(_, key, url)| PluginEnvEntry { key, url })
+        .collect::<Vec<_>>();
+    start_plugin_setup(app, &plugin, entries)
+}
+
+/// Open `/plugin setup` for a named plugin, offering every variable it
+/// declares (even satisfied ones, so a value can be replaced). Returns whether
+/// a dock opened.
+fn open_plugin_setup_for(app: &mut App, plugin: &str) -> bool {
+    let entries = crate::core::agent::plugins::declared_plugin_env(&app.project_root, plugin)
+        .into_iter()
+        .map(|(key, url)| PluginEnvEntry { key, url })
+        .collect::<Vec<_>>();
+    if entries.is_empty() {
+        return false;
+    }
+    start_plugin_setup(app, plugin, entries)
+}
+
+/// Install the dock state for `plugin` with `entries`, after announcing it.
+fn start_plugin_setup(app: &mut App, plugin: &str, entries: Vec<PluginEnvEntry>) -> bool {
+    app.note(&format!(
+        "◈ plugin setup · {} needs {} API key{} - paste them below",
+        plugin,
+        entries.len(),
+        if entries.len() == 1 { "" } else { "s" }
+    ));
+    app.plugin_setup = Some(PluginSetupPrompt {
+        plugin: plugin.to_string(),
+        entries,
+        current: 0,
+        input: String::new(),
+        error: None,
+    });
+    true
+}
+
+/// Keys for the `/plugin setup` prompt: Enter saves the value and advances,
+/// `s` skips an entry, Esc/Ctrl-C abandons the rest. Same masked-entry rules
+/// as the `/login` paste field.
+fn handle_plugin_setup_key(app: &mut App, key: KeyEvent, ctrl: bool) {
+    let cancel = key.code == KeyCode::Esc
+        || (ctrl && matches!(key.code, KeyCode::Char('c') | KeyCode::Char('d')));
+    if cancel {
+        app.plugin_setup = None;
+        app.note("plugin setup cancelled - resume with /plugin setup <name>");
+        return;
+    }
+    // Ctrl-V: some terminals send a paste as a key rather than Event::Paste.
+    if ctrl && key.code == KeyCode::Char('v') {
+        match super::secret_input::clipboard_text() {
+            Ok(text) => {
+                if let Some(prompt) = app.plugin_setup.as_mut() {
+                    prompt.paste(&text);
+                }
+            }
+            Err(e) => {
+                if let Some(prompt) = app.plugin_setup.as_mut() {
+                    prompt.error = Some(format!("could not read the clipboard: {e}"));
+                }
+            }
+        }
+        return;
+    }
+    let Some(prompt) = app.plugin_setup.as_mut() else {
+        return;
+    };
+    match key.code {
+        KeyCode::Enter => {
+            let plugin = prompt.plugin.clone();
+            let Some(entry) = prompt.entry() else { return };
+            let value = prompt.input.trim().to_string();
+            if value.is_empty() {
+                prompt.error = Some("nothing pasted - paste the key or press s to skip".into());
+                return;
+            }
+            if let Err(e) = crate::core::agent::plugins::save_plugin_env(&plugin, &entry.key, &value)
+            {
+                prompt.error = Some(e);
+                return;
+            }
+            let key_name = entry.key.clone();
+            prompt.advance();
+            if prompt.done() {
+                app.plugin_setup = None;
+                crate::core::agent::plugins::sync_env_registry(&app.project_root);
+                app.note(&format!("plugin setup · {plugin} · {key_name} saved"));
+                // Chain into the next plugin that still needs keys.
+                open_plugin_setup(app);
+            } else {
+                app.note(&format!(
+                    "plugin setup · {plugin} · {key_name} saved"
+                ));
+            }
+        }
+        KeyCode::Char('s') | KeyCode::Char('S') if !ctrl => {
+            let plugin = prompt.plugin.clone();
+            let key_name = prompt
+                .entry()
+                .map(|e| e.key.clone())
+                .unwrap_or_default();
+            prompt.advance();
+            if prompt.done() {
+                app.plugin_setup = None;
+                app.note(&format!("plugin setup · {plugin} · skipped {key_name}"));
+                open_plugin_setup(app);
+            }
+        }
+        KeyCode::Backspace => {
+            prompt.input.pop();
+        }
+        KeyCode::Char(ch) if !ctrl => prompt.input.push(ch),
+        _ => {}
+    }
+}
+
 fn handle_model_picker_key(app: &mut App, key: KeyEvent, ctrl: bool) {
     if key.code == KeyCode::Esc
         || (ctrl && matches!(key.code, KeyCode::Char('c') | KeyCode::Char('d')))
@@ -8744,6 +8929,12 @@ async fn handle_key(
     // transcript shortcuts.
     if app.login.is_some() {
         handle_login_key(app, key, ctrl);
+        return;
+    }
+
+    // Same for `/plugin setup`: it is collecting masked API keys.
+    if app.plugin_setup.is_some() {
+        handle_plugin_setup_key(app, key, ctrl);
         return;
     }
 
@@ -9783,8 +9974,8 @@ const SLASH_COMMANDS: &[SlashCommand] = &[
     },
     SlashCommand {
         name: "/plugin",
-        hint: "[list|install <spec>|remove <name>|search [query]]",
-        description: "Manage plugins: install from a git URL or the marketplace, list/remove installed, search the marketplace",
+        hint: "[list|install <spec>|remove <name>|search [query]|setup <name>]",
+        description: "Manage plugins: install from a git URL or the marketplace, list/remove installed, search the marketplace, set up required API keys",
         alias_of: None,
     },
     SlashCommand {
@@ -11749,6 +11940,14 @@ async fn plugin_command(app: &mut App, arg: &str) {
                 for p in &plugins {
                     app.push(Line::styled(summary_line(p), Style::new().cyan().bold()));
                 }
+                // Surface unsatisfied setup requirements right in the list:
+                // a plugin whose key is missing explains itself here.
+                for (plugin, var, _) in crate::core::agent::plugins::missing_plugin_env(&root) {
+                    app.push(Line::styled(
+                        format!("  {plugin}: key missing ({var}) - /plugin setup {plugin}"),
+                        Style::new().yellow(),
+                    ));
+                }
             } else {
                 match crate::core::agent::plugins::find_installed(&root, &rest) {
                     Some((directory, p)) => {
@@ -11812,6 +12011,19 @@ async fn plugin_command(app: &mut App, arg: &str) {
             }
             app.plugin_install_request = Some(rest);
             app.note("installing plugin...");
+        }
+        "setup" => {
+            if rest.is_empty() {
+                if !open_plugin_setup(app) {
+                    app.note(
+                        "no plugin is missing keys (usage: /plugin setup <name>)",
+                    );
+                }
+            } else if !open_plugin_setup_for(app, &rest) {
+                app.note(&format!(
+                    "plugin '{rest}' declares no setup keys (declare [setup.env] in its plugin.toml)"
+                ));
+            }
         }
         "remove" => {
             if rest.is_empty() {
@@ -14319,6 +14531,18 @@ fn draw(f: &mut Frame, app: &mut App) {
             height,
         };
         draw_login(f, rect, prompt);
+    } else if let Some(prompt) = &app.plugin_setup {
+        let height =
+            (plugin_setup_lines(prompt, chunks[2].width.saturating_sub(2)).len() as u16 + 2)
+                .min(chunks[1].height);
+        let y = chunks[2].y.saturating_sub(height).max(chunks[1].y);
+        let rect = ratatui::layout::Rect {
+            x: chunks[2].x,
+            y,
+            width: chunks[2].width,
+            height,
+        };
+        draw_plugin_setup(f, rect, prompt);
     } else if let Some(confirm) = &app.browser_confirm {
         let height =
             (browser_confirm_lines(confirm, chunks[2].width.saturating_sub(2)).len() as u16 + 2)
@@ -14776,6 +15000,82 @@ fn draw_login(f: &mut Frame, area: ratatui::layout::Rect, prompt: &LoginPrompt) 
         Paragraph::new(login_prompt_lines(prompt, inner.width)),
         inner,
     );
+}
+
+/// Docked `/plugin setup` prompt, styled like the `/login` dock: which plugin,
+/// which variable, the URL to obtain the key at, a masked field, and keys.
+fn draw_plugin_setup(f: &mut Frame, area: ratatui::layout::Rect, prompt: &PluginSetupPrompt) {
+    use ratatui::widgets::Clear;
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::new().cyan())
+        .title(Span::styled(
+            format!(" plugin setup: {} ", prompt.plugin),
+            Style::new().on_cyan().black().bold(),
+        ));
+
+    f.render_widget(Clear, area);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+    f.render_widget(
+        Paragraph::new(plugin_setup_lines(prompt, inner.width)),
+        inner,
+    );
+}
+
+/// The `/plugin setup` box's contents. The width parameter mirrors the other
+/// prompt-line builders (call sites size the dock from the row count).
+fn plugin_setup_lines(prompt: &PluginSetupPrompt, _width: u16) -> Vec<Line<'static>> {
+    let dim = Style::new().dark_gray();
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let total = prompt.entries.len();
+    match prompt.entry() {
+        Some(entry) => {
+            lines.push(Line::from(Span::styled(
+                format!(
+                    "{} needs {} ({}/{})",
+                    prompt.plugin,
+                    entry.key,
+                    prompt.current + 1,
+                    total
+                ),
+                Style::new().cyan().bold(),
+            )));
+            if entry.url.is_empty() {
+                lines.push(Line::from(Span::styled(
+                    "ask the plugin author where to obtain this key".to_string(),
+                    dim,
+                )));
+            } else {
+                lines.push(Line::from(vec![
+                    Span::styled("get it at: ", dim),
+                    Span::styled(entry.url.clone(), Style::new().cyan()),
+                ]));
+            }
+        }
+        None => {
+            lines.push(Line::from(Span::styled(
+                format!("{} setup complete", prompt.plugin),
+                Style::new().cyan().bold(),
+            )));
+        }
+    }
+    if let Some(error) = &prompt.error {
+        lines.push(Line::from(Span::styled(
+            error.clone(),
+            Style::new().red(),
+        )));
+    }
+    lines.push(Line::from(vec![
+        Span::styled(prompt.masked(), Style::new().bold()),
+        Span::styled("  ← paste here", dim),
+    ]));
+    lines.push(Line::from(Span::styled(
+        "Enter save · s skip · Esc cancel - the key is masked and never echoed",
+        dim,
+    )));
+    lines
 }
 
 /// Docked `/settings` edit prompt, styled like the `/login` dock: description,
@@ -16450,7 +16750,8 @@ mod tests {
         estimate_token_count, finish_account_login, finish_compaction, finish_context_report,
         finish_login, finish_plugin_install, finish_tokamak_login, finish_update_install,
         format_tokens, group_detail_lines, group_summary, handle_ask_key, handle_ask_mouse,
-        handle_key, handle_mouse, header_spans, image_mime, image_mime_of, input_content_lines,
+        handle_key, handle_mouse, handle_plugin_setup_key,
+        header_spans, image_mime, image_mime_of, input_content_lines,
         load_first_file_image, load_image_file, message_text, note_update, open_config_screen,
         open_rewind_picker, pairs_to_str, parse_command, partial_json_field,
         provider_label_for_model, rebuild_recall, replay_display_log, restore_goal,
@@ -29644,6 +29945,48 @@ mod tests {
             "{}",
             transcript_text(&app)
         );
+    }
+
+    /// A plugin whose manifest declares one required env var.
+    fn plugin_with_setup_requirement(root: &std::path::Path, var: &str, url: &str) {
+        let dir = root.join(".jan/agent/plugins/acme");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("plugin.toml"),
+            format!("name = \"acme\"\n\n[setup.env]\n{var} = \"{url}\"\n"),
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn plugin_setup_dock_masks_input_and_skips() {
+        let (mut app, root) = skill_test_app("deploy", "How to deploy.");
+        plugin_with_setup_requirement(&root, "ACME_TOKEN", "https://example.com/keys");
+
+        // The dock opens for the named plugin and shows the URL and a masked
+        // field; the hint row appears in `/plugin list` too.
+        run_command(&mut app, "plugin setup acme", &no_mcp()).await;
+        assert!(app.plugin_setup.is_some(), "dock must open");
+        let rows = render_rows(&mut app, 100, 30);
+        let rendered = rows.join("\n");
+        assert!(rendered.contains("ACME_TOKEN"), "{rendered}");
+        assert!(rendered.contains("https://example.com/keys"), "{rendered}");
+
+        // Typed characters render masked, never verbatim. Simulate the paste
+        // path directly: the typed secret must not appear in the frame.
+        if let Some(prompt) = app.plugin_setup.as_mut() {
+            prompt.paste("supersecret123");
+        }
+        let rows = render_rows(&mut app, 100, 30);
+        let rendered = rows.join("\n");
+        assert!(!rendered.contains("supersecret123"), "{rendered}");
+        assert!(rendered.contains('*'), "mask row: {rendered}");
+
+        // Esc cancels the dock.
+        handle_plugin_setup_key(&mut app, key(KeyCode::Esc), false);
+        assert!(app.plugin_setup.is_none());
+        assert!(transcript_text(&app).contains("plugin setup cancelled"));
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[tokio::test]

--- a/src-tauri/src/core/mcp/models.rs
+++ b/src-tauri/src/core/mcp/models.rs
@@ -18,10 +18,18 @@ pub struct McpServerConfig {
 /// Parse a raw `mcp_config.json` server entry into typed connection params.
 pub fn extract_command_args(config: &Value) -> Option<McpServerConfig> {
     let obj = config.as_object()?;
-    let command = obj.get("command")?.as_str()?.to_string();
-    let args = obj.get("args")?.as_array()?.clone();
     let url = obj.get("url").and_then(|u| u.as_str()).map(String::from);
     let transport_type = obj.get("type").and_then(|t| t.as_str()).map(String::from);
+    let (command, args) = match transport_type.as_deref() {
+        Some("http" | "sse") => {
+            url.as_ref()?;
+            (String::new(), Vec::new())
+        }
+        _ => (
+            obj.get("command")?.as_str()?.to_string(),
+            obj.get("args")?.as_array()?.clone(),
+        ),
+    };
     let timeout = obj
         .get("timeout")
         .and_then(|t| t.as_u64())
@@ -196,8 +204,6 @@ mod tests {
     #[test]
     fn test_extract_command_args_full_config() {
         let cfg = serde_json::json!({
-            "command": "",
-            "args": [],
             "type": "http",
             "url": "https://mcp.example.com/mcp",
             "timeout": 45,
@@ -236,6 +242,9 @@ mod tests {
         assert!(extract_command_args(&cfg).is_none());
         // args not an array
         let cfg = serde_json::json!({"command": "npx", "args": "oops"});
+        assert!(extract_command_args(&cfg).is_none());
+        // Remote transports require a URL, not a command fallback.
+        let cfg = serde_json::json!({"type": "http", "command": "npx", "args": []});
         assert!(extract_command_args(&cfg).is_none());
     }
 

--- a/src-tauri/src/core/mcp/oauth.rs
+++ b/src-tauri/src/core/mcp/oauth.rs
@@ -4,11 +4,11 @@
 //! transport, `core::cli::tui` for the `/mcp` screen) and the desktop
 //! activation stack is expected to adopt it unchanged.
 //!
-//! `rmcp`'s `auth` feature owns the protocol -- metadata discovery, PKCE, the
-//! token exchange and the `AuthClient` wrapper that injects the bearer token
-//! into either transport. What lives here is everything around it that rmcp
-//! leaves to the caller: a persistent token store keyed by server name, the
-//! loopback listener that receives the redirect, and absolute expiry tracking.
+//! `rmcp` owns metadata discovery and the authenticated transport. Session
+//! creation uses `oauth2` directly: rmcp 0.8 silently substitutes "mcp-client"
+//! when registration fails, producing an unusable consent URL. Jan requires
+//! successful registration before exposing a browser URL, and keeps the
+//! provider's rejection visible to the user.
 //!
 //! Absolute expiry is not redundant. `rmcp`'s `get_access_token` tests
 //! `expires_in()`, which is the *original* lifetime from the token response and
@@ -21,7 +21,7 @@ use std::net::{Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use rmcp::transport::auth::{AuthClient, OAuthState, OAuthTokenResponse};
+use rmcp::transport::auth::{AuthClient, OAuthClientConfig, OAuthState, OAuthTokenResponse};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -59,6 +59,9 @@ pub const NEEDS_AUTH_PREFIX: &str = "NEEDS_AUTH: ";
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StoredCredentials {
     pub client_id: String,
+    /// Some registrations issue a secret required again when refreshing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub client_secret: Option<oauth2::ClientSecret>,
     pub tokens: OAuthTokenResponse,
     /// Unix seconds at which `tokens`' access token stops being valid. `None`
     /// when the provider returned no `expires_in`, which means "until refused".
@@ -73,6 +76,7 @@ impl StoredCredentials {
         let expires_at = expires_at_from(&tokens);
         Self {
             client_id,
+            client_secret: None,
             tokens,
             expires_at,
             resource,
@@ -289,10 +293,23 @@ pub async fn advertises_oauth(url: &str) -> bool {
     manager.discover_metadata().await.is_ok()
 }
 
+type CodeClient = oauth2::basic::BasicClient<
+    oauth2::EndpointSet,
+    oauth2::EndpointNotSet,
+    oauth2::EndpointNotSet,
+    oauth2::EndpointNotSet,
+    oauth2::EndpointSet,
+>;
+
 /// An authorization in flight: the browser has somewhere to go and the loopback
 /// listener is already bound, so the redirect cannot race the port.
 pub struct PendingAuth {
-    state: OAuthState,
+    client: CodeClient,
+    http: reqwest::Client,
+    verifier: oauth2::PkceCodeVerifier,
+    csrf: oauth2::CsrfToken,
+    client_id: String,
+    client_secret: Option<oauth2::ClientSecret>,
     listener: tokio::net::TcpListener,
     server: String,
     resource: String,
@@ -302,8 +319,8 @@ pub struct PendingAuth {
     pub redirect_uri: String,
 }
 
-/// Start an authorization: bind the loopback listener, register (or reuse) a
-/// client, and build the consent url. Nothing is persisted and no browser is
+/// Start an authorization: bind the loopback listener, register a real
+/// client, and build the consent URL. Nothing is persisted and no browser is
 /// opened here -- the caller owns both.
 ///
 /// The listener is bound *before* the redirect uri is minted because dynamic
@@ -321,24 +338,75 @@ pub async fn begin(server: &str, url: &str) -> Result<PendingAuth, String> {
     // hostname form in a loopback redirect, and both resolve to this listener.
     let redirect_uri = format!("http://localhost:{port}/callback");
 
-    let mut state = OAuthState::new(url.to_string(), None)
+    let state = OAuthState::new(url.to_string(), None)
         .await
         .map_err(|e| format!("could not reach '{url}' for OAuth discovery: {e}"))?;
-    state
-        .start_authorization(&[], &redirect_uri, Some(CLIENT_NAME))
-        .await
+    let OAuthState::Unauthorized(manager) = state else {
+        return Err("OAuth discovery did not create an authorization manager".into());
+    };
+    let metadata = manager.discover_metadata().await
         .map_err(|e| format!("'{server}' does not offer OAuth we can use: {e}"))?;
-    let authorization_url = state
-        .get_authorization_url()
-        .await
-        .map_err(|e| format!("could not build the sign-in url for '{server}': {e}"))?;
+    let endpoint = metadata.registration_endpoint.as_deref()
+        .ok_or_else(|| format!("'{server}' requires a pre-registered OAuth client; no registration endpoint was advertised"))?;
+    let http = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .redirect(reqwest::redirect::Policy::none())
+        .build().map_err(|e| e.to_string())?;
+    let response = http.post(endpoint)
+        .header(reqwest::header::ACCEPT, "application/json")
+        .json(&serde_json::json!({
+            "client_name": CLIENT_NAME,
+            "redirect_uris": [&redirect_uri],
+            "grant_types": ["authorization_code", "refresh_token"],
+            "response_types": ["code"],
+            "token_endpoint_auth_method": "none",
+            "application_type": "native",
+        }))
+        .send().await
+        .map_err(|e| format!("OAuth client registration for '{server}' failed: {e}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        let detail: String = body.lines().next().unwrap_or("").trim().chars().take(200).collect();
+        return Err(format!(
+            "OAuth client registration for '{server}' was rejected (POST {endpoint}: HTTP {status}): {detail}. \
+             The provider must issue or approve a client ID for Jan before browser sign-in can work."
+        ));
+    }
+    #[derive(Deserialize)]
+    struct Registration {
+        client_id: String,
+        client_secret: Option<String>,
+    }
+    let registration: Registration = response.json().await
+        .map_err(|_| format!("OAuth registration for '{server}' returned no usable client credentials"))?;
+    let client_id = registration.client_id.trim().to_string();
+    if client_id.is_empty() {
+        return Err(format!("OAuth registration for '{server}' returned an empty client ID"));
+    }
+    let client_secret = registration.client_secret.filter(|s| !s.is_empty()).map(oauth2::ClientSecret::new);
+    let mut client = oauth2::basic::BasicClient::new(oauth2::ClientId::new(client_id.clone()))
+        .set_auth_uri(oauth2::AuthUrl::new(metadata.authorization_endpoint).map_err(|e| e.to_string())?)
+        .set_token_uri(oauth2::TokenUrl::new(metadata.token_endpoint).map_err(|e| e.to_string())?)
+        .set_redirect_uri(oauth2::RedirectUrl::new(redirect_uri.clone()).map_err(|e| e.to_string())?);
+    if let Some(secret) = &client_secret {
+        client = client.set_client_secret(secret.clone());
+    }
+    let (challenge, verifier) = oauth2::PkceCodeChallenge::new_random_sha256();
+    let (authorization_url, csrf) = client.authorize_url(oauth2::CsrfToken::new_random)
+        .set_pkce_challenge(challenge).url();
 
     Ok(PendingAuth {
-        state,
+        client,
+        http,
+        verifier,
+        csrf,
+        client_id,
+        client_secret,
         listener,
         server: server.to_string(),
         resource: url.to_string(),
-        authorization_url,
+        authorization_url: authorization_url.to_string(),
         redirect_uri,
     })
 }
@@ -348,25 +416,21 @@ impl PendingAuth {
     /// tokens. Consumes the flow: the PKCE verifier and CSRF token are
     /// single-use, so a failed exchange means starting over rather than
     /// retrying against spent state.
-    pub async fn complete(mut self, data_folder: &Path) -> Result<StoredCredentials, String> {
+    pub async fn complete(self, data_folder: &Path) -> Result<StoredCredentials, String> {
         let callback = tokio::time::timeout(CALLBACK_TIMEOUT, accept_callback(&self.listener))
             .await
             .map_err(|_| "timed out waiting for the browser to come back".to_string())??;
 
-        self.state
-            .handle_callback(&callback.code, &callback.state)
-            .await
+        if callback.state != *self.csrf.secret() {
+            return Err("OAuth callback state did not match this sign-in attempt".into());
+        }
+        let tokens = self.client
+            .exchange_code(oauth2::AuthorizationCode::new(callback.code))
+            .set_pkce_verifier(self.verifier)
+            .request_async(&self.http).await
             .map_err(|e| format!("could not exchange the authorization code: {e}"))?;
-
-        let (client_id, tokens) = self
-            .state
-            .get_credentials()
-            .await
-            .map_err(|e| format!("authorization finished without usable tokens: {e}"))?;
-        let tokens =
-            tokens.ok_or_else(|| "authorization finished without an access token".to_string())?;
-
-        let creds = StoredCredentials::from_exchange(client_id, tokens, self.resource);
+        let mut creds = StoredCredentials::from_exchange(self.client_id, tokens, self.resource);
+        creds.client_secret = self.client_secret;
         save(data_folder, &self.server, &creds)?;
         Ok(creds)
     }
@@ -554,6 +618,14 @@ pub async fn authorized_client(
         .set_credentials(&stored.client_id, stored.tokens.clone())
         .await
         .map_err(|e| format!("stored credentials for '{name}' are unusable: {e}"))?;
+    if let (Some(secret), OAuthState::Authorized(manager)) = (&stored.client_secret, &mut state) {
+        manager.configure_client(OAuthClientConfig {
+            client_id: stored.client_id.clone(),
+            client_secret: Some(secret.secret().clone()),
+            scopes: Vec::new(),
+            redirect_uri: url.to_string(),
+        }).map_err(|e| format!("could not restore OAuth registration for '{name}': {e}"))?;
+    }
 
     if stored.is_expired() {
         if !stored.has_refresh_token() {
@@ -571,11 +643,9 @@ pub async fn authorized_client(
             .await
             .map_err(|e| format!("refresh for '{name}' returned no tokens: {e}"))?;
         if let Some(tokens) = tokens {
-            save(
-                data_folder,
-                name,
-                &StoredCredentials::from_exchange(client_id, tokens, url.to_string()),
-            )?;
+            let mut refreshed = StoredCredentials::from_exchange(client_id, tokens, url.to_string());
+            refreshed.client_secret = stored.client_secret.clone();
+            save(data_folder, name, &refreshed)?;
         }
     }
 
@@ -604,6 +674,134 @@ mod tests {
             t.set_refresh_token(Some(RefreshToken::new("rt-1".to_string())));
         }
         t
+    }
+
+    async fn registration_server(
+        status: u16,
+        registration_body: &'static str,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let base = format!("http://{}", listener.local_addr().unwrap());
+        let origin = base.clone();
+        let task = tokio::spawn(async move {
+            loop {
+                let (mut socket, _) = listener.accept().await.unwrap();
+                let mut bytes = Vec::new();
+                let mut buf = [0; 4096];
+                loop {
+                    let n = socket.read(&mut buf).await.unwrap();
+                    if n == 0 { break; }
+                    bytes.extend_from_slice(&buf[..n]);
+                    if let Some(end) = bytes.windows(4).position(|b| b == b"\r\n\r\n") {
+                        let headers = String::from_utf8_lossy(&bytes[..end]);
+                        let length = headers.lines().find_map(|line| {
+                            let (key, value) = line.split_once(':')?;
+                            key.eq_ignore_ascii_case("content-length")
+                                .then(|| value.trim().parse::<usize>().unwrap())
+                        }).unwrap_or(0);
+                        if bytes.len() >= end + 4 + length { break; }
+                    }
+                }
+                let registration = bytes.starts_with(b"POST /register ");
+                let (code, body) = if registration {
+                    (status, registration_body.to_string())
+                } else if bytes.starts_with(b"POST /token ") {
+                    let request = String::from_utf8_lossy(&bytes).to_ascii_lowercase();
+                    assert!(request.contains("authorization: basic "));
+                    let refreshed = request.contains("grant_type=refresh_token");
+                    if !refreshed {
+                        assert!(request.contains("code_verifier="));
+                    }
+                    (200, json!({
+                        "access_token": if refreshed { "refreshed" } else { "issued" },
+                        "token_type": "Bearer", "expires_in": 3600, "refresh_token": "refresh",
+                    }).to_string())
+                } else {
+                    (200, json!({
+                        "authorization_endpoint": format!("{origin}/authorize"),
+                        "token_endpoint": format!("{origin}/token"),
+                        "registration_endpoint": format!("{origin}/register"),
+                    }).to_string())
+                };
+                let reply = format!(
+                    "HTTP/1.1 {code} Response\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                    body.len(),
+                );
+                socket.write_all(reply.as_bytes()).await.unwrap();
+            }
+        });
+        (base, task)
+    }
+
+    #[tokio::test]
+    async fn rejected_registration_never_opens_a_placeholder_client_url() {
+        let (base, task) = registration_server(403, r#"{"error":"unapproved_client"}"#).await;
+        let result = begin("restricted", &format!("{base}/mcp")).await;
+        task.abort();
+        let error = match result {
+            Err(error) => error,
+            Ok(_) => panic!("rejected registration must not produce a browser URL"),
+        };
+        assert!(error.contains("403"), "{error}");
+        assert!(error.contains("unapproved_client"), "{error}");
+    }
+
+    #[tokio::test]
+    async fn registered_client_completes_pkce_and_retains_secret_for_refresh() {
+        let (base, task) = registration_server(
+            201, r#"{"client_id":"registered","client_secret":"registration-secret"}"#,
+        ).await;
+        let url = format!("{base}/mcp");
+        let pending = begin("server", &url).await.unwrap();
+        let auth_url = reqwest::Url::parse(&pending.authorization_url).unwrap();
+        let params: BTreeMap<_, _> = auth_url.query_pairs().into_owned().collect();
+        assert_eq!(params["client_id"], "registered");
+        assert_eq!(params["code_challenge_method"], "S256");
+        let callback = format!("{}?code=issued-code&state={}", pending.redirect_uri, params["state"]);
+        let dir = tempfile::tempdir().unwrap();
+        let folder = dir.path().to_path_buf();
+        let completion = tokio::spawn(async move { pending.complete(&folder).await });
+        reqwest::get(callback).await.unwrap().error_for_status().unwrap();
+        let mut stored = completion.await.unwrap().unwrap();
+        assert_eq!(stored.tokens.access_token().secret(), "issued");
+        assert!(!format!("{stored:?}").contains("registration-secret"));
+        stored.expires_at = Some(0);
+        save(dir.path(), "server", &stored).unwrap();
+        let client = authorized_client(
+            dir.path(), "server", &url, &json!({}), reqwest::Client::new(),
+        ).await.unwrap().unwrap();
+        assert_eq!(client.get_access_token().await.unwrap(), "refreshed");
+        assert_eq!(
+            load(dir.path(), "server").unwrap().client_secret.unwrap().secret(),
+            "registration-secret",
+        );
+        task.abort();
+    }
+
+    #[tokio::test]
+    async fn empty_registered_client_id_is_rejected_before_browser_sign_in() {
+        let (base, task) = registration_server(201, r#"{"client_id":" "}"#).await;
+        let result = begin("server", &format!("{base}/mcp")).await;
+        task.abort();
+        assert!(matches!(result, Err(error) if error.contains("empty client ID")));
+    }
+
+    #[tokio::test]
+    async fn mismatched_callback_state_cannot_save_credentials() {
+        let (base, task) = registration_server(201, r#"{"client_id":"registered"}"#).await;
+        let pending = begin("server", &format!("{base}/mcp")).await.unwrap();
+        let callback = format!("{}?code=code&state=wrong-session", pending.redirect_uri);
+        let dir = tempfile::tempdir().unwrap();
+        let folder = dir.path().to_path_buf();
+        let completion = tokio::spawn(async move { pending.complete(&folder).await });
+        reqwest::get(callback).await.unwrap();
+        assert!(matches!(
+            completion.await.unwrap(),
+            Err(error) if error.contains("state did not match"),
+        ));
+        assert!(load(dir.path(), "server").is_none());
+        task.abort();
     }
 
     /// The message from a `parse_callback_query` outcome that must be an error.


### PR DESCRIPTION
## Summary
- Users can install a skill or plugin from inside Jan: search the catalog, select one result, enter required API keys with masked input, and review each MCP connection before enabling it.
- `/reload` refreshes skills, plugins, and project instructions in the current session without a restart; linked worktrees share the main checkout's resources, while shell credentials remain isolated per project.

```mermaid
flowchart TD
    A[Install a plugin or select one with /plugin setup] --> B[Enter required API keys - masked input]
    B --> C{Enable this plugin's MCP connection?}
    C -->|Not now or Esc| D[Leave connection disabled]
    C -->|Enable| E{OAuth sign-in required?}
    E -->|No| F[Connect to MCP server]
    E -->|Yes| G[Register OAuth client]
    G -->|Accepted| H[Browser sign-in]
    H --> F
    G -->|Rejected| I[Show error - do not open browser]
    J[Add or edit skills, plugins, or project instructions] --> K[Run /reload]
    K --> L[Continue in the same session with refreshed resources]
```

**Known limitation:** Remote Figma still rejects Jan's OAuth client registration with HTTP 403. This PR surfaces that error; it does not make the Figma integration work.

Fixes #8817

## Verification
- `cargo test --manifest-path src-tauri/Cargo.toml --no-default-features --features cli --lib` - 1,401 passed, including setup/search, credential isolation, OAuth rejection, and repaint regressions.
- `cargo test --manifest-path src-tauri/plugins/tauri-plugin-agent-tools/Cargo.toml --target-dir src-tauri/target --no-default-features --lib` - 266 passed, 1 ignored.
- `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --no-default-features --features cli --all-targets -- -D warnings` - passed.
- `cargo clippy --locked --manifest-path src-tauri/Cargo.toml --no-default-features --features test-tauri --all-targets -- -D warnings` - passed.
- `cargo clippy --manifest-path src-tauri/plugins/tauri-plugin-agent-tools/Cargo.toml --all-targets -- -D warnings` - passed without raising the crate's Rust 1.77.2 MSRV.
- `python3 .omp/local-tools/check_rust_diff_noise.py` - passed.
- `./build-tui.sh debug` - built and installed the CLI; binary comparison passed, and the TUI smoke verified plugin search, duplicate-name selection, masked key setup, and consent-gated MCP setup.
- [Rust Check workflow](https://github.com/janhq/jan/actions/runs/34188912508) - all jobs passed, including desktop, CLI, and agent-tools checks.
