### PR TITLE
feat(websearch): add You.com as a native search/fetch provider

### DIFF
--- a/docs/src/pages/docs/desktop/web-search.mdx
+++ b/docs/src/pages/docs/desktop/web-search.mdx
@@ -11,6 +11,7 @@ keywords:
     Exa,
     Tavily,
     SearXNG,
+    You.com,
     tool use,
     online search,
   ]
@@ -64,13 +65,14 @@ use. On by default. Works with no API key.
 
 ### Search Provider
 
-Choose the backend that answers `web_search` and `web_fetch`. Three providers are available:
+Choose the backend that answers `web_search` and `web_fetch`. Four providers are available:
 
 | Provider | API key | Notes |
 |----------|---------|-------|
 | **Exa** (default) | Optional | Uses a free, keyless endpoint out of the box. Add a key for higher rate limits and structured results. |
 | **Tavily** | Required | Needs a [Tavily](https://tavily.com) API key to return results. |
 | **SearXNG** | Optional | Self-hosted. Point Jan at your own [SearXNG](https://searxng.org) instance URL (with the JSON API enabled). |
+| **You.com** | Optional | Keyless search works out of the box, subject to a daily request cap. A [You.com](https://you.com/platform) API key lifts the cap and gives `web_fetch` extracted page content instead of raw HTML. |
 
 ### Exa API Key (optional)
 

--- a/src-tauri/plugins/tauri-plugin-websearch/src/provider.rs
+++ b/src-tauri/plugins/tauri-plugin-websearch/src/provider.rs
@@ -33,6 +33,23 @@ const EXA_REST_CONTENTS_URL: &str = "https://api.exa.ai/contents";
 const TAVILY_SEARCH_URL: &str = "https://api.tavily.com/search";
 const TAVILY_EXTRACT_URL: &str = "https://api.tavily.com/extract";
 
+const YOU_COM_HOSTED_URL: &str = "https://api.you.com/mcp?profile=free";
+// Identifies the calling application to You.com, per the convention its other
+// integrations follow. Carries no user or query data beyond the request itself,
+// and is sent only on requests to You.com.
+const YOU_COM_USER_AGENT: &str = concat!(
+    "jan-websearch/",
+    env!("CARGO_PKG_VERSION"),
+    " (https://github.com/janhq/jan)"
+);
+const YOU_COM_CLIENT_INFO: &str = concat!(
+    "sdk; client=jan-websearch/",
+    env!("CARGO_PKG_VERSION"),
+    "; ua=rust/unknown"
+);
+const YOU_COM_SEARCH_URL: &str = "https://ydc-index.io/v1/search";
+const YOU_COM_CONTENTS_URL: &str = "https://ydc-index.io/v1/contents";
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct SearchResult {
     pub title: String,
@@ -70,6 +87,7 @@ pub fn create_provider(
         None | Some("") | Some("exa") => Ok(Box::new(ExaProvider::new(api_key)?)),
         Some("tavily") => Ok(Box::new(TavilyProvider::new(api_key)?)),
         Some("searxng") => Ok(Box::new(SearxngProvider::new(endpoint)?)),
+        Some("you") => Ok(Box::new(YouComProvider::new(api_key)?)),
         Some(other) => Err(format!("Unknown web search provider '{other}'")),
     }
 }
@@ -151,7 +169,7 @@ impl ExaProvider {
                 text.chars().take(400).collect::<String>()
             ));
         }
-        parse_hosted_result_text(&text)
+        parse_hosted_result_text(&text, "Exa")
     }
 }
 
@@ -248,39 +266,41 @@ impl SearchProvider for ExaProvider {
     }
 }
 
