### PR TITLE
fix(log): stop app.log from deleting llama.cpp/worker logs on rotation

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -331,6 +331,8 @@ pub fn run() {
             app.handle().plugin(
                 tauri_plugin_log::Builder::default()
                     .level(log::LevelFilter::Debug)
+                    .max_file_size(10_000_000)
+                    .rotation_strategy(tauri_plugin_log::RotationStrategy::KeepSome(5))
                     .targets([
                         tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Stdout),
                         tauri_plugin_log::Target::new(tauri_plugin_log::TargetKind::Webview),


### PR DESCRIPTION
## Describe Your Changes

`tauri-plugin-log` v2.9.0 defaults to `max_file_size = 40_000` (40 KB) and `RotationStrategy::KeepOne`, which **deletes** the previous `app.log` on each rotation (`fs::remove_file`, no dated archive). Jan's setup (`src-tauri/src/lib.rs`) sets only `.level(Debug)` and targets, so both defaults apply.

At Debug level, startup logging alone (keyring entries, per-provider registration) exceeds 40 KB within ~30s of launch. Crossing the cap rotates and deletes the file, so a model load that happens after startup writes its `jan-llama-worker` / llama.cpp diagnostics into a segment the next rotation removes. Net effect: llama.cpp/worker logs never survive in `app.log`, which is exactly the lines needed to triage local-inference failures.

Sample `app.log` confirming it: 34,107 bytes / 176 lines, all inside a 29-second startup window, ending right after provider registration, with zero `jan-llama-worker:` lines.

Fix: raise the cap to 10 MB and switch to `KeepSome(5)` so logs are archived to dated files rather than deleted.

## Fixes Issues

- Closes #8913

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
