### PR TITLE
docs: fix JSDoc param and return types in fs.ts and threadInterface.ts

### DIFF
--- a/core/src/browser/fs.ts
+++ b/core/src/browser/fs.ts
@@ -73,7 +73,7 @@ const copyFile: (src: string, dest: string) => Promise<void> = (src, dest) =>
 /**
  * Gets the list of gguf files in a directory
  *
- * @param path - The paths to the file.
+ * @param paths - The directories to scan.
  * @returns {Promise<{any}>} - A promise that resolves with the list of gguf and non-gguf files
  */
 const getGgufFiles: (paths: string[]) => Promise<any> = (paths) =>

--- a/core/src/types/thread/threadInterface.ts
+++ b/core/src/types/thread/threadInterface.ts
@@ -17,7 +17,7 @@ export interface ThreadInterface {
    * Create a thread.
    * @abstract
    * @param {Thread} thread - The thread to save.
-   * @returns {Promise<void>} A promise that resolves when the thread is saved.
+   * @returns {Promise<Thread>} A promise that resolves when the thread is saved.
    */
   createThread(thread: Thread): Promise<Thread>
 


### PR DESCRIPTION
Docstring-only fixes:

- `browser/fs.ts` `getGgufFiles` documented `path`; the parameter is `paths` (plural array)
- `threadInterface.ts` `createThread` @returns said `Promise<void>` while the signature returns `Promise<Thread>`

Docstring-only; no code change.