### PR TITLE
fix(cowork): invoke skills with slash commands

### DIFF
--- a/src-tauri/plugins/tauri-plugin-agent-tools/build.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/build.rs
@@ -10,6 +10,7 @@ const COMMANDS: &[&str] = &[
     "skill_read",
     "skill_write",
     "skill_delete",
+    "skill_invoke",
     "memory_list",
     "memory_read",
     "memory_write",

--- a/src-tauri/plugins/tauri-plugin-agent-tools/guest-js/index.ts
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/guest-js/index.ts
@@ -183,6 +183,20 @@ export async function skillDelete(
     name,
   })
 }
+/** Build a user prompt for an installed skill, including its body and arguments. */
+export async function skillInvoke(
+  dataFolder: string,
+  name: string,
+  args: string,
+  project?: string
+): Promise<string> {
+  return await invoke('plugin:agent-tools|skill_invoke', {
+    dataFolder,
+    project,
+    name,
+    args,
+  })
+}
 
 /** Memory note names (stems), sorted. */
 export async function memoryList(

--- a/src-tauri/plugins/tauri-plugin-agent-tools/guest-js/types.ts
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/guest-js/types.ts
@@ -2,6 +2,8 @@
 export interface SkillMeta {
   name: string
   description: string
+  user_invocable?: boolean
+  model_invocable?: boolean
 }
 
 /** An image a tool returned, as a `data:` URL plus its display name. */

--- a/src-tauri/plugins/tauri-plugin-agent-tools/permissions/default.toml
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/permissions/default.toml
@@ -12,6 +12,7 @@ permissions = [
     "allow-skill-read",
     "allow-skill-write",
     "allow-skill-delete",
+    "allow-skill-invoke",
     "allow-memory-list",
     "allow-memory-read",
     "allow-memory-write",

--- a/src-tauri/plugins/tauri-plugin-agent-tools/permissions/schemas/schema.json
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/permissions/schemas/schema.json
@@ -487,6 +487,18 @@
           "markdownDescription": "Denies the skill_delete command without any pre-configured scope."
         },
         {
+          "description": "Enables the skill_invoke command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-skill-invoke",
+          "markdownDescription": "Enables the skill_invoke command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the skill_invoke command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-skill-invoke",
+          "markdownDescription": "Denies the skill_invoke command without any pre-configured scope."
+        },
+        {
           "description": "Enables the skill_list command without any pre-configured scope.",
           "type": "string",
           "const": "allow-skill-list",
@@ -643,10 +655,12 @@
           "markdownDescription": "Denies the workspace_path command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the agent tools plugin: skill/memory management plus built-in tool execution\n#### This default permission set includes:\n\n- `allow-workspace-path`\n- `allow-thread-workspace-path`\n- `allow-thread-workspace-delete`\n- `allow-thread-workspace-sweep`\n- `allow-session-workspace-path`\n- `allow-session-workspace-delete`\n- `allow-session-workspace-sweep`\n- `allow-skill-list`\n- `allow-skill-read`\n- `allow-skill-write`\n- `allow-skill-delete`\n- `allow-memory-list`\n- `allow-memory-read`\n- `allow-memory-write`\n- `allow-memory-catalog`\n- `allow-memory-delete`\n- `allow-tool-schemas`\n- `allow-sandbox-status`\n- `allow-subagent-result-reserve`\n- `allow-subagent-result-fill`\n- `allow-attachment-import`\n- `allow-execute-tool`\n- `allow-execute-tool-streaming`\n- `allow-start-monitor`\n- `allow-stop-monitor`\n- `allow-list-monitors`\n- `allow-stop-session-monitors`\n- `allow-preview-register-root`\n- `allow-preview-unregister-root`",
+
+          "description": "Default permissions for the agent tools plugin: skill/memory management plus built-in tool execution\n#### This default permission set includes:\n\n- `allow-workspace-path`\n- `allow-thread-workspace-path`\n- `allow-thread-workspace-delete`\n- `allow-thread-workspace-sweep`\n- `allow-session-workspace-path`\n- `allow-session-workspace-delete`\n- `allow-session-workspace-sweep`\n- `allow-skill-list`\n- `allow-skill-read`\n- `allow-skill-write`\n- `allow-skill-delete`\n- `allow-skill-invoke`\n- `allow-memory-list`\n- `allow-memory-read`\n- `allow-memory-write`\n- `allow-memory-catalog`\n- `allow-memory-delete`\n- `allow-tool-schemas`\n- `allow-sandbox-status`\n- `allow-subagent-result-reserve`\n- `allow-subagent-result-fill`\n- `allow-attachment-import`\n- `allow-execute-tool`\n- `allow-execute-tool-streaming`\n- `allow-start-monitor`\n- `allow-stop-monitor`\n- `allow-list-monitors`\n- `allow-stop-session-monitors`\n- `allow-preview-register-root`\n- `allow-preview-unregister-root`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the agent tools plugin: skill/memory management plus built-in tool execution\n#### This default permission set includes:\n\n- `allow-workspace-path`\n- `allow-thread-workspace-path`\n- `allow-thread-workspace-delete`\n- `allow-thread-workspace-sweep`\n- `allow-session-workspace-path`\n- `allow-session-workspace-delete`\n- `allow-session-workspace-sweep`\n- `allow-skill-list`\n- `allow-skill-read`\n- `allow-skill-write`\n- `allow-skill-delete`\n- `allow-memory-list`\n- `allow-memory-read`\n- `allow-memory-write`\n- `allow-memory-catalog`\n- `allow-memory-delete`\n- `allow-tool-schemas`\n- `allow-sandbox-status`\n- `allow-subagent-result-reserve`\n- `allow-subagent-result-fill`\n- `allow-attachment-import`\n- `allow-execute-tool`\n- `allow-execute-tool-streaming`\n- `allow-start-monitor`\n- `allow-stop-monitor`\n- `allow-list-monitors`\n- `allow-stop-session-monitors`\n- `allow-preview-register-root`\n- `allow-preview-unregister-root`"
+          "markdownDescription": "Default permissions for the agent tools plugin: skill/memory management plus built-in tool execution\n#### This default permission set includes:\n\n- `allow-workspace-path`\n- `allow-thread-workspace-path`\n- `allow-thread-workspace-delete`\n- `allow-thread-workspace-sweep`\n- `allow-session-workspace-path`\n- `allow-session-workspace-delete`\n- `allow-session-workspace-sweep`\n- `allow-skill-list`\n- `allow-skill-read`\n- `allow-skill-write`\n- `allow-skill-delete`\n- `allow-skill-invoke`\n- `allow-memory-list`\n- `allow-memory-read`\n- `allow-memory-write`\n- `allow-memory-catalog`\n- `allow-memory-delete`\n- `allow-tool-schemas`\n- `allow-sandbox-status`\n- `allow-subagent-result-reserve`\n- `allow-subagent-result-fill`\n- `allow-attachment-import`\n- `allow-execute-tool`\n- `allow-execute-tool-streaming`\n- `allow-start-monitor`\n- `allow-stop-monitor`\n- `allow-list-monitors`\n- `allow-stop-session-monitors`\n- `allow-preview-register-root`\n- `allow-preview-unregister-root`"
+
         }
       ]
     }

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/commands.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/commands.rs
@@ -224,6 +224,22 @@ pub async fn skill_delete(
 ) -> Result<(), AgentToolsError> {
     skills::delete(&resolve_store(&data_folder, project.as_deref()), &name).map_err(Into::into)
 }