-fn parse_hosted_result_text(body: &str) -> Result<String, String> {
-    let json_str = body
+/// Pull the tool payload out of an MCP `tools/call` response. Streamable HTTP
+/// answers with either a bare JSON-RPC object or an SSE stream, and a stream may
+/// carry progress notifications ahead of the answer, so the frame holding
+/// `result` or `error` is the one to read.
+fn parse_hosted_result_text(body: &str, provider: &str) -> Result<String, String> {
+    let envelope = match body
         .lines()
-        .find_map(|l| l.strip_prefix("data:").map(str::trim))
-        .unwrap_or_else(|| body.trim());
-    let parsed: Value = serde_json::from_str(json_str)
-        .map_err(|e| format!("Exa: invalid response payload: {e}"))?;
-    if let Some(err) = parsed.get("error") {
-        return Err(format!("Exa returned an error: {err}"));
+        .filter_map(|l| l.strip_prefix("data:").map(str::trim))
+        .filter_map(|frame| serde_json::from_str::<Value>(frame).ok())
+        .find(|v| v.get("result").is_some() || v.get("error").is_some())
+    {
+        Some(frame) => frame,
+        None => serde_json::from_str::<Value>(body.trim())
+            .map_err(|e| format!("{provider}: invalid response payload: {e}"))?,
+    };
+    if let Some(err) = envelope.get("error") {
+        return Err(format!("{provider} returned an error: {err}"));
     }
-    let result = parsed
+    let result = envelope
         .get("result")
-        .ok_or("Exa response missing 'result'")?;
-    if result.get("isError").and_then(|v| v.as_bool()) == Some(true) {
-        return Err(format!(
-            "Exa tool call failed: {}",
-            result
-                .get("content")
-                .and_then(|c| c.as_array())
-                .and_then(|a| a.first())
-                .and_then(|c| c.get("text"))
-                .and_then(|v| v.as_str())
-                .unwrap_or("unknown error")
-        ));
-    }
+        .ok_or_else(|| format!("{provider} response missing 'result'"))?;
     let text = result
         .get("content")
         .and_then(|c| c.as_array())
         .and_then(|a| a.first())
         .and_then(|c| c.get("text"))
-        .and_then(|v| v.as_str())
-        .ok_or("Exa response had no text content")?;
-    Ok(text.to_string())
+        .and_then(|v| v.as_str());
+    if result.get("isError").and_then(|v| v.as_bool()) == Some(true) {
+        return Err(format!(
+            "{provider} tool call failed: {}",
+            text.unwrap_or("unknown error")
+        ));
+    }
+    text.map(str::to_string)
+        .ok_or_else(|| format!("{provider} response had no text content"))
 }
 
 fn parse_hosted_search_text(text: &str) -> Vec<SearchResult> {
@@ -545,6 +565,199 @@ fn normalize_tavily_extract(body: &Value, requested_url: &str) -> Result<Fetched
     })
 }
 
