### PR TITLE
feat(cowork-ui): add restrained navigation icon motion

### DIFF
--- a/web-app/src/components/animated-icon/__tests__/animated-lucide.test.tsx
+++ b/web-app/src/components/animated-icon/__tests__/animated-lucide.test.tsx
@@ -1,0 +1,81 @@
+import '@testing-library/jest-dom/vitest'
+import { createRef, type HTMLAttributes, type ReactNode } from 'react'
+import { act, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LucideIcon } from 'lucide-react'
+
+const motionState = vi.hoisted(() => ({
+  reduced: false,
+  start: vi.fn(),
+}))
+
+vi.mock('motion/react', () => ({
+  motion: {
+    div: (
+      props: HTMLAttributes<HTMLDivElement> & {
+        animate?: unknown
+        variants?: unknown
+        children?: ReactNode
+      }
+    ) => {
+      const { animate, variants, children, ...rest } = props
+      void animate
+      void variants
+      return <div {...rest}>{children}</div>
+    },
+  },
+  useAnimation: () => ({ start: motionState.start }),
+  useReducedMotion: () => motionState.reduced,
+}))
+
+import {
+  AnimatedLucideIcon,
+  type AnimatedLucideIconHandle,
+} from '../animated-lucide'
+
+const MockIcon = (({ size }: { size?: number }) => (
+  <svg aria-label="mock icon" height={size} width={size} />
+)) as LucideIcon
+
+describe('AnimatedLucideIcon', () => {
+  beforeEach(() => {
+    motionState.reduced = false
+    motionState.start.mockReset()
+  })
+
+  it('renders the supplied icon and exposes start/stop controls', () => {
+    const ref = createRef<AnimatedLucideIconHandle>()
+
+    render(
+      <AnimatedLucideIcon
+        ref={ref}
+        icon={MockIcon}
+        preset="box"
+        size={16}
+        data-testid="icon-wrapper"
+      />
+    )
+
+    expect(screen.getByTestId('icon-wrapper')).toContainElement(
+      screen.getByLabelText('mock icon')
+    )
+    expect(screen.getByLabelText('mock icon')).toHaveAttribute('width', '16')
+
+    act(() => ref.current?.startAnimation())
+    act(() => ref.current?.stopAnimation())
+
+    expect(motionState.start).toHaveBeenNthCalledWith(1, 'animate')
+    expect(motionState.start).toHaveBeenNthCalledWith(2, 'normal')
+  })
+
+  it('does not start transforms when reduced motion is enabled', () => {
+    motionState.reduced = true
+    const ref = createRef<AnimatedLucideIconHandle>()
+
+    render(<AnimatedLucideIcon ref={ref} icon={MockIcon} preset="home" />)
+
+    act(() => ref.current?.startAnimation())
+
+    expect(motionState.start).not.toHaveBeenCalledWith('animate')
+  })
+})

--- a/web-app/src/components/animated-icon/__tests__/animated-lucide.test.tsx
+++ b/web-app/src/components/animated-icon/__tests__/animated-lucide.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom/vitest'
 import { createRef, type HTMLAttributes, type ReactNode } from 'react'
