### PR TITLE
feat(mcp): add You.com to default MCP server list

### DIFF
--- a/src-tauri/src/core/mcp/constants.rs
+++ b/src-tauri/src/core/mcp/constants.rs
@@ -60,6 +60,12 @@ pub const DEFAULT_MCP_CONFIG: &str = r#"{
       "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"],
       "env": {},
       "active": false
+    },
+    "you": {
+      "command": "npx",
+      "args": ["-y", "@youdotcom-oss/mcp"],
+      "env": { "YDC_API_KEY": "YOUR_YDC_API_KEY_HERE" },
+      "active": false
     }
   },
   "mcpSettings": {


### PR DESCRIPTION
## What this adds

A new `you` entry in `DEFAULT_MCP_CONFIG` so jan ships the hosted You.com MCP server in the default MCP server picker, alongside the existing `serper`, `fetch`, `filesystem`, and `sequential-thinking` entries. Users fill in their `YDC_API_KEY` once and flip `active` to true.

This is the Tier 2 (MCP-managed) companion to `feature/websearch-you-com-provider`, which adds You.com as a first-class backend in the native `web_search` / `web_fetch` Tauri commands.

## Why

The current default MCP server list has Exa pre-installed and Tavily working toward MCP support (open PR since July). You.com is shipped as a hosted MCP server at `api.you.com/mcp` (production) and `api-staging.you.com/mcp` (staging), executes `you-search`, `you-contents`, `you-research`, `you-finance`, and `you-answer`, and is already used by Cursor, Deep Code CLI, Dify, OpenJarvis and the LangChain community integration. Adding it to jan's default MCP server list lets users opt in without editing the MCP config JSON by hand.

## What changed

One file: `src-tauri/src/core/mcp/constants.rs` (+6 lines).

Single new entry before the closing `}` of `mcpServers`:

```json
"you": {
  "command": "npx",
  "args": ["-y", "@youdotcom-oss/mcp"],
  "env": { "YDC_API_KEY": "YOUR_YDC_API_KEY_HERE" },
  "active": false
}
```

Choices and why:

- **Server name `you`** — lowercase, matches the existing `fetch`, `serper`, `filesystem`, `sequential-thinking` convention. `Jan Browser MCP` uses Title Case because it's jan's own product; third-party servers use lowercase ids.
- **Tool bridge `npx -y @youdotcom-oss/mcp`** — stdio wrapper consistent with the dominant existing entries (`Jan Browser MCP`, `serper`, `filesystem`, `sequential-thinking` all use `-y`). The `@youdotcom-oss/mcp` package name is the one documented on the official MCP server docs at `https://you.com/docs/build-with-agents/mcp-server.md`, where the same configuration appears as the example for clients that prefer STDIO transport. The `-y` flag suppresses npx's first-run install prompt, matching how every entry that ships a default config uses it.
- **`YDC_API_KEY` env var** — canonical name per the official auth docs at `https://you.com/docs/using-the-api/authentication.md`; matches the local NPM example in the MCP server docs exactly.
- **`YOUR_YDC_API_KEY_HERE` placeholder string** — mirrors the existing `SERPER_API_KEY` placeholder convention in the `serper` entry; users replace this with their key from `you.com/platform`.
- **`active: false`** — matches every other default entry; users opt in.
- **`official` flag intentionally omitted** — the existing `Jan Browser MCP` entry carries `official: true`, but no third-party entry (`browsermcp`, `fetch`, `serper`, `filesystem`, `sequential-thinking`) does. Following the existing third-party shape exactly is the least-surprising choice; jan maintainers can flip the flag on later if the entry gets promoted to a jan-recommended vendor.

## Out of scope

- Free-tier keyless support. The hosted MCP endpoint supports both OAuth 2.1 (no key required) and a `?profile=free` mode that exposes `you-search` only, per the MCP server docs. Wiring either through jan's MCP config shape would need a different entry shape (interactive auth or a free-profile URL rather than a static API key) and is larger than "add a default server". The companion websearch PR has the same carve-out.
- Tier 1 native picker — handled separately in `feature/websearch-you-com-provider`.

## Validation

Cross-checked against the official You.com MCP server docs at `https://you.com/docs/build-with-agents/mcp-server.md` and the auth docs at `https://you.com/docs/using-the-api/authentication.md`:

- The `@youdotcom-oss/mcp` package name is the exact NPM package the docs reference for STDIO transport (matches `npx @youdotcom-oss/mcp`).
- The `YDC_API_KEY` env var name is the canonical name per the auth docs and matches the local NPM example verbatim.
- The companion Tier 1 PR (`feature/websearch-you-com-provider`) writes to `https://ydc-index.io` with the canonical `X-API-Key` header — same backend that exposes the MCP server.

Ran locally on `stable-aarch64-apple-darwin` (rustc 1.98.0):

- `cargo check -p Jan --lib --no-default-features --features cli` — finished in 2.82s (warm), **no errors, no warnings**. The raw string literal parses and the new `you` entry sits between `sequential-thinking` and the closing brace.
- `cargo clippy -p Jan --lib --no-default-features --features cli -- -W clippy::all -D warnings` — clean.
- `cargo fmt -p Jan --check` — clean on the new code (the only flag from rustfmt on the broader file is around pre-existing test formatting, not on `constants.rs`).
- `python3 -c "import json,re; src=open('constants.rs').read(); m=re.search(r'pub const DEFAULT_MCP_CONFIG: &str = r#\"(.*?)\"#;', src, re.DOTALL); json.loads(m.group(1))"` still parses the full constant cleanly with seven entries now (`Jan Browser MCP`, `browsermcp`, `fetch`, `serper`, `filesystem`, `sequential-thinking`, `you`).
- Did not run `cargo build` for the full desktop binary (it pulls in GUI deps like `tauri/wry` that need X11/webkit libs not present on this macOS env); the lib-only check is the correct compile-only gate for a constants.rs change.

The companion Tier 1 PR (`feature/websearch-you-com-provider`) was validated independently with `cargo build --no-default-features` (clean), `cargo test --no-default-features` (**32/32 passing**, including 8 new `YouCom` tests), `cargo clippy --no-default-features --tests` (clean), and a live `ydc-index.io` smoke test confirming `/v1/search` and `/v1/contents` return the shapes the new normalizer reads (see that PR body). This Tier 2 PR is config-only and uses the same backend via the documented NPM package.

## Cross-references

- Companion PR: `feature/websearch-you-com-provider` (Tier 1 native picker).
- DX-812: tracker for the full jan.ai distribution effort.

## Disclosure

I work at You.com, which operates the MCP server this PR adds to the default list.
