### PR TITLE
docs: fix @param modelId JSDoc tags that mismatch the actual 'model' parameter

### DIFF
--- a/core/src/types/model/modelInterface.ts
+++ b/core/src/types/model/modelInterface.ts
@@ -15,7 +15,7 @@ export interface ModelInterface {
 
   /**
    * Cancels the download of a specific model.
-   * @param {string} modelId - The ID of the model to cancel the download for.
+   * @param {string} model - The ID of the model to cancel the download for.
    * @returns {Promise<void>} A promise that resolves when the download has been cancelled.
    */
   cancelModelPull(model: string): Promise<void>

--- a/web-app/src/lib/models.ts
+++ b/web-app/src/lib/models.ts
@@ -75,7 +75,7 @@ export const removeYamlFrontMatter = (content: string): string => {
 
 /**
  * Extract model name from repo path, e.g. cortexso/tinyllama -> tinyllama
- * @param modelId
+ * @param model
  * @returns
  */
 export const extractModelName = (model?: string) => {
@@ -84,7 +84,7 @@ export const extractModelName = (model?: string) => {
 
 /**
  * Extract model name from repo path, e.g. https://huggingface.co/cortexso/tinyllama -> cortexso/tinyllama
- * @param modelId
+ * @param model
  * @returns
  */
 export const extractModelRepo = (model?: string) => {


### PR DESCRIPTION
Four JSDoc blocks document a `modelId` parameter while the actual parameter is named `model`:

- `extractModelName(model?: string)` and `extractModelRepo(model?: string)` in `web-app/src/lib/models.ts` (the `getModelCapabilities` tag at line 17 genuinely takes `modelId` and is left alone)
- `cancelModelPull(model: string)` and `deleteModel(model: string)` in `core/src/types/model/modelInterface.ts`

The tags now match the signatures. Docs-only.