+/// Which You.com transport the adapter uses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum YouComMode {
+    Hosted,
+    Rest(String),
+}
+
+/// You.com backend. Defaults to the keyless hosted endpoint; upgrades to the
+/// structured REST API when a key is supplied.
+///
+/// * Keyless (default): the hosted MCP endpoint answers `you-search` with no
+///   credentials. `web_fetch` has no keyless counterpart, so it falls back to a
+///   direct GET, the same way [`SearxngProvider`] handles a backend with no
+///   extraction endpoint.
+/// * Keyed (opt-in): the structured REST API at `https://ydc-index.io`, which
+///   adds `/v1/contents` for real content extraction and lifts the free tier's
+///   request cap.
+///
+/// Both transports return the same search payload, so one normalizer serves
+/// both.
+pub struct YouComProvider {
+    mode: YouComMode,
+    client: reqwest::Client,
+}
+
+impl YouComProvider {
+    pub fn new(api_key: Option<String>) -> Result<Self, String> {
+        let mode = match normalize_key(api_key) {
+            Some(key) => YouComMode::Rest(key),
+            None => YouComMode::Hosted,
+        };
+        Ok(Self {
+            mode,
+            client: build_http_client("You.com")?,
+        })
+    }
+
+    /// Send a prepared request and return the body, mapping transport and HTTP
+    /// failures into one message shape for both transports.
+    async fn send(&self, request: reqwest::RequestBuilder) -> Result<String, String> {
+        let resp = request
+            .header("content-type", "application/json")
+            .header("user-agent", YOU_COM_USER_AGENT)
+            .header("x-client-info", YOU_COM_CLIENT_INFO)
+            .send()
+            .await
+            .map_err(|e| format!("You.com request failed: {e}"))?;
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| format!("You.com: failed to read response body: {e}"))?;
+        if !status.is_success() {
+            return Err(format!(
+                "You.com failed with HTTP {}: {}",
+                status.as_u16(),
+                text.chars().take(400).collect::<String>()
+            ));
+        }
+        Ok(text)
+    }
+
+    /// Keyed transport: plain JSON POST authenticated with `X-API-Key`.
+    async fn post_rest(&self, url: &str, key: &str, body: Value) -> Result<Value, String> {
+        let text = self
+            .send(self.client.post(url).header("X-API-Key", key).json(&body))
+            .await?;
+        serde_json::from_str(&text).map_err(|e| format!("You.com: invalid JSON response: {e}"))
+    }
+
+    /// Keyless transport: one MCP `tools/call` for `you-search`, the only tool
+    /// the free profile exposes. The tool payload is the same JSON the REST
+    /// endpoint returns, so the caller can hand it to the same normalizer.
+    async fn hosted_search(&self, arguments: Value) -> Result<Value, String> {
+        let text = self
+            .send(
+                self.client
+                    .post(YOU_COM_HOSTED_URL)
+                    .header("accept", "application/json, text/event-stream")
+                    .json(&json!({
+                        "jsonrpc": "2.0",
+                        "id": 1,
+                        "method": "tools/call",
+                        "params": { "name": "you-search", "arguments": arguments }
+                    })),
+            )
+            .await?;
+        let payload = parse_hosted_result_text(&text, "You.com")?;
+        serde_json::from_str(&payload)
+            .map_err(|e| format!("You.com: invalid JSON in tool result: {e}"))
+    }
+}
+
+#[async_trait]
+impl SearchProvider for YouComProvider {
+    async fn search(&self, query: &str, count: u32) -> Result<Vec<SearchResult>, String> {
+        let args = json!({ "query": query, "count": count });
+        let parsed = match &self.mode {
+            YouComMode::Hosted => self.hosted_search(args).await?,
+            YouComMode::Rest(key) => self.post_rest(YOU_COM_SEARCH_URL, key, args).await?,
+        };
+        Ok(normalize_youcom_search(&parsed))
+    }
+
+    async fn fetch(&self, url: &str) -> Result<FetchedPage, String> {
+        match &self.mode {
+            // No keyless content endpoint, so read the page directly.
+            YouComMode::Hosted => fetch_url_direct(&self.client, url, "You.com").await,
+            YouComMode::Rest(key) => {
+                let parsed = self
+                    .post_rest(
+                        YOU_COM_CONTENTS_URL,
+                        key,
+                        json!({ "urls": [url], "formats": ["markdown"] }),
+                    )
+                    .await?;
+                normalize_youcom_contents(&parsed, url)
+            }
+        }
+    }
+}
+
+/// `/v1/search` groups results into sections. `web` is the section jan's
+/// `web_search` contract maps to, so a response carrying no `web` section
+/// (news-only, or empty) yields no results rather than falling back to `news`.
+fn normalize_youcom_search(body: &Value) -> Vec<SearchResult> {
+    let Some(web) = body
+        .get("results")
+        .and_then(|r| r.get("web"))
+        .and_then(|v| v.as_array())
+    else {
+        return Vec::new();
+    };
+    web.iter()
+        .map(|r| {
+            let title = r.get("title").and_then(|v| v.as_str()).unwrap_or("");
+            let url = r.get("url").and_then(|v| v.as_str()).unwrap_or("");
+            // `description` is the whole-result summary; `snippets` are keyword
+            // fragments, used only when a result carries no description.
+            let snippet = r
+                .get("description")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .or_else(|| {
+                    r.get("snippets")
+                        .and_then(|v| v.as_array())
+                        .and_then(|a| a.first())
+                        .and_then(|v| v.as_str())
+                })
+                .map(|s| clip_chars(s, 500))
+                .unwrap_or_default();
+            let published_at = r
+                .get("page_age")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(str::to_string);
+            SearchResult {
+                title: title.to_string(),
+                url: url.to_string(),
+                snippet,
+                published_at,
+            }
+        })
+        .collect()
+}
+
+/// `/v1/contents` answers with a bare array, one entry per requested URL.
+/// The request asks for `markdown`, so that is the only content field read.
+fn normalize_youcom_contents(body: &Value, requested_url: &str) -> Result<FetchedPage, String> {
+    let first = body
+        .as_array()
+        .and_then(|a| a.first())
+        .ok_or_else(|| format!("You.com returned no content for {requested_url}"))?;
+    let url = first
+        .get("url")
+        .and_then(|v| v.as_str())
+        .unwrap_or(requested_url)
+        .to_string();
+    let title = first
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    let raw = first.get("markdown").and_then(|v| v.as_str()).unwrap_or("");
+    let (content, truncated) = bound_text(raw);
+    Ok(FetchedPage {
+        url,
+        title,
+        content,
+        truncated,
+    })
+}
+
 /// SearXNG backend (self-hosted, key-less). Queries a user-supplied instance's
 /// JSON search API. SearXNG has no content-extraction endpoint, so `fetch` does
 /// a plain HTTP GET of the URL and returns the bounded raw response body.
