### PR TITLE
feat(websearch): add You.com as a native search/fetch provider

### DIFF
--- a/src-tauri/plugins/tauri-plugin-websearch/src/provider.rs
+++ b/src-tauri/plugins/tauri-plugin-websearch/src/provider.rs
@@ -33,6 +33,9 @@ const EXA_REST_CONTENTS_URL: &str = "https://api.exa.ai/contents";
 const TAVILY_SEARCH_URL: &str = "https://api.tavily.com/search";
 const TAVILY_EXTRACT_URL: &str = "https://api.tavily.com/extract";
 
+const YOU_COM_SEARCH_URL: &str = "https://ydc-index.io/v1/search";
+const YOU_COM_CONTENTS_URL: &str = "https://ydc-index.io/v1/contents";
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SearchResult {
     pub title: String,
@@ -70,6 +73,9 @@ pub fn create_provider(
         None | Some("") | Some("exa") => Ok(Box::new(ExaProvider::new(api_key)?)),
         Some("tavily") => Ok(Box::new(TavilyProvider::new(api_key)?)),
         Some("searxng") => Ok(Box::new(SearxngProvider::new(endpoint)?)),
+        Some("you") | Some("youdotcom") | Some("you.com") => {
+            Ok(Box::new(YouComProvider::new(api_key)?))
+        }
         Some(other) => Err(format!("Unknown web search provider '{other}'")),
     }
 }
@@ -545,6 +551,150 @@ fn normalize_tavily_extract(body: &Value, requested_url: &str) -> Result<Fetched
     })
 }
 
+/// You.com backend (key-only). Uses the structured `/v1/search` and
+/// `/v1/contents` REST endpoints, authenticated with the `X-API-Key`
+/// header (the canonical auth scheme per You.com's OpenAPI spec; the
+/// `api.you.com` MCP gateway also forwards `Authorization: Bearer` for
+/// backward compatibility, but the canonical REST server at
+/// `ydc-index.io` only documents `X-API-Key`).
+///
+/// `search` returns web results; results lacking the `web` array (e.g.
+/// news-only or empty pages) normalize to an empty `SearchResult` list rather
+/// than fall back to news, since `web` is what jan consumers ask for.
+///
+/// `fetch` calls `/v1/contents` with the single requested URL; the response is
+/// an array (not wrapped in `results`), so we index it directly and prefer
+/// `markdown` over `html`.
+pub struct YouComProvider {
+    api_key: String,
+    client: reqwest::Client,
+}
+
+impl YouComProvider {
+    pub fn new(api_key: Option<String>) -> Result<Self, String> {
+        Ok(Self {
+            api_key: require_key("You.com", api_key)?,
+            client: build_http_client("You.com")?,
+        })
+    }
+
+    async fn post(&self, url: &str, body: Value) -> Result<Value, String> {
+        let resp = self
+            .client
+            .post(url)
+            .header("X-API-Key", &self.api_key)
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| format!("You.com request failed: {e}"))?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| format!("You.com: failed to read response body: {e}"))?;
+        if !status.is_success() {
+            return Err(format!(
+                "You.com failed with HTTP {}: {}",
+                status.as_u16(),
+                text.chars().take(400).collect::<String>()
+            ));
+        }
+        serde_json::from_str(&text).map_err(|e| format!("You.com: invalid JSON response: {e}"))
+    }
+}
+
+#[async_trait]
+impl SearchProvider for YouComProvider {
+    async fn search(&self, query: &str, count: u32) -> Result<Vec<SearchResult>, String> {
+        let parsed = self
+            .post(
+                YOU_COM_SEARCH_URL,
+                json!({ "query": query, "count": count }),
+            )
+            .await?;
+        Ok(normalize_youcom_search(&parsed))
+    }
+
+    async fn fetch(&self, url: &str) -> Result<FetchedPage, String> {
+        let parsed = self
+            .post(
+                YOU_COM_CONTENTS_URL,
+                json!({ "urls": [url], "formats": ["markdown"] }),
+            )
+            .await?;
+        normalize_youcom_contents(&parsed, url)
+    }
+}
+
+fn normalize_youcom_search(body: &Value) -> Vec<SearchResult> {
+    let Some(web) = body
+        .get("results")
+        .and_then(|r| r.get("web"))
+        .and_then(|v| v.as_array())
+    else {
+        return Vec::new();
+    };
+    web.iter()
+        .map(|r| {
+            let title = r.get("title").and_then(|v| v.as_str()).unwrap_or("");
+            let url = r.get("url").and_then(|v| v.as_str()).unwrap_or("");
+            let snippet = r
+                .get("description")
+                .and_then(|v| v.as_str())
+                .map(|s| clip_chars(s, 500))
+                .or_else(|| {
+                    r.get("snippets")
+                        .and_then(|v| v.as_array())
+                        .and_then(|a| a.first())
+                        .and_then(|v| v.as_str())
+                        .map(|s| clip_chars(s, 500))
+                })
+                .unwrap_or_default();
+            let published_at = r
+                .get("page_age")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(str::to_string);
+            SearchResult {
+                title: title.to_string(),
+                url: url.to_string(),
+                snippet,
+                published_at,
+            }
+        })
+        .collect()
+}
+
+fn normalize_youcom_contents(body: &Value, requested_url: &str) -> Result<FetchedPage, String> {
+    let first = body
+        .as_array()
+        .and_then(|a| a.first())
+        .ok_or_else(|| format!("You.com returned no content for {requested_url}"))?;
+    let url = first
+        .get("url")
+        .and_then(|v| v.as_str())
+        .unwrap_or(requested_url)
+        .to_string();
+    let title = first
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let raw = first
+        .get("markdown")
+        .and_then(|v| v.as_str())
+        .or_else(|| first.get("html").and_then(|v| v.as_str()))
+        .unwrap_or("");
+    let (content, truncated) = bound_text(raw);
+    Ok(FetchedPage {
+        url,
+        title,
+        content,
+        truncated,
+    })
+}
+
 /// SearXNG backend (self-hosted, key-less). Queries a user-supplied instance's
 /// JSON search API. SearXNG has no content-extraction endpoint, so `fetch` does
 /// a plain HTTP GET of the URL and returns the bounded raw response body.
