### PR TITLE
fix: omit tauri Origin on outbound provider requests

### DIFF
--- a/src-tauri/src/core/server/proxy.rs
+++ b/src-tauri/src/core/server/proxy.rs
@@ -7,7 +7,10 @@ use hyper::server::conn::http1;
 use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
-use jan_utils::{extract_host_from_origin, is_cors_header, is_valid_host, remove_prefix};
+use jan_utils::{
+    extract_host_from_origin, is_cors_header, is_valid_host, remove_prefix,
+    skip_outbound_provider_header,
+};
 use reqwest::Client;
 use serde_json;
 use std::collections::HashMap;
@@ -2015,11 +2018,15 @@ async fn proxy_request(
 
         // Body is re-buffered/rewritten, so a stale inbound Content-Length would
         // mismatch the bytes we send and stall the upstream; reqwest re-derives it.
+        // Origin/Referer stay on the inbound CORS path and are not forwarded —
+        // the Tauri webview Origin (`http://tauri.localhost`) 403s CORS-strict
+        // backends such as Ollama.
         for (name, value) in headers.iter() {
             if name != hyper::header::HOST
                 && name != hyper::header::AUTHORIZATION
                 && name != hyper::header::CONTENT_LENGTH
                 && name != hyper::header::TRANSFER_ENCODING
+                && !skip_outbound_provider_header(name.as_str())
             {
                 outbound_req = outbound_req.header(name, value);
             }
@@ -2115,6 +2122,7 @@ async fn proxy_request(
                             && name != "content-type"
                             && name != hyper::header::CONTENT_LENGTH
                             && name != hyper::header::ACCEPT_ENCODING
+                            && !skip_outbound_provider_header(name.as_str())
                         {
                             fallback_req = fallback_req.header(name, value);
                         }

--- a/src-tauri/utils/src/http.rs
+++ b/src-tauri/utils/src/http.rs
@@ -15,6 +15,49 @@ pub fn is_cors_header(header_name: &str) -> bool {
     header_lower.starts_with("access-control-")
 }
 
+/// True when `value` is the Tauri webview origin or referer
+/// (`http://tauri.localhost`, `https://tauri.localhost[:port]`, `tauri://localhost`,
+/// or the opaque `null` origin).
+pub fn is_tauri_webview_origin(value: &str) -> bool {
+    let v = value.trim();
+    if v.is_empty() {
+        return false;
+    }
+    if v.eq_ignore_ascii_case("null") || v.eq_ignore_ascii_case("tauri://localhost") {
+        return true;
+    }
+    let host = extract_host_from_origin(v);
+    let host_without_port = if host.starts_with('[') {
+        host.split(']')
+            .next()
+            .unwrap_or(&host)
+            .trim_start_matches('[')
+            .to_string()
+    } else {
+        host.split(':').next().unwrap_or(&host).to_string()
+    };
+    host_without_port.eq_ignore_ascii_case("tauri.localhost")
+}
+
+/// Browser-context headers that must not be copied onto outbound provider calls.
+/// Jan's local API CORS still reads inbound `Origin` separately.
+pub fn skip_outbound_provider_header(name: &str) -> bool {
+    matches!(name.to_ascii_lowercase().as_str(), "origin" | "referer")
+}
+
+/// Drop `Origin` / `Referer` so a Tauri webview's `http://tauri.localhost` origin
+/// is not forwarded to CORS-strict backends (Ollama, nginx).
+pub fn filter_outbound_provider_headers<'a, I>(headers: I) -> Vec<(String, String)>
+where
+    I: IntoIterator<Item = (&'a str, &'a str)>,
+{
+    headers
+        .into_iter()
+        .filter(|(name, _)| !skip_outbound_provider_header(name))
+        .map(|(name, value)| (name.to_string(), value.to_string()))
+        .collect()
+}
+
 /// Validates if host is in trusted hosts list
 pub fn is_valid_host(host: &str, trusted_hosts: &[Vec<String>]) -> bool {
     if trusted_hosts.iter().any(|hosts| hosts.contains(&"*".to_string())) {
@@ -115,6 +158,46 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn tauri_webview_origin_is_detected() {
+        assert!(is_tauri_webview_origin("http://tauri.localhost"));
+        assert!(is_tauri_webview_origin("https://tauri.localhost"));
+        assert!(is_tauri_webview_origin("http://tauri.localhost:1420"));
+        assert!(is_tauri_webview_origin("tauri://localhost"));
+        assert!(is_tauri_webview_origin("null"));
+        assert!(is_tauri_webview_origin("http://tauri.localhost/index.html"));
+        assert!(!is_tauri_webview_origin("https://api.openai.com"));
+        assert!(!is_tauri_webview_origin("http://localhost:11434"));
+        assert!(!is_tauri_webview_origin(""));
+    }
+
+    #[test]
+    fn filter_outbound_provider_headers_strips_tauri_origin() {
+        let out = filter_outbound_provider_headers([
+            ("Content-Type", "application/json"),
+            ("Origin", "http://tauri.localhost"),
+            ("Referer", "http://tauri.localhost/"),
+            ("Authorization", "Bearer k"),
+        ]);
+        assert!(!out
+            .iter()
+            .any(|(n, _)| n.eq_ignore_ascii_case("origin") || n.eq_ignore_ascii_case("referer")));
+        assert!(out
+            .iter()
+            .any(|(n, v)| n == "Content-Type" && v == "application/json"));
+        assert!(out
+            .iter()
+            .any(|(n, v)| n == "Authorization" && v == "Bearer k"));
+    }
+
+    #[test]
+    fn skip_outbound_provider_header_matches_origin_and_referer() {
+        assert!(skip_outbound_provider_header("Origin"));
+        assert!(skip_outbound_provider_header("referer"));
+        assert!(!skip_outbound_provider_header("Authorization"));
+        assert!(!skip_outbound_provider_header("Content-Type"));
+    }
+
     // LAN reachability preserved: private/loopback IP literals are accepted even
     // with an empty allowlist, so a 0.0.0.0 bind still serves LAN clients.
     #[test]
@@ -125,7 +208,7 @@ mod tests {
         assert!(is_valid_host("172.16.4.4:8080", &trusted));
         assert!(is_valid_host("169.254.1.1", &trusted)); // link-local
         assert!(is_valid_host("[::1]:1337", &trusted)); // IPv6 loopback
-        // A public IP literal is NOT auto-trusted.
+                                                        // A public IP literal is NOT auto-trusted.
         assert!(!is_valid_host("8.8.8.8:1337", &trusted));
     }
 }

--- a/web-app/src/lib/__tests__/model-factory.deep.test.ts
+++ b/web-app/src/lib/__tests__/model-factory.deep.test.ts
@@ -231,7 +231,7 @@ describe('model-factory deep coverage', () => {
       const opts = getOpts()
       expect(opts.url({ path: '/chat/completions' })).toBe('http://localhost:8080/v1/chat/completions')
       expect(opts.headers().Authorization).toBe('Bearer llama-key')
-      expect(opts.headers().Origin).toBe('tauri://localhost')
+      expect(opts.headers().Origin).toBeUndefined()
     })
 
     it('custom fetch merges params and strips client-side keys', async () => {

--- a/web-app/src/lib/__tests__/model-factory.test.ts
+++ b/web-app/src/lib/__tests__/model-factory.test.ts
@@ -333,6 +333,31 @@ describe('createCustomFetch — named SSE event filtering scope', () => {
   })
 })
 
+describe('createCustomFetch — omits Tauri webview Origin', () => {
+  it('does not forward Origin: http://tauri.localhost', async () => {
+    const seen: { headers?: HeadersInit } = {}
+    const baseFetch: typeof globalThis.fetch = (async (
+      _input: RequestInfo | URL,
+      init?: RequestInit
+    ) => {
+      seen.headers = init?.headers
+      return new Response('{}', { status: 200 })
+    }) as typeof globalThis.fetch
+    const wrapped = createCustomFetch(baseFetch, {})
+    await wrapped('http://127.0.0.1:11434/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'http://tauri.localhost',
+      },
+      body: '{}',
+    })
+    const headers = seen.headers as Record<string, string>
+    expect(headers.Origin).toBe('')
+    expect(headers.Origin).not.toBe('http://tauri.localhost')
+  })
+})
+
 describe('createCustomFetch — max_tokens coercion', () => {
   async function captureSentBody(
     parameters: Record<string, unknown>,

--- a/web-app/src/lib/__tests__/omitTauriWebviewOrigin.test.ts
+++ b/web-app/src/lib/__tests__/omitTauriWebviewOrigin.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  fetchWithoutTauriWebviewOrigin,
+  headersWithoutTauriWebviewOrigin,
+  isTauriWebviewOrigin,
+} from '../omitTauriWebviewOrigin'
+
+describe('isTauriWebviewOrigin', () => {
+  it('detects the Tauri webview host', () => {
+    expect(isTauriWebviewOrigin('http://tauri.localhost')).toBe(true)
+    expect(isTauriWebviewOrigin('https://tauri.localhost')).toBe(true)
+    expect(isTauriWebviewOrigin('http://tauri.localhost:1420')).toBe(true)
+    expect(isTauriWebviewOrigin('tauri://localhost')).toBe(true)
+    expect(isTauriWebviewOrigin('null')).toBe(true)
+    expect(isTauriWebviewOrigin('http://tauri.localhost/index.html')).toBe(true)
+  })
+
+  it('leaves real provider origins alone', () => {
+    expect(isTauriWebviewOrigin('https://api.openai.com')).toBe(false)
+    expect(isTauriWebviewOrigin('http://localhost:11434')).toBe(false)
+    expect(isTauriWebviewOrigin('')).toBe(false)
+  })
+})
+
+describe('headersWithoutTauriWebviewOrigin', () => {
+  it('sets empty Origin so plugin-http omits the webview host', () => {
+    const headers = headersWithoutTauriWebviewOrigin({
+      'Content-Type': 'application/json',
+      Origin: 'http://tauri.localhost',
+    }) as Record<string, string>
+    expect(headers.Origin).toBe('')
+    expect(headers['Content-Type']).toBe('application/json')
+  })
+
+  it('strips tauri://localhost Origin', () => {
+    const headers = headersWithoutTauriWebviewOrigin({
+      Origin: 'tauri://localhost',
+    }) as Record<string, string>
+    expect(headers.Origin).toBe('')
+  })
+
+  it('injects empty Origin when the caller omitted it', () => {
+    const headers = headersWithoutTauriWebviewOrigin({
+      Authorization: 'Bearer k',
+    }) as Record<string, string>
+    expect(headers.Origin).toBe('')
+    expect(headers.Authorization).toBe('Bearer k')
+  })
+
+  it('keeps a non-webview Origin', () => {
+    const headers = headersWithoutTauriWebviewOrigin({
+      Origin: 'https://jan.ai',
+    }) as Record<string, string>
+    expect(headers.Origin).toBe('https://jan.ai')
+  })
+
+  it('drops a tauri.localhost Referer', () => {
+    const headers = headersWithoutTauriWebviewOrigin({
+      Referer: 'http://tauri.localhost/',
+      'Content-Type': 'application/json',
+    }) as Record<string, string>
+    expect(headers.Referer).toBeUndefined()
+    expect(headers.Origin).toBe('')
+  })
+})
+
+describe('fetchWithoutTauriWebviewOrigin', () => {
+  it('does not send Origin: http://tauri.localhost to the upstream fetch', async () => {
+    const inner = vi.fn().mockResolvedValue(new Response('{}', { status: 200 }))
+    const wrapped = fetchWithoutTauriWebviewOrigin(inner as unknown as typeof fetch)
+
+    await wrapped('http://127.0.0.1:11434/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'http://tauri.localhost',
+      },
+      body: '{}',
+    })
+
+    expect(inner).toHaveBeenCalledTimes(1)
+    const passed = inner.mock.calls[0][1]?.headers as Record<string, string>
+    expect(passed.Origin).toBe('')
+    expect(passed.Origin).not.toBe('http://tauri.localhost')
+  })
+})

--- a/web-app/src/lib/ai-model.ts
+++ b/web-app/src/lib/ai-model.ts
@@ -88,7 +88,6 @@ export function createLanguageModel(
       baseURL: 'http://localhost:1337/v1', // Placeholder - will be updated when model loads
       headers: {
         Authorization: 'Bearer placeholder', // Placeholder - will be updated when model loads
-        Origin: 'tauri://localhost',
       },
       // Include usage data in streaming responses for token speed calculation
       includeUsage: true,
@@ -124,11 +123,6 @@ export function createLanguageModel(
     apiKey: provider.api_key ?? '',
     baseURL: provider.base_url ?? 'http://localhost:1337/v1',
     headers: {
-      // Add Origin header for local providers
-      ...(provider.base_url?.includes('localhost:') ||
-      provider.base_url?.includes('127.0.0.1:')
-        ? { Origin: 'tauri://localhost' }
-        : {}),
       // OpenRouter identification headers
       ...(provider.provider === 'openrouter'
         ? {

--- a/web-app/src/lib/model-factory.ts
+++ b/web-app/src/lib/model-factory.ts
@@ -59,7 +59,8 @@ import { createGoogleGenerativeAI } from '@ai-sdk/google'
 import { invoke } from '@tauri-apps/api/core'
 import { findSessionByModel } from '@janhq/tauri-plugin-llamacpp-api'
 import { SessionInfo } from '@janhq/core'
-import { fetch as httpFetch } from '@tauri-apps/plugin-http'
+import { fetch as tauriHttpFetch } from '@tauri-apps/plugin-http'
+import { fetchWithoutTauriWebviewOrigin, headersWithoutTauriWebviewOrigin } from '@/lib/omitTauriWebviewOrigin'
 import { hasAudioSentinel, splitAudioSentinels } from './audio-sentinel'
 import { hasVideoSentinel, splitVideoSentinels } from './video-sentinel'
 import { filterDefaultSseEvents } from './sseEventTypeFilter'
@@ -80,6 +81,10 @@ import { i18n } from '@/i18n/react-i18next-compat'
 import { useAppState } from '@/hooks/useAppState'
 import { useGeneralSetting } from '@/hooks/useGeneralSetting'
 import { ensureAnthropicHeaders } from '@/lib/remoteModelCatalog'
+
+const httpFetch = fetchWithoutTauriWebviewOrigin(
+  tauriHttpFetch as typeof globalThis.fetch
+)
 
 /**
  * Llama.cpp timings structure from the response
@@ -511,6 +516,10 @@ export function createCustomFetch(
   }
 
   return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    init = {
+      ...init,
+      headers: headersWithoutTauriWebviewOrigin(init?.headers),
+    }
     let rawBody: Record<string, unknown> | null = null
     if (init?.method === 'POST' || !init?.method) {
       try {
@@ -1033,7 +1042,6 @@ export class ModelFactory {
       provider: 'llamacpp',
       headers: () => ({
         Authorization: `Bearer ${sessionInfo.api_key}`,
-        Origin: 'tauri://localhost',
       }),
       url: ({ path }) => {
         const url = new URL(`http://localhost:${sessionInfo.port}/v1${path}`)
@@ -1083,7 +1091,6 @@ export class ModelFactory {
     const baseUrl = `http://localhost:${sessionInfo.port}`
     const authHeaders = {
       Authorization: `Bearer ${sessionInfo.api_key}`,
-      Origin: 'tauri://localhost',
     }
 
     // Share the common fetch (param normalisation + error-body cleaning that

--- a/web-app/src/lib/omitTauriWebviewOrigin.ts
+++ b/web-app/src/lib/omitTauriWebviewOrigin.ts
@@ -1,0 +1,73 @@
+/**
+ * Tauri's HTTP plugin injects the webview origin (`http://tauri.localhost`)
+ * unless `Origin` is present. With `unsafe-headers` enabled, an empty `Origin`
+ * tells the plugin to omit the header entirely — CORS-strict backends
+ * (Ollama, nginx) 403 on the webview origin.
+ */
+
+export function isTauriWebviewOrigin(value: string): boolean {
+  const v = value.trim()
+  if (!v) return false
+  if (v.toLowerCase() === 'null' || v.toLowerCase() === 'tauri://localhost') {
+    return true
+  }
+  try {
+    const host = new URL(v).hostname
+    return host.toLowerCase() === 'tauri.localhost'
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Ensure outbound provider requests do not carry the Tauri webview Origin
+ * (or a Referer that points at it). An empty Origin is the plugin-http
+ * signal to strip the header; a caller-supplied non-webview Origin is kept.
+ */
+export function headersWithoutTauriWebviewOrigin(
+  headers?: HeadersInit
+): HeadersInit {
+  if (
+    !headers ||
+    (typeof headers === 'object' &&
+      !(headers instanceof Headers) &&
+      !Array.isArray(headers))
+  ) {
+    const out: Record<string, string> = headers
+      ? { ...(headers as Record<string, string>) }
+      : {}
+    const originKey = Object.keys(out).find((k) => k.toLowerCase() === 'origin')
+    const origin = originKey ? out[originKey] : undefined
+    if (originKey) delete out[originKey]
+    if (!origin || isTauriWebviewOrigin(origin)) {
+      out.Origin = ''
+    } else if (originKey) {
+      out[originKey] = origin
+    }
+    const refererKey = Object.keys(out).find((k) => k.toLowerCase() === 'referer')
+    if (refererKey && isTauriWebviewOrigin(out[refererKey])) {
+      delete out[refererKey]
+    }
+    return out
+  }
+
+  const h = new Headers(headers)
+  const origin = h.get('Origin')
+  if (!origin || isTauriWebviewOrigin(origin)) {
+    h.set('Origin', '')
+  }
+  const referer = h.get('Referer')
+  if (referer && isTauriWebviewOrigin(referer)) {
+    h.delete('Referer')
+  }
+  return h
+}
+
+export function fetchWithoutTauriWebviewOrigin(
+  baseFetch: typeof fetch
+): typeof fetch {
+  return ((input: RequestInfo | URL, init?: RequestInit) => {
+    const headers = headersWithoutTauriWebviewOrigin(init?.headers)
+    return baseFetch(input, { ...init, headers })
+  }) as typeof fetch
+}

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -429,12 +429,6 @@ function ProviderDetail() {
           'x-api-key': key,
           Authorization: `Bearer ${key}`,
         }
-        if (
-          provider.base_url.includes('localhost:') ||
-          provider.base_url.includes('127.0.0.1:')
-        ) {
-          headers['Origin'] = 'tauri://localhost'
-        }
 
         try {
           const response = await fetchImpl(`${provider.base_url}/models`, {

--- a/web-app/src/services/providers/__tests__/tauri.test.ts
+++ b/web-app/src/services/providers/__tests__/tauri.test.ts
@@ -86,8 +86,19 @@ describe('TauriProvidersService', () => {
   })
 
   describe('fetch', () => {
-    it('returns Tauri fetch', () => {
-      expect(svc.fetch()).toBe(fetchTauri)
+    it('wraps Tauri fetch so Origin is omitted', async () => {
+      vi.mocked(fetchTauri).mockResolvedValueOnce(new Response('{}') as any)
+      const wrapped = svc.fetch()
+      expect(wrapped).not.toBe(fetchTauri)
+      await wrapped('https://example.com/v1/models', {
+        headers: { Origin: 'http://tauri.localhost' },
+      })
+      expect(fetchTauri).toHaveBeenCalledWith(
+        'https://example.com/v1/models',
+        expect.objectContaining({
+          headers: expect.objectContaining({ Origin: '' }),
+        })
+      )
     })
   })
 
@@ -321,7 +332,7 @@ describe('TauriProvidersService', () => {
       errSpy.mockRestore()
     })
 
-    it('adds Origin header for localhost URLs', async () => {
+    it('omits Origin for localhost URLs', async () => {
       const localProvider = { ...baseProvider, base_url: 'http://localhost:1234' }
       vi.mocked(fetchTauri).mockResolvedValueOnce({
         ok: true,
@@ -333,9 +344,15 @@ describe('TauriProvidersService', () => {
       expect(fetchTauri).toHaveBeenCalledWith(
         'http://localhost:1234/models',
         expect.objectContaining({
-          headers: expect.objectContaining({ Origin: 'tauri://localhost' }),
+          headers: expect.objectContaining({ Origin: '' }),
         })
       )
+      const headers = vi.mocked(fetchTauri).mock.calls[0][1]?.headers as Record<
+        string,
+        string
+      >
+      expect(headers.Origin).not.toBe('http://tauri.localhost')
+      expect(headers.Origin).not.toBe('tauri://localhost')
     })
 
     it('adds auth headers when api key is available', async () => {

--- a/web-app/src/services/providers/tauri.ts
+++ b/web-app/src/services/providers/tauri.ts
@@ -9,6 +9,7 @@ import { ModelCapabilities } from '@/types/models'
 import { modelSettings } from '@/lib/predefined'
 import { ExtensionManager } from '@/lib/extension'
 import { fetch as fetchTauri } from '@tauri-apps/plugin-http'
+import { fetchWithoutTauriWebviewOrigin } from '@/lib/omitTauriWebviewOrigin'
 import { invoke } from '@tauri-apps/api/core'
 import { DefaultProvidersService } from './default'
 import { getModelCapabilities } from '@/lib/models'
@@ -20,8 +21,9 @@ import { ensureAnthropicHeaders } from '@/lib/remoteModelCatalog'
 
 export class TauriProvidersService extends DefaultProvidersService {
   fetch(): typeof fetch {
-    // Tauri implementation uses Tauri's fetch to avoid CORS issues
-    return fetchTauri as typeof fetch
+    // Tauri fetch avoids CORS; empty Origin omits the webview host so
+    // CORS-strict backends (Ollama) don't 403. See omitTauriWebviewOrigin.
+    return fetchWithoutTauriWebviewOrigin(fetchTauri as typeof fetch)
   }
 
   async getProviders(): Promise<ModelProvider[]> {
@@ -163,13 +165,6 @@ export class TauriProvidersService extends DefaultProvidersService {
           'Content-Type': 'application/json',
         }
 
-        if (
-          provider.base_url.includes('localhost:') ||
-          provider.base_url.includes('127.0.0.1:')
-        ) {
-          headers['Origin'] = 'tauri://localhost'
-        }
-
         if (key) {
           headers['x-api-key'] = key
           headers['Authorization'] = `Bearer ${key}`
@@ -183,7 +178,7 @@ export class TauriProvidersService extends DefaultProvidersService {
 
         ensureAnthropicHeaders(provider, headers)
 
-        const response = await fetchTauri(`${provider.base_url}/models`, {
+        const response = await this.fetch()(`${provider.base_url}/models`, {
           method: 'GET',
           headers,
         })


### PR DESCRIPTION
Fixes #8792

Tauri's HTTP plugin injects `Origin: http://tauri.localhost` on provider requests, and the local API proxy was forwarding inbound Origin/Referer upstream. CORS-strict backends (Ollama behind nginx, `OLLAMA_ORIGINS`) then 403.

This omits Origin/Referer on outbound provider calls (empty Origin is plugin-http's strip signal). Jan's own API CORS is unchanged.

thx