@@ -600,31 +813,7 @@ impl SearchProvider for SearxngProvider {
     }
 
     async fn fetch(&self, url: &str) -> Result<FetchedPage, String> {
-        let resp = self
-            .client
-            .get(url)
-            .send()
-            .await
-            .map_err(|e| format!("SearXNG fetch request failed: {e}"))?;
-        let status = resp.status();
-        let body = resp
-            .text()
-            .await
-            .map_err(|e| format!("SearXNG fetch: failed to read response body: {e}"))?;
-        if !status.is_success() {
-            return Err(format!(
-                "SearXNG fetch failed with HTTP {}",
-                status.as_u16()
-            ));
-        }
-        let title = extract_html_title(&body).unwrap_or_default();
-        let (content, truncated) = bound_text(&body);
-        Ok(FetchedPage {
-            url: url.to_string(),
-            title,
-            content,
-            truncated,
-        })
+        fetch_url_direct(&self.client, url, "SearXNG").await
     }
 }
 
@@ -656,6 +845,40 @@ fn normalize_searxng_search(body: &Value, count: u32) -> Vec<SearchResult> {
             }
         })
         .collect()
+}
+
+/// Fetch a URL directly and return its bounded body, titled from its `<title>`.
+/// Used by backends that have no content-extraction endpoint on the active
+/// transport, so `web_fetch` still answers instead of erroring.
+async fn fetch_url_direct(
+    client: &reqwest::Client,
+    url: &str,
+    provider: &str,
+) -> Result<FetchedPage, String> {
+    let resp = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("{provider} fetch request failed: {e}"))?;
+    let status = resp.status();
+    let body = resp
+        .text()
+        .await
+        .map_err(|e| format!("{provider} fetch: failed to read response body: {e}"))?;
+    if !status.is_success() {
+        return Err(format!(
+            "{provider} fetch failed with HTTP {}",
+            status.as_u16()
+        ));
+    }
+    let title = extract_html_title(&body).unwrap_or_default();
+    let (content, truncated) = bound_text(&body);
+    Ok(FetchedPage {
+        url: url.to_string(),
+        title,
+        content,
+        truncated,
+    })
 }
 
 fn extract_html_title(html: &str) -> Option<String> {
@@ -834,21 +1057,23 @@ mod tests {
     #[test]
     fn parse_hosted_result_text_reads_sse_frame() {
         let sse = "event: message\ndata: {\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"hello\"}]}}\n\n";
-        assert_eq!(parse_hosted_result_text(sse).unwrap(), "hello");
+        assert_eq!(parse_hosted_result_text(sse, "Exa").unwrap(), "hello");
     }
 
     #[test]
     fn parse_hosted_result_text_reads_raw_json() {
         let raw = "{\"result\":{\"content\":[{\"type\":\"text\",\"text\":\"hi\"}]}}";
-        assert_eq!(parse_hosted_result_text(raw).unwrap(), "hi");
+        assert_eq!(parse_hosted_result_text(raw, "Exa").unwrap(), "hi");
     }
 
     #[test]
     fn parse_hosted_result_text_surfaces_errors() {
         let err = "{\"error\":{\"code\":-32000,\"message\":\"boom\"}}";
-        assert!(parse_hosted_result_text(err).is_err());
+        assert!(parse_hosted_result_text(err, "Exa").is_err());
         let tool_err = "{\"result\":{\"isError\":true,\"content\":[{\"type\":\"text\",\"text\":\"bad\"}]}}";
-        assert!(parse_hosted_result_text(tool_err).unwrap_err().contains("bad"));
+        assert!(parse_hosted_result_text(tool_err, "Exa")
+            .unwrap_err()
+            .contains("bad"));
     }
 
     #[test]
@@ -941,5 +1166,226 @@ mod tests {
     #[test]
     fn normalize_exa_rest_fetch_no_results_errors() {
         assert!(normalize_exa_rest_fetch(&json!({"results": []}), "u").is_err());
+    }
+
+    #[test]
+    fn youcom_attribution_follows_the_client_info_grammar() {
+        // `<source>; client=<name>/<version>; ua=<runtime>/<version>`
+        let segments: Vec<&str> = YOU_COM_CLIENT_INFO.split("; ").collect();
+        assert_eq!(segments.len(), 3, "unexpected segment count");
+        assert_eq!(segments[0], "sdk");
+        let client = segments[1]
+            .strip_prefix("client=")
+            .expect("second segment names the client");
+        let (name, version) = client.split_once('/').expect("client carries a version");
+        assert_eq!(name, "jan-websearch");
+        assert!(!version.is_empty(), "client version must not be empty");
+        assert!(segments[2].starts_with("ua="));
+        // Values are interpolated verbatim; a stray delimiter would corrupt
+        // the segment split on the receiving side.
+        assert!(segments.iter().all(|s| !s.contains(';')));
+        assert!(YOU_COM_USER_AGENT.starts_with("jan-websearch/"));
+        assert!(YOU_COM_USER_AGENT.contains("github.com/janhq/jan"));
+    }
+
+    #[test]
+    fn youcom_key_selects_transport() {
+        assert_eq!(YouComProvider::new(None).unwrap().mode, YouComMode::Hosted);
+        assert_eq!(
+            YouComProvider::new(Some("   ".into())).unwrap().mode,
+            YouComMode::Hosted
+        );
+        assert_eq!(
+            YouComProvider::new(Some("ydc-key".into())).unwrap().mode,
+            YouComMode::Rest("ydc-key".into())
+        );
+    }
+
+    #[test]
+    fn create_provider_youcom_works_with_and_without_key() {
+        assert!(create_provider(Some("you"), None, None).is_ok());
+        assert!(create_provider(Some("you"), Some("ydc-key".into()), None).is_ok());
+    }
+
+    #[test]
+    fn parse_hosted_result_text_youcom_skips_notification_frames() {
+        // The hosted endpoint emits a progress notification ahead of the
+        // answer, so the result is not the first `data:` frame.
+        let payload = json!({
+            "results": {
+                "web": [
+                    { "url": "https://example.com", "title": "T", "description": "D" }
+                ]
+            }
+        });
+        let sse = format!(
+            "event: message\ndata: {}\n\nevent: message\ndata: {}\n\n",
+            json!({
+                "jsonrpc": "2.0",
+                "method": "notifications/message",
+                "params": { "level": "info", "data": "searching" }
+            }),
+            json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": { "content": [{ "type": "text", "text": payload.to_string() }] }
+            })
+        );
+        let text = parse_hosted_result_text(&sse, "You.com").expect("result frame must be found");
+        // The hosted payload is the same shape the REST endpoint returns, so
+        // the REST normalizer reads it unchanged.
+        let parsed: Value = serde_json::from_str(&text).expect("tool payload is JSON");
+        let results = normalize_youcom_search(&parsed);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].url, "https://example.com");
+        assert_eq!(results[0].snippet, "D");
+    }
+
+    #[test]
+    fn parse_hosted_result_text_youcom_reads_bare_json_body() {
+        let raw = json!({"result": {"content": [{"type": "text", "text": "hi"}]}}).to_string();
+        assert_eq!(parse_hosted_result_text(&raw, "You.com").unwrap(), "hi");
+    }
+
+    #[test]
+    fn parse_hosted_result_text_youcom_surfaces_errors() {
+        let err = json!({"error": {"code": -32000, "message": "boom"}}).to_string();
+        assert!(parse_hosted_result_text(&err, "You.com")
+            .unwrap_err()
+            .contains("boom"));
+
+        let tool_err = json!({
+            "result": {
+                "isError": true,
+                "content": [{"type": "text", "text": "quota exceeded"}]
+            }
+        })
+        .to_string();
+        assert!(parse_hosted_result_text(&tool_err, "You.com")
+            .unwrap_err()
+            .contains("quota exceeded"));
+
+        // A stream that never carries an answer must error rather than
+        // silently returning the notification.
+        let only_notification = format!(
+            "event: message\ndata: {}\n\n",
+            json!({"jsonrpc": "2.0", "method": "notifications/message", "params": {}})
+        );
+        assert!(parse_hosted_result_text(&only_notification, "You.com").is_err());
+    }
+
+    #[test]
+    fn normalize_youcom_search_maps_contract() {
+        // Field set mirrors a live `ydc-index.io/v1/search` web result,
+        // including the thumbnail and favicon keys the normalizer ignores.
+        let body = json!({
+            "results": {
+                "web": [
+                    {
+                        "url": "https://example.com",
+                        "title": "Example",
+                        "description": "A short summary.",
+                        "snippets": ["first excerpt", "second excerpt"],
+                        "thumbnail_url": "https://cdn.example.com/img.jpg",
+                        "original_thumbnail_url": "https://cdn.example.com/img.jpg",
+                        "favicon_url": "https://example.com/favicon.ico",
+                        "page_age": "2024-05-01T00:00:00.000Z"
+                    },
+                    { "url": "https://example.org", "title": "No date", "description": "Body." }
+                ]
+            }
+        });
+        let results = normalize_youcom_search(&body);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].url, "https://example.com");
+        // Description wins over snippets when both are present.
+        assert_eq!(results[0].snippet, "A short summary.");
+        assert_eq!(
+            results[0].published_at.as_deref(),
+            Some("2024-05-01T00:00:00.000Z")
+        );
+        assert!(results[1].published_at.is_none());
+    }
+
+    #[test]
+    fn normalize_youcom_search_falls_back_to_snippet_when_no_description() {
+        let body = json!({
+            "results": {
+                "web": [
+                    {
+                        "url": "https://example.com",
+                        "title": "Missing",
+                        "snippets": ["passage one", "passage two"]
+                    },
+                    {
+                        "url": "https://example.org",
+                        "title": "Empty",
+                        "description": "",
+                        "snippets": ["passage three"]
+                    }
+                ]
+            }
+        });
+        let results = normalize_youcom_search(&body);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].snippet, "passage one");
+        // An empty description falls through to snippets rather than
+        // yielding an empty snippet.
+        assert_eq!(results[1].snippet, "passage three");
+    }
+
+    #[test]
+    fn normalize_youcom_search_clips_long_snippet() {
+        let body = json!({
+            "results": {
+                "web": [
+                    { "url": "https://example.com", "description": "x".repeat(900) }
+                ]
+            }
+        });
+        let results = normalize_youcom_search(&body);
+        assert_eq!(results[0].snippet.chars().count(), 500);
+    }
+
+    #[test]
+    fn normalize_youcom_search_empty_or_news_only_is_empty() {
+        // A news-only response must not be reported as web results.
+        let news_only = json!({
+            "results": { "news": [{ "url": "https://x", "title": "X" }] }
+        });
+        assert!(normalize_youcom_search(&news_only).is_empty());
+        assert!(normalize_youcom_search(&json!({})).is_empty());
+        assert!(normalize_youcom_search(&json!({"results": {}})).is_empty());
+        assert!(normalize_youcom_search(&json!({"results": {"web": []}})).is_empty());
+    }
+
+    #[test]
+    fn normalize_youcom_contents_reads_markdown() {
+        let body = json!([
+            { "url": "https://example.com", "title": "T", "markdown": "hello world" }
+        ]);
+        let page = normalize_youcom_contents(&body, "https://example.com").unwrap();
+        assert_eq!(page.title, "T");
+        assert_eq!(page.url, "https://example.com");
+        assert_eq!(page.content, "hello world");
+        assert!(!page.truncated);
+    }
+
+    #[test]
+    fn normalize_youcom_contents_truncates_and_marks_truncated() {
+        let big = "a".repeat(FETCH_MAX_CHARS + 100);
+        let body = json!([
+            { "url": "https://example.com", "title": "T", "markdown": big }
+        ]);
+        let page = normalize_youcom_contents(&body, "https://example.com").unwrap();
+        assert!(page.truncated);
+        assert_eq!(page.content.chars().count(), FETCH_MAX_CHARS);
+    }
+
+    #[test]
+    fn normalize_youcom_contents_no_results_errors() {
+        assert!(normalize_youcom_contents(&json!([]), "u").is_err());
+        // A non-array body must error rather than panic.
+        assert!(normalize_youcom_contents(&json!({"results": []}), "u").is_err());
     }
 }

