### PR TITLE
docs: fix broken install-guide links in data-folder and troubleshooting pages

### DIFF
--- a/docs/src/pages/docs/desktop/data-folder.mdx
+++ b/docs/src/pages/docs/desktop/data-folder.mdx
@@ -226,4 +226,4 @@ Chat archive. Each thread (`/threads/jan_unixstamp/`) contains:
 
 ## Delete Jan Data
 Uninstall guides: [Mac](/docs/desktop/install/mac#step-2-clean-up-data-optional),
-[Windows](/docs/desktop/install/windows#step-2-handle-jan-data), or [Linux](docs/desktop/install/linux#uninstall-jan).
+[Windows](/docs/desktop/install/windows#step-2-clean-up-remaining-files), or [Linux](/docs/desktop/install/linux#uninstall-jan).

--- a/docs/src/pages/docs/desktop/troubleshooting.mdx
+++ b/docs/src/pages/docs/desktop/troubleshooting.mdx
@@ -412,7 +412,7 @@ When you start a chat with a model and encounter a **Failed to Fetch** or **Some
 
 **1. Check System & Hardware Requirements**
 - Hardware dependencies: Ensure your device meets all [hardware requirements](troubleshooting)
-- OS: Ensure your operating system meets the minimum requirements ([Mac](https://www.jan.ai/docs/desktop/install/mac#minimum-requirements), [Windows](/windows#compatibility), [Linux](https://www.jan.ai/docs/desktop/install/linux#compatibility)
+- OS: Ensure your operating system meets the minimum requirements ([Mac](https://www.jan.ai/docs/desktop/install/mac#minimum-requirements), [Windows](/docs/desktop/install/windows#compatibility), [Linux](https://www.jan.ai/docs/desktop/install/linux#compatibility)
 - RAM: Choose models that use less than 80% of your available RAM
   - For 8GB systems: Use models under 6GB
   - For 16GB systems: Use models under 13GB


### PR DESCRIPTION
Three broken links in the desktop docs:

- `data-folder.mdx`: the Linux uninstall guide link missed its leading slash (resolves relative to the page and 404s, unlike its site-absolute Mac/Windows siblings), and the Windows anchor `#step-2-handle-jan-data` matches no heading — the actual heading is `### Step 2: Clean Up Remaining Files`.
- `troubleshooting.mdx`: the Windows OS-requirements link points at `/windows#compatibility` instead of `/docs/desktop/install/windows#compatibility` (the pattern its Mac and Linux siblings use; the `## Compatibility` heading exists there).