### PR TITLE
ci: move the engine builds onto GitHub-hosted runners

### DIFF
--- a/.github/actions/setup-engine-toolchain/action.yml
+++ b/.github/actions/setup-engine-toolchain/action.yml
@@ -136,8 +136,11 @@ runs:
           case "$token" in cuda*) major="${token#cuda}" ;; esac
         done
         # Pinned: the redist tree has no "latest" alias. Add a line per major.
+        # 13.2 is the floor on Windows, not a preference: windows-2025 resolves
+        # to the vs2026 image, and crt/host_config.h rejects _MSC_VER >= 1950
+        # until then.
         case "$major" in
-        13) release='13.0.3' ;;
+        13) release='13.2.2' ;;
         12) release='12.4.1' ;;
         *)
           echo "error: no pinned CUDA redist release for cuda$major" >&2
@@ -219,6 +222,14 @@ runs:
           rm -rf "$archive" "$dir"
         done
         rm -rf "$tmp"
+
+        # nvcc looks for the runtime in `<nvcc>/../lib64` on Linux; the archives
+        # ship it as lib, and it is the installer that makes the other name.
+        # Without this, cmake's compiler-id link fails on -lcudadevrt.
+        if [ "$RUNNER_OS" = 'Linux' ] && [ ! -e "$root/lib64" ]; then
+          ln -s lib "$root/lib64"
+        fi
+
         echo "engine toolchain: fetched $((bytes / 1024 / 1024)) MB of CUDA $release in $((SECONDS - sw))s"
 
         # nvcc is under bin, or bin/x64 on some Windows releases while the DLLs

--- a/.github/actions/setup-engine-toolchain/action.yml
+++ b/.github/actions/setup-engine-toolchain/action.yml
@@ -1,11 +1,9 @@
 name: Setup engine toolchain
 description: >
-  Selects a JAN_ENGINE_VARIANT and asserts the runner can build it. The engine
-  jobs run on self-hosted runners whose images carry cmake, ccache and the
-  vendor toolkits, so this installs nothing for them -- it points ccache at the
-  runner's persistent cache and fails fast when the image cannot produce the
-  variant it was handed. The one exception is the Vulkan SDK, which the
-  GitHub-hosted images the desktop builds default to do not carry.
+  Selects a JAN_ENGINE_VARIANT and asserts the runner can build it. Every step
+  is guarded on the tool, not the runner label: what the image already carries
+  is left alone, the Vulkan SDK and the CUDA toolkit are fetched when absent,
+  and a runner that cannot produce the variant it was handed fails fast.
 
 inputs:
   variant:
@@ -115,6 +113,139 @@ runs:
           exit 1
           ;;
         esac
