### PR TITLE
fix(server): honor CORS enabled setting

### DIFF
--- a/src-tauri/src/core/server/commands.rs
+++ b/src-tauri/src/core/server/commands.rs
@@ -15,6 +15,7 @@ pub struct StartServerConfig {
     pub api_key: String,
     pub trusted_hosts: Vec<String>,
     pub proxy_timeout: u64,
+    pub cors_enabled: Option<bool>,
     pub enable_server_tool_execution: Option<bool>,
 }
 
@@ -31,6 +32,7 @@ pub async fn start_server<R: Runtime>(
         api_key,
         trusted_hosts,
         proxy_timeout,
+        cors_enabled,
         enable_server_tool_execution,
     } = config;
     let server_handle = state.server_handle.clone();
@@ -58,6 +60,7 @@ pub async fn start_server<R: Runtime>(
         api_key,
         vec![trusted_hosts],
         proxy_timeout,
+        cors_enabled.unwrap_or(true),
         state.provider_configs.clone(),
         state.model_param_defaults.clone(),
         state.mcp_servers.clone(),
@@ -87,4 +90,32 @@ pub async fn get_server_status(state: State<'_, AppState>) -> Result<bool, Strin
     let server_handle = state.server_handle.clone();
 
     Ok(proxy::is_server_running(server_handle).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::StartServerConfig;
+    use serde_json::json;
+
+    fn config_with(cors_enabled: Option<bool>) -> StartServerConfig {
+        let mut value = json!({
+            "host": "127.0.0.1",
+            "port": 1337,
+            "prefix": "/v1",
+            "api_key": "",
+            "trusted_hosts": ["localhost"],
+            "proxy_timeout": 600,
+            "enable_server_tool_execution": false
+        });
+        if let Some(enabled) = cors_enabled {
+            value["cors_enabled"] = json!(enabled);
+        }
+        serde_json::from_value(value).unwrap()
+    }
+
+    #[test]
+    fn cors_enabled_is_optional_and_accepts_false() {
+        assert_eq!(config_with(None).cors_enabled, None);
+        assert_eq!(config_with(Some(false)).cors_enabled, Some(false));
+    }
 }

--- a/src-tauri/src/core/server/proxy.rs
+++ b/src-tauri/src/core/server/proxy.rs
@@ -560,6 +560,7 @@ pub struct ProxyConfig {
     pub trusted_hosts: Vec<Vec<String>>,
     pub host: String,
     pub port: u16,
+    pub cors_enabled: bool,
     pub enable_server_tool_execution: bool,
 }
 
@@ -770,8 +771,13 @@ async fn proxy_request(
                 .unwrap());
         }
 
-        let mut response = Response::builder()
-            .status(StatusCode::OK)
+        let mut response = Response::builder().status(StatusCode::OK);
+
+        if !config.cors_enabled {
+            return Ok(response.body(empty()).unwrap());
+        }
+
+        response = response
             .header("Access-Control-Allow-Methods", allowed_methods.join(", "))
             .header("Access-Control-Allow-Headers", allowed_headers.join(", "))
             .header("Access-Control-Max-Age", "86400")
@@ -838,6 +844,7 @@ async fn proxy_request(
                     &host_header,
                     &origin_header,
                     &config.trusted_hosts,
+                    config.cors_enabled,
                 );
                 return Ok(error_response.body(full("Invalid host header")).unwrap());
             }
@@ -848,6 +855,7 @@ async fn proxy_request(
                 &host_header,
                 &origin_header,
                 &config.trusted_hosts,
+                config.cors_enabled,
             );
             return Ok(error_response.body(full("Missing host header")).unwrap());
         }
@@ -880,6 +888,7 @@ async fn proxy_request(
                 &host_header,
                 &origin_header,
                 &config.trusted_hosts,
+                config.cors_enabled,
             );
             return Ok(error_response
                 .body(full("Invalid or missing authorization token"))
@@ -896,6 +905,7 @@ async fn proxy_request(
             &host_header,
             &origin_header,
             &config.trusted_hosts,
+            config.cors_enabled,
         );
         return Ok(error_response.body(full("Not Found")).unwrap());
     }