-import { act, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { LucideIcon } from 'lucide-react'
 
@@ -63,6 +63,22 @@ describe('AnimatedLucideIcon', () => {
 
     act(() => ref.current?.startAnimation())
     act(() => ref.current?.stopAnimation())
+
+    expect(motionState.start).toHaveBeenNthCalledWith(1, 'animate')
+    expect(motionState.start).toHaveBeenNthCalledWith(2, 'normal')
+  })
+
+  it('self-animates on hover when the caller supplies no ref', () => {
+    render(
+      <AnimatedLucideIcon
+        icon={MockIcon}
+        preset="home"
+        data-testid="icon-wrapper"
+      />
+    )
+
+    fireEvent.mouseEnter(screen.getByTestId('icon-wrapper'))
+    fireEvent.mouseLeave(screen.getByTestId('icon-wrapper'))
 
     expect(motionState.start).toHaveBeenNthCalledWith(1, 'animate')
     expect(motionState.start).toHaveBeenNthCalledWith(2, 'normal')

--- a/web-app/src/components/animated-icon/animated-lucide.tsx
+++ b/web-app/src/components/animated-icon/animated-lucide.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import type { LucideIcon } from 'lucide-react'
+import type { Variants } from 'motion/react'
+import { motion, useAnimation, useReducedMotion } from 'motion/react'
+import type { HTMLAttributes, MouseEvent } from 'react'
+import { forwardRef, useCallback, useImperativeHandle, useRef } from 'react'
+
+import { cn } from '@/lib/utils'
+
+export type AnimatedLucidePreset = 'home' | 'handshake' | 'box' | 'sliders'
+
+export interface AnimatedLucideIconHandle {
+  startAnimation: () => void
+  stopAnimation: () => void
+}
+
+interface AnimatedLucideIconProps extends HTMLAttributes<HTMLDivElement> {
+  icon: LucideIcon
+  preset: AnimatedLucidePreset
+  size?: number
+}
+
+const PRESETS: Record<AnimatedLucidePreset, Variants> = {
+  home: {
+    normal: { rotate: 0, y: 0 },
+    animate: {
+      rotate: [0, -5, 0],
+      y: [0, -1, 0],
+      transition: { duration: 0.45, ease: 'easeInOut' },
+    },
+  },
+  handshake: {
+    normal: { rotate: 0 },
+    animate: {
+      rotate: [0, -5, 5, 0],
+      transition: { duration: 0.5, ease: 'easeInOut' },
+    },
+  },
+  box: {
+    normal: { rotate: 0 },
+    animate: {
+      rotate: [0, -7, 0],
+      transition: { duration: 0.45, ease: 'easeInOut' },
+    },
+  },
+  sliders: {
+    normal: { x: 0 },
+    animate: {
+      x: [0, -1, 1, 0],
+      transition: { duration: 0.45, ease: 'easeInOut' },
+    },
+  },
+}
+
+export const AnimatedLucideIcon = forwardRef<
+  AnimatedLucideIconHandle,
+  AnimatedLucideIconProps
+>(function AnimatedLucideIcon(
+  {
+    icon: Icon,
+    preset,
+    onMouseEnter,
+    onMouseLeave,
+    className,
+    size = 28,
+    ...props
+  },
+  ref
+) {
+  const controls = useAnimation()
+  const reducedMotion = useReducedMotion()
+  const isControlledRef = useRef(false)
+
+  useImperativeHandle(ref, () => {
+    isControlledRef.current = true
+
+    return {
+      startAnimation: () => {
+        if (!reducedMotion) void controls.start('animate')
+      },
+      stopAnimation: () => {
+        void controls.start('normal')
+      },
+    }
+  }, [controls, reducedMotion])
+
+  const handleMouseEnter = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (isControlledRef.current) {
+        onMouseEnter?.(event)
+      } else if (!reducedMotion) {
+        void controls.start('animate')
+      }
+    },
+    [controls, onMouseEnter, reducedMotion]
+  )
+
+  const handleMouseLeave = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (isControlledRef.current) {
+        onMouseLeave?.(event)
+      } else {
+        void controls.start('normal')
+      }
+    },
+    [controls, onMouseLeave]
+  )
+
+  return (
+    <div
+      {...props}
+      className={cn('inline-flex shrink-0', className)}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+    >
+      <motion.div
+        animate={controls}
+        variants={PRESETS[preset]}
+      >
+        <Icon aria-hidden="true" size={size} />
+      </motion.div>
+    </div>
+  )
+})

--- a/web-app/src/components/animated-icon/animated-lucide.tsx
+++ b/web-app/src/components/animated-icon/animated-lucide.tsx
@@ -114,10 +114,7 @@ export const AnimatedLucideIcon = forwardRef<
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
     >
-      <motion.div
-        animate={controls}
-        variants={PRESETS[preset]}
-      >
+      <motion.div animate={controls} variants={PRESETS[preset]}>
         <Icon aria-hidden="true" size={size} />
       </motion.div>
     </div>

