### PR TITLE
fix(agent-tui): preserve grouped tool results across timeline boundaries

### DIFF
--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -4661,40 +4661,26 @@ impl App {
                 // Grouped calls are already represented by the group row; retain
                 // their result on the group so an expand can show it later.
                 if self.grouped_ids.contains(&id) {
-                    // A group can be finalized (closed) before a folded call's
-                    // result lands - committing reasoning above a later call
-                    // closes the open group, then a new one opens. The result
-                    // must reach whichever group owns the id; routing it only
-                    // into the open group would drop it (and leave a stale
-                    // `✓` on the closed group).
-                    let open_owns = self
-                        .tool_group
-                        .as_ref()
-                        .is_some_and(|g| g.calls.iter().any(|c| c.id == id));
-                    if open_owns {
-                        let group = self.tool_group.as_mut().expect("checked above");
+                    if let Some(group) = self.tool_group.as_mut() {
                         if let Some(call) = group.calls.iter_mut().find(|c| c.id == id) {
                             call.is_error = is_error;
                             call.diff = diff;
                             call.content = Some(content);
                             group.last_result_error = Some(is_error);
+                            self.refresh_group_row();
+                            return;
                         }
-                        self.refresh_group_row();
-                    } else {
-                        // Owned by a group already closed (e.g. by the reasoning
-                        // flush above): update its retained call and rewrite the
-                        // row so a late error reads as `✗`, not `✓`.
-                        for group in self.groups.iter_mut() {
-                            if let Some(call) = group.calls.iter_mut().find(|c| c.id == id) {
-                                call.is_error = is_error;
-                                call.diff = diff;
-                                call.content = Some(content);
-                                group.last_result_error = Some(is_error);
-                                let idx = group.idx;
-                                let row = group.row(GroupRow::Closed);
-                                self.transcript[idx] = row;
-                                break;
-                            }
+                    }
+                    // A standalone edit/write or intervening display block can
+                    // close a group before its batch's results arrive.
+                    for group in &mut self.groups {
+                        if let Some(call) = group.calls.iter_mut().find(|c| c.id == id) {
+                            call.is_error = is_error;
+                            call.diff = diff;
+                            call.content = Some(content);
+                            group.last_result_error = Some(is_error);
+                            self.transcript[group.idx] = group.row(GroupRow::Closed);
+                            break;
                         }
                     }
                     return;
@@ -24910,40 +24896,129 @@ mod tests {
             .any(|l| l.contains("let me look")));
     }
 
-    #[test]
-    fn native_reasoning_before_next_tool_keeps_prior_result_paired() {
-        let mut app = test_app();
-        app.apply(StreamEvent::ToolCall {
-            id: "c1".into(),
-            name: "bash".into(),
-            args: json!({ "command": "first" }),
-        });
-        app.apply(StreamEvent::Reasoning {
-            text: "deciding on the next call".into(),
-        });
-        app.apply(StreamEvent::ToolCall {
-            id: "c2".into(),
-            name: "read".into(),
-            args: json!({ "path": "second.rs" }),
-        });
-        app.apply(StreamEvent::ToolResult {
-            id: "c1".into(),
-            content: "first result".into(),
-            is_error: false,
-            diff: None,
-        });
-        app.apply(StreamEvent::ToolResult {
-            id: "c2".into(),
-            content: "second result".into(),
-            is_error: false,
-            diff: None,
-        });
+    #[tokio::test]
+    async fn streamed_reasoning_before_mixed_tool_batch_keeps_results_paired() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
-        assert_eq!(app.groups.len(), 1, "the first group should be closed by reasoning");
-        assert_eq!(app.groups[0].calls[0].content.as_deref(), Some("first result"));
-        let current = app.tool_group.as_ref().expect("second group remains open");
-        assert_eq!(current.calls[0].id, "c2");
-        assert_eq!(current.calls[0].content.as_deref(), Some("second result"));
+        // Exercise the real HTTP normalizer, including started/argument events.
+        // The loop emits all authoritative calls before executing the batch.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await.unwrap();
+            let mut request = vec![0; 8192];
+            let mut used = 0;
+            loop {
+                let n = socket.read(&mut request[used..]).await.unwrap();
+                assert_ne!(n, 0);
+                used += n;
+                if request[..used].windows(4).any(|w| w == b"\r\n\r\n") {
+                    break;
+                }
+                request.resize(request.len() * 2, 0);
+            }
+            socket.write_all(b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nConnection: close\r\n\r\n").await.unwrap();
+            for delta in [
+                json!({"reasoning_content": "inspect before changing"}),
+                json!({"tool_calls": [{"index": 0, "id": "c1", "type": "function", "function": {"name": "bash", "arguments": "{\"command\":\"first\"}"}}]}),
+                json!({"tool_calls": [{"index": 1, "id": "c2", "type": "function", "function": {"name": "write", "arguments": "{\"path\":\"second.rs\",\"content\":\"new\"}"}}]}),
+                json!({"tool_calls": [{"index": 2, "id": "c3", "type": "function", "function": {"name": "read", "arguments": "{\"path\":\"third.rs\"}"}}]}),
+            ] {
+                let chunk = json!({"choices": [{"index": 0, "delta": delta}]});
+                socket
+                    .write_all(format!("data: {chunk}\n\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            socket.write_all(b"data: {\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"tool_calls\"}]}\n\ndata: [DONE]\n\n").await.unwrap();
+            socket.shutdown().await.unwrap();
+        });
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let completion = tokio::time::timeout(
+            Duration::from_secs(10),
+            crate::core::agent::genai_bridge::stream_chat_completions(
+                &reqwest13::Client::new(),
+                &format!("http://{addr}/v1/chat/completions"),
+                &[],
+                None,
+                &json!({"model": "m", "messages": [{"role": "user", "content": "go"}]}),
+                &tx,
+            ),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        server.await.unwrap();
+        drop(tx);
+
+        let mut app = test_app();
+        while let Some(event) = rx.recv().await {
+            app.apply(event);
+        }
+        // The real streamed reasoning precedes the in-progress tool display.
+        app.toggle_regions();
+        let live = render_rows(&mut app, 120, 50).join("\n");
+        assert!(live.contains("inspect before changing"), "{live}");
+        assert!(live.contains("Preparing bash"), "{live}");
+        assert!(
+            live.find("inspect before changing").unwrap() < live.find("Preparing bash").unwrap(),
+            "{live}"
+        );
+        app.toggle_regions();
+
+        for call in completion["choices"][0]["message"]["tool_calls"]
+            .as_array()
+            .unwrap()
+        {
+            app.apply(StreamEvent::ToolCall {
+                id: call["id"].as_str().unwrap().into(),
+                name: call["function"]["name"].as_str().unwrap().into(),
+                args: serde_json::from_str(call["function"]["arguments"].as_str().unwrap())
+                    .unwrap(),
+            });
+        }
+        // A standalone write closes c1's group before any batch result arrives.
+        // Resolve the later group first to detect attaching to the wrong owner.
+        for (id, content, is_error) in [
+            ("c3", "third result", false),
+            ("c1", "first failed", true),
+            ("c2", "second result", false),
+        ] {
+            app.apply(StreamEvent::ToolResult {
+                id: id.into(),
+                content: content.into(),
+                is_error,
+                diff: None,
+            });
+        }
+        let closed = &app.groups[0];
+        assert!(row_text(&app.transcript[closed.idx]).contains('✗'));
+        let first = group_detail_lines(closed, 120)
+            .iter()
+            .map(line_text)
+            .collect::<Vec<_>>()
+            .join("\n");
+        let third = group_detail_lines(app.tool_group.as_ref().unwrap(), 120)
+            .iter()
+            .map(line_text)
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            first.contains("first failed") && !first.contains("third result"),
+            "{first}"
+        );
+        assert!(
+            third.contains("third result") && !third.contains("first failed"),
+            "{third}"
+        );
+        app.toggle_regions();
+        let open_idx = app.tool_group.as_ref().unwrap().idx;
+        app.toggle_region(open_idx);
+        let rendered = render_rows(&mut app, 120, 50).join("\n");
+        let reasoning = rendered.find("inspect before changing").unwrap();
+        let first = rendered.find("first failed").unwrap();
+        let third = rendered.find("third result").unwrap();
+        assert!(reasoning < first && first < third, "{rendered}");
     }
 
     #[test]

--- a/src-tauri/src/core/cli/tui.rs
+++ b/src-tauri/src/core/cli/tui.rs
@@ -4661,15 +4661,42 @@ impl App {
                 // Grouped calls are already represented by the group row; retain
                 // their result on the group so an expand can show it later.
                 if self.grouped_ids.contains(&id) {
-                    if let Some(group) = self.tool_group.as_mut() {
+                    // A group can be finalized (closed) before a folded call's
+                    // result lands - committing reasoning above a later call
+                    // closes the open group, then a new one opens. The result
+                    // must reach whichever group owns the id; routing it only
+                    // into the open group would drop it (and leave a stale
+                    // `✓` on the closed group).
+                    let open_owns = self
+                        .tool_group
+                        .as_ref()
+                        .is_some_and(|g| g.calls.iter().any(|c| c.id == id));
+                    if open_owns {
+                        let group = self.tool_group.as_mut().expect("checked above");
                         if let Some(call) = group.calls.iter_mut().find(|c| c.id == id) {
                             call.is_error = is_error;
                             call.diff = diff;
                             call.content = Some(content);
                             group.last_result_error = Some(is_error);
                         }
+                        self.refresh_group_row();
+                    } else {
+                        // Owned by a group already closed (e.g. by the reasoning
+                        // flush above): update its retained call and rewrite the
+                        // row so a late error reads as `✗`, not `✓`.
+                        for group in self.groups.iter_mut() {
+                            if let Some(call) = group.calls.iter_mut().find(|c| c.id == id) {
+                                call.is_error = is_error;
+                                call.diff = diff;
+                                call.content = Some(content);
+                                group.last_result_error = Some(is_error);
+                                let idx = group.idx;
+                                let row = group.row(GroupRow::Closed);
+                                self.transcript[idx] = row;
+                                break;
+                            }
+                        }
                     }
-                    self.refresh_group_row();
                     return;
                 }
                 self.flush_assistant();
@@ -24881,6 +24908,42 @@ mod tests {
             .iter()
             .map(line_text)
             .any(|l| l.contains("let me look")));
+    }
+
+    #[test]
+    fn native_reasoning_before_next_tool_keeps_prior_result_paired() {
+        let mut app = test_app();
+        app.apply(StreamEvent::ToolCall {
+            id: "c1".into(),
+            name: "bash".into(),
+            args: json!({ "command": "first" }),
+        });
+        app.apply(StreamEvent::Reasoning {
+            text: "deciding on the next call".into(),
+        });
+        app.apply(StreamEvent::ToolCall {
+            id: "c2".into(),
+            name: "read".into(),
+            args: json!({ "path": "second.rs" }),
+        });
+        app.apply(StreamEvent::ToolResult {
+            id: "c1".into(),
+            content: "first result".into(),
+            is_error: false,
+            diff: None,
+        });
+        app.apply(StreamEvent::ToolResult {
+            id: "c2".into(),
+            content: "second result".into(),
+            is_error: false,
+            diff: None,
+        });
+
+        assert_eq!(app.groups.len(), 1, "the first group should be closed by reasoning");
+        assert_eq!(app.groups[0].calls[0].content.as_deref(), Some("first result"));
+        let current = app.tool_group.as_ref().expect("second group remains open");
+        assert_eq!(current.calls[0].id, "c2");
+        assert_eq!(current.calls[0].content.as_deref(), Some("second result"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Preserve tool results and error status when a mixed tool batch closes an earlier timeline group. Native reasoning remains above the tools it precedes.

  ```text
  Stream: reasoning -> bash c1 -> write c2 -> read c3 -> results
                         |           |          |
                      Group A     closes A   Group B

  Result for c1 arrives:
    Before: search only Group B -> dropped; stale success status
    After:  find owner Group A  -> retain result; display failure
  ```

- Isolated directly on `main`: one file, +139 / -1. No inherited changes from #8828. The verified defect is dropped results across a group boundary; ordinary native reasoning placement already worked in the reproduction.

Fixes #8887

## Verification
- `cargo test --lib --locked --no-default-features --features cli` (from `src-tauri`) - 1,394 passed after isolating the fix on main. Includes a canned-SSE regression through the real HTTP normalizer, with tool-start and argument events. The off-screen TUI renderer checks reasoning placement, expanded result ownership, and late-error status. Calls are applied in batch order and tool results are supplied by the test; no live model or real tools are executed.
- `cargo test --lib --locked --no-default-features --features cli streamed_reasoning_before_mixed_tool_batch -- --nocapture` (from `src-tauri`, before isolation) - failed with the original handler because the finalized row did not display the error; passed with the fix. The same regression passes in the full suite above.
- `cargo check --locked --no-default-features --features cli --bin jan` (from `src-tauri`) - passed on main.
- Shared Rust diff-noise guard with `--base origin/main` - passed. The worktree push-hook script is missing, so the shared validator was run manually before the lease-protected push.