### PR TITLE
fix: enhance CUDA runtime staging and improve ccache for builds

### DIFF
--- a/.github/actions/setup-engine-toolchain/action.yml
+++ b/.github/actions/setup-engine-toolchain/action.yml
@@ -15,8 +15,10 @@ inputs:
     required: true
   ccache-max:
     description: >
-      ccache size limit. 25G rather than the 5G default because CUDA objects are
-      large and a smaller cache thrashes instead of rolling over.
+      ccache size limit on self-hosted runners. 25G rather than the 5G default
+      because CUDA objects are large and a smaller cache thrashes instead of
+      rolling over. GitHub-hosted runners are capped at 2G, the actions/cache
+      upload budget for a Vulkan plus CPU-variant build.
     required: false
     default: '25G'
 
@@ -37,7 +39,11 @@ runs:
         else
           echo "CCACHE_DIR=${HOME}/.ccache" >> "$GITHUB_ENV"
         fi
-        echo "CCACHE_MAXSIZE=${{ inputs.ccache-max }}" >> "$GITHUB_ENV"
+        if [ "$RUNNER_ENVIRONMENT" = "github-hosted" ]; then
+          echo "CCACHE_MAXSIZE=2G" >> "$GITHUB_ENV"
+        else
+          echo "CCACHE_MAXSIZE=${{ inputs.ccache-max }}" >> "$GITHUB_ENV"
+        fi
         echo "CCACHE_NOHASHDIR=1" >> "$GITHUB_ENV"
 
     # GitHub-hosted images have no ccache and no persistent disk.
@@ -55,17 +61,16 @@ runs:
         Windows) choco install ccache -y --no-progress ;;
         esac
 
-    # build.rs holds the llama.cpp pin and cmake flags; the sha suffix makes
-    # every run save, since actions/cache writes only on an exact-key miss.
+    # build.rs holds the llama.cpp pin and cmake flags, so the cache is rebuilt
+    # when they change and an exact hit saves nothing; a per-commit key would
+    # upload on every run and churn the repo's 10 GB quota.
     - name: Restore the ccache directory
       if: runner.environment == 'github-hosted'
       uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: ${{ env.CCACHE_DIR }}
-        key: ccache-${{ runner.os }}-${{ inputs.variant }}-${{ hashFiles('src-tauri/plugins/tauri-plugin-llamacpp/build.rs') }}-${{ github.sha }}
-        restore-keys: |
-          ccache-${{ runner.os }}-${{ inputs.variant }}-${{ hashFiles('src-tauri/plugins/tauri-plugin-llamacpp/build.rs') }}-
-          ccache-${{ runner.os }}-${{ inputs.variant }}-
+        key: ccache-${{ runner.os }}-${{ inputs.variant }}-${{ hashFiles('src-tauri/plugins/tauri-plugin-llamacpp/build.rs') }}
+        restore-keys: ccache-${{ runner.os }}-${{ inputs.variant }}-
 
     # No GitHub-hosted image ships a Vulkan shader compiler, and the desktop
     # templates default to the vulkan variant on one. Guarded on glslc rather

--- a/.github/actions/setup-engine-toolchain/action.yml
+++ b/.github/actions/setup-engine-toolchain/action.yml
@@ -130,6 +130,11 @@ runs:
         fi
 
 
+    # nvcc on Windows accepts only cl as its host compiler and finds it on PATH.
+    - name: Enter the MSVC developer environment for nvcc
+      if: runner.os == 'Windows' && contains(inputs.variant, 'cuda')
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
     # Asserts the image, not the steps above: a mis-provisioned runner fails
     # here in seconds instead of five minutes into `make build`.
     # Stats zeroed so the post-build report covers this build only.

--- a/.github/actions/setup-engine-toolchain/action.yml
+++ b/.github/actions/setup-engine-toolchain/action.yml
@@ -97,10 +97,16 @@ runs:
           sudo apt-get install -y vulkan-sdk
           ;;
         Windows)
-          curl -fL -o "$RUNNER_TEMP/vulkan-sdk.exe" \
-            https://sdk.lunarg.com/sdk/download/latest/windows/vulkan_sdk.exe
-          "$RUNNER_TEMP/vulkan-sdk.exe" --root 'C:\VulkanSDK' \
-            --accept-licenses --default-answer --confirm-command install
+          # A persistent runner keeps the last run's install, and the installer
+          # refuses to install over it.
+          if [ -x /c/VulkanSDK/Bin/glslc.exe ]; then
+            echo "engine toolchain: reusing the Vulkan SDK in C:\VulkanSDK"
+          else
+            curl -fL -o "$RUNNER_TEMP/vulkan-sdk.exe" \
+              https://sdk.lunarg.com/sdk/download/latest/windows/vulkan_sdk.exe
+            "$RUNNER_TEMP/vulkan-sdk.exe" --root 'C:\VulkanSDK' \
+              --accept-licenses --default-answer --confirm-command install
+          fi
           echo 'VULKAN_SDK=C:\VulkanSDK' >> "$GITHUB_ENV"
           echo 'C:\VulkanSDK\Bin' >> "$GITHUB_PATH"
           ;;
@@ -139,6 +145,18 @@ runs:
     - name: Enter the MSVC developer environment for nvcc
       if: runner.os == 'Windows' && contains(inputs.variant, 'cuda')
       uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+
+    # Inside a VS developer environment rustc takes link.exe from PATH, and make
+    # runs its recipes through Git's sh.exe, whose MSYS runtime prepends its own
+    # usr/bin -- where GNU coreutils `link` lives. Pin the linker by full path.
+    - name: Pin cargo's linker to MSVC link.exe
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        if (-not $env:VCToolsInstallDir) { Write-Host "no VS developer environment; rustc locates link.exe itself"; exit 0 }
+        $link = Join-Path $env:VCToolsInstallDir 'bin\Hostx64\x64\link.exe'
+        if (-not (Test-Path $link)) { throw "link.exe not found at $link" }
+        Add-Content $env:GITHUB_ENV "CARGO_TARGET_X86_64_PC_WINDOWS_MSVC_LINKER=$link"
 
     # Asserts the image, not the steps above: a mis-provisioned runner fails
     # here in seconds instead of five minutes into `make build`.

--- a/.github/actions/setup-engine-toolchain/action.yml
+++ b/.github/actions/setup-engine-toolchain/action.yml
@@ -27,9 +27,8 @@ runs:
       shell: bash
       run: echo "JAN_ENGINE_VARIANT=${{ inputs.variant }}" >> "$GITHUB_ENV"
 
-    # The cache lives outside the workspace, which is re-cloned per run. Nothing
-    # is saved or restored through actions/cache: the runner's disk persists, so
-    # a hit costs no upload and survives across workflows.
+    # Outside the workspace, which is re-cloned per run. NOHASHDIR because cmake
+    # runs under cargo's hashed OUT_DIR, which would otherwise key every object.
     - name: Point ccache at the runner's persistent cache
       shell: bash
       run: |
@@ -39,6 +38,34 @@ runs:
           echo "CCACHE_DIR=${HOME}/.ccache" >> "$GITHUB_ENV"
         fi
         echo "CCACHE_MAXSIZE=${{ inputs.ccache-max }}" >> "$GITHUB_ENV"
+        echo "CCACHE_NOHASHDIR=1" >> "$GITHUB_ENV"
+
+    # GitHub-hosted images have no ccache and no persistent disk.
+    - name: Install ccache
+      if: runner.environment == 'github-hosted'
+      shell: bash
+      run: |
+        if command -v ccache >/dev/null 2>&1; then
+          echo "engine toolchain: ccache already on the image"
+          exit 0
+        fi
+        case "$RUNNER_OS" in
+        Linux)   sudo apt-get update && sudo apt-get install -y ccache ;;
+        macOS)   brew install ccache ;;
+        Windows) choco install ccache -y --no-progress ;;
+        esac
+
+    # build.rs holds the llama.cpp pin and cmake flags; the sha suffix makes
+    # every run save, since actions/cache writes only on an exact-key miss.
+    - name: Restore the ccache directory
+      if: runner.environment == 'github-hosted'
+      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+      with:
+        path: ${{ env.CCACHE_DIR }}
+        key: ccache-${{ runner.os }}-${{ inputs.variant }}-${{ hashFiles('src-tauri/plugins/tauri-plugin-llamacpp/build.rs') }}-${{ github.sha }}
+        restore-keys: |
+          ccache-${{ runner.os }}-${{ inputs.variant }}-${{ hashFiles('src-tauri/plugins/tauri-plugin-llamacpp/build.rs') }}-
+          ccache-${{ runner.os }}-${{ inputs.variant }}-
 
     # No GitHub-hosted image ships a Vulkan shader compiler, and the desktop
     # templates default to the vulkan variant on one. Guarded on glslc rather
@@ -105,6 +132,9 @@ runs:
 
     # Asserts the image, not the steps above: a mis-provisioned runner fails
     # here in seconds instead of five minutes into `make build`.
+    # Stats zeroed so the post-build report covers this build only.
     - name: Verify the toolchain
       shell: bash
-      run: make check-engine-toolchain
+      run: |
+        if command -v ccache >/dev/null 2>&1; then ccache -z; fi
+        make check-engine-toolchain

--- a/.github/workflows/engine-build.yml
+++ b/.github/workflows/engine-build.yml
@@ -86,7 +86,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       # The self-hosted CUDA images have Git for Windows off PATH (or absent) and
-      # no make, and every later step (dtolnay's included) is bash.
+      # no make; every later step (dtolnay's included) is bash, and make runs
+      # recipes like `mkdir -p` through the coreutils in Git's usr\bin.
       - name: Provision Git Bash and make on Windows
         if: runner.os == 'Windows'
         shell: pwsh
@@ -96,6 +97,7 @@ jobs:
           }
           Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\cmd'
           Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\bin'
+          Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\usr\bin'
           if (-not (Get-Command make -ErrorAction SilentlyContinue)) {
             choco install make -y --no-progress
             Add-Content $env:GITHUB_PATH 'C:\ProgramData\chocolatey\bin'

--- a/.github/workflows/engine-build.yml
+++ b/.github/workflows/engine-build.yml
@@ -84,6 +84,22 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+      # The self-hosted CUDA images carry neither Git for Windows nor make, and
+      # every later step (dtolnay's included) is bash. No-op on hosted images.
+      - name: Provision Git Bash and make on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          if (-not (Test-Path 'C:\Program Files\Git\bin\bash.exe')) {
+            choco install git -y --no-progress
+            Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\cmd'
+            Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\bin'
+          }
+          if (-not (Get-Command make -ErrorAction SilentlyContinue)) {
+            choco install make -y --no-progress
+            Add-Content $env:GITHUB_PATH 'C:\ProgramData\chocolatey\bin'
+          }
+
       - uses: dtolnay/rust-toolchain@stable
 
       # The plugin depends on tauri, so building its binary needs the GUI

--- a/.github/workflows/engine-build.yml
+++ b/.github/workflows/engine-build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - dev
+      - main
     paths:
       - .github/workflows/engine-build.yml
       - .github/actions/setup-engine-toolchain/action.yml

--- a/.github/workflows/engine-build.yml
+++ b/.github/workflows/engine-build.yml
@@ -97,7 +97,9 @@ jobs:
           }
           Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\cmd'
           Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\bin'