--- a/src-tauri/plugins/tauri-plugin-websearch/src/provider.rs
+++ b/src-tauri/plugins/tauri-plugin-websearch/src/provider.rs
@@ -565,6 +565,16 @@ fn normalize_tavily_extract(body: &Value, requested_url: &str) -> Result<Fetched
     })
 }
 
+/// Attach the shared You.com request headers. Callers set the body with
+/// `.json()`, which already sets `Content-Type: application/json` — setting it
+/// again here would duplicate the header (reqwest's `.header()` appends), and
+/// api.you.com rejects a multi-valued `Content-Type` with HTTP 415.
+fn with_youcom_headers(request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+    request
+        .header("user-agent", YOU_COM_USER_AGENT)
+        .header("x-client-info", YOU_COM_CLIENT_INFO)
+}
+
 /// Which You.com transport the adapter uses.
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum YouComMode {
@@ -605,10 +615,7 @@ impl YouComProvider {
     /// Send a prepared request and return the body, mapping transport and HTTP
     /// failures into one message shape for both transports.
     async fn send(&self, request: reqwest::RequestBuilder) -> Result<String, String> {
-        let resp = request
-            .header("content-type", "application/json")
-            .header("user-agent", YOU_COM_USER_AGENT)
-            .header("x-client-info", YOU_COM_CLIENT_INFO)
+        let resp = with_youcom_headers(request)
             .send()
             .await
             .map_err(|e| format!("You.com request failed: {e}"))?;
@@ -1186,6 +1193,32 @@ mod tests {
         assert!(segments.iter().all(|s| !s.contains(';')));
         assert!(YOU_COM_USER_AGENT.starts_with("jan-websearch/"));
         assert!(YOU_COM_USER_AGENT.contains("github.com/janhq/jan"));
+    }
+
+    #[test]
+    fn youcom_requests_send_a_single_content_type() {
+        // Regression test: reqwest's `.json()` sets `Content-Type` and
+        // `.header()` appends, so an extra explicit header produced a
+        // duplicated `content-type: application/json` — which api.you.com
+        // rejects with HTTP 415 ("Content-Type must be application/json").
+        let body = json!({ "jsonrpc": "2.0", "id": 1, "method": "tools/call" });
+        let req = with_youcom_headers(
+            YouComProvider::new(None)
+                .unwrap()
+                .client
+                .post(YOU_COM_HOSTED_URL)
+                .header("accept", "application/json, text/event-stream")
+                .json(&body),
+        )
+        .build()
+        .unwrap();
+        assert_eq!(req.headers().get_all("content-type").iter().count(), 1);
+        assert_eq!(
+            req.headers().get("content-type").unwrap(),
+            "application/json"
+        );
+        assert!(req.headers().contains_key("user-agent"));
+        assert!(req.headers().contains_key("x-client-info"));
     }
 
     #[test]

--- a/web-app/src/hooks/useWebSearchConfig.ts
+++ b/web-app/src/hooks/useWebSearchConfig.ts
@@ -36,6 +36,13 @@ export const WEB_SEARCH_PROVIDERS: WebSearchProviderMeta[] = [
     homepage: 'searxng.org',
     requiresEndpoint: true,
   },
+  {
+    id: 'you',
+    label: 'You.com',
+    keyless: true,
+    secretKey: 'you-api-key',
+    homepage: 'you.com',
+  },
 ]
 
 export const DEFAULT_SEARCH_PROVIDER = 'exa'


### PR DESCRIPTION
Closes #8842

Adds **You.com** as a fourth option in Jan's built-in `web_search` / `web_fetch` provider picker, alongside Exa, Tavily, and SearXNG. Exa stays the default — this only adds another choice.

Like Exa, it works with no API key and upgrades when you supply one.

## What's in the diff

| File | Change |
|---|---|
| `src-tauri/plugins/tauri-plugin-websearch/src/provider.rs` | `YouComProvider` (two transports) + normalizers + 14 tests |
| `web-app/src/hooks/useWebSearchConfig.ts` | One entry appended to `WEB_SEARCH_PROVIDERS` |
| `docs/src/pages/docs/desktop/web-search.mdx` | Provider table row, keyword, key-requirement note |

No new dependencies, no new user-facing strings, and no change to `DEFAULT_SEARCH_PROVIDER`.

## Two transports, picked by whether a key is present

This mirrors how `ExaProvider` chooses between its hosted and REST modes.

**Keyless (default)** — one MCP `tools/call` against `https://api.you.com/mcp?profile=free`, which answers `you-search` with no credentials. There is no keyless content-extraction tool, so `web_fetch` falls back to a direct GET — the same thing `SearxngProvider` does for a backend with no extraction endpoint. Suits trying the provider out; the free profile carries a daily request cap.

**Keyed (opt-in)** — the REST API, per You.com's published OpenAPI specs ([web-search.json](https://you.com/docs/openapi/web-search.json), [contents.json](https://you.com/docs/openapi/contents.json)):

- `POST https://ydc-index.io/v1/search`, body `{"query", "count"}`
- `POST https://ydc-index.io/v1/contents`, body `{"urls", "formats": ["markdown"]}`
- `X-API-Key` header on both

Both specs declare `servers[0].url` as `https://ydc-index.io` (`description: Production`) and a single `securitySchemes` entry of `{type: apiKey, in: header, name: X-API-Key}`. The key lifts the request cap and gives `web_fetch` extracted markdown instead of raw HTML.

**Both transports return the same search payload**, so one normalizer serves both — the hosted tool result is the same JSON the REST endpoint returns, not a reformatted text blob. Only `query` and `count` are sent; the search tool accepts more (freshness, locale, domain filters), but Jan's `web_search` contract doesn't expose them, so the backend doesn't invent them.

## Request attribution

Requests to You.com carry `User-Agent: jan-websearch/<crate version> (…)` and `X-Client-Info: sdk; client=jan-websearch/<crate version>; ua=rust/unknown`, the convention You.com's other integrations follow. They identify the calling component and its version — not the user, the query, or anything about the machine — and go only to You.com, on requests the user has already opted into by selecting this provider. The direct-GET `web_fetch` path deliberately sends neither, since it retrieves arbitrary third-party pages. A test pins the header grammar. Concretely, the server folds `X-Client-Info` into the error-report link it generates when a tool call fails, so a Jan user hitting an error produces a report that identifies where it came from.

**Flagging this explicitly: no other backend in this file sends anything like it.** Exa, Tavily, and SearXNG send only `content-type`, `accept`, and their auth header, so this would be a first for the plugin, and it comes from someone with an interest in the traffic being attributed. It is genuinely useful to us for supporting the integration, and I believe it is standard practice for an API client to identify itself — but if you would rather the plugin stay uniform and send nothing of the sort, say so and I will drop both headers. That is a one-line change and it does not affect anything else in this PR.

## Normalization

Modeled on the existing `TavilyProvider`:

- `description` becomes the snippet; a missing **or empty** description falls back to `snippets[0]`. Both are clipped at 500 chars via the shared `clip_chars`.
- `page_age` maps to `published_at`; empty values become `None`.
- `thumbnail_url`, `original_thumbnail_url`, and `favicon_url` are intentionally dropped — no other backend in this file tracks thumbnails.
- A response with no `web` section (news-only, or empty) yields **no results** rather than silently falling back to `news`, since `web` is what `web_search` promises.
- Keyed fetch reads `markdown` only, and bounds it with the plugin's existing `FETCH_MAX_CHARS`. The request asks for `formats: ["markdown"]` and the API returns only the formats requested, so an html fallback would be unreachable.

## Two consolidations instead of near-duplicates

Rather than adding a second copy of logic this file already had, I folded both into the existing helpers. Happy to split either out if you'd rather keep the diff strictly additive:

- **`parse_hosted_result_text`** now takes a provider label and selects the JSON-RPC frame carrying `result`/`error`, so it serves both hosted transports. For a stream whose first frame is already the answer, behavior is unchanged; the selection just doesn't assume it. The alternative was a second MCP envelope parser sitting beside the first.
- **`fetch_url_direct`** holds the direct-GET fetch that SearXNG already did inline, now shared by both backends that need it. `SearxngProvider::fetch` keeps its exact error strings.

`YouComProvider::post_rest` is still close to `TavilyProvider::post` — the auth header and label differ. A shared `post_json(...)` would collapse those and Exa's two inline copies too, but that's a refactor of code this PR doesn't otherwise touch, so I left it. Glad to do it if wanted.

## Testing

`cargo test --no-default-features` → **38 passed, 0 failed** (14 new). Coverage:

- transport selection: no key and whitespace-only key select hosted, a real key selects REST
- provider selection through `create_provider`, with and without a key
- attribution header grammar
- **hosted frame selection** — a stream that emits a progress notification ahead of the answer parses correctly, and the payload feeds the REST normalizer unchanged
- requests carry exactly one `Content-Type` — api.you.com answers a multi-valued header with HTTP 415; pinned by a test that builds the request the hosted way
- hosted error paths: JSON-RPC `error`, tool-level `isError`, and a stream that never carries an answer
- search field mapping against a fixture carrying the full live response field set
- snippet fallback for both a missing and an empty `description`, and clipping at 500 chars
- news-only, absent, and empty responses normalizing to no results
- markdown extraction, truncation at `FETCH_MAX_CHARS`, and the no-content error

Also run: `cargo clippy --no-default-features --tests -- -D warnings` (clean), `cargo fmt --check` (clean on new code), `tsc -b` and `eslint` on the web-app (byte-identical to the pre-change baseline).

Verified against the live API: both transports return the shapes the normalizers read, with and without the attribution headers.

Verified end to end in a desktop dev build: the Web Search settings picker lists You.com alongside the existing providers with the optional-key copy, Exa remains the default, and a chat with web search enabled ran a real keyless `web_search` → `web_fetch` chain. Keyless `web_fetch` is a direct GET of the target page (the SearXNG precedent), so pages behind bot protection can still 403; the keyed tier's `/v1/contents` is the remedy by design.

## Frontend

Jan's Web Search settings page is fully data-driven off `WEB_SEARCH_PROVIDERS`, and every string in `settings.json` already interpolates `{{provider}}`. The picker entry is pure data — **no component changes and no edits to any of the 17 locale files.** `keyless: true` makes the panel render the optional-key copy automatically.

## Disclosure

I work at You.com, which operates the APIs this PR talks to.




