### PR TITLE
fix(cowork): paste images into the chat input

### DIFF
--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -1261,7 +1261,10 @@ const ChatInput = memo(function ChatInput({
       newFiles.length > 0 ? [...prev, ...newFiles] : prev
     )
 
-    if (currentThreadId && newFiles.length > 0) {
+    // Cowork keys attachments by session id (`scopeKey`) and sends them as
+    // data URLs on submit. Ingesting against leftover chat `currentThreadId`
+    // can fail and strip the chip we just added.
+    if (!scopeKey && currentThreadId && newFiles.length > 0) {
       const ingestTotal = newFiles.length
       void (async () => {
         setFileIngestProgress({ completed: 0, total: ingestTotal })
@@ -1350,7 +1353,7 @@ const ChatInput = memo(function ChatInput({
     } else {
       setMessage('')
     }
-  }, [attachmentsKey, currentThreadId, setAttachmentsForThread, serviceHub, setFileIngestProgress])
+  }, [attachmentsKey, currentThreadId, scopeKey, setAttachmentsForThread, serviceHub, setFileIngestProgress])
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files

--- a/web-app/src/containers/__tests__/ChatInput.test.tsx
+++ b/web-app/src/containers/__tests__/ChatInput.test.tsx
@@ -3,6 +3,7 @@ import {
   render,
   screen,
   fireEvent,
+  createEvent,
   act,
   waitFor,
 } from '@testing-library/react'
@@ -336,6 +337,8 @@ const resetAll = () => {
   navigateHistoryMock.mockClear()
   enqueueMock.mockClear()
   clearQueueMock.mockClear()
+  setAttachmentsMock.mockClear()
+  clearAttachmentsMock.mockClear()
   for (const k of Object.keys(queueState)) delete queueState[k]
   getCurrentThreadMock.mockReturnValue(undefined)
 }
@@ -642,6 +645,177 @@ describe('ChatInput', () => {
   it('does not migrate the new-thread draft into a scopeKey surface', () => {
     renderInput({ scopeKey: 'code-session-1' })
     expect(transferAttachmentsMock).not.toHaveBeenCalled()
+  })
+
+  describe('clipboard paste', () => {
+    const pngFile = (name = 'shot.png') =>
+      new File([new Uint8Array([137, 80, 78, 71])], name, {
+        type: 'image/png',
+      })
+
+    const pasteFiles = (files: File[]) => {
+      fireEvent.paste(getTextarea(), {
+        clipboardData: {
+          items: files.map((file) => ({
+            kind: 'file',
+            type: file.type,
+            getAsFile: () => file,
+          })),
+          files,
+          types: files.map((f) => f.type),
+          getData: () => '',
+        },
+      })
+    }
+
+    const enableVision = () => {
+      selectedModelOverride = {
+        id: 'model-a',
+        capabilities: ['tools', 'vision'],
+        provider: 'llamacpp',
+      }
+    }
+
+    const installFileReader = () => {
+      const Original = globalThis.FileReader
+      let n = 0
+      class FakeFileReader {
+        result: string | ArrayBuffer | null = null
+        onload: ((this: FileReader, ev: ProgressEvent<FileReader>) => void) | null =
+          null
+        readAsDataURL(_blob: Blob) {
+          n += 1
+          this.result = `data:image/png;base64,${btoa(`img${n}`)}`
+          queueMicrotask(() => {
+            this.onload?.({} as ProgressEvent<FileReader>)
+          })
+        }
+      }
+      globalThis.FileReader = FakeFileReader as unknown as typeof FileReader
+      return () => {
+        globalThis.FileReader = Original
+      }
+    }
+
+    it('attaches pasted images under the Cowork scope key', async () => {
+      enableVision()
+      const restore = installFileReader()
+      try {
+        renderInput({ scopeKey: 'cowork-1' })
+        await waitFor(() =>
+          expect(screen.getByText('Add Images')).toBeInTheDocument()
+        )
+        pasteFiles([pngFile()])
+        await waitFor(() => expect(setAttachmentsMock).toHaveBeenCalled())
+        expect(setAttachmentsMock.mock.calls[0][0]).toBe('cowork-1')
+        const next = setAttachmentsMock.mock.calls[0][1]([])
+        expect(next).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              type: 'image',
+              mimeType: 'image/png',
+              dataUrl: expect.stringMatching(/^data:image\/png;base64,/),
+            }),
+          ])
+        )
+      } finally {
+        restore()
+      }
+    })
+
+    it('attaches multiple pasted images in one paste', async () => {
+      enableVision()
+      const restore = installFileReader()
+      try {
+        renderInput({ scopeKey: 'cowork-1' })
+        await waitFor(() =>
+          expect(screen.getByText('Add Images')).toBeInTheDocument()
+        )
+        pasteFiles([pngFile('one.png'), pngFile('two.png')])
+        await waitFor(() => expect(setAttachmentsMock).toHaveBeenCalled())
+        const next = setAttachmentsMock.mock.calls[0][1]([])
+        expect(next).toHaveLength(2)
+      } finally {
+        restore()
+      }
+    })
+
+    it('does not attach on a plain text paste', async () => {
+      enableVision()
+      renderInput({ scopeKey: 'cowork-1' })
+      await waitFor(() =>
+        expect(screen.getByText('Add Images')).toBeInTheDocument()
+      )
+      const event = createEvent.paste(getTextarea(), {
+        clipboardData: {
+          items: [
+            {
+              kind: 'string',
+              type: 'text/plain',
+              getAsFile: () => null,
+            },
+          ],
+          files: [],
+          types: ['text/plain'],
+          getData: (type: string) => (type === 'text/plain' ? 'hello' : ''),
+        },
+      })
+      fireEvent(getTextarea(), event)
+      expect(event.defaultPrevented).toBe(false)
+      expect(setAttachmentsMock).not.toHaveBeenCalled()
+    })
+
+    it('does not keep an unsupported pasted image as an attachment', async () => {
+      enableVision()
+      renderInput({ scopeKey: 'cowork-1' })
+      await waitFor(() =>
+        expect(screen.getByText('Add Images')).toBeInTheDocument()
+      )
+      const gif = new File([new Uint8Array([1, 2, 3])], 'shot.gif', {
+        type: 'image/gif',
+      })
+      pasteFiles([gif])
+      await waitFor(() => expect(setAttachmentsMock).toHaveBeenCalled())
+      const next = setAttachmentsMock.mock.calls[0][1]([])
+      expect(next).toEqual([])
+    })
+
+    it('attaches pasted images on the Chat thread key as well', async () => {
+      enableVision()
+      const restore = installFileReader()
+      try {
+        renderInput()
+        await waitFor(() =>
+          expect(screen.getByText('Add Images')).toBeInTheDocument()
+        )
+        pasteFiles([pngFile()])
+        await waitFor(() => expect(setAttachmentsMock).toHaveBeenCalled())
+        expect(setAttachmentsMock.mock.calls[0][0]).toBe('thread-1')
+      } finally {
+        restore()
+      }
+    })
+
+    it('does not attach images when the model has no vision', () => {
+      renderInput({ scopeKey: 'cowork-1' })
+      const event = createEvent.paste(getTextarea(), {
+        clipboardData: {
+          items: [
+            {
+              kind: 'file',
+              type: 'image/png',
+              getAsFile: () => pngFile(),
+            },
+          ],
+          files: [pngFile()],
+          types: ['image/png'],
+          getData: () => '',
+        },
+      })
+      fireEvent(getTextarea(), event)
+      expect(event.defaultPrevented).toBe(false)
+      expect(setAttachmentsMock).not.toHaveBeenCalled()
+    })
   })
 
   describe('tool controls', () => {

--- a/web-app/src/lib/__tests__/coworkTurns.test.ts
+++ b/web-app/src/lib/__tests__/coworkTurns.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { coworkTurnsToUIMessages } from '@/lib/coworkTurns'
+import {
+  coworkTurnsToUIMessages,
+  imageUrlsFromChatFiles,
+  userPartsFromCoworkInput,
+} from '@/lib/coworkTurns'
 import type { CoworkTurn } from '@/hooks/useCoworkSessions'
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -100,5 +104,79 @@ describe('coworkTurnsToUIMessages', () => {
     const committed = coworkTurnsToUIMessages(turns, 'c')
     const live = coworkTurnsToUIMessages(turns, 'l')
     expect(committed[0].id).not.toBe(live[0].id)
+  })
+
+  it('turns user-row images into file parts so the transcript can render them', () => {
+    const url = 'data:image/png;base64,AAA'
+    const parts = partsOf(
+      coworkTurnsToUIMessages([
+        { role: 'user', content: 'look', images: [url] },
+      ])
+    )
+    expect(parts).toEqual([
+      { type: 'text', text: 'look' },
+      { type: 'file', mediaType: 'image/png', url },
+    ])
+  })
+
+  it('still renders an image-only user turn', () => {
+    const url = 'data:image/jpeg;base64,BBB'
+    const parts = partsOf(
+      coworkTurnsToUIMessages([{ role: 'user', content: '', images: [url] }])
+    )
+    expect(parts).toEqual([
+      { type: 'file', mediaType: 'image/jpeg', url },
+    ])
+  })
+})
+
+describe('userPartsFromCoworkInput', () => {
+  it('keeps a text part and appends each file, matching Chat send', () => {
+    expect(
+      userPartsFromCoworkInput('hi', [
+        { type: 'file', mediaType: 'image/png', url: 'data:image/png;base64,AAA' },
+      ])
+    ).toEqual([
+      { type: 'text', text: 'hi' },
+      {
+        type: 'file',
+        mediaType: 'image/png',
+        url: 'data:image/png;base64,AAA',
+      },
+    ])
+  })
+
+  it('keeps the text part on a file-only send', () => {
+    const parts = userPartsFromCoworkInput('', [
+      { type: 'file', mediaType: 'image/png', url: 'data:image/png;base64,AAA' },
+    ])
+    expect(parts[0]).toEqual({ type: 'text', text: '' })
+    expect(parts).toHaveLength(2)
+  })
+
+  it('skips files that have no url or media type', () => {
+    expect(
+      userPartsFromCoworkInput('x', [
+        { type: 'file', mediaType: '', url: 'data:image/png;base64,AAA' },
+        { type: 'file', mediaType: 'image/png', url: '' },
+      ])
+    ).toEqual([{ type: 'text', text: 'x' }])
+  })
+})
+
+describe('imageUrlsFromChatFiles', () => {
+  it('keeps only image files with a url', () => {
+    expect(
+      imageUrlsFromChatFiles([
+        { type: 'file', mediaType: 'image/png', url: 'data:image/png;base64,AAA' },
+        { type: 'file', mediaType: 'audio/wav', url: 'data:audio/wav;base64,BBB' },
+        { type: 'file', mediaType: 'image/jpeg', url: '' },
+      ])
+    ).toEqual(['data:image/png;base64,AAA'])
+  })
+
+  it('returns an empty list when nothing was attached', () => {
+    expect(imageUrlsFromChatFiles()).toEqual([])
+    expect(imageUrlsFromChatFiles([])).toEqual([])
   })
 })

--- a/web-app/src/lib/coworkTurns.ts
+++ b/web-app/src/lib/coworkTurns.ts
@@ -3,6 +3,53 @@ import type { UIMessage } from 'ai'
 import type { CoworkTurn } from '@/types/coworkSession'
 import { reasoningPartsFromText } from '@/lib/messages'
 
+/** Media ChatInput already serializes on submit (`onSubmit(text, files)`). */
+export type ChatMediaFile = {
+  type: string
+  mediaType: string
+  url: string
+}
+
+export function imageUrlsFromChatFiles(files?: ChatMediaFile[]): string[] {
+  if (!files?.length) return []
+  return files
+    .filter((file) => file.url && file.mediaType.startsWith('image/'))
+    .map((file) => file.url)
+}
+
+/**
+ * Same shape Chat's thread send uses: a text part (possibly empty) plus
+ * each attached file. Empty text is kept so a file-only send still has the
+ * part some templates expect as the first user content.
+ */
+export function userPartsFromCoworkInput(
+  text: string,
+  files?: ChatMediaFile[]
+): Array<
+  | { type: 'text'; text: string }
+  | { type: 'file'; mediaType: string; url: string }
+> {
+  const parts: Array<
+    | { type: 'text'; text: string }
+    | { type: 'file'; mediaType: string; url: string }
+  > = [{ type: 'text', text }]
+  for (const file of files ?? []) {
+    if (!file.url || !file.mediaType) continue
+    parts.push({
+      type: 'file',
+      mediaType: file.mediaType,
+      url: file.url,
+    })
+  }
+  return parts
+}
+
+function mediaTypeFromDataUrl(url: string): string {
+  const match = /^data:([^;,]+)/.exec(url)
+  const type = match?.[1]
+  return type && type.startsWith('image/') ? type : 'image/jpeg'
+}
+
 /**
  * Adapts the code screen's flat `CoworkTurn[]` transcript into the AI SDK
  * `UIMessage[]` shape that `MessageItem` (the shared chat renderer) consumes.
@@ -39,10 +86,21 @@ export function coworkTurnsToUIMessages(
   turns.forEach((turn, i) => {
     if (turn.role === 'user') {
       flushAssistant()
+      const parts: any[] = []
+      if (turn.content) {
+        parts.push({ type: 'text', text: turn.content })
+      }
+      for (const url of turn.images ?? []) {
+        parts.push({
+          type: 'file',
+          mediaType: mediaTypeFromDataUrl(url),
+          url,
+        })
+      }
       messages.push({
         id: `${idPrefix}-user-${i}`,
         role: 'user',
-        parts: [{ type: 'text', text: turn.content }],
+        parts: parts.length > 0 ? parts : [{ type: 'text', text: '' }],
       } as any)
       return
     }

--- a/web-app/src/routes/cowork.tsx
+++ b/web-app/src/routes/cowork.tsx
@@ -27,7 +27,12 @@ import DropdownModelProvider from '@/containers/DropdownModelProvider'
 import { useModelProvider } from '@/hooks/useModelProvider'
 import { MessageItem } from '@/containers/MessageItem'
 import SkillSelector from '@/containers/SkillSelector'
-import { coworkTurnsToUIMessages } from '@/lib/coworkTurns'
+import {
+  coworkTurnsToUIMessages,
+  imageUrlsFromChatFiles,
+  userPartsFromCoworkInput,
+  type ChatMediaFile,
+} from '@/lib/coworkTurns'
 import { useToolCallRuntime } from '@/hooks/useToolCallRuntime'
 import { PromptProgress } from '@/components/PromptProgress'
 import { useAppState } from '@/hooks/useAppState'
@@ -241,14 +246,17 @@ function CoworkPage() {
   /**
    * Drive one request. `text` is null for a resume — a retry after a failure
    * re-runs the committed history rather than re-sending the question, which
-   * would leave the model reading it twice.
+   * would leave the model reading it twice. `files` is ChatInput's media
+   * payload (pasted/picked images); ignored on resume.
    */
-  const runRequest = async (text: string | null) => {
+  const runRequest = async (text: string | null, files?: ChatMediaFile[]) => {
     if (running) return
     const sid = ensureCurrentSession()
     const store = useCoworkSessions.getState()
     const current = store.sessions.find((s) => s.id === sid)
-    if (!text && !(current?.messages?.length ?? 0)) return
+    const imageUrls = text != null ? imageUrlsFromChatFiles(files) : []
+    const hasUserTurn = Boolean(text) || imageUrls.length > 0
+    if (!hasUserTurn && !(current?.messages?.length ?? 0)) return
     if (!selectedModel?.id) {
       toast.error(t('common:selectModel'))
       return
@@ -266,7 +274,15 @@ function CoworkPage() {
     setStoppedBy(null)
     setRunError(undefined)
     setLiveUsage(null)
-    liveTurnsRef.current = text ? [{ role: 'user', content: text }] : []
+    liveTurnsRef.current = hasUserTurn
+      ? [
+          {
+            role: 'user',
+            content: text ?? '',
+            images: imageUrls.length > 0 ? imageUrls : undefined,
+          },
+        ]
+      : []
     setLiveTurns(liveTurnsRef.current)
     useCoworkRun.getState().resetSubagents(sid)
     setRunning(true)
@@ -333,13 +349,13 @@ function CoworkPage() {
     }
 
     const baseMessages = current?.messages ?? []
-    const messages = text
+    const messages = hasUserTurn
       ? [
           ...baseMessages,
           {
             id: `${sid}-user-${baseMessages.length}`,
             role: 'user',
-            parts: [{ type: 'text', text }],
+            parts: userPartsFromCoworkInput(text ?? '', files),
           } as any,
         ]
       : [...baseMessages]
@@ -537,7 +553,8 @@ function CoworkPage() {
   const runRequestRef = useRef(runRequest)
   runRequestRef.current = runRequest
 
-  const handleSubmit = (text: string) => void runRequest(text)
+  const handleSubmit = (text: string, files?: ChatMediaFile[]) =>
+    void runRequest(text, files)
 
   /**
    * Take the last turn again. Rewinding to the question and resuming is the

--- a/web-app/src/test/setup.ts
+++ b/web-app/src/test/setup.ts
@@ -110,6 +110,11 @@ const mockServiceHub = {
     save: vi.fn().mockResolvedValue('/path/to/file'),
     message: vi.fn().mockResolvedValue(undefined),
   }),
+  uploads: () => ({
+    ingestImage: vi.fn().mockResolvedValue({ id: 'img-1' }),
+    ingestFileAttachment: vi.fn().mockResolvedValue({ id: 'doc-1' }),
+    ingestFileAttachmentForProject: vi.fn().mockResolvedValue({ id: 'doc-1' }),
+  }),
   opener: vi.fn().mockReturnValue({
     open: vi.fn().mockResolvedValue(undefined),
     revealItemInDir: vi.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
Fixes #8877.

Cowork already uses `ChatInput`, so clipboard paste was attaching files in the composer. Submit then dropped them: `handleSubmit` only took the text, `runRequest` only sent a text part, and `coworkTurnsToUIMessages` ignored `turn.images`. After send the chip disappeared and the image never reached the model or the transcript.

This wires ChatInput's existing `files` payload through the Cowork run, maps those images onto the user turn / UIMessage file parts, and skips RAG ingest on scoped surfaces so a leftover chat thread id cannot strip the chip.

Tests cover image paste attaching under `scopeKey`, text paste still working, unsupported clipboard content, and the turn/file-part helpers.

Thanks for the issue.