-          Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\usr\bin'
+          # Appended, not prepended: usr\bin also holds GNU link, which must
+          # not shadow MSVC's link.exe for rustc.
+          Add-Content $env:GITHUB_ENV "PATH=$env:PATH;C:\Program Files\Git\usr\bin"
           if (-not (Get-Command make -ErrorAction SilentlyContinue)) {
             choco install make -y --no-progress
             Add-Content $env:GITHUB_PATH 'C:\ProgramData\chocolatey\bin'

--- a/.github/workflows/engine-build.yml
+++ b/.github/workflows/engine-build.yml
@@ -140,6 +140,12 @@ jobs:
       - name: Compile the engine-gated test suites
         run: make check-engine-tests
 
+      - name: Report ccache statistics
+        if: success() || failure()
+        shell: bash
+        run: |
+          if command -v ccache >/dev/null 2>&1; then ccache -s; else echo "ccache not available"; fi
+
       # --version proves the worker starts and resolves libggml through the
       # rpath; --list-devices additionally exercises the shim and the pinned
       # llama.cpp assert. Device enumeration is best-effort because a headless

--- a/.github/workflows/engine-build.yml
+++ b/.github/workflows/engine-build.yml
@@ -84,17 +84,17 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      # The self-hosted CUDA images carry neither Git for Windows nor make, and
-      # every later step (dtolnay's included) is bash. No-op on hosted images.
+      # The self-hosted CUDA images have Git for Windows off PATH (or absent) and
+      # no make, and every later step (dtolnay's included) is bash.
       - name: Provision Git Bash and make on Windows
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           if (-not (Test-Path 'C:\Program Files\Git\bin\bash.exe')) {
             choco install git -y --no-progress
-            Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\cmd'
-            Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\bin'
           }
+          Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\cmd'
+          Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\bin'
           if (-not (Get-Command make -ErrorAction SilentlyContinue)) {
             choco install make -y --no-progress
             Add-Content $env:GITHUB_PATH 'C:\ProgramData\chocolatey\bin'

--- a/.github/workflows/jan-tauri-build-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-nightly.yaml
@@ -87,6 +87,8 @@ jobs:
       channel: nightly
       cortex_api_port: '39261'
 
+  # The CUDA runners are the self-hosted images janhq/llama.cpp builds on; a
+  # cuda variant needs the toolkit at build time and ships Vulkan beside it.
   build-windows-x64:
     uses: ./.github/workflows/template-tauri-build-windows-x64.yml
     secrets: inherit
@@ -98,6 +100,8 @@ jobs:
       new_version: ${{ needs.get-update-version.outputs.new_version }}
       channel: nightly
       cortex_api_port: '39261'
+      runner: windows-cuda-13-0
+      engine_variant: cuda13-vulkan
   build-linux-x64:
     uses: ./.github/workflows/template-tauri-build-linux-x64.yml
     secrets: inherit
@@ -110,6 +114,8 @@ jobs:
       channel: nightly
       cortex_api_port: '39261'
       disable_updater: ${{ github.event.inputs.disable_updater == 'true' }}
+      runner: ubuntu-22-04-cuda-13-0
+      engine_variant: cuda13-vulkan
 
   sync-temp-to-latest:
     needs:

--- a/.github/workflows/template-tauri-build-linux-x64.yml
+++ b/.github/workflows/template-tauri-build-linux-x64.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Install Tauri dependencies
         run: |
           sudo apt update
-          sudo apt install -y libglib2.0-dev libatk1.0-dev libpango1.0-dev libgtk-3-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev librsvg2-dev libfuse2 libappindicator3-dev xdg-utils
+          sudo apt install -y libglib2.0-dev libatk1.0-dev libpango1.0-dev libgtk-3-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev librsvg2-dev libfuse2 libappindicator3-dev xdg-utils pkg-config file desktop-file-utils
 
       # `make build` compiles jan-llama-worker, which the deb and the AppImage
       # both bundle. The default variant is vulkan because it covers AMD, Intel
@@ -217,10 +217,7 @@ jobs:
           --password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" \
           "$APP_IMAGE"
 
-        # linuxdeploy is an AppImage; a runner container without FUSE cannot
-        # mount it, and tauri reports only `failed to run linuxdeploy`.
         env:
-          APPIMAGE_EXTRACT_AND_RUN: '1'
           RELEASE_CHANNEL: '${{ inputs.channel }}'
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
@@ -240,9 +237,8 @@ jobs:
       # Publish app
 
       # tauri reports a linuxdeploy failure as `failed to run linuxdeploy` and
-      # discards its output, so ask the tool itself. `--version` alone separates
-      # the two candidates: a tool that cannot run at all is an AppImage that
-      # could not mount, anything else is the AppDir it was handed.
+      # discards its output, so re-run the exact command it ran (bundler
+      # linux/appimage/linuxdeploy.rs) and let the tool speak.
       - name: Diagnose the AppImage bundler
         if: failure()
         run: |
@@ -253,9 +249,10 @@ jobs:
           appdir=$(ls -d src-tauri/target/release/bundle/appimage/*.AppDir 2>/dev/null | head -1)
           [ -n "$appdir" ] || { echo "no AppDir left behind; the build failed before bundling"; exit 0; }
           echo "--- engine binaries tauri staged into the AppDir"
-          find "$appdir" \( -name '*.so*' -o -name 'jan-llama-worker' \) | head -40
-          echo "--- linuxdeploy over that AppDir"
-          "$tool" --appdir "$appdir" || true
+          find "$appdir" \( -name 'libggml*' -o -name 'libcu*' -o -name 'jan-llama-worker' \) | head -40
+          echo "--- tauri's linuxdeploy command over that AppDir"
+          OUTPUT="$PWD/diagnose.AppImage" ARCH=x86_64 PATH="$PWD/.cache/tauri:$PATH" \
+            "$tool" --appimage-extract-and-run --appdir "$appdir" --plugin gtk --output appimage || echo "exit $?"
         env:
           APPIMAGE_EXTRACT_AND_RUN: '1'
 

--- a/.github/workflows/template-tauri-build-linux-x64.yml
+++ b/.github/workflows/template-tauri-build-linux-x64.yml
@@ -225,6 +225,13 @@ jobs:
           AUTO_UPDATER_DISABLED: ${{ inputs.disable_updater && 'true' || 'false' }}
           JAN_SIGNING_KEY: ${{ secrets.JAN_SIGNING_KEY }}
           TAURI_TRAY: libappindicator3
+
+      - name: Report ccache statistics
+        if: success() || failure()
+        shell: bash
+        run: |
+          if command -v ccache >/dev/null 2>&1; then ccache -s; else echo "ccache not available"; fi
+
       # Publish app
 
       # tauri reports a linuxdeploy failure as `failed to run linuxdeploy` and

--- a/.github/workflows/template-tauri-build-linux-x64.yml
+++ b/.github/workflows/template-tauri-build-linux-x64.yml
@@ -217,7 +217,10 @@ jobs:
           --password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" \
           "$APP_IMAGE"
 
+        # linuxdeploy is an AppImage; a runner container without FUSE cannot
+        # mount it, and tauri reports only `failed to run linuxdeploy`.
         env:
+          APPIMAGE_EXTRACT_AND_RUN: '1'
           RELEASE_CHANNEL: '${{ inputs.channel }}'
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}

--- a/.github/workflows/template-tauri-build-linux-x64.yml
+++ b/.github/workflows/template-tauri-build-linux-x64.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Install Tauri dependencies
         run: |
           sudo apt update
-          sudo apt install -y libglib2.0-dev libatk1.0-dev libpango1.0-dev libgtk-3-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev librsvg2-dev libfuse2 libappindicator3-dev
+          sudo apt install -y libglib2.0-dev libatk1.0-dev libpango1.0-dev libgtk-3-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev librsvg2-dev libfuse2 libappindicator3-dev xdg-utils
 
       # `make build` compiles jan-llama-worker, which the deb and the AppImage
       # both bundle. The default variant is vulkan because it covers AMD, Intel

--- a/.github/workflows/template-tauri-build-linux-x64.yml
+++ b/.github/workflows/template-tauri-build-linux-x64.yml
@@ -112,6 +112,8 @@ jobs:
       - name: Install jq
         uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
 
+      - uses: dtolnay/rust-toolchain@stable
+
       - name: Install ctoml
         run: |
           cargo install ctoml

--- a/.github/workflows/template-tauri-build-macos.yml
+++ b/.github/workflows/template-tauri-build-macos.yml
@@ -222,6 +222,12 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           JAN_SIGNING_KEY: ${{ secrets.JAN_SIGNING_KEY }}
 
+      - name: Report ccache statistics
+        if: success() || failure()
+        shell: bash
+        run: |
+          if command -v ccache >/dev/null 2>&1; then ccache -s; else echo "ccache not available"; fi
+
       # The engine build is fifteen minutes of cmake whose output cargo only
       # surfaces as a tail. When it fails, the whole log is the artifact worth
       # having.

--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -97,17 +97,17 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      # The self-hosted CUDA images carry neither Git for Windows nor make, and
-      # every later step (dtolnay's included) is bash. No-op on hosted images.
+      # The self-hosted CUDA images have Git for Windows off PATH (or absent) and
+      # no make, and every later step (dtolnay's included) is bash.
       - name: Provision Git Bash and make on Windows
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
           if (-not (Test-Path 'C:\Program Files\Git\bin\bash.exe')) {
             choco install git -y --no-progress
-            Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\cmd'
-            Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\bin'
           }
+          Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\cmd'
+          Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\bin'
           if (-not (Get-Command make -ErrorAction SilentlyContinue)) {
             choco install make -y --no-progress
             Add-Content $env:GITHUB_PATH 'C:\ProgramData\chocolatey\bin'
@@ -126,6 +126,8 @@ jobs:
 
       - name: Install jq
         uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
+
+      - uses: dtolnay/rust-toolchain@stable
 
       - name: Install ctoml
         run: |

--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -98,8 +98,9 @@ jobs:
           ref: ${{ inputs.ref }}
 
       # The self-hosted CUDA images have Git for Windows off PATH (or absent) and
-      # no make, and every later step (dtolnay's included) is bash.
-      - name: Provision Git Bash and make on Windows
+      # no make; every later step (dtolnay's included) is bash, and make runs
+      # recipes like `mkdir -p` through the coreutils in Git's usr\bin.
+      - name: Provision Git Bash, make and dotnet on Windows
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
@@ -108,9 +109,15 @@ jobs:
           }
           Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\cmd'
           Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\bin'
+          Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\usr\bin'
           if (-not (Get-Command make -ErrorAction SilentlyContinue)) {
             choco install make -y --no-progress
             Add-Content $env:GITHUB_PATH 'C:\ProgramData\chocolatey\bin'
+          }
+          if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+            choco install dotnet-8.0-sdk -y --no-progress
+            Add-Content $env:GITHUB_PATH 'C:\Program Files\dotnet'
+            Add-Content $env:GITHUB_PATH "$env:USERPROFILE\.dotnet\tools"
           }
 
       - name: Replace Icons for Beta Build

--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -212,6 +212,10 @@ jobs:
               new_build_version="${base_version}.${t_value}"
           }
           generate_build_version ${{ inputs.new_version }}
+          # The template's File paths are absolute; the workspace differs between
+          # hosted (D:\a\jan\jan) and self-hosted (C:\w\jan\jan) runners.
+          ws='${{ github.workspace }}'
+          sed -i "s|jan_workspace|${ws//\\/\\\\}|g" ./src-tauri/tauri.bundle.windows.nsis.template
           sed -i "s/jan_version/$new_base_version/g" ./src-tauri/tauri.bundle.windows.nsis.template
           sed -i "s/jan_build/$new_build_version/g" ./src-tauri/tauri.bundle.windows.nsis.template
 

--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -117,8 +117,8 @@ jobs:
           if (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
             choco install dotnet-8.0-sdk -y --no-progress
             Add-Content $env:GITHUB_PATH 'C:\Program Files\dotnet'
-            Add-Content $env:GITHUB_PATH "$env:USERPROFILE\.dotnet\tools"
           }
+          Add-Content $env:GITHUB_PATH "$env:USERPROFILE\.dotnet\tools"
 
       - name: Replace Icons for Beta Build
         if: inputs.channel != 'stable'
@@ -259,9 +259,13 @@ jobs:
           echo "---------nsis.template---------"
           cat ./src-tauri/tauri.bundle.windows.nsis.template
 
+      # A persistent runner may already carry a newer AzureSignTool, and
+      # installing an older version over it is an error.
       - name: Install AzureSignTool
         run: |
-          dotnet tool install --global --version 6.0.0 AzureSignTool
+          if (-not (Get-Command AzureSignTool -ErrorAction SilentlyContinue)) {
+            dotnet tool install --global --version 6.0.0 AzureSignTool
+          }
 
       - name: Config Yarn
         run: |

--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -276,6 +276,12 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           JAN_SIGNING_KEY: ${{ secrets.JAN_SIGNING_KEY }}
 
+      - name: Report ccache statistics
+        if: success() || failure()
+        shell: bash
+        run: |
+          if command -v ccache >/dev/null 2>&1; then ccache -s; else echo "ccache not available"; fi
+
       # The engine build is fifteen minutes of cmake whose output cargo only
       # surfaces as a tail. When it fails, the whole log is the artifact worth
       # having.

--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -109,7 +109,9 @@ jobs:
           }
           Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\cmd'
           Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\bin'
-          Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\usr\bin'
+          # Appended, not prepended: usr\bin also holds GNU link, which must
+          # not shadow MSVC's link.exe for rustc.
+          Add-Content $env:GITHUB_ENV "PATH=$env:PATH;C:\Program Files\Git\usr\bin"
           if (-not (Get-Command make -ErrorAction SilentlyContinue)) {
             choco install make -y --no-progress
             Add-Content $env:GITHUB_PATH 'C:\ProgramData\chocolatey\bin'

--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -97,6 +97,22 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
+      # The self-hosted CUDA images carry neither Git for Windows nor make, and
+      # every later step (dtolnay's included) is bash. No-op on hosted images.
+      - name: Provision Git Bash and make on Windows
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          if (-not (Test-Path 'C:\Program Files\Git\bin\bash.exe')) {
+            choco install git -y --no-progress
+            Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\cmd'
+            Add-Content $env:GITHUB_PATH 'C:\Program Files\Git\bin'
+          }
+          if (-not (Get-Command make -ErrorAction SilentlyContinue)) {
+            choco install make -y --no-progress
+            Add-Content $env:GITHUB_PATH 'C:\ProgramData\chocolatey\bin'
+          }
+
       - name: Replace Icons for Beta Build
         if: inputs.channel != 'stable'
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -327,6 +327,12 @@ JAN_ENGINE_VULKAN_FALLBACK ?= 1
 JAN_ENGINE_CUDA_ARCHS ?=
 export JAN_ENGINE_CUDA_ARCHS
 
+# Overrides the AMD GPUs a HIP build targets (cmake GPU_TARGETS). Empty means
+# the list build.rs carries over from the previous engine's releases:
+#     make build-engine JAN_ENGINE_VARIANT=rocm JAN_ENGINE_HIP_TARGETS=gfx1100
+JAN_ENGINE_HIP_TARGETS ?=
+export JAN_ENGINE_HIP_TARGETS
+
 # One token to one cargo feature. `engine` alone is the CPU-only worker, and it
 # is implied by every other feature, so `cpu` maps to it and the GPU tokens do
 # not have to name it.

--- a/extensions/llamacpp-extension/src/preset.test.ts
+++ b/extensions/llamacpp-extension/src/preset.test.ts
@@ -810,3 +810,53 @@ describe('generatePreset spec type', () => {
     )
   })
 })
+
+describe('threadCacheDir separator handling', () => {
+  const WIN_EXT = '\\\\?\\C:\\Users\\u\\AppData\\Roaming\\Jan-nightly\\data\\llamacpp'
+
+  it('joins a POSIX path with a forward slash', () => {
+    expect(threadCacheDir('/p')).toBe('/p/thread-cache')
+    expect(threadCacheDir('/home/u/.local/share/Jan/data/llamacpp')).toBe(
+      '/home/u/.local/share/Jan/data/llamacpp/thread-cache'
+    )
+  })
+
+  it('joins a Windows extended path with a backslash', () => {
+    // Win32 normalizes `/` to `\` for ordinary paths but not for `\\?\` ones,
+    // where a `/` is a literal name character -- so create_dir_all fails with
+    // ERROR_INVALID_NAME (os error 123) and the worker exits 7 before serving.
+    expect(threadCacheDir(WIN_EXT)).toBe(`${WIN_EXT}\\thread-cache`)
+    expect(threadCacheDir(WIN_EXT)).not.toContain('/')
+  })
+
+  it('joins a plain Windows path with a backslash', () => {
+    expect(threadCacheDir('C:\\Users\\u\\llamacpp')).toBe(
+      'C:\\Users\\u\\llamacpp\\thread-cache'
+    )
+  })
+
+  it('does not read a backslash in a POSIX name as a Windows separator', () => {
+    // `\` is a legal filename character on Linux, so the separator follows the
+    // path's root rather than whether a backslash appears anywhere in it.
+    expect(threadCacheDir('/home/u/od\\d/llamacpp')).toBe(
+      '/home/u/od\\d/llamacpp/thread-cache'
+    )
+  })
+
+  it('does not double an existing trailing separator', () => {
+    expect(threadCacheDir('/p/')).toBe('/p/thread-cache')
+    expect(threadCacheDir('C:\\p\\')).toBe('C:\\p\\thread-cache')
+  })
+
+  it('is the one definition the preset and the erase path both use', async () => {
+    // index.ts's forgetThreadCache passes threadCacheDir(providerPath) as
+    // cacheDir, and llama.cpp joins state file names onto slot-save-path, so a
+    // preset that derived the directory differently would erase from a
+    // directory the worker never wrote to.
+    await generatePreset(WIN_EXT, 'C:\\jan', CONFIG)
+    const ini = Object.entries(writtenFiles).find(([p]) =>
+      p.endsWith('router.preset.ini')
+    )?.[1] as string
+    expect(ini).toContain(`slot-save-path = ${threadCacheDir(WIN_EXT)}`)
+  })
+})

--- a/extensions/llamacpp-extension/src/preset.ts
+++ b/extensions/llamacpp-extension/src/preset.ts
@@ -87,7 +87,22 @@ export const DEFAULT_EMBEDDING_UBATCH = 2048
  * definition.
  */
 export function threadCacheDir(providerPath: string): string {
-  return `${providerPath}/thread-cache`
+  const sep = isWindowsPath(providerPath) ? '\\' : '/'
+  return `${providerPath.replace(/[\\/]+$/, '')}${sep}thread-cache`
+}
+
+/**
+ * Whether a path is rooted the Windows way: a drive letter, a UNC share, or an
+ * extended `\\?\` prefix.
+ *
+ * Tested on the root rather than on "contains a backslash" because `\` is a
+ * legal filename character on Linux. Win32 normalizes `/` to `\` for the first
+ * two, but *not* for an extended path, where a `/` is a literal name character
+ * -- `create_dir_all` then fails with ERROR_INVALID_NAME and the worker exits
+ * before it serves anything.
+ */
+function isWindowsPath(p: string): boolean {
+  return /^(?:[A-Za-z]:|\\\\)/.test(p)
 }
 
 // Fallback context size when the user hasn't set one, to avoid loading a

--- a/extensions/llamacpp-extension/src/test/index.test.ts
+++ b/extensions/llamacpp-extension/src/test/index.test.ts
@@ -41,6 +41,7 @@ vi.mock('@janhq/tauri-plugin-llamacpp-api', async () => {
       models_max: 1,
     }),
     engineDevices: vi.fn().mockResolvedValue([]),
+    eraseThreadSlotState: vi.fn().mockResolvedValue(0),
   }
 })
 