+/// Build a user prompt for an installed skill, including its body and arguments.
+#[tauri::command]
+pub async fn skill_invoke(
+    data_folder: String,
+    project: Option<String>,
+    name: String,
+    args: String,
+) -> Result<String, AgentToolsError> {
+    skills::build_invocation_message(
+        &resolve_store(&data_folder, project.as_deref()),
+        &name,
+        &args,
+    )
+    .map(|(message, _)| message)
+    .map_err(Into::into)
+}
 
 /// Memory note names (stems), sorted.
 #[tauri::command]

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/lib.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/lib.rs
@@ -45,6 +45,7 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
             commands::skill_read,
             commands::skill_write,
             commands::skill_delete,
+            commands::skill_invoke,
             commands::memory_list,
             commands::memory_read,
             commands::memory_write,
@@ -107,10 +108,7 @@ mod permission_tests {
         let declared = names_between(include_str!("../build.rs"), "COMMANDS: &[&str] = &[", "];");
         assert!(!handlers.is_empty(), "failed to parse generate_handler!");
         assert!(!declared.is_empty(), "failed to parse build.rs COMMANDS");
-        let missing: Vec<_> = handlers
-            .iter()
-            .filter(|c| !declared.contains(c))
-            .collect();
+        let missing: Vec<_> = handlers.iter().filter(|c| !declared.contains(c)).collect();
         assert!(
             missing.is_empty(),
             "commands registered but absent from build.rs COMMANDS: {missing:?}"

--- a/src-tauri/plugins/tauri-plugin-agent-tools/src/skills.rs
+++ b/src-tauri/plugins/tauri-plugin-agent-tools/src/skills.rs
@@ -153,7 +153,8 @@ pub fn discover(store: &Path) -> Vec<SkillEntry> {
     };
     // Keyed by name so a duplicate stem collapses to one entry; BTreeMap also
     // gives the sorted-by-name order for free.
-    let mut by_name: std::collections::BTreeMap<String, SkillEntry> = std::collections::BTreeMap::new();
+    let mut by_name: std::collections::BTreeMap<String, SkillEntry> =
+        std::collections::BTreeMap::new();
     let mut consider = |entry: SkillEntry| {
         match by_name.get(&entry.name) {
             // Keep an existing folder entry over an incoming flat one.
@@ -259,7 +260,6 @@ fn default_jan_skill_meta() -> SkillMeta {
     }
 }
 
-
 fn meta_for(name: String, parsed: &ParsedSkill) -> SkillMeta {
     SkillMeta {
         name,
@@ -346,6 +346,41 @@ pub fn read_raw(store: &Path, name: &str) -> Result<String, String> {
 
 /// A skill's markdown body with the frontmatter fence stripped — what the
 /// `skill_read` tool hands the model when it loads a skill on demand.
+pub fn build_invocation_message(
+    store: &Path,
+    name: &str,
+    args: &str,
+) -> Result<(String, String), String> {
+    let meta = list_meta(store)
+        .into_iter()
+        .find(|m| m.name == name)
+        .ok_or_else(|| format!("ERROR: skill '{name}' not found"))?;
+    if !meta.user_invocable {
+        return Err(format!("ERROR: skill '{name}' is not user-invocable"));
+    }
+    let entry = resolve(store, name)?;
+    let parsed = parse(&std::fs::read_to_string(&entry.file).map_err(|e| format!("ERROR: {e}"))?);
+    let mut message = format!("{}\n\n{}", invocation_wrapper(name, "skill"), parsed.body);
+    if entry.is_folder {
+        let base = entry.file.parent().unwrap_or(store);
+        message.push_str(&format!(
+            "\n\n---\n[Skill directory: {}]\nResolve relative paths in the skill against that directory.\n",
+            base.display()
+        ));
+    }
+    let args = args.trim();
+    if !args.is_empty() {
+        message.push_str(&format!("User: {args}\n"));
+    }
+    Ok((message, meta.description))
+}
+
+fn invocation_wrapper(name: &str, kind: &str) -> String {
+    format!(
+        "[IMPORTANT: You have invoked the \"{name}\" {kind} - follow its instructions. The full {kind} content is loaded below.]"
+    )
+}
+/// `skill_read` tool hands the model when it loads a skill on demand.
 pub fn read_body(store: &Path, name: &str) -> Result<String, String> {
     Ok(parse(&read_raw(store, name)?).body)
 }
@@ -419,7 +454,10 @@ mod tests {
     fn discover_finds_folder_and_flat_skills_sorted() {
         let root = std::env::temp_dir().join(format!(
             "jan_skills_test_{}",
-            std::time::SystemTime::UNIX_EPOCH.elapsed().unwrap().as_nanos()
+            std::time::SystemTime::UNIX_EPOCH
+                .elapsed()
+                .unwrap()
+                .as_nanos()
         ));
         let dir = skills_dir(&root);
         std::fs::create_dir_all(dir.join("b_folder")).unwrap();
@@ -435,7 +473,10 @@ mod tests {
     fn write_new_creates_folder_form_read_delete_roundtrip() {
         let root = std::env::temp_dir().join(format!(
             "jan_skills_rt_{}",
-            std::time::SystemTime::UNIX_EPOCH.elapsed().unwrap().as_nanos()
+            std::time::SystemTime::UNIX_EPOCH
+                .elapsed()
+                .unwrap()
+                .as_nanos()
         ));
         write(&root, "deploy", "---\ndescription: d\n---\nbody").unwrap();
         assert!(skills_dir(&root).join("deploy").join("SKILL.md").is_file());
@@ -472,6 +513,56 @@ mod tests {
     }
 
     #[test]
+    fn invocation_includes_body_directory_and_arguments() {
+        let root = std::env::temp_dir().join(format!(
+            "jan_skills_invoke_{}",
+            std::time::SystemTime::UNIX_EPOCH
+                .elapsed()
+                .unwrap()
+                .as_nanos()
+        ));
+        let skill_dir = skills_dir(&root).join("deploy");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\ndescription: Ship it\n---\n\nDeploy carefully.",
+        )
+        .unwrap();
+
+        let (message, description) =
+            build_invocation_message(&root, "deploy", "staging\nkeep config unchanged").unwrap();
+        assert_eq!(description, "Ship it");
+        assert!(message.contains("Deploy carefully."));
+        assert!(message.contains("[Skill directory:"));
+        assert!(message.contains("User: staging\nkeep config unchanged"));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn invocation_rejects_non_user_invocable_skill() {
+        let root = std::env::temp_dir().join(format!(
+            "jan_skills_invoke_private_{}",
+            std::time::SystemTime::UNIX_EPOCH
+                .elapsed()
+                .unwrap()
+                .as_nanos()
+        ));
+        let dir = skills_dir(&root);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("private.md"),
+            "---\ndescription: Internal\nuser-invocable: false\n---\nbody",
+        )
+        .unwrap();
+
+        let error = build_invocation_message(&root, "private", "").unwrap_err();
+        assert!(error.contains("not user-invocable"));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
     fn catalog_respects_invocation_flags() {
         let root = std::env::temp_dir().join(format!(
             "jan_skills_sides_{}",
@@ -494,7 +585,11 @@ mod tests {
         write("user_only", "disable-model-invocation: true\n");
 
         let model: Vec<_> = catalog(&root, &[]).into_iter().map(|m| m.name).collect();
-        assert_eq!(model, vec!["both", "model_only", "jan"], "model side: {model:?}");
+        assert_eq!(
+            model,
+            vec!["both", "model_only", "jan"],
+            "model side: {model:?}"
+        );
 
         // Both flags still visible to the management list.
         let all = list_meta(&root);
@@ -518,7 +613,10 @@ mod tests {
     fn catalog_enabled_whitelist_filters() {
         let root = std::env::temp_dir().join(format!(
             "jan_skills_wl_{}",
-            std::time::SystemTime::UNIX_EPOCH.elapsed().unwrap().as_nanos()
+            std::time::SystemTime::UNIX_EPOCH
+                .elapsed()
+                .unwrap()
+                .as_nanos()
         ));
         write(&root, "a", "body a").unwrap();
         write(&root, "b", "body b").unwrap();
@@ -537,14 +635,20 @@ mod tests {
     fn write_existing_flat_stays_flat() {
         let root = std::env::temp_dir().join(format!(
             "jan_skills_flat_{}",
-            std::time::SystemTime::UNIX_EPOCH.elapsed().unwrap().as_nanos()
+            std::time::SystemTime::UNIX_EPOCH
+                .elapsed()
+                .unwrap()
+                .as_nanos()
         ));
         let dir = skills_dir(&root);
         std::fs::create_dir_all(&dir).unwrap();
         std::fs::write(dir.join("legacy.md"), "old").unwrap();
 
         write(&root, "legacy", "new").unwrap();
-        assert_eq!(std::fs::read_to_string(dir.join("legacy.md")).unwrap(), "new");
+        assert_eq!(
+            std::fs::read_to_string(dir.join("legacy.md")).unwrap(),
+            "new"
+        );
         assert!(!dir.join("legacy").exists());
         let _ = std::fs::remove_dir_all(&root);
     }
@@ -556,7 +660,10 @@ mod tests {
         // an edit isn't swallowed into a flat file the reader ignores.
         let root = std::env::temp_dir().join(format!(
             "jan_skills_both_{}",
-            std::time::SystemTime::UNIX_EPOCH.elapsed().unwrap().as_nanos()
+            std::time::SystemTime::UNIX_EPOCH
+                .elapsed()
+                .unwrap()
+                .as_nanos()
         ));
         let dir = skills_dir(&root);
         std::fs::create_dir_all(dir.join("dup")).unwrap();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -93,6 +93,7 @@ macro_rules! invoke_commands_with_extras {
         core::agent::commands::agent_skill_hub_import,
         core::agent::commands::agent_skill_enabled_get,
         core::agent::commands::agent_skill_enabled_set,
+        core::agent::commands::agent_skill_invoke,
         core::agent::commands::agent_plugin_list,
         core::agent::commands::agent_plugin_install,
         core::agent::commands::agent_plugin_remove,

--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -155,6 +155,7 @@ type ChatInputProps = {
    * across surfaces.
    */
   tokenSource?: TokenUsageSource
+  highlightedPrefix?: string | null
 }
 
 // Video containers llama-server can decode via ffmpeg/ffprobe into frames.
@@ -187,8 +188,10 @@ const ChatInput = memo(function ChatInput({
   ownsToolSet = true,
   surfaceControls,
   tokenSource,
+  highlightedPrefix,
 }: ChatInputProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const highlightRef = useRef<HTMLDivElement>(null)
   const [isFocused, setIsFocused] = useState(false)
   const [rows, setRows] = useState(1)
   const serviceHub = useServiceHub()
@@ -2101,6 +2104,18 @@ const ChatInput = memo(function ChatInput({
                 ))}
               </div>
             )}
+            <div className="relative">
+              {highlightedPrefix && prompt.startsWith(highlightedPrefix) && (
+                <div
+                  ref={highlightRef}
+                  aria-hidden="true"
+                  className={cn('pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words px-4 pt-4 text-transparent', className)}
+                  style={{ overflowWrap: 'break-word' }}
+                >
+                  <mark className="rounded-sm bg-primary/20 text-transparent">{highlightedPrefix}</mark>
+                  {prompt.slice(highlightedPrefix.length)}
+                </div>
+              )}
             <TextareaAutosize
               dir="auto"
               ref={textareaRef}
@@ -2109,6 +2124,12 @@ const ChatInput = memo(function ChatInput({
               maxRows={10}
               value={prompt}
               data-testid={'chat-input'}
+              onScroll={(event) => {
+                if (highlightRef.current) {
+                  highlightRef.current.scrollTop = event.currentTarget.scrollTop
+                  highlightRef.current.scrollLeft = event.currentTarget.scrollLeft
+                }
+              }}
               onChange={(e) => {
                 const value = e.target.value
                 const cursorIdx = e.target.selectionStart
@@ -2192,6 +2213,7 @@ const ChatInput = memo(function ChatInput({
                 className
               )}
             />
+            </div>
             {/* @path file reference picker popover */}
             {filePickerOpen && effectiveAgentMode && (
               <div className="relative">

--- a/web-app/src/containers/MessageItem.tsx
+++ b/web-app/src/containers/MessageItem.tsx
@@ -64,7 +64,7 @@ export type MessageItemProps = {
   versionInfo?: { index: number; count: number }
   onSwitchVersion?: (messageId: string, dir: -1 | 1) => void
   isAnimating?: boolean
-  hideActions?: boolean
+  highlightedPrefix?: string | null
 }
 
 export const MessageItem = memo(
@@ -85,7 +85,7 @@ export const MessageItem = memo(
     onDelete,
     onRetry,
     versionInfo,
-    onSwitchVersion,
+    highlightedPrefix,
   }: MessageItemProps) => {
     const { t } = useTranslation()
     const selectedModel = useModelProvider((state) => state.selectedModel)
@@ -321,7 +321,19 @@ export const MessageItem = memo(
                 )}
                 {displayText && (
                   <div dir="auto" className="select-text whitespace-pre-wrap">
-                    {displayText}
+                    {highlightedPrefix && displayText.startsWith(highlightedPrefix) ? (
+                      <>
+                        <span
+                          data-testid="skill-command-prefix"
+                          className="rounded-sm bg-primary-foreground/20 px-1 font-medium"
+                        >
+                          {highlightedPrefix}
+                        </span>
+                        {displayText.slice(highlightedPrefix.length)}
+                      </>
+                    ) : (
+                      displayText
+                    )}
                   </div>
                 )}
               </div>

--- a/web-app/src/containers/__tests__/MessageItem.test.tsx
+++ b/web-app/src/containers/__tests__/MessageItem.test.tsx
@@ -155,6 +155,7 @@ describe('MessageItem', () => {
     render(
       <MessageItem
         message={makeMsg({ role: 'user', parts: [{ type: 'text', text: 'Hi there' }] }) as any}
+        highlightedPrefix={null}
         isFirstMessage
         isLastMessage
         status={'ready' as any}
@@ -162,6 +163,27 @@ describe('MessageItem', () => {
     )
     expect(screen.getByText('Hi there')).toBeInTheDocument()
     expect(screen.queryByTestId('render-markdown')).not.toBeInTheDocument()
+  })
+  it('highlights a recognized skill prefix in a submitted user message', () => {
+    render(
+      <MessageItem
+        message={
+          makeMsg({
+            role: 'user',
+            parts: [{ type: 'text', text: '/code-review inspect this change' }],
+          }) as any
+        }
+        highlightedPrefix="/code-review"
+        isFirstMessage
+        isLastMessage
+        status={'ready' as any}
+      />
+    )
+
+    expect(screen.getByTestId('skill-command-prefix')).toHaveTextContent(
+      '/code-review'
+    )
+    expect(screen.getByText(/inspect this change/)).toBeInTheDocument()
   })
 
   it('renders attached files from user text metadata', () => {

--- a/web-app/src/lib/__tests__/skillCommands.test.ts
+++ b/web-app/src/lib/__tests__/skillCommands.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import {
+  filterSkillCommands,
+  parseSkillCommand,
+  resolveSkillCommand,
+} from '@/lib/skillCommands'
+
+describe('skill slash commands', () => {
+  const skills = [
+    { name: 'deploy', description: 'Ship the app', user_invocable: true },
+    { name: 'private', description: 'Internal only', user_invocable: false },
+    { name: 'lint', description: 'Run lint', user_invocable: true },
+  ]
+
+  it('parses explicit and short forms with arguments', () => {
+    expect(parseSkillCommand('/skill:deploy staging --force')).toEqual({
+      name: 'deploy',
+      args: 'staging --force',
+      explicit: true,
+    })
+    expect(parseSkillCommand('/lint changed files')).toEqual({
+      name: 'lint',
+      args: 'changed files',
+      explicit: false,
+    })
+  })
+
+  it('does not treat ordinary text as a skill command', () => {
+    expect(parseSkillCommand('please fix /skill:deploy')).toBeNull()
+    expect(parseSkillCommand('/')).toBeNull()
+  })
+
+  it('filters unavailable and non-user-invocable skills for the popup', () => {
+    expect(filterSkillCommands(skills, 'de')).toEqual([skills[0]])
+    expect(filterSkillCommands(skills, '')).toEqual([skills[0], skills[2]])
+  })
+
+  it('resolves short names and keeps explicit names unambiguous', () => {
+    expect(resolveSkillCommand(skills, { name: 'deploy', args: '', explicit: false })).toEqual(
+      skills[0]
+    )
+    expect(resolveSkillCommand(skills, { name: 'missing', args: '', explicit: true })).toBeNull()
+  })
+})

--- a/web-app/src/lib/__tests__/skillCommands.test.ts
+++ b/web-app/src/lib/__tests__/skillCommands.test.ts
@@ -3,6 +3,7 @@ import {
   filterSkillCommands,
   parseSkillCommand,
   resolveSkillCommand,
+  skillCommandPrefix,
 } from '@/lib/skillCommands'
 
 describe('skill slash commands', () => {
@@ -40,5 +41,19 @@ describe('skill slash commands', () => {
       skills[0]
     )
     expect(resolveSkillCommand(skills, { name: 'missing', args: '', explicit: true })).toBeNull()
+  })
+})
+
+describe('skill command highlighting', () => {
+  const skills = [{ name: 'code-review', description: 'Review code', user_invocable: true }]
+
+  it('returns only the recognized command prefix', () => {
+    expect(skillCommandPrefix('/code-review hi hi', skills)).toBe('/code-review')
+    expect(skillCommandPrefix('/code-review', skills)).toBe('/code-review')
+  })
+
+  it('does not highlight unknown or embedded command-like text', () => {
+    expect(skillCommandPrefix('/missing hello', skills)).toBeNull()
+    expect(skillCommandPrefix('please /code-review', skills)).toBeNull()
   })
 })

--- a/web-app/src/lib/__tests__/skillStore.test.ts
+++ b/web-app/src/lib/__tests__/skillStore.test.ts
@@ -4,6 +4,7 @@ import {
   readSkill,
   writeSkill,
   deleteSkill,
+  invokeSkill,
   projectScope,
   storeScope,
 } from '@/lib/skillStore'
@@ -16,6 +17,7 @@ const { api, invoke, getJanDataFolder } = vi.hoisted(() => ({
     skillRead: vi.fn(),
     skillWrite: vi.fn(),
     skillDelete: vi.fn(),
+    skillInvoke: vi.fn(),
   },
   invoke: vi.fn(),
   getJanDataFolder: vi.fn(),
@@ -106,5 +108,21 @@ describe('skillStore', () => {
       await writeSkill(scope, 'lint', 'text')
       expect(getJanDataFolder).not.toHaveBeenCalled()
     })
+  })
+
+  it('invokes a project skill through the core command with arguments', async () => {
+    await invokeSkill(projectScope('/proj'), 'deploy', 'staging --force')
+    expect(invoke).toHaveBeenCalledWith('agent_skill_invoke', {
+      project: '/proj',
+      name: 'deploy',
+      args: 'staging --force',
+    })
+    expect(api.skillInvoke).not.toHaveBeenCalled()
+  })
+
+  it('invokes a global skill through the plugin guest API', async () => {
+    await invokeSkill(storeScope, 'deploy', 'quickly')
+    expect(api.skillInvoke).toHaveBeenCalledWith('/data', 'deploy', 'quickly')
+    expect(invoke).not.toHaveBeenCalled()
   })
 })

--- a/web-app/src/lib/skillCommands.ts
+++ b/web-app/src/lib/skillCommands.ts
@@ -1,0 +1,48 @@
+export type SkillCommandMeta = {
+  name: string
+  description: string
+  user_invocable?: boolean
+}
+
+export type ParsedSkillCommand = {
+  name: string
+  args: string
+  explicit: boolean
+}
+
+export function parseSkillCommand(text: string): ParsedSkillCommand | null {
+  const trimmed = text.trim()
+  const match = trimmed.match(/^\/(?:skill:)?([^\s/]+)(?:\s+([\s\S]*))?$/)
+  if (!match || !match[1]) return null
+  return {
+    name: match[1],
+    args: match[2]?.trim() ?? '',
+    explicit: trimmed.startsWith('/skill:'),
+  }
+}
+
+export function filterSkillCommands(
+  skills: SkillCommandMeta[],
+  query: string
+): SkillCommandMeta[] {
+  const normalized = query.toLowerCase()
+  return skills.filter(
+    (skill) =>
+      skill.user_invocable !== false && skill.name.toLowerCase().includes(normalized)
+  )
+}
+
+export function resolveSkillCommand(
+  skills: SkillCommandMeta[],
+  parsed: ParsedSkillCommand
+): SkillCommandMeta | null {
+  const available = skills.filter((skill) => skill.user_invocable !== false)
+  const exact = available.find((skill) => skill.name === parsed.name)
+  if (exact) return exact
+  if (parsed.explicit) return null
+  const matches = available.filter((skill) => {
+    const plain = skill.name.includes(':') ? skill.name.split(':').pop() : skill.name
+    return plain === parsed.name
+  })
+  return matches.length === 1 ? matches[0] : null
+}

--- a/web-app/src/lib/skillCommands.ts
+++ b/web-app/src/lib/skillCommands.ts
@@ -46,3 +46,14 @@ export function resolveSkillCommand(
   })
   return matches.length === 1 ? matches[0] : null
 }
+
+export function skillCommandPrefix(
+  text: string,
+  skills: SkillCommandMeta[]
+): string | null {
+  const match = text.match(/^\/(?:skill:)?([^\s/]+)/)
+  if (!match) return null
+  const parsed = parseSkillCommand(text)
+  if (!parsed || !resolveSkillCommand(skills, parsed)) return null
+  return match[0]
+}

--- a/web-app/src/lib/skillStore.ts
+++ b/web-app/src/lib/skillStore.ts
@@ -4,6 +4,7 @@ import {
   skillRead,
   skillWrite,
   skillDelete,
+  skillInvoke,
   type SkillMeta,
 } from '@janhq/tauri-plugin-agent-tools-api'
 import { getServiceHub } from '@/hooks/useServiceHub'
@@ -93,4 +94,18 @@ export async function deleteSkill(
     return
   }
   await skillDelete(await dataFolder(), name)
+}
+export async function invokeSkill(
+  scope: SkillScope,
+  name: string,
+  args: string
+): Promise<string> {
+  if (scope.kind === 'project') {
+    return await invoke<string>('agent_skill_invoke', {
+      project: scope.folder,
+      name,
+      args,
+    })
+  }
+  return await skillInvoke(await dataFolder(), name, args)
 }

--- a/web-app/src/routes/cowork.tsx
+++ b/web-app/src/routes/cowork.tsx
@@ -1348,6 +1348,20 @@ function CoworkPage() {
                         isReasoningAtBottom={isReasoningAtBottom}
                         onReasoningScroll={handleReasoningScroll}
                         onReasoningScrollToBottom={forceScrollReasoningToBottom}
+                        highlightedPrefix={
+                          message.role === 'user'
+                            ? skillCommandPrefix(
+                                message.parts
+                                  .filter(
+                                    (part): part is { type: 'text'; text: string } =>
+                                      part.type === 'text'
+                                  )
+                                  .map((part) => part.text)
+                                  .join('\n'),
+                                skillCommands
+                              )
+                            : null
+                        }
                       />
                       {/* Derived from the message's own write parts, so nothing
                         shared with the chat surface needs to know artifacts

--- a/web-app/src/routes/cowork.tsx
+++ b/web-app/src/routes/cowork.tsx
@@ -15,9 +15,11 @@ import {
 } from 'react'
 import { toast } from 'sonner'
 import { invoke } from '@tauri-apps/api/core'
+import { Bot, Command, Sparkles } from 'lucide-react'
+import { cn } from '@/lib/utils'
 import { getLoadedModels } from '@janhq/tauri-plugin-llamacpp-api'
 import { sessionWorkspacePath } from '@janhq/tauri-plugin-agent-tools-api'
-import { cn, getModelDisplayName, getProviderTitle } from '@/lib/utils'
+import { getModelDisplayName, getProviderTitle } from '@/lib/utils'
 import { predefinedProviders } from '@/constants/providers'
 import { providerHasRemoteApiKeys } from '@/lib/provider-api-keys'
 import { runSlashCommand, SLASH_COMMANDS } from '@/lib/coworkCommands'
@@ -139,12 +141,14 @@ export const Route = createFileRoute(route.cowork as any)({
   component: CoworkPage,
 })
 
-// A row in the slash menu — commands and model options share one shape so the
-// keyboard navigation works uniformly across both.
+// Slash-menu rows share keyboard behavior but expose their category visually.
+type MenuItemKind = 'skill' | 'command' | 'model'
+
 type MenuItem = {
   key: string
   label: string
   description: string
+  kind: MenuItemKind
   onSelect: () => void
 }
 
@@ -1072,6 +1076,7 @@ function CoworkPage() {
           key: `${m.providerName}/${m.id}`,
           label: m.label,
           description: getProviderTitle(m.providerName),
+          kind: 'model' as const,
           onSelect: () => switchModel(m.providerName, m.id),
         }))
     }
@@ -1085,6 +1090,7 @@ function CoworkPage() {
           key: `skill:${skill.name}`,
           label: `/${explicit ? 'skill:' : ''}${skill.name}`,
           description: skill.description,
+          kind: 'skill' as const,
           onSelect: () =>
             usePrompt
               .getState()
@@ -1097,6 +1103,7 @@ function CoworkPage() {
               key: c.name,
               label: c.name,
               description: t(c.descKey),
+              kind: 'command' as const,
               onSelect: () => {
                 if (c.mode === 'args') {
                   usePrompt.getState().setPrompt(`${c.name} `)
@@ -1435,11 +1442,24 @@ function CoworkPage() {
                           i === menuIndex ? 'bg-accent' : 'hover:bg-accent'
                         )}
                       >
-                        <span className="font-mono font-medium">
-                          {item.label}
+                        <span
+                          className="flex size-6 shrink-0 items-center justify-center text-muted-foreground"
+                          aria-hidden="true"
+                        >
+                          {item.kind === 'skill' ? <Sparkles className="size-4" strokeWidth={1.8} /> : null}
+                          {item.kind === 'command' ? <Command className="size-4" strokeWidth={1.8} /> : null}
+                          {item.kind === 'model' ? <Bot className="size-4" strokeWidth={1.8} /> : null}
                         </span>
-                        <span className="truncate text-xs text-muted-foreground">
-                          {item.description}
+                        <span className="min-w-0 flex-1">
+                          <span className="flex items-center gap-2">
+                            <span className="font-mono font-medium">{item.label}</span>
+                            <span className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+                              {item.kind}
+                            </span>
+                          </span>
+                          <span className="block truncate text-xs text-muted-foreground">
+                            {item.description}
+                          </span>
                         </span>
                       </button>
                     ))}

--- a/web-app/src/routes/cowork.tsx
+++ b/web-app/src/routes/cowork.tsx
@@ -121,6 +121,19 @@ import {
   subagentCompletionNotice,
   SubagentInbox,
 } from '@/lib/coworkSubagent'
+import {
+  invokeSkill,
+  listSkills,
+  projectScope,
+  storeScope,
+  type SkillMeta,
+  type SkillScope,
+} from '@/lib/skillStore'
+import {
+  filterSkillCommands,
+  parseSkillCommand,
+  resolveSkillCommand,
+} from '@/lib/skillCommands'
 
 export const Route = createFileRoute(route.cowork as any)({
   component: CoworkPage,
@@ -172,6 +185,25 @@ function CoworkPage() {
     [sessions, currentId]
   )
   const folder = session?.folder ?? null
+
+  const skillScope = useMemo<SkillScope>(
+    () => (folder ? projectScope(folder) : storeScope),
+    [folder]
+  )
+  const [skillCommands, setSkillCommands] = useState<SkillMeta[]>([])
+  useEffect(() => {
+    let alive = true
+    void listSkills(skillScope)
+      .then((skills) => {
+        if (alive) setSkillCommands(skills)
+      })
+      .catch(() => {
+        if (alive) setSkillCommands([])
+      })
+    return () => {
+      alive = false
+    }
+  }, [skillScope])
   const planMode = session?.planMode ?? false
 
   const [running, setRunning] = useState(false)
@@ -927,6 +959,38 @@ function CoworkPage() {
     files?: CoworkMediaPart[],
     documents?: Attachment[]
   ) => {
+    const skillCommand = parseSkillCommand(text)
+    const isBuiltInCommand = skillCommand
+      ? SLASH_COMMANDS.some((command) => command.name === `/${skillCommand.name}`)
+      : false
+    const skill =
+      skillCommand && (skillCommand.explicit || !isBuiltInCommand)
+        ? resolveSkillCommand(skillCommands, skillCommand)
+        : null
+    if (skillCommand?.explicit && !skill) {
+      toast.error(`Skill '${skillCommand.name}' is not available`)
+      return
+    }
+
+    // Explicit skill syntax must never fall through to the model or a normal
+    // slash command when the skill is unavailable.
+    if (skill && skillCommand) {
+      const attachedFiles = documents
+        ?.filter((d): d is Attachment & { path: string } => !!d.path)
+        .map((d) => ({
+          name: d.name,
+          path: d.path,
+          fileType: d.fileType,
+          size: d.size,
+        }))
+      void invokeSkill(skillScope, skill.name, skillCommand.args)
+        .then((expanded) =>
+          runRequest(expanded, { media: files, files: attachedFiles })
+        )
+        .catch((error) => toast.error(String(error)))
+      return
+    }
+
     // Slash commands are client-side actions; they never reach the agent.
     if (text.trim().startsWith('/')) {
       runSlashCommand(text, {
@@ -951,6 +1015,7 @@ function CoworkPage() {
         })),
     })
   }
+
 
   // Slash-command menu: the input text lives in the shared usePrompt store, so
   // the menu (and its keyboard nav) works without touching ChatInput.
@@ -995,7 +1060,7 @@ function CoworkPage() {
   )
 
   // Build the current menu: model picker when the text is `/models[ filter]`,
-  // otherwise the command list filtered by the typed `/token`.
+  // otherwise installed skills and built-in commands filtered by `/token`.
   const menuItems: MenuItem[] = useMemo(() => {
     const inModelMode = prompt === '/models' || prompt.startsWith('/models ')
     if (inModelMode) {
@@ -1011,27 +1076,43 @@ function CoworkPage() {
         }))
     }
     if (prompt.startsWith('/') && !prompt.includes(' ')) {
-      const q = prompt.slice(1)
-      return SLASH_COMMANDS.filter((c) => c.name.slice(1).startsWith(q)).map(
-        (c) => ({
-          key: c.name,
-          label: c.name,
-          description: t(c.descKey),
-          onSelect: () => {
-            if (c.mode === 'args') {
-              usePrompt.getState().setPrompt(`${c.name} `)
-            } else {
-              usePrompt.getState().setPrompt('')
-              handleSubmit(c.name)
-            }
-          },
-        })
-      )
+      const rawQuery = prompt.slice(1)
+      const explicit = rawQuery.startsWith('skill:')
+      const skillQuery = explicit ? rawQuery.slice('skill:'.length) : rawQuery
+      const skills = filterSkillCommands(skillCommands, skillQuery)
+        .slice(0, 50)
+        .map((skill) => ({
+          key: `skill:${skill.name}`,
+          label: `/${explicit ? 'skill:' : ''}${skill.name}`,
+          description: skill.description,
+          onSelect: () =>
+            usePrompt
+              .getState()
+              .setPrompt(`/${explicit ? 'skill:' : ''}${skill.name} `),
+        }))
+      const commands = explicit
+        ? []
+        : SLASH_COMMANDS.filter((c) => c.name.slice(1).startsWith(rawQuery)).map(
+            (c) => ({
+              key: c.name,
+              label: c.name,
+              description: t(c.descKey),
+              onSelect: () => {
+                if (c.mode === 'args') {
+                  usePrompt.getState().setPrompt(`${c.name} `)
+                } else {
+                  usePrompt.getState().setPrompt('')
+                  handleSubmit(c.name)
+                }
+              },
+            })
+          )
+      return [...skills, ...commands]
     }
     return []
     // handleSubmit is recreated every render but only reads refs/stores.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [prompt, allModels, switchModel, t])
+  }, [prompt, allModels, skillCommands, switchModel, t])
 
   // Reset the highlighted row whenever the menu contents change.
   useEffect(() => setMenuIndex(0), [prompt])

--- a/web-app/src/routes/cowork.tsx
+++ b/web-app/src/routes/cowork.tsx
@@ -135,6 +135,7 @@ import {
   filterSkillCommands,
   parseSkillCommand,
   resolveSkillCommand,
+  skillCommandPrefix,
 } from '@/lib/skillCommands'
 
 export const Route = createFileRoute(route.cowork as any)({
@@ -1470,6 +1471,7 @@ function CoworkPage() {
                   initialMessage={true}
                   scopeKey={session?.id}
                   ownsToolSet={false}
+                  highlightedPrefix={skillCommandPrefix(prompt, skillCommands)}
                   onSubmit={handleSubmit}
                   onStop={handleStop}
                   chatStatus={running ? 'streaming' : 'ready'}


### PR DESCRIPTION
## Summary
- Cowork users can invoke an installed skill from the chat input with a slash command, so `/skill-name` (or `/skill:skill-name`) runs a skill and passes any trailing text as its arguments.
- Skills show up in the slash-command autocomplete menu, and a skill that is unavailable or not user-invocable surfaces a clear error instead of being sent as a normal prompt.

Fixes #8880

## Verification
- `node_modules/.bin/vitest run src/lib/__tests__/skillCommands.test.ts src/lib/__tests__/skillStore.test.ts src/containers/__tests__/MessageItem.test.tsx src/containers/__tests__/ChatInput.test.tsx src/lib/__tests__/coworkTurns.test.ts` - 98 passed
