### PR TITLE
feat(mcp): add You.com to default MCP server list

### DIFF
--- a/src-tauri/src/core/mcp/constants.rs
+++ b/src-tauri/src/core/mcp/constants.rs
@@ -60,6 +60,12 @@ pub const DEFAULT_MCP_CONFIG: &str = r#"{
       "args": ["-y", "@modelcontextprotocol/server-sequential-thinking"],
       "env": {},
       "active": false
+    },
+    "you": {
+      "command": "npx",
+      "args": ["-y", "@youdotcom-oss/mcp"],
+      "env": { "YDC_API_KEY": "YOUR_YDC_API_KEY_HERE" },
+      "active": false
     }
   },
   "mcpSettings": {


### PR DESCRIPTION
Closes #8843

Adds a `you` entry to `DEFAULT_MCP_CONFIG` so the You.com MCP server is one toggle away in the default server list, instead of something users have to hand-write into `mcp_config.json`.

## The diff

```json
"you": {
  "command": "npx",
  "args": ["-y", "@youdotcom-oss/mcp"],
  "env": { "YDC_API_KEY": "YOUR_YDC_API_KEY_HERE" },
  "active": false
}
```

Six lines in `src-tauri/src/core/mcp/constants.rs`. Nothing else changes.

## Why each field looks like this

Every choice mirrors an entry already in the file rather than inventing a convention:

- **`you`** — lowercase, like `fetch`, `serper`, `filesystem`, and `sequential-thinking`.
- **`npx -y @youdotcom-oss/mcp`** — the STDIO package documented on [You.com's MCP server docs](https://you.com/docs/build-with-agents/mcp-server.md). The `-y` flag matches every npx entry in this config except `browsermcp` (`Jan Browser MCP`, `serper`, `filesystem`, `sequential-thinking`) and suppresses the first-run install prompt.
- **`YDC_API_KEY`** — the env var name from the same docs.
- **`active: false`** — opt-in, like every other default entry.
- **no `official` flag** — only Jan's own `Jan Browser MCP` carries one. No third-party entry in this config does, so adding one here would have been the surprising choice. Flip it on later if You.com ever gets promoted to a recommended vendor.

Key order in the object matches its siblings.

## What the server provides

`you-search`, `you-contents`, `you-research`, `you-balance`, and `you-discover` are exposed by default, with `you-finance` available opt-in via `YDC_ALLOWED_TOOLS`. The package is published as [`@youdotcom-oss/mcp`](https://www.npmjs.com/package/@youdotcom-oss/mcp) and listed in the official MCP Registry as `io.github.youdotcom-oss/mcp`.

## Testing

- `cargo test -p Jan --lib --no-default-features --features cli mcp::` → **34 passed, 0 failed**. This includes `test_extract_command_args_parses_default_mcp_config_servers`, which parses every entry in `DEFAULT_MCP_CONFIG` and asserts each one has a usable command — the test that actually guards this file.
- `cargo check` and `cargo clippy -- -D warnings` clean; `cargo fmt --check` clean.
- Verified the raw string literal still parses as JSON and now yields 7 servers.

## Vetting notes

Flagging the things a maintainer would reasonably want to confirm before shipping a third-party service in the default list, since I have an obvious interest here:

- **Nothing runs unless a user opts in.** `active: false`, and the entry carries a placeholder rather than a real credential — the same shape `serper` ships.
- **Indentation and key order match the sibling entries exactly** (4/6 spaces, `command` / `args` / `env` / `active`), so the embedded JSON literal stays uniform.
- **Package provenance:** [`@youdotcom-oss/mcp`](https://www.npmjs.com/package/@youdotcom-oss/mcp) is published from the [youdotcom-oss/dx-toolkit](https://github.com/youdotcom-oss/dx-toolkit/tree/main/packages/mcp) repo and listed in the official MCP Registry as `io.github.youdotcom-oss/mcp`.
- **`npx` version is unpinned**, matching `serper`, `browsermcp`, `filesystem`, and `sequential-thinking`. Happy to pin it if you would rather new entries did.

## Relationship to the other PR

A companion PR adds a You.com backend to `tauri-plugin-websearch` for the native `web_search` / `web_fetch` path. The two are independent — this one is the MCP-managed route, that one is the built-in-tools route. Either can land without the other.

## Disclosure

I work at You.com, which operates the MCP server this PR adds to the default list.