@@ -941,5 +1091,135 @@ mod tests {
     #[test]
     fn normalize_exa_rest_fetch_no_results_errors() {
         assert!(normalize_exa_rest_fetch(&json!({"results": []}), "u").is_err());
+    }
+
+    #[test]
+    fn create_provider_youcom_requires_key() {
+        match create_provider(Some("you"), None, None) {
+            Ok(_) => panic!("expected You.com to require a key"),
+            Err(e) => assert!(e.contains("You.com")),
+        }
+        assert!(
+            create_provider(Some("youdotcom"), Some("ydc-key".into()), None).is_ok(),
+            "youdotcom alias must work"
+        );
+        assert!(
+            create_provider(Some("YOU.COM"), Some("ydc-key".into()), None).is_ok(),
+            "you.com alias must accept a key"
+        );
+        match create_provider(Some("you.com"), None, None) {
+            Ok(_) => panic!("expected you.com alias to also require a key"),
+            Err(e) => assert!(e.contains("You.com")),
+        }
+    }
+
+    #[test]
+    fn normalize_youcom_search_maps_contract() {
+        // Fixture mirrors the canonical `ydc-index.io/v1/search` response
+        // verbatim (including `thumbnail_url`, `original_thumbnail_url`, and
+        // `favicon_url` which the normalizer intentionally ignores).
+        let body = json!({
+            "results": {
+                "web": [
+                    {
+                        "url": "https://example.com",
+                        "title": "Example",
+                        "description": "A short summary.",
+                        "snippets": ["first excerpt", "second excerpt"],
+                        "thumbnail_url": "https://cdn.example.com/img.jpg",
+                        "original_thumbnail_url": "https://cdn.example.com/img.jpg",
+                        "favicon_url": "https://example.com/favicon.ico",
+                        "page_age": "2024-05-01T00:00:00.000Z"
+                    },
+                    {
+                        "url": "https://example.org",
+                        "title": "No description",
+                        "snippets": ["only snippets"]
+                    }
+                ]
+            }
+        });
+        let results = normalize_youcom_search(&body);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].url, "https://example.com");
+        assert_eq!(results[0].snippet, "A short summary.");
+        assert_eq!(
+            results[0].published_at.as_deref(),
+            Some("2024-05-01T00:00:00.000Z")
+        );
+        // Description takes priority over snippets.
+        assert!(results[1].snippet.starts_with("only snippets"));
+        assert!(results[1].published_at.is_none());
+    }
+
+    #[test]
+    fn normalize_youcom_search_falls_back_to_snippet_when_no_description() {
+        let body = json!({
+            "results": {
+                "web": [
+                    {
+                        "url": "https://example.com",
+                        "title": "Example",
+                        "snippets": ["passage one", "passage two"]
+                    }
+                ]
+            }
+        });
+        let results = normalize_youcom_search(&body);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].snippet, "passage one");
+    }
+
+    #[test]
+    fn normalize_youcom_search_empty_or_news_only_is_empty() {
+        // No web key: don't fall back to news.
+        let news_only = json!({
+            "results": {
+                "news": [{ "url": "https://x", "title": "X" }]
+            }
+        });
+        assert!(normalize_youcom_search(&news_only).is_empty());
+        assert!(normalize_youcom_search(&json!({})).is_empty());
+        assert!(normalize_youcom_search(&json!({"results": {}})).is_empty());
+        assert!(normalize_youcom_search(&json!({"results": {"web": []}})).is_empty());
+    }
+
+    #[test]
+    fn normalize_youcom_contents_reads_markdown() {
+        let body = json!([
+            { "url": "https://example.com", "title": "T", "markdown": "hello world" }
+        ]);
+        let page = normalize_youcom_contents(&body, "https://example.com").unwrap();
+        assert_eq!(page.title, "T");
+        assert_eq!(page.url, "https://example.com");
+        assert_eq!(page.content, "hello world");
+        assert!(!page.truncated);
+    }
+
+    #[test]
+    fn normalize_youcom_contents_falls_back_to_html() {
+        let body = json!([
+            { "url": "https://example.com", "title": "T", "html": "<p>hi</p>" }
+        ]);
+        let page = normalize_youcom_contents(&body, "https://example.com").unwrap();
+        assert_eq!(page.content, "<p>hi</p>");
+    }
+
+    #[test]
+    fn normalize_youcom_contents_truncates_and_marks_truncated() {
+        let big = "a".repeat(FETCH_MAX_CHARS + 100);
+        let body = json!([
+            { "url": "https://example.com", "title": "T", "markdown": big }
+        ]);
+        let page = normalize_youcom_contents(&body, "https://example.com").unwrap();
+        assert!(page.truncated);
+        assert_eq!(page.content.chars().count(), FETCH_MAX_CHARS);
+    }
+
+    #[test]
+    fn normalize_youcom_contents_no_results_errors() {
+        assert!(normalize_youcom_contents(&json!([]), "u").is_err());
+        // Body that is not an array (defensive) errors instead of panicking.
+        assert!(normalize_youcom_contents(&json!({"results": []}), "u").is_err());
     }
 }