@@ -1268,5 +1269,46 @@ describe('embedding readiness during the first-run fetch', () => {
     expect(report.status).toBe('warning')
     expect(report.pending).toBeUndefined()
     expect(report.error).toContain('no embedder')
+  })
+})
+
+describe('forgetThreadCache', () => {
+  let extension: llamacpp_extension
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    extension = new llamacpp_extension('http://localhost', 'llamacpp')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // The worker resolves state file names against slot-save-path, so erasing
+  // has to name the very directory the preset named. On Windows the provider
+  // path is extended (`\\?\C:\...`), where a `/` is a literal name character
+  // rather than a separator.
+  it('erases from the directory the preset names, on a Windows provider path', async () => {
+    const { getJanDataFolderPath, joinPath } = await import('@janhq/core')
+    const { eraseThreadSlotState } = await import(
+      '@janhq/tauri-plugin-llamacpp-api'
+    )
+    const { threadCacheDir } = await import('../preset')
+    const providerPath = '\\\\?\\C:\\Users\\u\\AppData\\Roaming\\Jan-nightly\\data\\llamacpp'
+
+    vi.mocked(getJanDataFolderPath).mockResolvedValue(
+      '\\\\?\\C:\\Users\\u\\AppData\\Roaming\\Jan-nightly\\data'
+    )
+    vi.mocked(joinPath).mockResolvedValue(providerPath)
+
+    await extension.forgetThreadCache('t1')
+
+    expect(eraseThreadSlotState).toHaveBeenCalledWith({
+      threadId: 't1',
+      cacheDir: threadCacheDir(providerPath),
+    })
+    expect(
+      vi.mocked(eraseThreadSlotState).mock.calls[0][0].cacheDir
+    ).not.toContain('/')
   })
 })

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -7587,6 +7587,7 @@ dependencies = [
  "tauri-plugin-hardware",
  "thiserror 2.0.18",
  "tokio",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/src-tauri/build-utils/check-engine-toolchain.sh
+++ b/src-tauri/build-utils/check-engine-toolchain.sh
@@ -42,7 +42,13 @@ if has_token hip || has_token rocm; then
     echo "error: JAN_ENGINE_VARIANT=$VARIANT needs hipcc on PATH (install ROCm)" >&2
     exit 1
   }
