### PR TITLE
fix(llamacpp): forward GPU Layers to llama-server even when Fit is on

### DIFF
--- a/extensions/llamacpp-extension/src/preset.test.ts
+++ b/extensions/llamacpp-extension/src/preset.test.ts
@@ -336,12 +336,21 @@ describe('generatePreset n-gpu-layers under fit', () => {
     expect(ini).toContain('n-gpu-layers = 33')
   })
 
-  it('omits per-model n-gpu-layers when auto-fit is enabled', async () => {
+  // Fit only auto-fills unset n_gpu_layers. Skipping an explicit value made
+  // the GPU Layers setting a silent no-op whenever Fit was on.
+  it('emits per-model n-gpu-layers even when auto-fit is enabled', async () => {
     setupModel('llama', { n_gpu_layers: 33 })
     await generatePreset('/p', '/jan', { fit: true } as any, {
     })
     const ini = writtenFiles['/p/router.preset.ini']
-    expect(ini).not.toContain('n-gpu-layers')
+    expect(ini).toContain('n-gpu-layers = 33')
+  })
+
+  it('omits n-gpu-layers when unset so auto-fit can still choose offload', async () => {
+    setupModel('llama', {})
+    await generatePreset('/p', '/jan', { fit: true } as any, {
+    })
+    expect(writtenFiles['/p/router.preset.ini']).not.toContain('n-gpu-layers')
   })
 })
 
@@ -523,6 +532,12 @@ describe('generatePreset upstream-default skipping', () => {
     setupModel('c', { n_gpu_layers: -3 })
     await generatePreset('/p', '/jan', { fit: false } as any)
     expect(modelSection('c')).not.toContain('n-gpu-layers')
+  })
+
+  it('emits an explicit n-gpu-layers = 100 even when fit is enabled', async () => {
+    setupModel('m', { n_gpu_layers: 100 })
+    await generatePreset('/p', '/jan', { fit: true } as any)
+    expect(modelSection('m')).toContain('n-gpu-layers = 100')
   })
 
   // mlock and no_mmap are two deprecated aliases for one upstream field, so

--- a/extensions/llamacpp-extension/src/preset.ts
+++ b/extensions/llamacpp-extension/src/preset.ts
@@ -554,10 +554,9 @@ export async function generatePreset(
     // Per-model overrides -- same default-skipping rules as the [*] block.
     // An explicit 0 means "native" (load the model's own trained context).
     //
-    // Emitted even with auto-fit on, unlike n-gpu-layers below: upstream's fit
-    // explicitly leaves a user-set context alone (common/fit.cpp: "context size
-    // set by user -> no change") and only bails on an explicit n_gpu_layers. The
-    // old gate is why "Increase Context Size" did nothing while Fit was on.
+    // Emitted even with auto-fit on: upstream's fit leaves a user-set context
+    // alone (common/fit.cpp: "context size set by user -> no change"). The old
+    // gate is why "Increase Context Size" did nothing while Fit was on.
     let ctxEmitted = false
     if (
       typeof mc.ctx_size === 'number' &&
@@ -567,11 +566,14 @@ export async function generatePreset(
       lines.push(`ctx-size = ${mc.ctx_size}`)
       ctxEmitted = true
     }
-    // Skipped when auto-fit is on: an explicit n-gpu-layers makes fit abort its
-    // layer-offload computation. -1 is auto and -2 or below means all layers,
-    // so the floor is -2 rather than 0.
+    // Emitted even with auto-fit on, same as ctx-size. Fit only auto-fills
+    // *unset* n_gpu_layers; an explicit value is left alone (common/fit.cpp:
+    // "n_gpu_layers already set by user -> abort" the layer-offload search,
+    // after context has already been fitted). Gating this on Fit made GPU
+    // Layers a silent no-op whenever Fit was on. Leave the key out when the
+    // user did not set it, so Fit can still choose offload. -1 is auto and
+    // -2 or below means all layers, so the floor is -2 rather than 0.
     if (
-      !fitEnabled &&
       typeof mc.n_gpu_layers === 'number' &&
       mc.n_gpu_layers >= -2
     ) {

--- a/web-app/src/containers/ModelSetting.tsx
+++ b/web-app/src/containers/ModelSetting.tsx
@@ -352,11 +352,6 @@ export function ModelSetting({
                     title={config.title}
                     description={config.description}
                     controllerType={config.controller_type}
-                    disabledReason={
-                      fitEnabled && key === 'ngl'
-                        ? t('common:modelSettings.nglDisabledByFit')
-                        : undefined
-                    }
                     controllerProps={{
                       ...config.controller_props,
                       value: config.controller_props?.value,

--- a/web-app/src/lib/predefined.ts
+++ b/web-app/src/lib/predefined.ts
@@ -15,7 +15,7 @@ export const modelSettings = {
     key: 'ngl',
     title: 'GPU Layers',
     description:
-      'Model layers to keep in VRAM. Leave empty for automatic (VRAM-aware) offload; -1 is auto, -2 offloads all layers, 0 is CPU only.',
+      'Model layers to keep in VRAM. Leave empty for automatic (VRAM-aware) offload, including when Auto-fit is on. A set value is used as-is and overrides Auto-fit\'s layer choice; -1 is auto, -2 offloads all layers, 0 is CPU only.',
     controller_type: 'input',
     controller_props: {
       // Empty, not 100: a value here pins offload and defeats llama.cpp's own


### PR DESCRIPTION
Fixes #8894

Router mode was dropping a user-set `n_gpu_layers` from `router.preset.ini` whenever Fit was on. llama.cpp Fit only auto-fills *unset* GPU layers (it leaves an explicit value alone after sizing context), so that gate made the GPU Layers control a silent no-op — models stayed on CPU even when the UI showed 100.

This emits per-model `n-gpu-layers` whenever `model.yml` has a value, Fit or not, and still omits the key when the user left it empty so Fit can choose offload. Same idea as the recent ctx-size change. The GPU Layers field is editable again; empty still means auto.

Verified with the preset unit tests (explicit ngl with Fit on/off, unset ngl still omitted, 100 still forwarded).

thx