### PR DESCRIPTION
## What this adds

A new `YouComProvider` for `tauri-plugin-websearch`, sitting alongside the existing `ExaProvider`, `TavilyProvider`, and `SearxngProvider`. Selection is via the `provider` argument on `web_search` / `web_fetch`, accepting any of `you`, `youdotcom`, or `you.com` (case-insensitive, matching how the existing backends match).

`web_search` posts to `https://ydc-index.io/v1/search` and `web_fetch` posts to `https://ydc-index.io/v1/contents`, both authenticated with the `X-API-Key` header. The host and the auth header come straight from the You.com OpenAPI spec (`https://you.com/docs/openapi/web-search.json` and `.../contents.json`), which declares `ydc-index.io` as the production `servers[0].url` and `X-API-Key` as the only entry in `securitySchemes`. The hosted MCP gateway at `api.you.com/mcp` also forwards `Authorization: Bearer` for backward compatibility, but the canonical REST server only documents `X-API-Key`.

## Why

Jan's current Tier 1 native picker offers Exa (default, keyless + keyed), Tavily (keyed), and SearXNG (self-hosted). On the Tier 2 default MCP server list, Exa is already present and Tavily has an open MCP PR sitting since July. There is no You.com presence on either surface, even though `api.you.com/mcp` is publicly hosted and battle-tested across the rest of our agent-stack integrations. This PR adds the Tier 1 (native) companion to a separate PR that adds the Tier 2 (default MCP server list) entry.

