### PR TITLE
fix(llamacpp): Fix llama.cpp library path on Fedora/RHEL #8838

### DIFF
--- a/src-tauri/plugins/tauri-plugin-llamacpp/build.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/build.rs
@@ -387,6 +387,8 @@ mod engine {
             src.join("ggml").display()
         ));
         cfg.arg(format!("-DCMAKE_INSTALL_PREFIX={}", prefix.display()));
+        // Ensure libraries are installed in lib, not in platform specific dirs (e.g. lib64 on Fedora/RHEL).
+        cfg.arg("-DCMAKE_INSTALL_LIBDIR=lib");
         cfg.args([
             "-DCMAKE_BUILD_TYPE=Release",
             "-DCMAKE_POSITION_INDEPENDENT_CODE=ON",


### PR DESCRIPTION
Fixes #8838

## Summary
- Set `CMAKE_INSTALL_LIBDIR` to `lib` when building llama.cpp.
- Prevents llama.cpp from installing `ggml` libraries into `lib64` on Fedora/RHEL.
- Fixes the linker errors reported in #8838.

## Testing
  Tested on Fedora 44 and confirmed that the `ggml` libraries are installed under `lib` and the linker can find them successfully.