-  echo "engine toolchain: hipcc found"
+  rocm="${ROCM_PATH:-${HIP_PATH:-/opt/rocm}}"
+  [ -f "$rocm/include/rocwmma/rocwmma.hpp" ] || {
+    echo "error: the hip backend builds with GGML_HIP_ROCWMMA_FATTN and needs rocwmma-dev" >&2
+    echo "       (no $rocm/include/rocwmma/rocwmma.hpp; set ROCM_PATH if ROCm lives elsewhere)" >&2
+    exit 1
+  }
+  echo "engine toolchain: hipcc and rocwmma found"
 fi
 
 command -v cmake >/dev/null 2>&1 || {

--- a/src-tauri/build-utils/check-engine-toolchain.sh
+++ b/src-tauri/build-utils/check-engine-toolchain.sh
@@ -65,10 +65,14 @@ MINGW* | MSYS* | CYGWIN*)
     echo "error: the engine build needs clang on PATH on Windows (install LLVM)" >&2
     exit 1
   }
-  command -v cl >/dev/null 2>&1 || {
+  if ! command -v cl >/dev/null 2>&1; then
+    if [ -n "$want" ]; then
+      echo "error: nvcc needs cl on PATH on Windows; run from a Visual Studio developer prompt" >&2
+      exit 1
+    fi
     echo "warning: cl is not on PATH; run from a Visual Studio developer prompt" >&2
     echo "         if the build cannot find the MSVC headers and libraries." >&2
-  }
+  fi
   echo "engine toolchain: ninja and clang found"
   ;;
 esac

--- a/src-tauri/build-utils/sign-engine.sh
+++ b/src-tauri/build-utils/sign-engine.sh
@@ -60,6 +60,13 @@ MINGW* | MSYS* | CYGWIN*)
     signed=$((signed + 1))
   done
   [ "$signed" -gt 0 ] || give_up "no engine binaries in $DEST to sign."
+  # The CUDA runtime ships under NVIDIA's own Authenticode signature; re-signing
+  # would replace it, so it is verified rather than signed.
+  for target in "$DEST"/cudart64_*.dll "$DEST"/cublas*.dll; do
+    [ -f "$target" ] || continue
+    status=$(powershell -NoProfile -Command "(Get-AuthenticodeSignature '$target').Status" | tr -d '\r')
+    [ "$status" = "Valid" ] || give_up "$(basename "$target") has no valid Authenticode signature ($status)."
+  done
   echo "Signed $signed engine binaries"
   ;;
 esac

--- a/src-tauri/build-utils/stage-engine.sh
+++ b/src-tauri/build-utils/stage-engine.sh
@@ -1,40 +1,17 @@
 #!/usr/bin/env bash
-# Stages the llama.cpp engine worker and the ggml runtime it needs into
-# src-tauri/resources/bin, which is what tauri.<os>.conf.json bundles.
-#
-# The ggml compute backends are MODULE libraries loaded by name at runtime, and
-# ggml resolves them against the *executable's own directory*
-# (ggml/src/ggml-backend-reg.cpp: search paths are GGML_BACKEND_DIR, then the
-# exe dir, then the cwd). So they have to sit next to jan-llama-worker, not
-# merely somewhere in the bundle. libggml/libggml-base are ordinary shared
-# libraries found via the rpath ($ORIGIN / @loader_path) build.rs emits, which
-# resolves to the same directory.
-#
-# A CUDA module additionally links the toolkit's cudart/cublas/cublasLt at
-# load time, and nothing on a user's machine provides those (the driver ships
-# libcuda only). They are copied out of the build host's toolkit beside the
-# module, so the bundle's tauri.<os>.conf.json globs are lib*.so* / *.dll rather
-# than libggml*: a Vulkan-only bundle has no cudart to match, and the bundler
-# treats a glob with zero matches as an error.
+# Stages jan-llama-worker and the ggml runtime into src-tauri/resources/bin.
+# Backend modules must sit beside the worker: ggml searches the exe directory
+# (ggml-backend-reg.cpp), and libggml/libggml-base resolve via $ORIGIN.
 set -euo pipefail
 
-# Positional first: cmd.exe has no `VAR=value command` prefix, so the Windows
-# recipes pass the profile as an argument. The env var stays for callers that
-# already set it.
+# Positional first: cmd.exe has no `VAR=value command` prefix.
 PROFILE="${1:-${JAN_ENGINE_PROFILE:-release}}"
 PLUGIN_DIR="src-tauri/plugins/tauri-plugin-llamacpp"
 TARGET_DIR="${CARGO_TARGET_DIR:-$PLUGIN_DIR/target}/$PROFILE"
 DEST="src-tauri/resources/bin"
 
-# Two extensions, not one. The core libraries (libggml, libggml-base) are
-# SHARED, but under GGML_BACKEND_DL every compute backend is a CMake MODULE
-# library -- and CMake gives a MODULE the `.so` suffix on macOS too, which is
-# also the only extension ggml's own loader looks for there
-# (ggml/src/ggml-backend-reg.cpp: backend_filename_extension() is `.dll` on
-# Windows and `.so` everywhere else, with no __APPLE__ case). Staging only
-# `.dylib` on Darwin therefore ships the two core libraries and not one single
-# backend, so Metal and every CPU variant go missing silently -- the loader runs
-# with silent=true under NDEBUG.
+# MODULE libraries are `.so` on macOS too, and that is the only extension
+# ggml's loader looks for there (no __APPLE__ case in backend_filename_extension).
 case "$(uname -s)" in
   MINGW*|MSYS*|CYGWIN*) EXE=".exe"; LIBEXT="dll";   MODEXT="dll" ;;
   Darwin)               EXE="";     LIBEXT="dylib"; MODEXT="so"  ;;
@@ -49,34 +26,26 @@ fi
 
 mkdir -p "$DEST"
 
-# The bundle globs take whatever sits in DEST, so a module or runtime left by
-# an earlier variant's staging would ship with this one.
-purge_stale() {
-  find "$DEST" -maxdepth 1 \( -name 'libggml*' -o -name 'ggml*.dll' \
-    -o -name 'libcudart.so*' -o -name 'libcublas*.so*' \
-    -o -name 'cudart64_*.dll' -o -name 'cublas*.dll' \) -exec rm -f {} +
-}
-purge_stale
+# The bundle globs ship whatever is in DEST, including an earlier variant's leftovers.
+find "$DEST" -maxdepth 1 \( -name 'libggml*' -o -name 'ggml*.dll' \
+  -o -name 'libcudart.so*' -o -name 'libcublas*.so*' \
+  -o -name 'cudart64_*.dll' -o -name 'cublas*.dll' \) -exec rm -f {} +
 
 install -m755 "$WORKER" "$DEST/jan-llama-worker$EXE"
 echo "stage-engine: staged jan-llama-worker$EXE"
 
-# Newest match only, so a stale artefact from an earlier variant is never
-# picked.
 newest() {
   find "$TARGET_DIR/build" -maxdepth 3 "$@" -print0 2>/dev/null \
     | xargs -0 -r ls -dt 2>/dev/null | head -1 || true
 }
 
-# build.rs normally installs the ggml prefix under the build script's OUT_DIR,
-# but on Windows it relocates the cmake trees out of the target tree when
-# OUT_DIR is too close to MAX_PATH. It records the root it chose in OUT_DIR.
+# On Windows build.rs may relocate the cmake trees out of OUT_DIR (MAX_PATH)
+# and leave the chosen root in a marker file.
 PREFIX="$(newest -type d -name ggml-prefix)"
 if [ -z "$PREFIX" ]; then
   MARKER="$(newest -type f -name engine-build-root.txt)"
   if [ -n "$MARKER" ]; then
     ROOT="$(tr -d '\r\n' < "$MARKER")"
-    # The marker holds a native path; under Git Bash that is `C:\...`.
     if command -v cygpath >/dev/null 2>&1; then
       ROOT="$(cygpath -u "$ROOT")"
     fi
@@ -91,10 +60,14 @@ if [ -z "$PREFIX" ]; then
   exit 1
 fi
 
-# Backend modules live in bin/, the core libraries in lib/ (see build.rs).
-#
-# Only Darwin has two distinct extensions; elsewhere a second glob over the same
-# suffix would list every file twice.
+# cp -P keeps the libggml.so -> .so.0 -> .so.0.N.0 soname chain as links.
+stage_lib() {
+  local name
+  name="$(basename "$1")"
+  cp -Pf "$1" "$DEST/$name"
+  [ -L "$1" ] || chmod 644 "$DEST/$name"
+}
+
 exts=("$LIBEXT")
 [ "$MODEXT" = "$LIBEXT" ] || exts+=("$MODEXT")
 