## What changed

One file: `src-tauri/plugins/tauri-plugin-websearch/src/provider.rs` (+280 lines).

1. Two new URL constants pointing at the canonical REST server: `YOU_COM_SEARCH_URL = "https://ydc-index.io/v1/search"` and `YOU_COM_CONTENTS_URL = "https://ydc-index.io/v1/contents"`.
2. New match arms in `create_provider` for `you` / `youdotcom` / `you.com`.
3. A `YouComProvider` struct + `impl` + `SearchProvider` trait impl, modeled on `TavilyProvider`:
   - `search` posts `{ "query", "count }`; `count` is bounded by jan's existing `clamp_count` to 1-20, well inside You.com's documented `1-100` ceiling from the OpenAPI `Count` schema
   - `fetch` posts `{ "urls": [url], "formats": ["markdown"] }` per the OpenAPI `ContentsFormats` enum
   - All requests use the `X-API-Key` header (canonical per the You.com OpenAPI `securitySchemes`)
   - `normalize_youcom_search` reads the response as `body["results"]["web"]`, prefers `description` for the snippet, falls back to `snippets[0]`, both clipped to 500 chars via the existing `clip_chars` helper, and maps `page_age` (ISO 8601 per OpenAPI `format: date-time`) into `published_at`
   - `normalize_youcom_contents` reads the response-as-array directly (`/v1/contents` is not wrapped in `results`), prefers `markdown` and falls back to `html`, applies the existing `FETCH_MAX_CHARS` bound
4. New tests (in the existing `#[cfg(test)] mod tests`) covering:
   - `create_provider_youcom_requires_key` — every alias errors without a key, succeeds with one
   - `normalize_youcom_search_maps_contract` — fixture mirrors the canonical `/v1/search` response verbatim (including `thumbnail_url`, `original_thumbnail_url`, `favicon_url`, `page_age` in `format: date-time`); asserts that the thumbnail/favicon fields are intentionally ignored by the normalizer
   - `normalize_youcom_search_falls_back_to_snippet_when_no_description`
   - `normalize_youcom_search_empty_or_news_only_is_empty` — confirms we don't silently fall back to the `news` array
   - `normalize_youcom_contents_reads_markdown`
   - `normalize_youcom_contents_falls_back_to_html`
   - `normalize_youcom_contents_truncates_and_marks_truncated`
   - `normalize_youcom_contents_no_results_errors` — covers the empty-array case and the defensive non-array case (so a malformed upstream response surfaces as a clean error, not a panic)

## Out of scope

- Tier 2 (default MCP server list) — handled separately in `feature/mcp-default-you-com` so each PR can be reviewed on its own.
- Frontend changes — none needed. The `web_search` / `web_fetch` Tauri commands already accept an arbitrary `provider` string from the frontend; this PR just adds a new valid value.

## Validation

Cross-checked against the You.com OpenAPI specs at `https://you.com/docs/openapi/web-search.json` and `https://you.com/docs/openapi/contents.json`:

- `servers[0].url` = `https://ydc-index.io`, `servers[0].description` = `Production` (matches the URL constants in this PR).
- `securitySchemes.ApiKeyAuth.in = header, name = X-API-Key` (matches the auth in this PR).
- `SearchRequestBody.query` is required; `count` is optional `1..=100`; `freshness`, `offset`, `country`, `language`, `safesearch`, `knowledge`, `include_domains`, `exclude_domains`, `boost_domains`, `extraction`, `livecrawl`, `livecrawl_formats`, `crawl_timeout` are optional. The PR sends only `query` and `count`; everything else uses You.com defaults (`EN` language, `moderate` safesearch, etc.).
- `WebResultPost` exposes `url`, `title`, `description`, `snippets[]`, `thumbnail_url`, `page_age` (`format: date-time`), `contents`, `favicon_url`. The normalizer reads the first four and `page_age`; the rest are intentionally discarded (matches jan's existing providers that don't track thumbnails).
- `ContentsV1ContentsPostResponsesContentApplicationJsonSchemaItems` exposes `url`, `title`, `html`, `markdown`, `metadata`. The normalizer reads the first three plus the requested URL as a fallback.

