### PR TITLE
feat: add llmman as a predefined provider

### DIFF
--- a/web-app/src/constants/providers.ts
+++ b/web-app/src/constants/providers.ts
@@ -399,4 +399,25 @@ export const predefinedProviders = [
     ],
     models: [],
   },
+  {
+    active: true,
+    api_key: '',
+    base_url: 'http://localhost:17434/v1',
+    explore_models_url: 'https://hub.docker.com/catalogs/models',
+    provider: 'llmman',
+    settings: [
+      {
+        key: 'base-url',
+        title: 'Base URL',
+        description:
+          'The base endpoint to use. llmman serves an OpenAI-compatible API on port 17434 by default; change this if you started it with a different LLMMAN_HOST.',
+        controller_type: 'input',
+        controller_props: {
+          placeholder: 'http://localhost:17434/v1',
+          value: 'http://localhost:17434/v1',
+        },
+      },
+    ],
+    models: [],
+  },
 ]

--- a/web-app/src/lib/utils.ts
+++ b/web-app/src/lib/utils.ts
@@ -186,6 +186,8 @@ export const getProviderTitle = (provider: string) => {
       return 'MiniMax'
     case 'nvidia':
       return 'NVIDIA NIM'
+    case 'llmman':
+      return 'llmman'
     default:
       return provider.charAt(0).toUpperCase() + provider.slice(1)
   }


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), which runs local models distributed as OCI artifacts and serves an OpenAI-compatible API on port 17434.

Being local it takes no API key, so unlike the other predefined providers its only setting is the **base URL** — for users who started llmman on a different `LLMMAN_HOST`. `getProviderTitle` gets a case so the name stays lowercase rather than being title-cased to "Llmman" by the default branch.

`getProviderLogo` is deliberately left alone: it already returns `undefined` for providers with no bundled logo, which is the graceful path. I didn't add an SVG because the ones in `public/images/model-provider/` are true vectors and the only llmman asset I have is raster. Happy to add one if you'd like.

**Testing:** `tsc --noEmit -p tsconfig.app.json` reports 7297 lines both before and after, verified against a stashed baseline, with zero mentioning llmman. (High absolute count because I typechecked without installing dependencies — the delta is the meaningful part.)

One caveat on method: I first ran this against `tsconfig.json` and got a clean 0/0, which is meaningless — that config is `"files": []` with project references, so it checks nothing. The numbers above are from `tsconfig.app.json`, which actually compiles the app.

Not verified: no run of the app, so the provider settings UI and a real completion are untested.

> AI-assisted, reviewed before submitting.