@@ -103,22 +76,16 @@ for ext in "${exts[@]}"; do
   srcs+=("$PREFIX"/bin/*."$ext"* "$PREFIX"/lib/libggml*."$ext"*)
 done
 
-# cp -P, not install: cmake ships libggml.so -> .so.0 -> .so.0.21.0 as symlinks,
-# and `install` dereferences them, writing three full copies of every core
-# library. Preserving the links keeps the soname chain the loader expects and
-# stops the bundle carrying the same bytes three times.
 staged=0
 modules=0
 cuda_module=""
 for src in "${srcs[@]}"; do
   [ -e "$src" ] || [ -L "$src" ] || continue
-  name="$(basename "$src")"
-  cp -Pf "$src" "$DEST/$name"
-  [ -L "$src" ] || chmod 644 "$DEST/$name"
+  stage_lib "$src"
   staged=$((staged + 1))
-  case "$name" in
+  case "$(basename "$src")" in
     libggml.*|libggml-base.*|ggml.dll|ggml-base.dll) ;;
-    libggml-cuda.*|ggml-cuda.dll) modules=$((modules + 1)); cuda_module="$DEST/$name" ;;
+    libggml-cuda.*|ggml-cuda.dll) modules=$((modules + 1)); cuda_module="$DEST/$(basename "$src")" ;;
     *) modules=$((modules + 1)) ;;
   esac
 done
@@ -128,9 +95,7 @@ if [ "$staged" -eq 0 ]; then
   exit 1
 fi
 
-# Asserted, not merely printed: the two core libraries alone make `staged`
-# non-zero, so a run that staged no backend module at all would otherwise pass
-# the check above and ship an app with no compute backend to load.
+# The two core libraries alone make `staged` non-zero.
 if [ "$modules" -eq 0 ]; then
   echo "stage-engine: staged $staged ggml libraries but no backend module" >&2
   echo "stage-engine: expected *.$MODEXT MODULE libraries in $PREFIX/bin" >&2
@@ -141,15 +106,13 @@ echo "stage-engine: staged $staged ggml libraries ($modules backend modules) int
 
 [ -n "$cuda_module" ] || exit 0
 
-# The toolkit that compiled the module is the one to ship from: its runtime
-# major matches by construction. CUDA_PATH is what the Windows installer sets,
-# CUDA_HOME the usual Linux spelling, nvcc's parent the fallback for both.
+# The runtime comes from the toolkit that compiled the module, so the major
+# matches by construction.
 cuda_root() {
-  local d
+  local d nvcc
   for d in "${CUDA_PATH:-}" "${CUDA_HOME:-}"; do
     if [ -n "$d" ] && [ -d "$d" ]; then echo "$d"; return 0; fi
   done
-  local nvcc
   nvcc="$(command -v nvcc 2>/dev/null || true)"
   [ -n "$nvcc" ] || return 1
   (cd "$(dirname "$nvcc")/.." && pwd)
@@ -157,13 +120,12 @@ cuda_root() {
 
 ROOT="$(cuda_root)" || {
   echo "stage-engine: staged $(basename "$cuda_module") but found no CUDA toolkit" >&2
-  echo "stage-engine: set CUDA_PATH/CUDA_HOME or put nvcc on PATH to stage its runtime" >&2
+  echo "stage-engine: set CUDA_PATH/CUDA_HOME or put nvcc on PATH" >&2
   exit 1
 }
 
-# CUDA 13 moved the Windows DLLs from bin/ to bin/x64/. On Linux lib64 is a
-# symlink to targets/<arch>/lib, so the first directory that holds cudart wins
-# rather than copying the same files twice.
+# CUDA 13 moved the Windows DLLs to bin/x64. lib64 is a symlink to
+# targets/<arch>/lib, so only the first directory holding cudart is used.
 if [ "$LIBEXT" = "dll" ]; then
   candidates=("$ROOT/bin/x64" "$ROOT/bin")
   runtime_globs=('cudart64_*.dll' 'cublas64_*.dll' 'cublasLt64_*.dll')
@@ -186,9 +148,7 @@ for pat in "${runtime_globs[@]}"; do
   matched=0
   for src in "$LIBDIR"/$pat; do
     [ -e "$src" ] || [ -L "$src" ] || continue
-    name="$(basename "$src")"
-    cp -Pf "$src" "$DEST/$name"
-    [ -L "$src" ] || chmod 644 "$DEST/$name"
+    stage_lib "$src"
     matched=$((matched + 1))
   done
   if [ "$matched" -eq 0 ]; then
@@ -198,9 +158,7 @@ for pat in "${runtime_globs[@]}"; do
   runtime=$((runtime + matched))
 done
 
-# The name-pattern copy above is a guess about what the module wants; the ELF
-# NEEDED list is the fact. A missing entry here is exactly the silent
-# fall-to-Vulkan this step exists to prevent.
+# The globs are a guess at what the module wants; its NEEDED list is the fact.
 if [ "$LIBEXT" = "so" ] && command -v objdump >/dev/null 2>&1; then
   missing=""
   while read -r needed; do

--- a/src-tauri/build-utils/stage-engine.sh
+++ b/src-tauri/build-utils/stage-engine.sh
@@ -133,7 +133,7 @@ roots=("${CUDA_PATH:-}" "${CUDA_HOME:-}")
 LIBDIR=""
 for root in "${roots[@]}"; do
   [ -n "$root" ] && [ -d "$root" ] || continue
-  hit="$(find "$root" -maxdepth 3 -iname "$first" -print -quit 2>/dev/null)"
+  hit="$(find -H "$root" -maxdepth 3 -iname "$first" -print -quit 2>/dev/null)"
   if [ -n "$hit" ]; then LIBDIR="$(dirname "$hit")"; break; fi
 done
 [ -n "$LIBDIR" ] || {

--- a/src-tauri/build-utils/stage-engine.sh
+++ b/src-tauri/build-utils/stage-engine.sh
@@ -106,68 +106,62 @@ echo "stage-engine: staged $staged ggml libraries ($modules backend modules) int
 
 [ -n "$cuda_module" ] || exit 0
 
-# The runtime comes from the toolkit that compiled the module, so the major
-# matches by construction.
-cuda_root() {
-  local d nvcc
-  for d in "${CUDA_PATH:-}" "${CUDA_HOME:-}"; do
-    if [ -n "$d" ] && [ -d "$d" ]; then echo "$d"; return 0; fi
-  done
-  nvcc="$(command -v nvcc 2>/dev/null || true)"
-  [ -n "$nvcc" ] || return 1
-  (cd "$(dirname "$nvcc")/.." && pwd)
-}
+# The module's own import names say which runtime it needs and with which
+# major; they are plain strings in the binary (ELF .dynstr, PE import table),
+# so no objdump/dumpbin is needed. cublasLt is reached through cublas, hence
+# the closure over what has been staged.
+if [ "$LIBEXT" = "dll" ]; then
+  import_re='(cudart|cublas|cublasLt)64_[0-9]+\.dll'
+  libdirs_of() { echo "$1/bin/x64" "$1/bin"; }
+else
+  import_re='libcu(dart|blas|blasLt)\.so\.[0-9]+'
+  libdirs_of() { echo "$1/lib64" "$1/lib" "$1"/targets/*/lib; }
+fi
+imports_of() { tr -d '\0' < "$1" | grep -aoE "$import_re" | sort -u; }
 
