### PR TITLE
fix(cowork): preserve session context through Settings

### DIFF
--- a/web-app/src/components/left-sidebar/NavTabs.tsx
+++ b/web-app/src/components/left-sidebar/NavTabs.tsx
@@ -19,16 +19,16 @@ type TabItem = {
 const openCoworkStart = () =>
   startNewSession(Object.keys(useCoworkRun.getState().runId))
 
-export function NavTabs() {
+export function NavTabs({ surfacePath }: { surfacePath: string }) {
   const { t } = useTranslation()
   const { pathname } = useLocation()
 
-  const isCowork = isCoworkRoute(pathname)
+  const isCowork = isCoworkRoute(surfacePath)
   // Home owns the chat surfaces (new chat, threads, projects); Cowork owns /cowork.
   const isHome =
-    pathname === route.home ||
-    pathname.startsWith('/threads') ||
-    pathname.startsWith('/project')
+    surfacePath === route.home ||
+    surfacePath.startsWith('/threads') ||
+    surfacePath.startsWith('/project')
 
   const tabs: TabItem[] = [
     { label: t('common:home'), to: route.home, icon: HomeIcon, isActive: isHome },
@@ -37,7 +37,9 @@ export function NavTabs() {
       to: route.cowork,
       icon: Handshake,
       isActive: isCowork,
-      onClick: openCoworkStart,
+      onClick: isCowork && pathname.startsWith('/settings')
+        ? undefined
+        : openCoworkStart,
     },
   ]
 
@@ -50,6 +52,7 @@ export function NavTabs() {
             key={tab.to}
             to={tab.to}
             onClick={tab.onClick}
+            aria-current={tab.isActive ? 'page' : undefined}
             className={cn(
               'flex flex-1 items-center justify-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium transition-colors',
               tab.isActive

--- a/web-app/src/components/left-sidebar/__tests__/settingsNavigation.test.tsx
+++ b/web-app/src/components/left-sidebar/__tests__/settingsNavigation.test.tsx
@@ -1,0 +1,107 @@
+import '@testing-library/jest-dom/vitest'
+import type { ReactNode } from 'react'
+import { beforeEach, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+const navigation = vi.hoisted(() => ({
+  pathname: '/cowork',
+  session: 'existing-session',
+}))
+vi.mock('@tanstack/react-router', () => ({
+  useLocation: () => ({ pathname: navigation.pathname }),
+  Link: ({
+    to,
+    onClick,
+    children,
+    ...props
+  }: {
+    to: string
+    onClick?: () => void
+    children: ReactNode
+  }) => (
+    <a
+      {...props}
+      href={to}
+      onClick={(event) => {
+        event.preventDefault()
+        onClick?.()
+        navigation.pathname = to
+      }}
+    >
+      {children}
+    </a>
+  ),
+}))
+vi.mock('@/i18n/react-i18next-compat', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+vi.mock('@/hooks/useCoworkSessions', () => ({
+  startNewSession: () => {
+    navigation.session = 'new-session'
+  },
+}))
+vi.mock('@/hooks/useCoworkRun', () => ({
+  useCoworkRun: { getState: () => ({ runId: {} }) },
+}))
+vi.mock('@/hooks/useLeftPanel', () => ({
+  useLeftPanel: () => ({ open: true }),
+}))
+vi.mock('@/stores/titlebar-layout-store', () => ({
+  useTitlebarLayout: () => 0,
+}))
+vi.mock('@/containers/DownloadManegement', () => ({
+  DownloadManagement: () => null,
+}))
+vi.mock('../NavCowork', () => ({ NavCowork: () => <div>Cowork sessions</div> }))
+vi.mock('../NavMain', () => ({ NavMain: () => <div>Chat navigation</div> }))
+vi.mock('../NavChats', () => ({ NavChats: () => <div>Chat threads</div> }))
+vi.mock('../NavProjects', () => ({ NavProjects: () => null }))
+vi.mock('@/components/ui/sidebar', () => {
+  const Box = ({ children }: { children: ReactNode }) => <div>{children}</div>
+  return {
+    Sidebar: Box,
+    SidebarContent: Box,
+    SidebarHeader: Box,
+    SidebarTrigger: () => null,
+    SidebarRail: () => null,
+  }
+})
+
+import { LeftSidebar } from '..'
+
+beforeEach(() => {
+  navigation.pathname = '/cowork'
+  navigation.session = 'existing-session'
+})
+
+it('keeps Cowork navigation across Settings pages and returns without starting a session', () => {
+  const view = render(<LeftSidebar />)
+  navigation.pathname = '/settings/general'
+  view.rerender(<LeftSidebar />)
+  expect(screen.getByText('Cowork sessions')).toBeInTheDocument()
+  expect(screen.queryByText('Chat threads')).not.toBeInTheDocument()
+  expect(screen.getByRole('link', { name: 'common:cowork' })).toHaveAttribute(
+    'aria-current',
+    'page'
+  )
+  navigation.pathname = '/settings/providers'
+  view.rerender(<LeftSidebar />)
+  fireEvent.click(screen.getByRole('link', { name: 'common:cowork' }))
+  view.rerender(<LeftSidebar />)
+  expect(navigation.pathname).toBe('/cowork')
+  expect(navigation.session).toBe('existing-session')
+})
+
+it('keeps Home navigation for Settings opened from a chat', () => {
+  navigation.pathname = '/threads/chat-1'
+  const view = render(<LeftSidebar />)
+  navigation.pathname = '/settings/general'
+  view.rerender(<LeftSidebar />)
+  expect(screen.getByText('Chat threads')).toBeInTheDocument()
+  expect(screen.getByRole('link', { name: 'common:home' })).toHaveAttribute(
+    'aria-current',
+    'page'
+  )
+  fireEvent.click(screen.getByRole('link', { name: 'common:cowork' }))
+  expect(navigation.session).toBe('new-session')
+})

--- a/web-app/src/components/left-sidebar/index.tsx
+++ b/web-app/src/components/left-sidebar/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { DownloadManagement } from '@/containers/DownloadManegement'
 import { NavChats } from './NavChats'
 import { NavCowork } from './NavCowork'
@@ -16,12 +17,17 @@ import {
 import { cn } from '@/lib/utils'
 import { useTitlebarLayout } from '@/stores/titlebar-layout-store'
 import { useLocation } from '@tanstack/react-router'
-import { isCoworkRoute } from '@/constants/routes'
+import { isCoworkRoute, route } from '@/constants/routes'
 
 export function LeftSidebar() {
   const { open: isLeftPanelOpen } = useLeftPanel()
   const { pathname } = useLocation()
-  const isCowork = isCoworkRoute(pathname)
+  const inSettings =
+    pathname === route.settings.index || pathname.startsWith('/settings/')
+  const [lastSurfacePath, setLastSurfacePath] = useState(pathname)
+  if (!inSettings && lastSurfacePath !== pathname) setLastSurfacePath(pathname)
+  const surfacePath = inSettings ? lastSurfacePath : pathname
+  const isCowork = isCoworkRoute(surfacePath)
   // Right-align the header when native controls own the top-left (macOS, or a Linux
   // DE placing buttons left); "Jan" moves into the right cluster except on macOS.
   const leftButtons = useTitlebarLayout((s) => s.layout.left.length)
@@ -41,7 +47,7 @@ export function LeftSidebar() {
               <SidebarTrigger className="text-muted-foreground rounded-full hover:bg-sidebar-foreground/8! -mt-0.5 relative z-50 ml-0.5" />
             </div>
           </div>
-          <NavTabs />
+          <NavTabs surfacePath={surfacePath} />
           {isCowork ? <NavCowork /> : <NavMain />}
         </SidebarHeader>
         <SidebarContent className="mask-b-from-95% mask-t-from-98%">


### PR DESCRIPTION
## Summary
- Opening Settings from Cowork retains its navigation and returns to the same session instead of switching to Chat or starting a new session.
- Settings opened from Home keeps Home navigation; ordinary Cowork-tab clicks still start a fresh session.

```diff
 Cowork session -> Settings -> Cowork tab
- Chat sidebar              new session
+ Cowork sidebar            original session
```

Fixes #8896

## Verification
- `node ../node_modules/vitest/vitest.mjs run src/components/left-sidebar/__tests__/settingsNavigation.test.tsx src/hooks/__tests__/useCoworkSessions.test.ts --reporter=dot` (from `web-app`) - 24 tests passed.
- `node node_modules/typescript/bin/tsc -p tsconfig.verify.json --noEmit --incremental false` - passed using a temporary config pointing at freshly generated current plugin declarations; verification config removed afterward.
- Full-app visual QA not completed: browser startup stalled at “Booting up Jan,” then browser tooling timed out. React integration coverage verifies Settings navigation and session preservation.