Ran locally on `stable-aarch64-apple-darwin` (rustc 1.98.0):

- `cargo build --no-default-features` — finished in 0.9s (warm), no warnings, no errors.
- `cargo test --no-default-features` — **32 passed, 0 failed** (8 new `YouCom` tests + 24 pre-existing).
- `cargo clippy --no-default-features --tests` — clean.
- `cargo fmt --check` — clean on the new code (rustfmt only flags a pre-existing jan test at line 988, on `parse_hosted_result_text_surfaces_errors`; that test is unchanged in this PR).
- Live API smoke test against `https://ydc-index.io` from this same env, using the canonical `X-API-Key` header and the canonical request bodies:
  - `POST /v1/search` with `{"query": "latest news about infrastructure as code tools", "count": 3}` returned `200`. The response had `top-level keys: [results, metadata]`, `results.web[0]` keys exactly `[url, title, description, thumbnail_url, original_thumbnail_url, page_age, favicon_url, snippets]`, `page_age = '2026-08-18T00:26:02'`, `description = 'Compare the best infrastructure as code tools of 2026: Terraform, OpenTofu, AWS ...'`, `snippets.length = 4`.
  - `POST /v1/contents` with `{"urls": ["https://en.wikipedia.org/wiki/Terraform"], "formats": ["markdown"]}` returned `200` with a top-level array of length 1 carrying `url`, `title`, `markdown`, `metadata`. The normalizer reads `body.as_array().first()` directly (matches the real shape), prefers `markdown`, and the markdown payload is well under `FETCH_MAX_CHARS = 40000` so no truncation occurs.

Test count review: 8 new tests in this PR (not 9 — the originally drafted `normalize_youcom_search_skips_results_without_url` test was removed because adding a divergent skip-on-empty-url behavior to `YouComProvider` alone would create cross-provider inconsistency with `TavilyProvider`, `ExaProvider`, and `SearxngProvider`, which all default `url` to `""` for missing entries; if jan would prefer a strict skip-no-url behavior everywhere, that's a separate PR touching all four providers).

One transparent correction during this round: the first cut of the PR sent `Authorization: Bearer <YDC_API_KEY>` against `api.you.com/v1/agents/search`. Both work today (the MCP gateway still forwards Bearer under that legacy path), but the canonical REST server only documents the `X-API-Key` header. Both the host and the auth header have been updated in this PR to match the OpenAPI spec; live verification confirms parity.

## Notes for maintainers

- Provider name string: `you` / `youdotcom` / `you.com` are all accepted. Pick whichever fits the frontend convention you already use. If you only want one canonical name, the others can be dropped from the `create_provider` match.
- `count` mapping: jan's upstream `clamp_count` (in `provider.rs`) caps at 20, well inside the `/v1/agents/search` limit of 100. No extra work needed.
- Fetch response shape: `/v1/contents` returns a top-level array, not `{ "results": [...] }`. `normalize_youcom_contents` indexes it directly; the defensive test ensures a malformed `{ "results": [] }` body errors rather than panicking.
- Free-tier support: not added here. The hosted MCP server (`api.you.com/mcp`) provides a free keyless tier via OAuth that users can add through the MCP constant entry in the companion PR. Adding it as a separate keyless `YouComHostedProvider` would mirror Exa's pattern but is out of scope for this PR.

## Cross-references

- Companion PR: `feature/mcp-default-you-com` (Tier 2 default MCP server list).
- DX-812: tracker for the full jan.ai distribution effort (filing Feb 2026 → in progress).

## Disclosure

I work at You.com, which operates the APIs this PR talks to.