-ROOT="$(cuda_root)" || {
-  echo "stage-engine: staged $(basename "$cuda_module") but found no CUDA toolkit" >&2
-  echo "stage-engine: set CUDA_PATH/CUDA_HOME or put nvcc on PATH" >&2
+needed="$(imports_of "$cuda_module")"
+[ -n "$needed" ] || {
+  echo "stage-engine: $(basename "$cuda_module") imports no CUDA runtime library" >&2
   exit 1
 }
 
-# CUDA 13 moved the Windows DLLs to bin/x64. lib64 is a symlink to
-# targets/<arch>/lib, so only the first directory holding cudart is used.
-if [ "$LIBEXT" = "dll" ]; then
-  candidates=("$ROOT/bin/x64" "$ROOT/bin")
-  runtime_globs=('cudart64_*.dll' 'cublas64_*.dll' 'cublasLt64_*.dll')
-else
-  candidates=("$ROOT/lib64" "$ROOT"/targets/*/lib)
-  runtime_globs=('libcudart.so.[0-9]*' 'libcublas.so.[0-9]*' 'libcublasLt.so.[0-9]*')
-fi
-
+first="$(echo "$needed" | head -1)"
 LIBDIR=""
-for d in "${candidates[@]}"; do
-  if compgen -G "$d/${runtime_globs[0]}" >/dev/null; then LIBDIR="$d"; break; fi
+nvcc="$(command -v nvcc 2>/dev/null || true)"
+for root in "${CUDA_PATH:-}" "${CUDA_HOME:-}" "${nvcc:+$(cd "$(dirname "$nvcc")/.." && pwd)}"; do
+  [ -n "$root" ] && [ -d "$root" ] || continue
+  for d in $(libdirs_of "$root"); do
+    if [ -e "$d/$first" ] || [ -L "$d/$first" ]; then LIBDIR="$d"; break 2; fi
+  done
 done
 [ -n "$LIBDIR" ] || {
-  echo "stage-engine: no ${runtime_globs[0]} under $ROOT (looked in: ${candidates[*]})" >&2
+  echo "stage-engine: $(basename "$cuda_module") needs $first, found in no CUDA toolkit" >&2
+  echo "stage-engine: looked under CUDA_PATH, CUDA_HOME and nvcc's parent" >&2
   exit 1
 }
 
 runtime=0
-for pat in "${runtime_globs[@]}"; do
-  matched=0
-  for src in "$LIBDIR"/$pat; do
-    [ -e "$src" ] || [ -L "$src" ] || continue
-    stage_lib "$src"
-    matched=$((matched + 1))
+staged_names=""
+queue="$needed"
+while [ -n "$queue" ]; do
+  next=""
+  for name in $queue; do
+    case " $staged_names " in *" $name "*) continue ;; esac
+    matched=0
+    for src in "$LIBDIR/$name"*; do
+      [ -e "$src" ] || [ -L "$src" ] || continue
+      stage_lib "$src"
+      matched=$((matched + 1))
+    done
+    if [ "$matched" -eq 0 ]; then
+      echo "stage-engine: $name is imported but missing from $LIBDIR" >&2
+      exit 1
+    fi
+    runtime=$((runtime + matched))
+    staged_names="$staged_names $name"
+    next="$next $(imports_of "$DEST/$name")"
   done
-  if [ "$matched" -eq 0 ]; then
-    echo "stage-engine: $LIBDIR has no $pat; the CUDA module would not load without it" >&2
-    exit 1
-  fi
-  runtime=$((runtime + matched))
+  queue="$next"
 done
-
-# The globs are a guess at what the module wants; its NEEDED list is the fact.
-if [ "$LIBEXT" = "so" ] && command -v objdump >/dev/null 2>&1; then
-  missing=""
-  while read -r needed; do
-    [ -e "$DEST/$needed" ] || missing="$missing $needed"
-  done < <(objdump -p "$cuda_module" | awk '/NEEDED/ && $2 ~ /^libcu(dart|blas)/ {print $2}')
-  if [ -n "$missing" ]; then
-    echo "stage-engine: $(basename "$cuda_module") needs$missing, not staged from $LIBDIR" >&2
-    exit 1
-  fi
-fi
 
 echo "stage-engine: staged $runtime CUDA runtime libraries from $LIBDIR"

--- a/src-tauri/build-utils/stage-engine.sh
+++ b/src-tauri/build-utils/stage-engine.sh
@@ -133,7 +133,7 @@ roots=("${CUDA_PATH:-}" "${CUDA_HOME:-}")
 LIBDIR=""
 for root in "${roots[@]}"; do
   [ -n "$root" ] && [ -d "$root" ] || continue
-  hit="$(find -H "$root" -maxdepth 3 -iname "$first" -print -quit 2>/dev/null)"
+  hit="$(find -L "$root" -maxdepth 4 -iname "$first" -print -quit 2>/dev/null)"
   if [ -n "$hit" ]; then LIBDIR="$(dirname "$hit")"; break; fi
 done
 [ -n "$LIBDIR" ] || {

--- a/src-tauri/build-utils/stage-engine.sh
+++ b/src-tauri/build-utils/stage-engine.sh
@@ -9,6 +9,13 @@
 # merely somewhere in the bundle. libggml/libggml-base are ordinary shared
 # libraries found via the rpath ($ORIGIN / @loader_path) build.rs emits, which
 # resolves to the same directory.
+#
+# A CUDA module additionally links the toolkit's cudart/cublas/cublasLt at
+# load time, and nothing on a user's machine provides those (the driver ships
+# libcuda only). They are copied out of the build host's toolkit beside the
+# module, so the bundle's tauri.<os>.conf.json globs are lib*.so* / *.dll rather
+# than libggml*: a Vulkan-only bundle has no cudart to match, and the bundler
+# treats a glob with zero matches as an error.
 set -euo pipefail
 
 # Positional first: cmd.exe has no `VAR=value command` prefix, so the Windows
@@ -41,6 +48,16 @@ if [ ! -f "$WORKER" ]; then
 fi
 
 mkdir -p "$DEST"
+
+# The bundle globs take whatever sits in DEST, so a module or runtime left by
+# an earlier variant's staging would ship with this one.
+purge_stale() {
+  find "$DEST" -maxdepth 1 \( -name 'libggml*' -o -name 'ggml*.dll' \
+    -o -name 'libcudart.so*' -o -name 'libcublas*.so*' \
+    -o -name 'cudart64_*.dll' -o -name 'cublas*.dll' \) -exec rm -f {} +
+}
+purge_stale
+
 install -m755 "$WORKER" "$DEST/jan-llama-worker$EXE"
 echo "stage-engine: staged jan-llama-worker$EXE"
 
@@ -92,6 +109,7 @@ done
 # stops the bundle carrying the same bytes three times.
 staged=0
 modules=0
+cuda_module=""
 for src in "${srcs[@]}"; do
   [ -e "$src" ] || [ -L "$src" ] || continue
   name="$(basename "$src")"
@@ -100,6 +118,7 @@ for src in "${srcs[@]}"; do
   staged=$((staged + 1))
   case "$name" in
     libggml.*|libggml-base.*|ggml.dll|ggml-base.dll) ;;
+    libggml-cuda.*|ggml-cuda.dll) modules=$((modules + 1)); cuda_module="$DEST/$name" ;;
     *) modules=$((modules + 1)) ;;
   esac
 done
@@ -119,3 +138,78 @@ if [ "$modules" -eq 0 ]; then
 fi
 
 echo "stage-engine: staged $staged ggml libraries ($modules backend modules) into $DEST"
+
+[ -n "$cuda_module" ] || exit 0
+
+# The toolkit that compiled the module is the one to ship from: its runtime
+# major matches by construction. CUDA_PATH is what the Windows installer sets,
+# CUDA_HOME the usual Linux spelling, nvcc's parent the fallback for both.
+cuda_root() {
+  local d
+  for d in "${CUDA_PATH:-}" "${CUDA_HOME:-}"; do
+    if [ -n "$d" ] && [ -d "$d" ]; then echo "$d"; return 0; fi
+  done
+  local nvcc
+  nvcc="$(command -v nvcc 2>/dev/null || true)"
+  [ -n "$nvcc" ] || return 1
+  (cd "$(dirname "$nvcc")/.." && pwd)
+}
+
+ROOT="$(cuda_root)" || {
+  echo "stage-engine: staged $(basename "$cuda_module") but found no CUDA toolkit" >&2
+  echo "stage-engine: set CUDA_PATH/CUDA_HOME or put nvcc on PATH to stage its runtime" >&2
+  exit 1
+}
+
+# CUDA 13 moved the Windows DLLs from bin/ to bin/x64/. On Linux lib64 is a
+# symlink to targets/<arch>/lib, so the first directory that holds cudart wins
+# rather than copying the same files twice.
+if [ "$LIBEXT" = "dll" ]; then
+  candidates=("$ROOT/bin/x64" "$ROOT/bin")
+  runtime_globs=('cudart64_*.dll' 'cublas64_*.dll' 'cublasLt64_*.dll')
+else
+  candidates=("$ROOT/lib64" "$ROOT"/targets/*/lib)
+  runtime_globs=('libcudart.so.[0-9]*' 'libcublas.so.[0-9]*' 'libcublasLt.so.[0-9]*')
+fi
+
+LIBDIR=""
+for d in "${candidates[@]}"; do
+  if compgen -G "$d/${runtime_globs[0]}" >/dev/null; then LIBDIR="$d"; break; fi
+done
+[ -n "$LIBDIR" ] || {
+  echo "stage-engine: no ${runtime_globs[0]} under $ROOT (looked in: ${candidates[*]})" >&2
+  exit 1
+}
+
+runtime=0
+for pat in "${runtime_globs[@]}"; do
+  matched=0
+  for src in "$LIBDIR"/$pat; do
+    [ -e "$src" ] || [ -L "$src" ] || continue
+    name="$(basename "$src")"
+    cp -Pf "$src" "$DEST/$name"
+    [ -L "$src" ] || chmod 644 "$DEST/$name"
+    matched=$((matched + 1))
+  done
+  if [ "$matched" -eq 0 ]; then
+    echo "stage-engine: $LIBDIR has no $pat; the CUDA module would not load without it" >&2
+    exit 1
+  fi
+  runtime=$((runtime + matched))
+done
+
+# The name-pattern copy above is a guess about what the module wants; the ELF
+# NEEDED list is the fact. A missing entry here is exactly the silent
+# fall-to-Vulkan this step exists to prevent.
+if [ "$LIBEXT" = "so" ] && command -v objdump >/dev/null 2>&1; then
+  missing=""
+  while read -r needed; do
+    [ -e "$DEST/$needed" ] || missing="$missing $needed"
+  done < <(objdump -p "$cuda_module" | awk '/NEEDED/ && $2 ~ /^libcu(dart|blas)/ {print $2}')
+  if [ -n "$missing" ]; then
+    echo "stage-engine: $(basename "$cuda_module") needs$missing, not staged from $LIBDIR" >&2
+    exit 1
+  fi
+fi
+
+echo "stage-engine: staged $runtime CUDA runtime libraries from $LIBDIR"

--- a/src-tauri/build-utils/stage-engine.sh
+++ b/src-tauri/build-utils/stage-engine.sh
@@ -112,10 +112,8 @@ echo "stage-engine: staged $staged ggml libraries ($modules backend modules) int
 # the closure over what has been staged.
 if [ "$LIBEXT" = "dll" ]; then
   import_re='(cudart|cublas|cublasLt)64_[0-9]+\.dll'
-  libdirs_of() { echo "$1/bin/x64" "$1/bin"; }
 else
   import_re='libcu(dart|blas|blasLt)\.so\.[0-9]+'
-  libdirs_of() { echo "$1/lib64" "$1/lib" "$1"/targets/*/lib; }
 fi
 imports_of() { tr -d '\0' < "$1" | grep -aoE "$import_re" | sort -u; }
 
@@ -125,18 +123,22 @@ needed="$(imports_of "$cuda_module")"
   exit 1
 }
 
+# Toolkit layouts differ (lib64, lib, targets/<arch>/lib; bin or bin/x64, with
+# nvcc itself under bin/x64 on newer Windows toolkits), so the runtime is
+# searched for by name under each candidate root rather than by fixed path.
 first="$(echo "$needed" | head -1)"
-LIBDIR=""
 nvcc="$(command -v nvcc 2>/dev/null || true)"
-for root in "${CUDA_PATH:-}" "${CUDA_HOME:-}" "${nvcc:+$(cd "$(dirname "$nvcc")/.." && pwd)}"; do
+roots=("${CUDA_PATH:-}" "${CUDA_HOME:-}")
+[ -n "$nvcc" ] && roots+=("$(dirname "$nvcc")/.." "$(dirname "$nvcc")/../..")
+LIBDIR=""
+for root in "${roots[@]}"; do
   [ -n "$root" ] && [ -d "$root" ] || continue
-  for d in $(libdirs_of "$root"); do
-    if [ -e "$d/$first" ] || [ -L "$d/$first" ]; then LIBDIR="$d"; break 2; fi
-  done
+  hit="$(find "$root" -maxdepth 3 -iname "$first" -print -quit 2>/dev/null)"
+  if [ -n "$hit" ]; then LIBDIR="$(dirname "$hit")"; break; fi
 done
 [ -n "$LIBDIR" ] || {
   echo "stage-engine: $(basename "$cuda_module") needs $first, found in no CUDA toolkit" >&2
-  echo "stage-engine: looked under CUDA_PATH, CUDA_HOME and nvcc's parent" >&2
+  echo "stage-engine: CUDA_PATH='${CUDA_PATH:-}' CUDA_HOME='${CUDA_HOME:-}' nvcc='${nvcc}'" >&2
   exit 1
 }
 

--- a/src-tauri/plugins/tauri-plugin-llamacpp/Cargo.lock
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/Cargo.lock
@@ -3447,6 +3447,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
@@ -48,6 +48,18 @@ reqwest = { version = "0.12", features = ["json", "blocking", "stream", "rustls-
 [target.'cfg(unix)'.dependencies]
 nix = { version = "=0.30.1", features = ["signal", "process"] }
 
+# The kill-on-close job object the worker is spawned into. Windows has no
+# process group, so this is what keeps a force-quit Jan from orphaning it.
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.60.2", features = [
+  "Win32_Foundation",
+  # CreateJobObjectW takes SECURITY_ATTRIBUTES, and the extended limit struct
+  # lives behind Threading; both are gated separately from JobObjects itself.
+  "Win32_Security",
+  "Win32_System_JobObjects",
+  "Win32_System_Threading",
+] }
+
 # The supervised worker. `required-features` keeps it out of the default build,
 # where there is no compiled llama.cpp to link against.
 [[bin]]

--- a/src-tauri/plugins/tauri-plugin-llamacpp/build.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/build.rs
@@ -179,12 +179,19 @@ mod engine {
         ("engine-metal", "-DGGML_METAL=ON"),
     ];
 
+    /// The GPUs a HIP build targets when JAN_ENGINE_HIP_TARGETS is unset: the
+    /// list janhq/llama.cpp's menlo-build.yml shipped for the previous engine.
+    /// Without an explicit list cmake asks `rocm_agent_enumerator`, which on a
+    /// GPU-less build host yields nothing or the compiler's single default.
+    const HIP_TARGETS: &str = "gfx908;gfx90a;gfx942;gfx1030;gfx1100;gfx1101;gfx1102;gfx1103;gfx1150;gfx1151;gfx1200;gfx1201";
+
     pub fn build() {
         println!("cargo:rerun-if-changed=shim/jan_llama_shim.cpp");
         println!("cargo:rerun-if-changed=shim/jan_llama_shim.h");
         println!("cargo:rerun-if-env-changed=JAN_LLAMA_PREBUILT_DIR");
         println!("cargo:rerun-if-env-changed=JAN_LLAMA_CPP_DIR");
         println!("cargo:rerun-if-env-changed=JAN_ENGINE_CUDA_ARCHS");
+        println!("cargo:rerun-if-env-changed=JAN_ENGINE_HIP_TARGETS");
         println!("cargo:rerun-if-env-changed=JAN_ENGINE_BUILD_LOG");
         println!("cargo:rerun-if-env-changed=JAN_ENGINE_BUILD_DIR");
 
@@ -453,6 +460,19 @@ mod engine {
                 println!("cargo:rerun-if-env-changed=JAN_ENGINE_CUDA_ARCHS");
                 cfg.arg(format!("-DCMAKE_CUDA_ARCHITECTURES={archs}"));
             }
+        }
+        if feature_enabled("engine-hip") {
+            let targets = env::var("JAN_ENGINE_HIP_TARGETS").unwrap_or_default();
+            let targets = targets.trim();
+            let targets = if targets.is_empty() {
+                HIP_TARGETS
+            } else {
+                targets
+            };
+            cfg.arg(format!("-DGPU_TARGETS={targets}"));
+            // rocWMMA flash attention, as the previous engine shipped it; needs
+            // rocwmma-dev, which check-engine-toolchain.sh asserts.
+            cfg.arg("-DGGML_HIP_ROCWMMA_FATTN=ON");
         }
         if feature_enabled("engine-cuda") {
             // NCCL is multi-GPU collective communication for distributed

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/engine/worker.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/engine/worker.rs
@@ -208,12 +208,82 @@ impl std::fmt::Debug for WorkerHandle {
     }
 }
 
+/// Ties the worker's lifetime to ours on Windows, which has no process group.
+///
+/// `kill_on_drop` is a tokio destructor, and `TerminateProcess` runs no
+/// destructors, so a force-quit Jan -- Task Manager, or the NSIS installer's own
+/// kill of the running app -- leaves the worker alive. It exits eventually,
+/// because losing our end of its stdin pipe is its stop signal, but only after
+/// draining requests, saving slots and freeing every model, and until then it
+/// holds VRAM and keeps `ggml*.dll` mapped -- which is precisely what makes the
+/// next install fail to overwrite them.
+///
+/// A job object whose last handle dies with this process is the one reaping the
+/// OS will do on our behalf. Unix gets this from `process_group(0)`.
+#[cfg(windows)]
+mod reap {
+    use std::os::windows::io::RawHandle;
+    use windows_sys::Win32::Foundation::{CloseHandle, HANDLE};
+    use windows_sys::Win32::System::JobObjects::{
+        AssignProcessToJobObject, CreateJobObjectW, JobObjectExtendedLimitInformation,
+        SetInformationJobObject, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+        JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+    };
+
+    /// Closing this kills every process still in the job.
+    pub struct Job(HANDLE);
+
+    // The handle is opaque to everything but `Drop`, which owns it exclusively.
+    unsafe impl Send for Job {}
+    unsafe impl Sync for Job {}
+
+    impl Drop for Job {
+        fn drop(&mut self) {
+            unsafe { CloseHandle(self.0) };
+        }
+    }
+
+    /// Best effort: a Jan already confined to a job that forbids nesting should
+    /// lose the reaping guarantee, not the engine.
+    pub fn confine(child: RawHandle) -> Option<Job> {
+        let job = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+        if job.is_null() {
+            log::warn!("could not create a job object for the worker");
+            return None;
+        }
+        let job = Job(job);
+        let mut limits: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { std::mem::zeroed() };
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let set = unsafe {
+            SetInformationJobObject(
+                job.0,
+                JobObjectExtendedLimitInformation,
+                &limits as *const _ as *const std::ffi::c_void,
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+        };
+        if set == 0 {
+            log::warn!("could not set kill-on-close on the worker's job object");
+            return None;
+        }
+        if unsafe { AssignProcessToJobObject(job.0, child as HANDLE) } == 0 {
+            log::warn!("could not put the worker in its job object");
+            return None;
+        }
+        Some(job)
+    }
+}
+
 pub struct WorkerHandle {
     pub port: u16,
     pub pid: u32,
     pub api_key: String,
     pub models: Vec<String>,
     child: Child,
+    /// Declared after `child` so it is dropped after it: the graceful stop must
+    /// get its turn before closing the job would kill the worker outright.
+    #[cfg(windows)]
+    _job: Option<reap::Job>,
 }
 
 impl WorkerHandle {
@@ -335,6 +405,10 @@ pub async fn spawn(
         .kill_on_drop(true);
 
     let mut child = cmd.spawn().map_err(|e| WorkerError::Spawn(e.to_string()))?;
+    // Before the handshake, so every error path below drops the job too and
+    // cannot leak a worker that never reported for duty.
+    #[cfg(windows)]
+    let job = child.raw_handle().and_then(reap::confine);
 
     let stdout = child
         .stdout
@@ -406,6 +480,8 @@ pub async fn spawn(
         api_key: api_key.to_string(),
         models: hs.models,
         child,
+        #[cfg(windows)]
+        _job: job,
     })
 }
 

--- a/src-tauri/tauri.bundle.windows.nsis.template
+++ b/src-tauri/tauri.bundle.windows.nsis.template
@@ -66,27 +66,136 @@ Var UpdateMode
 Var NoShortcutMode
 Var WixMode
 Var OldMainBinaryName
+Var LockedFile
 
-; A bundled sidecar can outlive the app that spawned it: an MCP server started
-; through `bun x` is a grandchild of Jan and Windows has no process group to
-; reap it, so `bun.exe` is often still mapped when the next installer runs.
-; Windows refuses to overwrite a mapped image, which is how an update fails
-; with "unable to open $INSTDIR\bun.exe for writing" -- `File` is fatal, so the
-; whole install aborts. A mapped image can still be renamed, so move the locked
-; copy aside and write the new one over the freed name. The leftover is deleted
-; by the next install, or by the uninstaller's `RMDir /r`; scheduling it with
-; /REBOOTOK instead would raise the reboot flag on a per-user install that
-; cannot honour it.
+; Waits for a bundled sidecar to exit, killing it once it has had its grace.
+;
+; `CheckIfAppIsRunning` covers the main binary only, and its `Sleep 500` is far
+; short of what jan-llama-worker needs: killing Jan closes the stdin the worker
+; treats as "stop", but unwinding then drains in-flight requests for up to
+; DRAIN_TIMEOUT (10s), saves each resident slot and frees every model, all with
+; ggml*.dll still mapped. Nothing reaps it either -- there is no job object
+; around it, and `kill_on_drop` is a destructor TerminateProcess skips -- so a
+; force-quit Jan leaves it running on its own.
+;
+; Hence poll for the exit rather than sleep a guessed interval, and leave it
+; STOP_GRACE polls to unwind before killing: a kill costs the user the slot save
+; the teardown exists to do. Killing is still reached, because a worker orphaned
+; by an earlier crash has no stdin left to close and will never exit on its own.
+!define STOP_GRACE 12
+!define STOP_LIMIT 60
+!macro StopBundledProcess exe
+  StrCpy $R4 0
+  ${Do}
+    !if "${INSTALLMODE}" == "currentUser"
+      nsis_tauri_utils::FindProcessCurrentUser "${exe}"
+    !else
+      nsis_tauri_utils::FindProcess "${exe}"
+    !endif
+    Pop $R5
+    ${If} $R5 <> 0
+      ${ExitDo}
+    ${EndIf}
+    ${If} $R4 >= ${STOP_GRACE}
+      !if "${INSTALLMODE}" == "currentUser"
+        nsis_tauri_utils::KillProcessCurrentUser "${exe}"
+      !else
+        nsis_tauri_utils::KillProcess "${exe}"
+      !endif
+      Pop $R5
+    ${EndIf}
+    IntOp $R4 $R4 + 1
+    ${If} $R4 >= ${STOP_LIMIT}
+      ${ExitDo}
+    ${EndIf}
+    Sleep 500
+  ${Loop}
+!macroend
+
+; Frees one path that a still-running process may have mapped.
+;
+; Windows refuses to overwrite a mapped image, which is how an update fails with
+; "Error opening file for writing" -- `File` is fatal, so the whole install
+; aborts. A mapped image can still be renamed on the same volume, which is the
+; replacement MSDN's "Dynamic-Link Library Updates" prescribes: the old copy
+; keeps serving whoever holds it and the new one is written over the freed name.
+; The leftover is deleted by the next install, or by the uninstaller's
+; `RMDir /r`; scheduling it with /REBOOTOK instead would raise the reboot flag on
+; a per-user install that cannot honour it.
+;
+; A failure is recorded in $LockedFile rather than swallowed, so the install can
+; stop before it has written anything instead of dying part-extracted.
 !macro UnlockBundledBinary path
   ${If} ${FileExists} "${path}"
-    ClearErrors
-    Delete "${path}"
-    ${If} ${Errors}
+    StrCpy $R6 0
+    ${Do}
+      ClearErrors
+      Delete "${path}"
+      ${IfNot} ${Errors}
+        ${ExitDo}
+      ${EndIf}
       ClearErrors
       Delete "${path}.old"
-      Rename "${path}" "${path}.old"
       ClearErrors
+      Rename "${path}" "${path}.old"
+      ${IfNot} ${Errors}
+        ${ExitDo}
+      ${EndIf}
+      IntOp $R6 $R6 + 1
+      ${If} $R6 >= 5
+        StrCpy $LockedFile "${path}"
+        ${ExitDo}
+      ${EndIf}
+      Sleep 200
+    ${Loop}
+    ClearErrors
+  ${EndIf}
+!macroend
+
+; The same, over a wildcard: the runtime DLLs are staged by variant, so the
+; installer knows them only as the globs its `File` directives use.
+;
+; Rescanned until a pass finds nothing, because the renames mutate the directory
+; being enumerated and FindNext may skip an entry across that; `.old` does not
+; match a `*.dll` pattern, so a pass cannot see its own leftovers.
+!macro UnlockBundledPattern dir pattern
+  StrCpy $R2 0
+  ${Do}
+    FindFirst $R8 $R9 "${dir}\${pattern}"
+    ${Do}
+      ${If} $R9 == ""
+        ${ExitDo}
+      ${EndIf}
+      StrCpy $R7 "${dir}\$R9"
+      !insertmacro UnlockBundledBinary "$R7"
+      FindNext $R8 $R9
+    ${Loop}
+    FindClose $R8
+    IntOp $R2 $R2 + 1
+    ${If} $R2 >= 3
+    ${OrIf} $LockedFile != ""
+      ${ExitDo}
     ${EndIf}
+  ${Loop}
+!macroend
+
+; Everything a previous install may still have mapped, freed before the first
+; `File` write so a lock aborts with the app's own message instead of NSIS's
+; mid-extraction one. bun and uv are not stopped by name: the user's own bun may
+; be running and is not ours to kill, so those rely on the rename alone.
+!macro FreeBundledFiles
+  !insertmacro StopBundledProcess "jan-llama-worker.exe"
+  !insertmacro UnlockBundledBinary "$INSTDIR\resources\bin\jan.exe"
+  !insertmacro UnlockBundledBinary "$INSTDIR\resources\bin\jan-llama-worker.exe"
+  !insertmacro UnlockBundledPattern "$INSTDIR\resources\bin" "ggml*.dll"
+  !insertmacro UnlockBundledPattern "$INSTDIR\resources\bin" "cudart64_*.dll"
+  !insertmacro UnlockBundledPattern "$INSTDIR\resources\bin" "cublas*.dll"
+  !insertmacro UnlockBundledBinary "$INSTDIR\bun.exe"
+  !insertmacro UnlockBundledBinary "$INSTDIR\uv.exe"
+  ${If} $LockedFile != ""
+    nsis_tauri_utils::StrReplace "$(failedToKillApp)" "{{product_name}}" "${PRODUCTNAME}"
+    Pop $R3
+    Abort "$R3$\n$LockedFile"
   ${EndIf}
 !macroend
 
@@ -712,6 +821,7 @@ Section Install
   !endif
 
   !insertmacro CheckIfAppIsRunning "${MAINBINARYNAME}.exe" "${PRODUCTNAME}"
+  !insertmacro FreeBundledFiles
 
   ; Copy main executable
   File "${MAINBINARYSRCPATH}"
@@ -725,8 +835,6 @@ Section Install
     SetOutPath "$INSTDIR\resources\pre-install"
     File /nonfatal /a /r "jan_workspace\src-tauri\resources\pre-install\"
     SetOutPath "$INSTDIR\resources\bin"
-    !insertmacro UnlockBundledBinary "$INSTDIR\resources\bin\jan.exe"
-    !insertmacro UnlockBundledBinary "$INSTDIR\resources\bin\jan-llama-worker.exe"
     File /a "/oname=jan.exe" "jan_workspace\src-tauri\resources\bin\jan.exe"
     ; The engine. This block is a hand-maintained snapshot of
     ; tauri.windows.conf.json's `bundle.resources`, which the NSIS bundler does
@@ -744,8 +852,6 @@ Section Install
     SetOutPath $INSTDIR
 
   ; Copy external binaries
-    !insertmacro UnlockBundledBinary "$INSTDIR\bun.exe"
-    !insertmacro UnlockBundledBinary "$INSTDIR\uv.exe"
     File /a "/oname=bun.exe" "jan_workspace\src-tauri\resources\bin\bun-x86_64-pc-windows-msvc.exe"
     File /a "/oname=uv.exe" "jan_workspace\src-tauri\resources\bin\uv-x86_64-pc-windows-msvc.exe"
 
@@ -859,6 +965,7 @@ Section Uninstall
   !endif
 
   !insertmacro CheckIfAppIsRunning "${MAINBINARYNAME}.exe" "${PRODUCTNAME}"
+  !insertmacro StopBundledProcess "jan-llama-worker.exe"
 
   ; Delete the app directory and its content from disk
   ; Copy main executable

--- a/src-tauri/tauri.bundle.windows.nsis.template
+++ b/src-tauri/tauri.bundle.windows.nsis.template
@@ -35,16 +35,16 @@ ${StrLoc}
 !define HOMEPAGE ""
 !define INSTALLMODE "currentUser"
 !define LICENSE ""
-!define INSTALLERICON "D:\a\jan\jan\src-tauri\icons\icon.ico"
+!define INSTALLERICON "jan_workspace\src-tauri\icons\icon.ico"
 !define SIDEBARIMAGE ""
 !define HEADERIMAGE ""
 !define MAINBINARYNAME "jan_mainbinaryname"
-!define MAINBINARYSRCPATH "D:\a\jan\jan\src-tauri\target\release\jan_mainbinaryname.exe"
+!define MAINBINARYSRCPATH "jan_workspace\src-tauri\target\release\jan_mainbinaryname.exe"
 !define BUNDLEID "jan_bundleid"
 !define COPYRIGHT ""
 !define OUTFILE "nsis-output.exe"
 !define ARCH "x64"
-!define ADDITIONALPLUGINSPATH "D:\a\jan\jan\src-tauri\target\release\nsis\x64\Plugins\x86-unicode\additional"
+!define ADDITIONALPLUGINSPATH "jan_workspace\src-tauri\target\release\nsis\x64\Plugins\x86-unicode\additional"
 !define ALLOWDOWNGRADES "true"
 !define DISPLAYLANGUAGESELECTOR "false"
 !define INSTALLWEBVIEW2MODE "downloadBootstrapper"
@@ -452,7 +452,7 @@ FunctionEnd
 ;Languages
 !insertmacro MUI_LANGUAGE "English"
 !insertmacro MUI_RESERVEFILE_LANGDLL
-  !include "D:\a\jan\jan\src-tauri\target\release\nsis\x64\English.nsh"
+  !include "jan_workspace\src-tauri\target\release\nsis\x64\English.nsh"
 
 Function .onInit
   ${GetOptions} $CMDLINE "/P" $PassiveMode
@@ -698,11 +698,11 @@ Section Install
     CreateDirectory "$INSTDIR\resources\pre-install"
     CreateDirectory "$INSTDIR\resources\bin"
     SetOutPath $INSTDIR
-    File /a "/oname=LICENSE" "D:\a\jan\jan\src-tauri\resources\LICENSE"
+    File /a "/oname=LICENSE" "jan_workspace\src-tauri\resources\LICENSE"
     SetOutPath "$INSTDIR\resources\pre-install"
-    File /nonfatal /a /r "D:\a\jan\jan\src-tauri\resources\pre-install\"
+    File /nonfatal /a /r "jan_workspace\src-tauri\resources\pre-install\"
     SetOutPath "$INSTDIR\resources\bin"
-    File /a "/oname=jan.exe" "D:\a\jan\jan\src-tauri\resources\bin\jan.exe"
+    File /a "/oname=jan.exe" "jan_workspace\src-tauri\resources\bin\jan.exe"
     ; The engine. This block is a hand-maintained snapshot of
     ; tauri.windows.conf.json's `bundle.resources`, which the NSIS bundler does
     ; not read once CI points it at this template, so anything added there has
@@ -711,13 +711,16 @@ Section Install
     ; inference permanently unavailable, since there is no runtime backend
     ; download to fall back on, so a build that staged nothing must fail loudly
     ; here the way stage-engine.sh already does.
-    File /a "/oname=jan-llama-worker.exe" "D:\a\jan\jan\src-tauri\resources\bin\jan-llama-worker.exe"
-    File /a "D:\a\jan\jan\src-tauri\resources\bin\ggml*.dll"
+    File /a "/oname=jan-llama-worker.exe" "jan_workspace\src-tauri\resources\bin\jan-llama-worker.exe"
+    File /a "jan_workspace\src-tauri\resources\bin\ggml*.dll"
+    ; CUDA runtime, present only in a cuda variant (stage-engine.sh).
+    File /nonfatal /a "jan_workspace\src-tauri\resources\bin\cudart64_*.dll"
+    File /nonfatal /a "jan_workspace\src-tauri\resources\bin\cublas*.dll"
     SetOutPath $INSTDIR
 
   ; Copy external binaries
-    File /a "/oname=bun.exe" "D:\a\jan\jan\src-tauri\resources\bin\bun-x86_64-pc-windows-msvc.exe"
-    File /a "/oname=uv.exe" "D:\a\jan\jan\src-tauri\resources\bin\uv-x86_64-pc-windows-msvc.exe"
+    File /a "/oname=bun.exe" "jan_workspace\src-tauri\resources\bin\bun-x86_64-pc-windows-msvc.exe"
+    File /a "/oname=uv.exe" "jan_workspace\src-tauri\resources\bin\uv-x86_64-pc-windows-msvc.exe"
 
   ; Create file associations
 

--- a/src-tauri/tauri.bundle.windows.nsis.template
+++ b/src-tauri/tauri.bundle.windows.nsis.template
@@ -67,6 +67,29 @@ Var NoShortcutMode
 Var WixMode
 Var OldMainBinaryName
 
+; A bundled sidecar can outlive the app that spawned it: an MCP server started
+; through `bun x` is a grandchild of Jan and Windows has no process group to
+; reap it, so `bun.exe` is often still mapped when the next installer runs.
+; Windows refuses to overwrite a mapped image, which is how an update fails
+; with "unable to open $INSTDIR\bun.exe for writing" -- `File` is fatal, so the
+; whole install aborts. A mapped image can still be renamed, so move the locked
+; copy aside and write the new one over the freed name. The leftover is deleted
+; by the next install, or by the uninstaller's `RMDir /r`; scheduling it with
+; /REBOOTOK instead would raise the reboot flag on a per-user install that
+; cannot honour it.
+!macro UnlockBundledBinary path
+  ${If} ${FileExists} "${path}"
+    ClearErrors
+    Delete "${path}"
+    ${If} ${Errors}
+      ClearErrors
+      Delete "${path}.old"
+      Rename "${path}" "${path}.old"
+      ClearErrors
+    ${EndIf}
+  ${EndIf}
+!macroend
+
 Name "${PRODUCTNAME}"
 BrandingText "${COPYRIGHT}"
 OutFile "${OUTFILE}"
@@ -702,6 +725,8 @@ Section Install
     SetOutPath "$INSTDIR\resources\pre-install"
     File /nonfatal /a /r "jan_workspace\src-tauri\resources\pre-install\"
     SetOutPath "$INSTDIR\resources\bin"
+    !insertmacro UnlockBundledBinary "$INSTDIR\resources\bin\jan.exe"
+    !insertmacro UnlockBundledBinary "$INSTDIR\resources\bin\jan-llama-worker.exe"
     File /a "/oname=jan.exe" "jan_workspace\src-tauri\resources\bin\jan.exe"
     ; The engine. This block is a hand-maintained snapshot of
     ; tauri.windows.conf.json's `bundle.resources`, which the NSIS bundler does
@@ -719,6 +744,8 @@ Section Install
     SetOutPath $INSTDIR
 
   ; Copy external binaries
+    !insertmacro UnlockBundledBinary "$INSTDIR\bun.exe"
+    !insertmacro UnlockBundledBinary "$INSTDIR\uv.exe"
     File /a "/oname=bun.exe" "jan_workspace\src-tauri\resources\bin\bun-x86_64-pc-windows-msvc.exe"
     File /a "/oname=uv.exe" "jan_workspace\src-tauri\resources\bin\uv-x86_64-pc-windows-msvc.exe"
 
@@ -850,7 +877,9 @@ Section Uninstall
 
   ; Delete external binaries
     Delete "$INSTDIR\bun.exe"
+    Delete "$INSTDIR\bun.exe.old"
     Delete "$INSTDIR\uv.exe"
+    Delete "$INSTDIR\uv.exe.old"
 
   ; Delete app associations
 

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -27,7 +27,7 @@
       "resources/LICENSE",
       "resources/bin/jan",
       "resources/bin/jan-llama-worker",
-      "resources/bin/libggml*.so*"
+      "resources/bin/lib*.so*"
     ],
     "externalBin": [
       "resources/bin/uv"

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -43,7 +43,7 @@
       "resources/LICENSE",
       "resources/bin/jan.exe",
       "resources/bin/jan-llama-worker.exe",
-      "resources/bin/ggml*.dll"
+      "resources/bin/*.dll"
     ],
     "externalBin": [
       "resources/bin/bun",


### PR DESCRIPTION
## Describe Your Changes

libggml-cuda links cudart/cublas/cublasLt from the toolkit at load time, and stage-engine.sh copied only libggml*, so a cuda bundle silently required a CUDA install on the user's machine and otherwise fell back to Vulkan.

stage-engine.sh now copies the three runtime families out of the build host's toolkit (CUDA_PATH -> CUDA_HOME -> nvcc's parent; bin/x64 before bin on Windows since CUDA 13 moved the DLLs) whenever it staged a CUDA module, and fails the build if the toolkit is missing, a family has no match, or a NEEDED cudart/cublas entry is absent from resources/bin. It also purges stale ggml/CUDA files from resources/bin first so an earlier variant's leftovers cannot ship.

The bundle globs widen to lib*.so* / *.dll: tauri-utils treats a zero-match resource glob as an error, and a Vulkan-only bundle has no cudart to match.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