@@ -933,6 +943,7 @@ async fn proxy_request(
                         &host_header,
                         &origin_header,
                         &config.trusted_hosts,
+                        config.cors_enabled,
                     );
                     return Ok(error_response
                         .body(full("Failed to read request body"))
@@ -968,6 +979,7 @@ async fn proxy_request(
                                     &host_header,
                                     &origin_header,
                                     &config.trusted_hosts,
+                                    config.cors_enabled,
                                 );
                                 return Ok(error_response
                                     .body(full("Invalid /messages payload for orchestration mode"))
@@ -1002,6 +1014,7 @@ async fn proxy_request(
                                     &host_header,
                                     &origin_header,
                                     &config.trusted_hosts,
+                                    config.cors_enabled,
                                 );
                                 return Ok(response_builder.body(full(body_str)).unwrap());
                             }
@@ -1013,6 +1026,7 @@ async fn proxy_request(
                                     &host_header,
                                     &origin_header,
                                     &config.trusted_hosts,
+                                    config.cors_enabled,
                                 );
                                 return Ok(error_response.body(full(e)).unwrap());
                             }
@@ -1080,6 +1094,7 @@ async fn proxy_request(
                                     &host_header,
                                     &origin_header,
                                     &config.trusted_hosts,
+                                    config.cors_enabled,
                                 );
                                 return Ok(error_response
                                     .body(full(format!(
@@ -1098,6 +1113,7 @@ async fn proxy_request(
                             &host_header,
                             &origin_header,
                             &config.trusted_hosts,
+                            config.cors_enabled,
                         );
                         return Ok(error_response.body(full(error_msg)).unwrap());
                     }
@@ -1110,6 +1126,7 @@ async fn proxy_request(
                         &host_header,
                         &origin_header,
                         &config.trusted_hosts,
+                        config.cors_enabled,
                     );
                     let error_msg = format!("Invalid JSON body: {}", e);
                     return Ok(error_response.body(full(error_msg)).unwrap());
@@ -1136,6 +1153,7 @@ async fn proxy_request(
                         &host_header,
                         &origin_header,
                         &config.trusted_hosts,
+                        config.cors_enabled,
                     );
                     return Ok(error_response
                         .body(full("Failed to read request body"))
@@ -1152,6 +1170,7 @@ async fn proxy_request(
                         &host_header,
                         &origin_header,
                         &config.trusted_hosts,
+                        config.cors_enabled,
                     );
                     return Ok(error_response
                         .body(full(format!("Invalid JSON body: {e}")))
@@ -1177,6 +1196,7 @@ async fn proxy_request(
                     &host_header,
                     &origin_header,
                     &config.trusted_hosts,
+                    config.cors_enabled,
                 );
                 return Ok(error_response
                     .body(full("stream=true is not supported for /orchestrations"))
@@ -1192,6 +1212,7 @@ async fn proxy_request(
                         &host_header,
                         &origin_header,
                         &config.trusted_hosts,
+                        config.cors_enabled,
                     );
                     return Ok(error_response
                         .body(full("Missing required field 'messages'"))
@@ -1208,6 +1229,7 @@ async fn proxy_request(
                         &host_header,
                         &origin_header,
                         &config.trusted_hosts,
+                        config.cors_enabled,
                     );
                     return Ok(error_response.body(full(e)).unwrap());
                 }
@@ -1233,6 +1255,7 @@ async fn proxy_request(
                                 &host_header,
                                 &origin_header,
                                 &config.trusted_hosts,
+                                config.cors_enabled,
                             );
                             return Ok(error_response.body(full(e)).unwrap());
                         }
@@ -1280,6 +1303,7 @@ async fn proxy_request(
                         &host_header,
                         &origin_header,
                         &config.trusted_hosts,
+                        config.cors_enabled,
                     );
                     return Ok(error_response
                         .body(full("No running model sessions available"))
@@ -1299,6 +1323,7 @@ async fn proxy_request(
                             &host_header,
                             &origin_header,
                             &config.trusted_hosts,
+                            config.cors_enabled,
                         );
                         return Ok(error_response.body(full(e)).unwrap());
                     }
@@ -1320,6 +1345,7 @@ async fn proxy_request(
                         &host_header,
                         &origin_header,
                         &config.trusted_hosts,
+                        config.cors_enabled,
                     );
                     return Ok(error_response.body(full(e)).unwrap());
                 }
@@ -1379,6 +1405,7 @@ async fn proxy_request(
                             &host_header,
                             &origin_header,
                             &config.trusted_hosts,
+                            config.cors_enabled,
                         );
                         return Ok(error_response.body(full(e)).unwrap());
                     }
@@ -1398,6 +1425,7 @@ async fn proxy_request(
                         &host_header,
                         &origin_header,
                         &config.trusted_hosts,
+                        config.cors_enabled,
                     );
                     return Ok(response_builder.body(full(body_str)).unwrap());
                 }
@@ -1447,6 +1475,7 @@ async fn proxy_request(
                 &host_header,
                 &origin_header,
                 &config.trusted_hosts,
+                config.cors_enabled,
             );
             let payload = format!(
                 "{{\"error\":\"max_turns reached while resolving tool calls\",\"last_response\":{body_str}}}"
@@ -1471,6 +1500,7 @@ async fn proxy_request(
                         &host_header,
                         &origin_header,
                         &config.trusted_hosts,
+                        config.cors_enabled,
                     );
                     return Ok(error_response
                         .body(full("Failed to read request body"))
@@ -1524,6 +1554,7 @@ async fn proxy_request(
                                     &host_header,
                                     &origin_header,
                                     &config.trusted_hosts,
+                                    config.cors_enabled,
                                 );
                                 return Ok(response_builder.body(full(body_str)).unwrap());
                             }
@@ -1535,6 +1566,7 @@ async fn proxy_request(
                                     &host_header,
                                     &origin_header,
                                     &config.trusted_hosts,
+                                    config.cors_enabled,
                                 );
                                 return Ok(error_response.body(full(e)).unwrap());
                             }
@@ -1645,6 +1677,7 @@ async fn proxy_request(
                                     &host_header,
                                     &origin_header,
                                     &config.trusted_hosts,
+                                    config.cors_enabled,
                                 );
                                 return Ok(error_response
                                     .body(full("No models are available"))
@@ -1672,6 +1705,7 @@ async fn proxy_request(
                                     &host_header,
                                     &origin_header,
                                     &config.trusted_hosts,
+                                    config.cors_enabled,
                                 );
                                 return Ok(error_response
                                     .body(full(format!(
@@ -1692,6 +1726,7 @@ async fn proxy_request(
                             &host_header,
                             &origin_header,
                             &config.trusted_hosts,
+                            config.cors_enabled,
                         );
                         return Ok(error_response.body(full(error_msg)).unwrap());
                     }
@@ -1704,6 +1739,7 @@ async fn proxy_request(
                         &host_header,
                         &origin_header,
                         &config.trusted_hosts,
+                        config.cors_enabled,
                     );
                     let error_msg = format!("Invalid JSON body: {}", e);
                     return Ok(error_response.body(full(error_msg)).unwrap());
@@ -1785,6 +1821,7 @@ async fn proxy_request(
                 &host_header,
                 &origin_header,
                 &config.trusted_hosts,
+                config.cors_enabled,
             );
 
             log::debug!(
@@ -1873,6 +1910,7 @@ async fn proxy_request(
                 &host_header,
                 &origin_header,
                 &config.trusted_hosts,
+                config.cors_enabled,
             );
 
             return Ok(response_builder.body(full(html)).unwrap());
@@ -1916,6 +1954,7 @@ async fn proxy_request(
                     &host_header,
                     &origin_header,
                     &config.trusted_hosts,
+                    config.cors_enabled,
                 );
                 return Ok(error_response.body(full("Not Found")).unwrap());
             } else {
@@ -1928,6 +1967,7 @@ async fn proxy_request(
                     &host_header,
                     &origin_header,
                     &config.trusted_hosts,
+                    config.cors_enabled,
                 );
                 return Ok(error_response.body(full("Not Found")).unwrap());
             }
@@ -1946,6 +1986,7 @@ async fn proxy_request(
                 &host_header,
                 &origin_header,
                 &config.trusted_hosts,
+                config.cors_enabled,
             );
             return Ok(error_response.body(full("Internal routing error")).unwrap());
         }
@@ -1966,6 +2007,7 @@ async fn proxy_request(
                 &host_header,
                 &origin_header,
                 &config.trusted_hosts,
+                config.cors_enabled,
             );
             return Ok(error_response
                 .body(full("Internal server error: unhandled request path"))
@@ -2141,6 +2183,7 @@ async fn proxy_request(
                                 &host_header,
                                 &origin_header,
                                 &config.trusted_hosts,
+                                config.cors_enabled,
                             );
                             return Ok(error_response
                                 .body(full(fallback_error))
@@ -2158,6 +2201,7 @@ async fn proxy_request(
                             &host_header,
                             &origin_header,
                             &config.trusted_hosts,
+                            config.cors_enabled,
                         );
 
                         let is_streaming = openai_body
@@ -2196,6 +2240,7 @@ async fn proxy_request(
                         &host_header,
                         &origin_header,
                         &config.trusted_hosts,
+                        config.cors_enabled,
                     );
                     return Ok(error_response.body(full(error_body)).unwrap());
                 } else if is_error {
@@ -2211,6 +2256,7 @@ async fn proxy_request(
                         &host_header,
                         &origin_header,
                         &config.trusted_hosts,
+                        config.cors_enabled,
                     );
                     return Ok(error_response.body(full(error_body)).unwrap());
                 }
@@ -2229,6 +2275,7 @@ async fn proxy_request(
                     &host_header,
                     &origin_header,
                     &config.trusted_hosts,
+                    config.cors_enabled,
                 );
 
                 // When the provider fronts a non-chat/completions API, translate the
@@ -2287,6 +2334,7 @@ async fn proxy_request(
                     &host_header,
                     &origin_header,
                     &config.trusted_hosts,
+                    config.cors_enabled,
                 );
                 return Ok(error_response.body(full(error_msg)).unwrap());
             }
@@ -2300,6 +2348,7 @@ async fn proxy_request(
         &host_header,
         &origin_header,
         &config.trusted_hosts,
+        config.cors_enabled,
     );
     Ok(error_response.body(full("Internal proxy error")).unwrap())
 }
@@ -2337,8 +2386,13 @@ pub(crate) fn add_cors_headers_with_host_and_origin(
     _host: &str,
     origin: &str,
     trusted_hosts: &[Vec<String>],
+    cors_enabled: bool,
 ) -> hyper::http::response::Builder {
     let mut builder = builder;
+
+    if !cors_enabled {
+        return builder;
+    }
 
     let origin_trusted = if !origin.is_empty() {
         let origin_host = extract_host_from_origin(origin);
@@ -2382,6 +2436,7 @@ pub async fn start_server(
     proxy_api_key: String,
     trusted_hosts: Vec<Vec<String>>,
     proxy_timeout: u64,
+    cors_enabled: bool,
     provider_configs: Arc<Mutex<HashMap<String, ProviderConfig>>>,
     model_param_defaults: Arc<Mutex<HashMap<String, serde_json::Value>>>,
     mcp_servers: SharedMcpServers,
@@ -2399,6 +2454,7 @@ pub async fn start_server(
         proxy_api_key,
         trusted_hosts,
         proxy_timeout,
+        cors_enabled,
         provider_configs,
         model_param_defaults,
         mcp_servers,
@@ -2420,6 +2476,7 @@ async fn start_server_internal(
     proxy_api_key: String,
     trusted_hosts: Vec<Vec<String>>,
     proxy_timeout: u64,
+    cors_enabled: bool,
     provider_configs: Arc<Mutex<HashMap<String, ProviderConfig>>>,
     model_param_defaults: Arc<Mutex<HashMap<String, serde_json::Value>>>,
     mcp_servers: SharedMcpServers,
@@ -2451,6 +2508,7 @@ async fn start_server_internal(
         trusted_hosts,
         host: host.clone(),
         port,
+        cors_enabled,
         enable_server_tool_execution,
     };
 
@@ -2952,8 +3010,92 @@ async fn forward_non_streaming(
 
 #[cfg(test)]
 mod tests {
-    use super::{is_insecure_public_bind, map_bind_error};
-    use std::net::SocketAddr;
+    use super::{is_insecure_public_bind, map_bind_error, start_server, stop_server};
+    use crate::core::{
+        mcp::models::McpSettings,
+        server::MlxBackendSession,
+        state::{ProviderConfig, ServerHandle, SharedMcpServers},
+    };
+    use std::{collections::HashMap, net::SocketAddr, sync::Arc};
+    use tauri_plugin_llamacpp::state::LlamacppState;
+    use tokio::sync::Mutex;
+
+    async fn preflight(cors_enabled: bool) -> reqwest::Response {
+        let reservation = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let port = reservation.local_addr().unwrap().port();
+        drop(reservation);
+
+        let server_handle: Arc<Mutex<Option<ServerHandle>>> = Arc::new(Mutex::new(None));
+        let mlx_sessions: Arc<Mutex<HashMap<i32, MlxBackendSession>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let mcp_servers: SharedMcpServers = Arc::new(Mutex::new(HashMap::new()));
+
+        start_server(
+            server_handle.clone(),
+            Arc::new(LlamacppState::default()),
+            mlx_sessions,
+            "127.0.0.1".to_string(),
+            port,
+            "/v1".to_string(),
+            String::new(),
+            vec![vec!["localhost".to_string()]],
+            60,
+            cors_enabled,
+            Arc::new(Mutex::new(HashMap::<String, ProviderConfig>::new())),
+            Arc::new(Mutex::new(HashMap::new())),
+            mcp_servers,
+            Arc::new(Mutex::new(McpSettings::default())),
+            String::new(),
+            false,
+        )
+        .await
+        .unwrap();
+
+        let response = reqwest::Client::new()
+            .request(
+                reqwest::Method::OPTIONS,
+                format!("http://127.0.0.1:{port}/v1/models"),
+            )
+            .header("Host", format!("localhost:{port}"))
+            .header("Origin", "http://localhost:3000")
+            .header("Access-Control-Request-Method", "GET")
+            .send()
+            .await
+            .unwrap();
+
+        stop_server(server_handle).await.unwrap();
+        response
+    }
+
+    #[tokio::test]
+    async fn cors_disabled_preflight_omits_cors_headers() {
+        let response = preflight(false).await;
+
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        assert!(!response
+            .headers()
+            .keys()
+            .any(|name| name.as_str().starts_with("access-control-")));
+        assert!(!response.headers().contains_key("vary"));
+    }
+
+    #[tokio::test]
+    async fn cors_enabled_preflight_keeps_cors_headers() {
+        let response = preflight(true).await;
+
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+        assert_eq!(
+            response
+                .headers()
+                .get("access-control-allow-origin")
+                .unwrap(),
+            "http://localhost:3000"
+        );
+        assert!(response
+            .headers()
+            .contains_key("access-control-allow-methods"));
+        assert!(response.headers().contains_key("vary"));
+    }
 
     #[test]
     fn loopback_never_warns() {

--- a/src-tauri/src/core/server/tests.rs
+++ b/src-tauri/src/core/server/tests.rs
@@ -69,6 +69,7 @@ mod server_tests {
             trusted_hosts: vec![vec!["localhost".to_string()]],
             host: "localhost".to_string(),
             port: 1337,
+            cors_enabled: true,
             enable_server_tool_execution: false,
         };
         assert_eq!(config.prefix, "/v1");
@@ -86,6 +87,7 @@ mod server_tests {
             trusted_hosts: vec![],
             host: "127.0.0.1".to_string(),
             port: 8080,
+            cors_enabled: true,
             enable_server_tool_execution: false,
         };
         assert_eq!(config.prefix, "");
@@ -1046,6 +1048,7 @@ mod server_tests {
             "localhost",
             "http://localhost:3000",
             &trusted,
+            true,
         );
         let resp = builder
             .body(http_body_util::Empty::<hyper::body::Bytes>::new())
@@ -1070,6 +1073,7 @@ mod server_tests {
             "localhost",
             "http://evil.example.com",
             &trusted,
+            true,
         );
         let resp = builder
             .body(http_body_util::Empty::<hyper::body::Bytes>::new())
@@ -1085,12 +1089,33 @@ mod server_tests {
         let trusted = vec![vec!["localhost".to_string()]];
         let builder = hyper::Response::builder();
         let builder =
-            proxy::add_cors_headers_with_host_and_origin(builder, "localhost", "", &trusted);
+            proxy::add_cors_headers_with_host_and_origin(builder, "localhost", "", &trusted, true);
         let resp = builder
             .body(http_body_util::Empty::<hyper::body::Bytes>::new())
             .unwrap();
         let h = resp.headers();
         assert!(!h.contains_key("access-control-allow-origin"));
+    }
+
+    #[test]
+    fn add_cors_headers_when_disabled_omits_all_cors_headers() {
+        let trusted = vec![vec!["localhost".to_string()]];
+        let builder = proxy::add_cors_headers_with_host_and_origin(
+            hyper::Response::builder(),
+            "localhost",
+            "http://localhost:3000",
+            &trusted,
+            false,
+        );
+        let response = builder
+            .body(http_body_util::Empty::<hyper::body::Bytes>::new())
+            .unwrap();
+
+        assert!(!response
+            .headers()
+            .keys()
+            .any(|name| name.as_str().starts_with("access-control-")));
+        assert!(!response.headers().contains_key("vary"));
     }
 
     #[test]
@@ -1108,11 +1133,13 @@ mod server_tests {
             trusted_hosts: vec![vec!["a".to_string()]],
             host: "h".to_string(),
             port: 1,
+            cors_enabled: false,
             enable_server_tool_execution: true,
         };
         let cloned = cfg.clone();
         assert_eq!(cloned.prefix, "/p");
         assert_eq!(cloned.proxy_api_key, "k");
+        assert!(!cloned.cors_enabled);
         assert!(cloned.enable_server_tool_execution);
     }
 

--- a/web-app/src/lib/__tests__/service.test.ts
+++ b/web-app/src/lib/__tests__/service.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const invoke = vi.fn()
+
+vi.mock('@janhq/core', () => ({
+  CoreRoutes: ['startServer'],
+  APIRoutes: [],
+}))
+
+vi.mock('@/hooks/useServiceHub', () => ({
+  getServiceHub: () => ({
+    core: () => ({ invoke }),
+  }),
+}))
+
+vi.mock('@/lib/platform', () => ({
+  isPlatformTauri: () => true,
+}))
+
+import { APIs } from '@/lib/service'
+
+describe('startServer compatibility shim', () => {
+  beforeEach(() => {
+    invoke.mockReset()
+  })
+
+  it('forwards the CORS toggle to the backend config', () => {
+    const startServer = (APIs as Record<string, (args?: unknown) => unknown>)
+      .startServer
+
+    startServer({
+      host: '127.0.0.1',
+      port: 1337,
+      prefix: '/v1',
+      apiKey: '',
+      trustedHosts: ['localhost'],
+      proxyTimeout: 600,
+      isCorsEnabled: false,
+    })
+
+    expect(invoke).toHaveBeenCalledWith('start_server', {
+      config: expect.objectContaining({ cors_enabled: false }),
+    })
+  })
+})

--- a/web-app/src/lib/service.ts
+++ b/web-app/src/lib/service.ts
@@ -99,6 +99,7 @@ export const APIs = {
               api_key: pickString(raw, ['api_key', 'apiKey']),
               trusted_hosts: pickStringArray(raw, ['trusted_hosts', 'trustedHosts']),
               proxy_timeout: pickNumber(raw, ['proxy_timeout', 'proxyTimeout']),
+              cors_enabled: pickBoolean(raw, ['cors_enabled', 'isCorsEnabled']),
               enable_server_tool_execution: pickBoolean(raw, [
                 'enable_server_tool_execution',
                 'enableServerToolExecution',


### PR DESCRIPTION
Fixes #8507

## Summary

- forward the existing UI isCorsEnabled value through the start-server compatibility shim
- default omitted backend values to enabled so existing callers keep their current behavior
- suppress CORS headers for validated preflight, success, and error responses when disabled
- keep the existing Host, requested-method, and requested-header validation paths unchanged

## Before / after

Before: the disabled regression failed because Access-Control-* headers were still present.

After: disabled loopback OPTIONS requests return without CORS headers, while the enabled control still reflects a trusted Origin. The existing toggle UI is unchanged, so there is no visual screenshot delta.

## Validation

- cargo test core::server: 145 passed
- cargo clippy with test-tauri, all targets, and warnings denied: passed
- focused frontend Vitest: 1 passed
- frontend TypeScript no-emit check: passed
- git diff --check: passed