### PR TITLE
fix(cowork-ui): contain composer controls beside artifact preview

### DIFF
--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -2787,7 +2787,7 @@ const ChatInput = memo(function ChatInput({
                   })()}
               </div>
               {surfaceControls && (
-                <div className="flex min-w-0 flex-1 items-center gap-1">
+                <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto scrollbar-hide">
                   <Separator
                     orientation="vertical"
                     className="mx-1 h-4 shrink-0"

--- a/web-app/src/containers/__tests__/ChatInput.test.tsx
+++ b/web-app/src/containers/__tests__/ChatInput.test.tsx
@@ -705,4 +705,19 @@ describe('ChatInput', () => {
       expect(dimmed!.contains(screen.getByText('plan'))).toBe(false)
     })
   })
-})
+  it('contains surface controls within the composer control row', () => {
+    renderInput({
+      surfaceControls: (
+        <>
+          <button>folder</button>
+          <button>terminal</button>
+          <button>changes</button>
+        </>
+      ),
+    })
+
+    const controls = screen.getByText('folder').parentElement
+    expect(controls).toHaveClass('overflow-x-auto', 'scrollbar-hide')
+    expect(controls).toHaveClass('min-w-0', 'flex-1')
+  })
+ })


### PR DESCRIPTION
## Summary

Opening an artifact preview made the Cowork conversation narrower. The composer controls then ran past the input's right edge and could be clipped or hidden behind the preview panel.

This keeps the composer contained: the surface controls can scroll within their own row, while the send button stays in place. Closing or resizing the preview still leaves the normal composer layout unchanged.

Fixes #8883

## Verification

- `yarn workspace @janhq/web-app vitest --run src/containers/__tests__/ChatInput.test.tsx src/containers/__tests__/CoworkPreviewPanel.test.tsx` - 41 tests passed.
- Browser check at 1024px with the artifact preview open - the composer controls stayed inside the composer and did not overlap the preview panel.
- Full web-app suite - 278 files passed; 16 unrelated files still fail because this local test environment does not provide the expected `localStorage`/Tauri mocks.