+
+    # For the CUDA manifest below.
+    - name: Install jq
+      if: contains(inputs.variant, 'cuda') && runner.environment == 'github-hosted'
+      uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
+
+    # Redist archives, not the vendor installer: 1.1 GB of compiler, runtime
+    # and cuBLAS against 3-4 GB that is mostly display driver and Nsight.
+    - name: Provision the CUDA toolkit
+      if: contains(inputs.variant, 'cuda')
+      shell: bash
+      run: |
+        set -euo pipefail
+        if command -v nvcc >/dev/null 2>&1; then
+          echo "engine toolchain: nvcc already on the image"
+          exit 0
+        fi
+
+        major=""
+        for token in ${VARIANT//-/ }; do
+          case "$token" in cuda*) major="${token#cuda}" ;; esac
+        done
+        # Pinned: the redist tree has no "latest" alias. Add a line per major.
+        case "$major" in
+        13) release='13.0.3' ;;
+        12) release='12.4.1' ;;
+        *)
+          echo "error: no pinned CUDA redist release for cuda$major" >&2
+          echo "       add one to $(basename "$GITHUB_ACTION_PATH")/action.yml, or run this" >&2
+          echo "       variant on a self-hosted runner whose image carries the toolkit" >&2
+          exit 1
+          ;;
+        esac
+
+        case "$RUNNER_OS" in
+        Linux)
+          platform='linux-x86_64'
+          root="$HOME/cuda-$release"
+          root_native="$root"
+          ;;
+        Windows)
+          platform='windows-x86_64'
+          root="/c/cuda-$release"
+          root_native="C:\\cuda-$release"
+          ;;
+        *)
+          echo "error: no CUDA redist provisioning for $RUNNER_OS" >&2
+          exit 1
+          ;;
+        esac
+
+        # cuBLAS is the only maths library ggml links; the rest is nvcc's own
+        # toolchain, the runtime, and headers ggml includes.
+        packages='
+          cuda_nvcc cuda_crt libnvvm libnvptxcompiler libnvjitlink libnvfatbin
+          cuda_cuobjdump cuda_nvdisasm cuda_nvprune cuda_cuxxfilt cuda_nvrtc
+          cuda_cudart libcublas cuda_cccl cuda_nvtx cuda_profiler_api
+        '
+        # These three ship inside cuda_nvcc before 12.8 and standalone after,
+        # so their absence from a manifest is expected, not a broken list.
+        bundled_before_12_8=' cuda_crt libnvvm libnvptxcompiler '
+
+        base='https://developer.download.nvidia.com/compute/cuda/redist'
+        manifest="$RUNNER_TEMP/redistrib.json"
+        curl -fsSL -o "$manifest" "$base/redistrib_$release.json"
+
+        # One at a time, deleted as we go: the whole set unpacked beside its
+        # archives does not comfortably fit the Windows runner's disk.
+        unpack() {
+          case "$1" in
+          *.zip)
+            if command -v 7z >/dev/null 2>&1; then 7z x -y -o"$2" "$1" >/dev/null
+            elif command -v unzip >/dev/null 2>&1; then unzip -q -o "$1" -d "$2"
+            else echo "error: no 7z or unzip to unpack $1" >&2; return 1
+            fi
+            ;;
+          *) tar -xf "$1" -C "$2" ;;
+          esac
+        }
+
+        tmp="$RUNNER_TEMP/cuda-redist"
+        rm -rf "$tmp"
+        mkdir -p "$tmp" "$root"
+        sw=$SECONDS
+        bytes=0
+        for pkg in $packages; do
+          rel=$(jq -r --arg p "$pkg" --arg pl "$platform" \
+            '.[$p][$pl].relative_path // empty' "$manifest")
+          if [ -z "$rel" ]; then
+            case "$bundled_before_12_8" in
+            *" $pkg "*) echo "engine toolchain: $pkg is part of cuda_nvcc in $release"; continue ;;
+            esac
+            echo "error: $pkg has no $platform archive in redistrib_$release.json" >&2
+            exit 1
+          fi
+          archive="$tmp/$(basename "$rel")"
+          curl -fsSL -o "$archive" "$base/$rel"
+          bytes=$((bytes + $(wc -c < "$archive")))
+          unpack "$archive" "$tmp"
+          # Each unpacks to <name>-archive/{bin,lib,include}; merge them into
+          # one root, which is what CUDA_PATH has to point at.
+          dir="$tmp/$(basename "$rel" | sed 's/\.tar\.xz$//; s/\.zip$//')"
+          cp -r "$dir"/* "$root"/
+          rm -rf "$archive" "$dir"
+        done
+        rm -rf "$tmp"
+        echo "engine toolchain: fetched $((bytes / 1024 / 1024)) MB of CUDA $release in $((SECONDS - sw))s"
+
+        # nvcc is under bin, or bin/x64 on some Windows releases while the DLLs
+        # stay in bin. Locate it rather than assume, and put both on PATH.
+        nvcc=$(find "$root/bin" -maxdepth 2 \( -name 'nvcc' -o -name 'nvcc.exe' \) | head -1)
+        [ -n "$nvcc" ] || { echo "error: no nvcc under $root/bin" >&2; exit 1; }
+        "$nvcc" --version
+
+        for lib in cudart cublas cublasLt; do
+          find "$root" -name "*$lib*" -print -quit | grep -q . || {
+            echo "error: no $lib under $root -- the package list is incomplete" >&2
+            exit 1
+          }
+        done
+
+        {
+          echo "CUDA_PATH=$root_native"
+          echo "CUDA_HOME=$root_native"
+        } >> "$GITHUB_ENV"
+        if [ "$RUNNER_OS" = "Windows" ]; then
+          printf '%s\\bin\n%s\\bin\\x64\n' "$root_native" "$root_native" >> "$GITHUB_PATH"
+        else
+          echo "$root/bin" >> "$GITHUB_PATH"
+          echo "LD_LIBRARY_PATH=$root/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
+        fi
+      env:
+        VARIANT: ${{ inputs.variant }}
 
     # Windows builds the engine the way upstream llama.cpp builds this exact
     # configuration: Ninja plus its own clang toolchain file. No developer

--- a/.github/workflows/engine-build.yml
+++ b/.github/workflows/engine-build.yml
@@ -42,21 +42,21 @@ jobs:
         shell: bash
         run: |
           pr='[
-            {"name":"linux-x64-vulkan","variant":"vulkan","runs-on":"ubuntu-22-04"}
+            {"name":"linux-x64-vulkan","variant":"vulkan","runs-on":"ubuntu-22.04"}
           ]'
           full='[
-            {"name":"linux-x64-cuda13","variant":"cuda13-vulkan","runs-on":"ubuntu-22-04-cuda-13-0"},
-            {"name":"linux-x64-cuda12","variant":"cuda12-vulkan","runs-on":"ubuntu-22-04-cuda-12-4"},
-            {"name":"linux-x64-rocm","variant":"rocm-vulkan","runs-on":"ubuntu-22-04","rocm":true},
-            {"name":"windows-x64-cuda13","variant":"cuda13-vulkan","runs-on":"windows-cuda-13-0"},
-            {"name":"windows-x64-cuda12","variant":"cuda12-vulkan","runs-on":"windows-cuda-12-0"},
-            {"name":"macos-arm64-metal","variant":"metal","runs-on":"macos-selfhosted-14-arm64"}
+            {"name":"linux-x64-cuda13","variant":"cuda13-vulkan","runs-on":"ubuntu-22.04"},
+            {"name":"linux-x64-cuda12","variant":"cuda12-vulkan","runs-on":"ubuntu-22.04"},
+            {"name":"linux-x64-rocm","variant":"rocm-vulkan","runs-on":"ubuntu-22.04","rocm":true},
+            {"name":"windows-x64-cuda13","variant":"cuda13-vulkan","runs-on":"windows-2025"},
+            {"name":"windows-x64-cuda12","variant":"cuda12-vulkan","runs-on":"windows-2025"},
+            {"name":"macos-arm64-metal","variant":"metal","runs-on":"macos-latest"}
           ]'
           # Not in `full`, and each for a reason rather than an oversight:
-          #   linux-arm64-cuda13   no arm64 CUDA runner in the pool yet (sbsa
-          #                        works, the label does not exist)
-          #   linux-arm64-vulkan   same pool gap; nothing self-hosted is arm64
-          #   windows-arm64-vulkan windows-11-arm has no engine toolchain image
+          #   linux-arm64-cuda13   ubuntu-*-arm exists; the sbsa redist and the
+          #                        aarch64 Vulkan SDK are untried here
+          #   linux-arm64-vulkan   same, untried rather than blocked
+          #   windows-arm64-vulkan see jan-tauri-build-windows-arm64.yml
           #   windows-x64-rocm     no Windows HIP SDK image; ROCm on Windows is
           #                        an installer run, not an apt line
           if [ "${{ github.event_name }}" = "pull_request" ]; then
@@ -68,14 +68,12 @@ jobs:
   worker:
     name: jan-llama-worker (${{ matrix.name }})
     needs: variants
-    # Fork PRs must not reach this job: every runner label in the matrix is
-    # self-hosted and persistent, and the job compiles `build.rs`, `shim/**`
-    # and `engine/**` from the PR tip, then runs `sudo apt-get install`. A
-    # build script is arbitrary code execution by construction, so a fork PR
-    # touching this workflow's paths filter would get root on a box that later
-    # hosts tag-time release builds. Same guard as
-    # jan-tauri-build-nightly.yaml; `workflow_dispatch` and tag pushes are
-    # unaffected because they are not `pull_request` events.
+    # No label here is self-hosted any more, so this guard is belt and braces:
+    # the job compiles `build.rs`, `shim/**` and `engine/**` from the PR tip and
+    # then runs `sudo apt-get install`, which is arbitrary code execution by
+    # construction, but now only ever on an ephemeral image. Drop the `if` to
+    # give fork PRs engine coverage. Same guard as jan-tauri-build-nightly.yaml;
+    # `workflow_dispatch` and tag pushes are unaffected.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ${{ matrix.runs-on }}
     strategy:
@@ -85,9 +83,25 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      # The self-hosted CUDA images have Git for Windows off PATH (or absent) and
-      # no make; every later step (dtolnay's included) is bash, and make runs
-      # recipes like `mkdir -p` through the coreutils in Git's usr\bin.
+      # rocm-hip-sdk is some 15 GB installed and fits nothing else. Only this
+      # variant is that tight, so no other one pays the couple of minutes.
+      # tool-cache holds the Node later steps want; swap keeps a parallel ggml
+      # compile from being OOM-killed.
+      - name: Free disk space
+        if: matrix.rocm && runner.environment == 'github-hosted'
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          swap-storage: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+
+      # Hosted images have no make, and the self-hosted ones have Git for
+      # Windows off PATH; every later step (dtolnay's included) is bash, and
+      # make runs recipes like `mkdir -p` through Git's usr\bin coreutils.
       - name: Provision Git Bash and make on Windows
         if: runner.os == 'Windows'
         shell: pwsh
@@ -116,9 +130,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libglib2.0-dev libatk1.0-dev libpango1.0-dev libgtk-3-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev librsvg2-dev
 
-      # The CUDA images carry their own toolkit; no image in the pool carries
-      # ROCm, so the one HIP job provisions it, guarded so a reprovisioned image
-      # skips the apt work entirely. Mirrors llama.cpp's own menlo-build.yml.
+      # No image carries ROCm, so the one HIP job provisions it -- guarded so an
+      # image that does carry it skips the apt work entirely. Mirrors llama.cpp's
+      # own menlo-build.yml, which installs it the same way on this same image.
       - name: Provision ROCm
         if: matrix.rocm && runner.os == 'Linux'
         run: |

--- a/.github/workflows/jan-tauri-build-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-nightly.yaml
@@ -87,8 +87,8 @@ jobs:
       channel: nightly
       cortex_api_port: '39261'
 
-  # The CUDA runners are the self-hosted images janhq/llama.cpp builds on; a
-  # cuda variant needs the toolkit at build time and ships Vulkan beside it.
+  # No runner label: the templates default to a GitHub-hosted image and
+  # setup-engine-toolchain fetches CUDA from NVIDIA's redist archives.
   build-windows-x64:
     uses: ./.github/workflows/template-tauri-build-windows-x64.yml
     secrets: inherit
@@ -100,7 +100,6 @@ jobs:
       new_version: ${{ needs.get-update-version.outputs.new_version }}
       channel: nightly
       cortex_api_port: '39261'
-      runner: windows-cuda-13-0
       engine_variant: cuda13-vulkan
   build-linux-x64:
     uses: ./.github/workflows/template-tauri-build-linux-x64.yml
@@ -114,7 +113,6 @@ jobs:
       channel: nightly
       cortex_api_port: '39261'
       disable_updater: ${{ github.event.inputs.disable_updater == 'true' }}
-      runner: ubuntu-22-04-cuda-13-0
       engine_variant: cuda13-vulkan
 
   sync-temp-to-latest:

--- a/.github/workflows/template-tauri-build-linux-x64-external.yml
+++ b/.github/workflows/template-tauri-build-linux-x64-external.yml
@@ -45,19 +45,20 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Free Disk Space Before Build
-        run: |
-          echo "Disk space before cleanup:"
-          df -h
-          sudo rm -rf /usr/local/.ghcup
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/local/lib/android/sdk/ndk
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-          sudo apt-get clean
-          echo "Disk space after cleanup:"
-          df -h
+      # Hosted only: it uninstalls rather than deletes, which on a persistent
+      # runner would outlive the job. tool-cache holds the Node the next step
+      # wants; swap keeps a parallel engine compile from being OOM-killed.
+      - name: Free disk space
+        if: runner.environment == 'github-hosted'
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          swap-storage: false
+          large-packages: false # minutes of apt; only the rocm job needs it
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: true
 
       - name: Replace Icons for Beta Build
         if: inputs.channel != 'stable'

--- a/.github/workflows/template-tauri-build-linux-x64-flatpak.yml
+++ b/.github/workflows/template-tauri-build-linux-x64-flatpak.yml
@@ -69,19 +69,20 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Free Disk Space Before Build
-        run: |
-          echo "Disk space before cleanup:"
-          df -h
-          sudo rm -rf /usr/local/.ghcup
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/local/lib/android/sdk/ndk
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-          sudo apt-get clean
-          echo "Disk space after cleanup:"
-          df -h
+      # Hosted only: it uninstalls rather than deletes, which on a persistent
+      # runner would outlive the job. tool-cache holds the Node the next step
+      # wants; swap keeps a parallel engine compile from being OOM-killed.
+      - name: Free disk space
+        if: runner.environment == 'github-hosted'
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          swap-storage: false
+          large-packages: false # minutes of apt; only the rocm job needs it
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: true
 
       - name: Installing node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/template-tauri-build-linux-x64.yml
+++ b/.github/workflows/template-tauri-build-linux-x64.yml
@@ -84,19 +84,20 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Free Disk Space Before Build
-        run: |
-          echo "Disk space before cleanup:"
-          df -h
-          sudo rm -rf /usr/local/.ghcup
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/local/lib/android/sdk/ndk
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-          sudo apt-get clean
-          echo "Disk space after cleanup:"
-          df -h
+      # Hosted only: it uninstalls rather than deletes, which on a persistent
+      # runner would outlive the job. tool-cache holds the Node the next step
+      # wants; swap keeps a parallel engine compile from being OOM-killed.
+      - name: Free disk space
+        if: runner.environment == 'github-hosted'
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          swap-storage: false
+          large-packages: false # minutes of apt; only the rocm job needs it
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: true
 
       - name: Replace Icons for Beta Build
         if: inputs.channel != 'stable'

--- a/src-tauri/build-utils/shim-linuxdeploy.sh
+++ b/src-tauri/build-utils/shim-linuxdeploy.sh
@@ -11,7 +11,7 @@ export COREPACK_HOME=${COREPACK_HOME:-${XDG_CACHE_HOME:-$HOME/.cache}/node/corep
 # move cache home to <project root>/.cache
 export XDG_CACHE_HOME=${PWD}/.cache
 
-LINUXDEPLOY_VER="1-alpha-20250213-2"
+LINUXDEPLOY_VER="1-alpha-20251107-1"
 LINUXDEPLOY="$XDG_CACHE_HOME/tauri/linuxdeploy-$LINUXDEPLOY_VER-x86_64.AppImage"
 SYMLINK="$XDG_CACHE_HOME/tauri/linuxdeploy-x86_64.AppImage"
 
@@ -32,5 +32,17 @@ ln -s "$LINUXDEPLOY" "$SYMLINK"
 # and the GitHub-hosted images no longer ship libfuse2. Extracting instead is
 # the documented fallback and costs a little disk on a host that has FUSE.
 export APPIMAGE_EXTRACT_AND_RUN=1
+
+# libggml-cuda.so needs libcuda.so.1, which comes with the NVIDIA driver, not the
+# toolkit, and linuxdeploy fails on any dependency it cannot resolve. Resolve it
+# to the toolkit's stub, and exclude it so the stub never lands in the AppImage:
+# at runtime it has to be the user's driver.
+CUDA_STUB="${CUDA_PATH:-}/lib/stubs/libcuda.so"
+if [ -f "$CUDA_STUB" ]; then
+  mkdir -p "$XDG_CACHE_HOME/cuda-stubs"
+  cp "$CUDA_STUB" "$XDG_CACHE_HOME/cuda-stubs/libcuda.so.1"
+  export LD_LIBRARY_PATH="$XDG_CACHE_HOME/cuda-stubs${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+  export LINUXDEPLOY_EXCLUDED_LIBRARIES="libcuda.so.1"
+fi
 
 "$@"


### PR DESCRIPTION
## Describe Your Changes

This pull request modernizes and simplifies the engine build workflows, making them more robust and portable by removing dependencies on self-hosted runners and improving provisioning for CUDA and ROCm toolchains. It also standardizes disk space cleanup across workflows and updates runner labels to use GitHub-hosted images.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