--- a/web-app/src/components/left-sidebar/NavCowork.tsx
+++ b/web-app/src/components/left-sidebar/NavCowork.tsx
@@ -44,6 +44,11 @@ import {
   type SettingsIconHandle,
 } from '@/components/animated-icon/settings'
 import {
+  AnimatedLucideIcon,
+  type AnimatedLucideIconHandle,
+  type AnimatedLucidePreset,
+} from '@/components/animated-icon/animated-lucide'
+import {
   startNewSession,
   useCoworkSessions,
   type CoworkSession,
@@ -55,6 +60,7 @@ import SkillsManagerDialog from '@/containers/dialogs/SkillsManagerDialog'
 type CoworkNavItem = {
   title: string
   icon: LucideIcon
+  preset: AnimatedLucidePreset
   onClick: () => void
 }
 
@@ -128,6 +134,31 @@ const SessionItem = memo(function SessionItem({
   )
 })
 
+function CoworkNavItemRow({ item }: { item: CoworkNavItem }) {
+  const iconRef = useRef<AnimatedLucideIconHandle>(null)
+
+  return (
+    <SidebarMenuItem>
+      <SidebarMenuButton
+        onBlur={() => iconRef.current?.stopAnimation()}
+        onClick={item.onClick}
+        onFocus={() => iconRef.current?.startAnimation()}
+        onMouseEnter={() => iconRef.current?.startAnimation()}
+        onMouseLeave={() => iconRef.current?.stopAnimation()}
+      >
+        <AnimatedLucideIcon
+          ref={iconRef}
+          icon={item.icon}
+          preset={item.preset}
+          className="text-foreground/70"
+          size={16}
+        />
+        <span>{item.title}</span>
+      </SidebarMenuButton>
+    </SidebarMenuItem>
+  )
+}
+
 export function NavCowork() {
   const { t } = useTranslation()
   const navigate = useNavigate()
@@ -170,11 +201,13 @@ export function NavCowork() {
     {
       title: t('common:artifacts'),
       icon: Box,
+      preset: 'box',
       onClick: () => navigate({ to: route.artifacts }),
     },
     {
       title: t('common:customize'),
       icon: SlidersHorizontal,
+      preset: 'sliders',
       onClick: () => setSkillsOpen(true),
     },
   ]
@@ -209,17 +242,9 @@ export function NavCowork() {
             <span>{t('common:newSession')}</span>
           </SidebarMenuButton>
         </SidebarMenuItem>
-        {items.map((item) => {
-          const Icon = item.icon
-          return (
-            <SidebarMenuItem key={item.title}>
-              <SidebarMenuButton onClick={item.onClick}>
-                <Icon className="text-foreground/70" size={16} />
-                <span>{item.title}</span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          )
-        })}
+        {items.map((item) => (
+          <CoworkNavItemRow key={item.title} item={item} />
+        ))}
         <SidebarMenuItem>
           <SidebarMenuButton
             onClick={() => navigate({ to: route.settings.general })}

--- a/web-app/src/components/left-sidebar/NavTabs.tsx
+++ b/web-app/src/components/left-sidebar/NavTabs.tsx
@@ -1,15 +1,22 @@
+import { useRef } from 'react'
 import { Link, useLocation } from '@tanstack/react-router'
-import { Handshake, HomeIcon } from 'lucide-react'
+import { Handshake, HomeIcon, type LucideIcon } from 'lucide-react'
 import { route, isCoworkRoute } from '@/constants/routes'
 import { cn } from '@/lib/utils'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { startNewSession } from '@/hooks/useCoworkSessions'
 import { useCoworkRun } from '@/hooks/useCoworkRun'
+import {
+  AnimatedLucideIcon,
+  type AnimatedLucideIconHandle,
+  type AnimatedLucidePreset,
+} from '@/components/animated-icon/animated-lucide'
 
 type TabItem = {
   label: string
   to: string
-  icon: typeof HomeIcon
+  icon: LucideIcon
+  preset: AnimatedLucidePreset
   isActive: boolean
   onClick?: () => void
 }
@@ -18,6 +25,36 @@ type TabItem = {
 // landing on whichever one was viewed last. Sessions are picked from the list.
 const openCoworkStart = () =>
   startNewSession(Object.keys(useCoworkRun.getState().runId))
+
+function NavTab({ tab }: { tab: TabItem }) {
+  const iconRef = useRef<AnimatedLucideIconHandle>(null)
+
+  return (
+    <Link
+      to={tab.to}
+      onClick={tab.onClick}
+      aria-current={tab.isActive ? 'page' : undefined}
+      className={cn(
+        'flex flex-1 items-center justify-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium transition-colors',
+        tab.isActive
+          ? 'bg-sidebar text-foreground shadow-sm'
+          : 'text-muted-foreground hover:text-foreground'
+      )}
+      onBlur={() => iconRef.current?.stopAnimation()}
+      onFocus={() => iconRef.current?.startAnimation()}
+      onMouseEnter={() => iconRef.current?.startAnimation()}
+      onMouseLeave={() => iconRef.current?.stopAnimation()}
+    >
+      <AnimatedLucideIcon
+        ref={iconRef}
+        icon={tab.icon}
+        preset={tab.preset}
+        size={15}
+      />
+      <span>{tab.label}</span>
+    </Link>
+  )
+}
 
 export function NavTabs({ surfacePath }: { surfacePath: string }) {
   const { t } = useTranslation()
@@ -31,40 +68,31 @@ export function NavTabs({ surfacePath }: { surfacePath: string }) {
     surfacePath.startsWith('/project')
 
   const tabs: TabItem[] = [
-    { label: t('common:home'), to: route.home, icon: HomeIcon, isActive: isHome },
+    {
+      label: t('common:home'),
+      to: route.home,
+      icon: HomeIcon,
+      preset: 'home',
+      isActive: isHome,
+    },
     {
       label: t('common:cowork'),
       to: route.cowork,
       icon: Handshake,
+      preset: 'handshake',
       isActive: isCowork,
-      onClick: isCowork && pathname.startsWith('/settings')
-        ? undefined
-        : openCoworkStart,
+      onClick:
+        isCowork && pathname.startsWith('/settings')
+          ? undefined
+          : openCoworkStart,
     },
   ]
 
   return (
     <div className="mt-1 flex items-center gap-0.5 rounded-lg bg-sidebar-foreground/5 p-0.5">
-      {tabs.map((tab) => {
-        const Icon = tab.icon
-        return (
-          <Link
-            key={tab.to}
-            to={tab.to}
-            onClick={tab.onClick}
-            aria-current={tab.isActive ? 'page' : undefined}
-            className={cn(
-              'flex flex-1 items-center justify-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium transition-colors',
-              tab.isActive
-                ? 'bg-sidebar text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground'
-            )}
-          >
-            <Icon size={15} />
-            <span>{tab.label}</span>
-          </Link>
-        )
-      })}
+      {tabs.map((tab) => (
+        <NavTab key={tab.to} tab={tab} />
+      ))}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Home, Cowork, Artifacts, and Customize navigation icons now provide restrained hover and keyboard-focus feedback instead of remaining static.
- Existing routes, labels, icon dimensions, active styling, and reduced-motion behavior remain unchanged.

Fixes #8914

## Verification
- `./node_modules/.bin/vitest run src/components/animated-icon/__tests__/animated-lucide.test.tsx src/components/left-sidebar/__tests__/settingsNavigation.test.tsx` - 2 files and 4 tests passed.
- `./node_modules/.bin/tsc --noEmit -p tsconfig.app.json` - passed.
- `./node_modules/.bin/eslint src/components/animated-icon/animated-lucide.tsx src/components/left-sidebar/NavTabs.tsx src/components/left-sidebar/NavCowork.tsx` - passed.
- `git diff --check origin/main` - passed.
