### PR TITLE
feat: add NeuronPool OpenAI-compatible provider

### DIFF
--- a/web-app/src/constants/providers.ts
+++ b/web-app/src/constants/providers.ts
@@ -399,4 +399,38 @@ export const predefinedProviders = [
     ],
     models: [],
   },
+  {
+    active: true,
+    api_key: '',
+    base_url: 'https://neuronpool.damnknee.workers.dev/v1',
+    explore_models_url: 'https://neuronpool.damnknee.workers.dev/v1/models',
+    provider: 'neuronpool',
+    settings: [
+      {
+        key: 'api-key',
+        title: 'API Key',
+        description:
+          'Mint a buyer key on the NeuronPool dashboard. Keys look like sk-neuronpool-…',
+        controller_type: 'input',
+        controller_props: {
+          placeholder: 'sk-neuronpool-…',
+          value: '',
+          type: 'password',
+          input_actions: ['unobscure', 'copy'],
+        },
+      },
+      {
+        key: 'base-url',
+        title: 'Base URL',
+        description:
+          'OpenAI-compatible base. Include /v1. Live Worker until api.neuronpool.dev resolves.',
+        controller_type: 'input',
+        controller_props: {
+          placeholder: 'https://neuronpool.damnknee.workers.dev/v1',
+          value: 'https://neuronpool.damnknee.workers.dev/v1',
+        },
+      },
+    ],
+    models: [],
+  },
 ]


### PR DESCRIPTION
Add NeuronPool to `predefinedProviders` so Jan's remote-provider dropdown can target the live coordinator (`https://neuronpool.damnknee.workers.dev/v1`). Models hydrate from GET /v1/models. Draft until api.neuronpool.dev resolves.