### PR TITLE
fix(cowork): notify when workspace folder is unavailable

### DIFF
--- a/web-app/src/containers/CoworkWorkspacePill.tsx
+++ b/web-app/src/containers/CoworkWorkspacePill.tsx
@@ -42,8 +42,24 @@ export function CoworkWorkspacePill({
   const serviceHub = useServiceHub()
   const folderName = folder ? basenameOf(folder) : null
 
-  const notifyMissingWorkspace = () => {
-    toast.error(t('common:workspace.missing'), {
+  const notifyWorkspaceActionError = (
+    action: 'open' | 'reveal',
+    error: unknown
+  ) => {
+    const detail = error instanceof Error ? error.message : String(error)
+    const missing = /ENOENT|no such file|does not exist|not found|path not found/i.test(detail)
+    const title = missing
+      ? t('common:workspace.unavailable')
+      : t(
+          action === 'open'
+            ? 'common:workspace.openFailed'
+            : 'common:workspace.revealFailed'
+        )
+
+    toast.error(title, {
+      description: missing
+        ? t('common:workspace.missing', { folder: folderName })
+        : detail,
       action: {
         label: t('common:workspace.change'),
         onClick: onAttach,
@@ -55,8 +71,8 @@ export function CoworkWorkspacePill({
     if (!folder) return
     try {
       await serviceHub.opener().openPath(folder)
-    } catch {
-      notifyMissingWorkspace()
+    } catch (error) {
+      notifyWorkspaceActionError('open', error)
     }
   }
 
@@ -64,8 +80,8 @@ export function CoworkWorkspacePill({
     if (!folder) return
     try {
       await serviceHub.opener().revealItemInDir(folder)
-    } catch {
-      notifyMissingWorkspace()
+    } catch (error) {
+      notifyWorkspaceActionError('reveal', error)
     }
   }
 

--- a/web-app/src/containers/CoworkWorkspacePill.tsx
+++ b/web-app/src/containers/CoworkWorkspacePill.tsx
@@ -1,4 +1,5 @@
 import { Folder, FolderPlus, GitBranch, PencilLine } from 'lucide-react'
+import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import {
   Popover,
@@ -40,6 +41,33 @@ export function CoworkWorkspacePill({
   const { t } = useTranslation()
   const serviceHub = useServiceHub()
   const folderName = folder ? basenameOf(folder) : null
+
+  const notifyMissingWorkspace = () => {
+    toast.error(t('common:workspace.missing'), {
+      action: {
+        label: t('common:workspace.change'),
+        onClick: onAttach,
+      },
+    })
+  }
+
+  const handleOpen = async () => {
+    if (!folder) return
+    try {
+      await serviceHub.opener().openPath(folder)
+    } catch {
+      notifyMissingWorkspace()
+    }
+  }
+
+  const handleReveal = async () => {
+    if (!folder) return
+    try {
+      await serviceHub.opener().revealItemInDir(folder)
+    } catch {
+      notifyMissingWorkspace()
+    }
+  }
 
   return (
     <Popover>
@@ -99,7 +127,7 @@ export function CoworkWorkspacePill({
                 variant="ghost"
                 size="sm"
                 className="ml-auto h-7"
-                onClick={() => void serviceHub.opener().openPath(folder)}
+                onClick={handleOpen}
               >
                 {t('common:workspace.open')}
               </Button>
@@ -107,7 +135,7 @@ export function CoworkWorkspacePill({
                 variant="ghost"
                 size="sm"
                 className="h-7"
-                onClick={() => void serviceHub.opener().revealItemInDir(folder)}
+                onClick={handleReveal}
               >
                 {t('common:workspace.reveal')}
               </Button>

--- a/web-app/src/containers/__tests__/CoworkWorkspacePill.test.tsx
+++ b/web-app/src/containers/__tests__/CoworkWorkspacePill.test.tsx
@@ -9,6 +9,11 @@ vi.mock('@/i18n/react-i18next-compat', () => ({
   }),
 }))
 
+const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }))
+vi.mock('sonner', () => ({
+  toast: { error: toastError },
+}))
+
 const openPath = vi.fn()
 const revealItemInDir = vi.fn()
 vi.mock('@/hooks/useServiceHub', () => ({
@@ -19,8 +24,9 @@ import { CoworkWorkspacePill } from '../CoworkWorkspacePill'
 
 describe('CoworkWorkspacePill', () => {
   beforeEach(() => {
-    openPath.mockReset()
-    revealItemInDir.mockReset()
+    openPath.mockReset().mockResolvedValue(undefined)
+    revealItemInDir.mockReset().mockResolvedValue(undefined)
+    toastError.mockReset()
   })
 
   it('invites attaching a folder when none is attached', async () => {
@@ -76,6 +82,58 @@ describe('CoworkWorkspacePill', () => {
 
     await userEvent.click(screen.getByText('common:workspace.reveal'))
     expect(revealItemInDir).toHaveBeenCalledWith('/home/u/Projects/jan-app')
+  })
+
+  it('notifies and offers a replacement when the folder cannot be opened', async () => {
+    openPath.mockRejectedValueOnce(new Error('path does not exist'))
+    const onAttach = vi.fn()
+    render(
+      <CoworkWorkspacePill
+        folder="/home/u/Projects/jan-app"
+        onAttach={onAttach}
+        onDetach={vi.fn()}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /a11yWithFolder/ }))
+    await userEvent.click(screen.getAllByText('common:workspace.open')[0])
+
+    await vi.waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith(
+        'common:workspace.missing',
+        expect.objectContaining({
+          action: expect.objectContaining({
+            label: 'common:workspace.change',
+            onClick: onAttach,
+          }),
+        })
+      )
+    })
+  })
+
+  it('notifies and offers a replacement when the folder cannot be revealed', async () => {
+    revealItemInDir.mockRejectedValueOnce(new Error('path does not exist'))
+    const onAttach = vi.fn()
+    render(
+      <CoworkWorkspacePill
+        folder="/home/u/Projects/jan-app"
+        onAttach={onAttach}
+        onDetach={vi.fn()}
+      />
+    )
+    await userEvent.click(screen.getByRole('button', { name: /a11yWithFolder/ }))
+    await userEvent.click(screen.getByText('common:workspace.reveal'))
+
+    await vi.waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith(
+        'common:workspace.missing',
+        expect.objectContaining({
+          action: expect.objectContaining({
+            label: 'common:workspace.change',
+            onClick: onAttach,
+          }),
+        })
+      )
+    })
   })
 
   it('detaches the folder', async () => {

--- a/web-app/src/containers/__tests__/CoworkWorkspacePill.test.tsx
+++ b/web-app/src/containers/__tests__/CoworkWorkspacePill.test.tsx
@@ -99,8 +99,9 @@ describe('CoworkWorkspacePill', () => {
 
     await vi.waitFor(() => {
       expect(toastError).toHaveBeenCalledWith(
-        'common:workspace.missing',
+        'common:workspace.unavailable',
         expect.objectContaining({
+          description: 'common:workspace.missing jan-app',
           action: expect.objectContaining({
             label: 'common:workspace.change',
             onClick: onAttach,
@@ -108,6 +109,9 @@ describe('CoworkWorkspacePill', () => {
         })
       )
     })
+    const [, options] = toastError.mock.calls[0]
+    options.action.onClick()
+    expect(onAttach).toHaveBeenCalledOnce()
   })
 
   it('notifies and offers a replacement when the folder cannot be revealed', async () => {
@@ -125,8 +129,9 @@ describe('CoworkWorkspacePill', () => {
 
     await vi.waitFor(() => {
       expect(toastError).toHaveBeenCalledWith(
-        'common:workspace.missing',
+        'common:workspace.unavailable',
         expect.objectContaining({
+          description: 'common:workspace.missing jan-app',
           action: expect.objectContaining({
             label: 'common:workspace.change',
             onClick: onAttach,

--- a/web-app/src/locales/en/common.json
+++ b/web-app/src/locales/en/common.json
@@ -690,7 +690,10 @@
     "detach": "Detach folder",
     "open": "Open",
     "reveal": "Reveal",
-    "missing": "This folder isn't there anymore. Attach a different one.",
+    "unavailable": "Workspace unavailable",
+    "missing": "The workspace folder {{folder}} is no longer available. Choose a different folder.",
+    "openFailed": "Couldn't open workspace",
+    "revealFailed": "Couldn't reveal workspace",
     "a11yWithFolder": "Project folder {{folder}}, attached with read and write access. Change or detach it.",
     "a11yNoFolder": "No project folder attached. Attach one."
   },


### PR DESCRIPTION
## Summary
- Cowork now reports when the selected workspace folder is unavailable instead of silently dropping Open or Reveal failures.
- Missing-path and other native action failures use clear notifications, and both offer Change folder recovery without ending the session.

```mermaid
sequenceDiagram
    participant User
    participant Cowork as Cowork workspace pill
    participant OS as Native opener
    participant Toast as Notification
    participant Picker as Folder picker

    User->>Cowork: Click Open or Reveal
    Cowork->>OS: Open selected workspace
    alt workspace exists
        OS-->>Cowork: Success
    else workspace moved or renamed
        OS-->>Cowork: Path failure
        Cowork->>Toast: Workspace unavailable
        Toast-->>User: Choose a different folder
        User->>Toast: Click Change folder
        Toast->>Picker: Open directory picker
        Picker-->>Cowork: Replacement workspace
    end
```

Fixes #8881

## Verification
- `yarn vitest --run web-app/src/containers/__tests__/CoworkWorkspacePill.test.tsx web-app/src/locales/__tests__/localeKeys.test.ts web-app/src/i18n/__tests__/keys.test.ts` - 3 files passed, 16 tests passed; the preview-panel suite was unavailable because the parent PR's private agent-tools API package has no built `dist-js` entry in this checkout.
- `yarn workspace @janhq/web-app exec eslint src/containers/CoworkWorkspacePill.tsx src/containers/__tests__/CoworkWorkspacePill.test.tsx --no-warn-ignored` - passed
- `git diff --check` - passed
