### PR TITLE
fix(llamacpp): install ggml into lib/ so Fedora lib64 hosts can link

### DIFF
--- a/src-tauri/build-utils/stage-engine.sh
+++ b/src-tauri/build-utils/stage-engine.sh
@@ -71,9 +71,11 @@ stage_lib() {
 exts=("$LIBEXT")
 [ "$MODEXT" = "$LIBEXT" ] || exts+=("$MODEXT")
 
+# lib64 is a fallback for a stale prefix that installed there before
+# CMAKE_INSTALL_LIBDIR=lib was passed (Fedora/RHEL GNUInstallDirs default).
 srcs=()
 for ext in "${exts[@]}"; do
-  srcs+=("$PREFIX"/bin/*."$ext"* "$PREFIX"/lib/libggml*."$ext"*)
+  srcs+=("$PREFIX"/bin/*."$ext"* "$PREFIX"/lib/libggml*."$ext"* "$PREFIX"/lib64/libggml*."$ext"*)
 done
 
 staged=0

--- a/src-tauri/plugins/tauri-plugin-llamacpp/build.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/build.rs
@@ -229,7 +229,17 @@ mod engine {
                 if env::var("CARGO_CFG_TARGET_OS").unwrap_or_default() == "windows" {
                     dirs.extend(ARCHIVE_DIRS.iter().map(|d| llama.join(d).join(CONFIG)));
                 }
-                dirs.push(ggml.join("lib"));
+                // CMAKE_INSTALL_LIBDIR=lib is the intended layout. Fall back to
+                // lib64 for a stale prefix that already installed there
+                // (Fedora/RHEL GNUInstallDirs default).
+                let ggml_lib = ggml.join("lib");
+                if ggml_lib.is_dir() {
+                    dirs.push(ggml_lib);
+                } else if ggml.join("lib64").is_dir() {
+                    dirs.push(ggml.join("lib64"));
+                } else {
+                    dirs.push(ggml_lib);
+                }
                 (dirs, llama, ggml.join("bin"))
             };
 
@@ -387,7 +397,8 @@ mod engine {
             src.join("ggml").display()
         ));
         cfg.arg(format!("-DCMAKE_INSTALL_PREFIX={}", prefix.display()));
-        // Ensure libraries are installed in lib, not in platform specific dirs (e.g. lib64 on Fedora/RHEL).
+        // GNUInstallDirs defaults to lib64 on Fedora/RHEL; link search and
+        // stage-engine.sh both assume lib/.
         cfg.arg("-DCMAKE_INSTALL_LIBDIR=lib");
         cfg.args([
             "-DCMAKE_BUILD_TYPE=Release",


### PR DESCRIPTION
Fixes #8838

On Fedora, cmake/GNUInstallDirs installs ggml into `ggml-prefix/lib64/`, but `build.rs` only adds `lib/` to the linker search path and `stage-engine.sh` only stages `$PREFIX/lib/libggml*`. Linking `jan-llama-worker` then fails with `cannot find -lggml`.

Passed `-DCMAKE_INSTALL_LIBDIR=lib` next to `CMAKE_INSTALL_PREFIX` so Debian and Fedora share the layout the rest of the crate already assumes. `lib64` is still accepted as a fallback in the search path and the staging glob, for a stale prefix that already landed there.

Didn't rebuild the full engine here. The issue's `find` output already shows the libs in `lib64/` while the link line only has `-L.../ggml-prefix/lib`. `bash -n` on `stage-engine.sh` is clean.

thx
