### PR TITLE
feat: support windows arm64 on nightly

### DIFF
--- a/.github/workflows/jan-tauri-build-agent-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-agent-nightly.yaml
@@ -83,10 +83,13 @@ jobs:
       ]
     runs-on: ubuntu-22.04
     # build-windows-arm64 is here for its outputs, not as a gate -- see the
-    # ARM_SHA branch below. The four legs the published CLI updates from stay
-    # required.
+    # ARM_SHA branch below. Every other dependency is re-asserted by hand: a
+    # status function anywhere in `if` drops the implicit success() gate for the
+    # whole `needs` set, so without get-update-version a failed version job
+    # would publish a manifest with an empty version and empty urls.
     if: >-
       !cancelled()
+      && needs.get-update-version.result == 'success'
       && needs.build-linux-x64.result == 'success'
       && needs.build-macos.result == 'success'
       && needs.build-windows-x64.result == 'success'

--- a/.github/workflows/jan-tauri-build-agent-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-agent-nightly.yaml
@@ -84,9 +84,7 @@ jobs:
     runs-on: ubuntu-22.04
     # build-windows-arm64 is here for its outputs, not as a gate -- see the
     # ARM_SHA branch below. Every other dependency is re-asserted by hand: a
-    # status function anywhere in `if` drops the implicit success() gate for the
-    # whole `needs` set, so without get-update-version a failed version job
-    # would publish a manifest with an empty version and empty urls.
+    # status function in `if` drops the implicit success() gate for all of `needs`.
     if: >-
       !cancelled()
       && needs.get-update-version.result == 'success'
@@ -130,9 +128,8 @@ jobs:
           }
           MANIFEST
 
-          # Appended rather than inlined above: empty when the ARM64 leg failed
-          # or was skipped, and an entry with a blank url is one the CLI finds
-          # and then fails to download.
+          # Appended, not inlined: empty when the ARM64 leg failed, and a blank url
+          # is one the CLI finds and then fails to download.
           ARM_SHA="${{ needs.build-windows-arm64.outputs.SHA256 }}"
           if [ -n "$ARM_SHA" ]; then
             jq --arg url "https://delta.jan.ai/agent-nightly/${{ needs.build-windows-arm64.outputs.FILE_NAME }}" \

--- a/.github/workflows/jan-tauri-build-agent-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-agent-nightly.yaml
@@ -53,6 +53,15 @@ jobs:
       new_version: ${{ needs.get-update-version.outputs.new_version }}
       channel: agent-nightly
 
+  build-windows-arm64:
+    uses: ./.github/workflows/template-cli-build-windows-arm64.yml
+    needs: [get-update-version, resolve-ref]
+    secrets: inherit
+    with:
+      ref: ${{ needs.resolve-ref.outputs.ref }}
+      new_version: ${{ needs.get-update-version.outputs.new_version }}
+      channel: agent-nightly
+
   build-linux-aarch64:
     uses: ./.github/workflows/template-cli-build-linux-aarch64.yml
     needs: [get-update-version, resolve-ref]
@@ -63,8 +72,25 @@ jobs:
       channel: agent-nightly
 
   sync-manifest:
-    needs: [get-update-version, build-linux-x64, build-macos, build-windows-x64, build-linux-aarch64]
+    needs:
+      [
+        get-update-version,
+        build-linux-x64,
+        build-macos,
+        build-windows-x64,
+        build-windows-arm64,
+        build-linux-aarch64,
+      ]
     runs-on: ubuntu-22.04
+    # build-windows-arm64 is here for its outputs, not as a gate -- see the
+    # ARM_SHA branch below. The four legs the published CLI updates from stay
+    # required.
+    if: >-
+      !cancelled()
+      && needs.build-linux-x64.result == 'success'
+      && needs.build-macos.result == 'success'
+      && needs.build-windows-x64.result == 'success'
+      && needs.build-linux-aarch64.result == 'success'
     steps:
       - uses: actions/checkout@v4
 
@@ -100,6 +126,21 @@ jobs:
             }
           }
           MANIFEST
+
+          # Appended rather than inlined above: empty when the ARM64 leg failed
+          # or was skipped, and an entry with a blank url is one the CLI finds
+          # and then fails to download.
+          ARM_SHA="${{ needs.build-windows-arm64.outputs.SHA256 }}"
+          if [ -n "$ARM_SHA" ]; then
+            jq --arg url "https://delta.jan.ai/agent-nightly/${{ needs.build-windows-arm64.outputs.FILE_NAME }}" \
+               --arg sha "$ARM_SHA" \
+               '.platforms["windows-aarch64"] = {url: $url, sha256: $sha}' \
+               manifest.json > /tmp/m.json
+            mv /tmp/m.json manifest.json
+          else
+            echo "::warning::no ARM64 CLI build this run -- publishing manifest.json without windows-aarch64"
+          fi
+
           cat manifest.json
 
       - name: Upload manifest to S3

--- a/.github/workflows/jan-tauri-build-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-nightly.yaml
@@ -139,21 +139,14 @@ jobs:
         build-macos,
       ]
     runs-on: ubuntu-22.04
-    # build-windows-arm64 does not gate *success*: while ARM64 is being
-    # stabilised, a failed leg still publishes a manifest for x64, linux and
-    # macOS rather than withholding it.
+    # build-windows-arm64 does not gate success: a failed ARM leg still publishes
+    # for x64, linux and macOS. It does still gate *scheduling* -- `needs` waits
+    # regardless of `if` -- so a hung ARM build delays the manifest by its 180m
+    # timeout.
     #
-    # It does still gate *scheduling* -- `needs` waits for the job to reach a
-    # terminal state whatever `if` says -- so a hung ARM build can delay the
-    # manifest by up to its 180-minute timeout. Accepted for now: the fix is a
-    # follow-up job that patches the key in after publishing, and that is only
-    # worth its second S3 sync once ARM64 runs on every nightly.
-    #
-    # Every other dependency is then re-asserted by hand, because a status
-    # function anywhere in `if` drops the implicit success() gate for the whole
-    # `needs` set, not just for the job being excused. Without the first two a
-    # failed get-update-version would publish latest.json with an empty version
-    # and empty urls -- which every platform's updater then fails to parse.
+    # Every other dependency is re-asserted by hand: a status function anywhere in
+    # `if` drops the implicit success() gate for the whole `needs` set, not just
+    # for the job being excused.
     if: >-
       !cancelled()
       && needs.get-update-version.result == 'success'
@@ -176,9 +169,8 @@ jobs:
           LINUX_URL="https://delta.jan.ai/nightly/${{ needs.build-linux-x64.outputs.APPIMAGE_FILE_NAME }}"
           WINDOWS_SIGNATURE="${{ needs.build-windows-x64.outputs.WIN_SIG }}"
           WINDOWS_URL="https://delta.jan.ai/nightly/${{ needs.build-windows-x64.outputs.FILE_NAME }}"
-          # Empty when that leg failed or was skipped. The key is then left out
-          # of the manifest rather than written empty: an entry with a blank url
-          # is one the updater finds and then fails to download.
+          # Empty when that leg failed or was skipped; the key is then left out
+          # rather than written blank, which the updater would find and fail on.
           WINDOWS_ARM_SIGNATURE="${{ needs.build-windows-arm64.outputs.WIN_SIG }}"
           WINDOWS_ARM_URL="https://delta.jan.ai/nightly/${{ needs.build-windows-arm64.outputs.FILE_NAME }}"
           [ -n "$WINDOWS_ARM_SIGNATURE" ] || echo "::warning::no ARM64 build this run -- publishing latest.json without windows-aarch64"

--- a/.github/workflows/jan-tauri-build-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-nightly.yaml
@@ -140,10 +140,17 @@ jobs:
     runs-on: ubuntu-22.04
     # build-windows-arm64 is in `needs` for its outputs, not as a gate: while
     # ARM64 is being stabilised a failed leg must not withhold the manifest
-    # from x64, linux and macOS users. The three legs people actually update
-    # from are still required, so a broken one still stops publication.
+    # from x64, linux and macOS users.
+    #
+    # Every other dependency is then re-asserted by hand, because a status
+    # function anywhere in `if` drops the implicit success() gate for the whole
+    # `needs` set, not just for the job being excused. Without the first two a
+    # failed get-update-version would publish latest.json with an empty version
+    # and empty urls -- which every platform's updater then fails to parse.
     if: >-
       !cancelled()
+      && needs.get-update-version.result == 'success'
+      && needs.set-public-provider.result == 'success'
       && needs.build-windows-x64.result == 'success'
       && needs.build-linux-x64.result == 'success'
       && needs.build-macos.result == 'success'

--- a/.github/workflows/jan-tauri-build-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-nightly.yaml
@@ -25,6 +25,7 @@ on:
       - '.github/workflows/template-get-update-version.yml'
       - '.github/workflows/template-tauri-build-macos.yml'
       - '.github/workflows/template-tauri-build-windows-x64.yml'
+      - '.github/workflows/template-tauri-build-windows-arm64.yml'
       - '.github/workflows/template-tauri-build-linux-x64.yml'
       - '.github/workflows/template-noti-discord-and-update-url-readme.yml'
       - 'src-tauri/**'
@@ -138,9 +139,15 @@ jobs:
         build-macos,
       ]
     runs-on: ubuntu-22.04
-    # build-windows-arm64 is in `needs` for its outputs, not as a gate: while
-    # ARM64 is being stabilised a failed leg must not withhold the manifest
-    # from x64, linux and macOS users.
+    # build-windows-arm64 does not gate *success*: while ARM64 is being
+    # stabilised, a failed leg still publishes a manifest for x64, linux and
+    # macOS rather than withholding it.
+    #
+    # It does still gate *scheduling* -- `needs` waits for the job to reach a
+    # terminal state whatever `if` says -- so a hung ARM build can delay the
+    # manifest by up to its 180-minute timeout. Accepted for now: the fix is a
+    # follow-up job that patches the key in after publishing, and that is only
+    # worth its second S3 sync once ARM64 runs on every nightly.
     #
     # Every other dependency is then re-asserted by hand, because a status
     # function anywhere in `if` drops the implicit success() gate for the whole

--- a/.github/workflows/jan-tauri-build-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-nightly.yaml
@@ -114,6 +114,18 @@ jobs:
       cortex_api_port: '39261'
       disable_updater: ${{ github.event.inputs.disable_updater == 'true' }}
       engine_variant: cuda13-vulkan
+  build-windows-arm64:
+    uses: ./.github/workflows/template-tauri-build-windows-arm64.yml
+    secrets: inherit
+    needs: [get-update-version, set-public-provider]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    with:
+      ref: ${{ needs.set-public-provider.outputs.ref }}
+      public_provider: ${{ needs.set-public-provider.outputs.public_provider }}
+      new_version: ${{ needs.get-update-version.outputs.new_version }}
+      channel: nightly
+      engine_variant: cuda13-vulkan
+      vulkan_fallback: '1'
 
   sync-temp-to-latest:
     needs:
@@ -121,11 +133,21 @@ jobs:
         get-update-version,
         set-public-provider,
         build-windows-x64,
+        build-windows-arm64,
         build-linux-x64,
         build-macos,
       ]
     runs-on: ubuntu-22.04
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    # build-windows-arm64 is in `needs` for its outputs, not as a gate: while
+    # ARM64 is being stabilised a failed leg must not withhold the manifest
+    # from x64, linux and macOS users. The three legs people actually update
+    # from are still required, so a broken one still stops publication.
+    if: >-
+      !cancelled()
+      && needs.build-windows-x64.result == 'success'
+      && needs.build-linux-x64.result == 'success'
+      && needs.build-macos.result == 'success'
+      && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - name: Getting the repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -140,6 +162,12 @@ jobs:
           LINUX_URL="https://delta.jan.ai/nightly/${{ needs.build-linux-x64.outputs.APPIMAGE_FILE_NAME }}"
           WINDOWS_SIGNATURE="${{ needs.build-windows-x64.outputs.WIN_SIG }}"
           WINDOWS_URL="https://delta.jan.ai/nightly/${{ needs.build-windows-x64.outputs.FILE_NAME }}"
+          # Empty when that leg failed or was skipped. The key is then left out
+          # of the manifest rather than written empty: an entry with a blank url
+          # is one the updater finds and then fails to download.
+          WINDOWS_ARM_SIGNATURE="${{ needs.build-windows-arm64.outputs.WIN_SIG }}"
+          WINDOWS_ARM_URL="https://delta.jan.ai/nightly/${{ needs.build-windows-arm64.outputs.FILE_NAME }}"
+          [ -n "$WINDOWS_ARM_SIGNATURE" ] || echo "::warning::no ARM64 build this run -- publishing latest.json without windows-aarch64"
           DARWIN_SIGNATURE="${{ needs.build-macos.outputs.MAC_UNIVERSAL_SIG }}"
           DARWIN_URL="https://delta.jan.ai/nightly/Jan-nightly_${{ needs.get-update-version.outputs.new_version }}.app.tar.gz"
 
@@ -149,6 +177,8 @@ jobs:
             --arg linux_url "$LINUX_URL" \
             --arg windows_signature "$WINDOWS_SIGNATURE" \
             --arg windows_url "$WINDOWS_URL" \
+            --arg windows_arm_signature "$WINDOWS_ARM_SIGNATURE" \
+            --arg windows_arm_url "$WINDOWS_ARM_URL" \
             --arg darwin_arm_signature "$DARWIN_SIGNATURE" \
             --arg darwin_arm_url "$DARWIN_URL" \
             --arg darwin_amd_signature "$DARWIN_SIGNATURE" \
@@ -159,6 +189,10 @@ jobs:
               | .platforms["linux-x86_64"].url = $linux_url
               | .platforms["windows-x86_64"].signature = $windows_signature
               | .platforms["windows-x86_64"].url = $windows_url
+              | if $windows_arm_signature == "" then . else
+                  .platforms["windows-aarch64"].signature = $windows_arm_signature
+                  | .platforms["windows-aarch64"].url = $windows_arm_url
+                end
               | .platforms["darwin-aarch64"].signature = $darwin_arm_signature
               | .platforms["darwin-aarch64"].url = $darwin_arm_url
               | .platforms["darwin-x86_64"].signature = $darwin_amd_signature

--- a/.github/workflows/jan-tauri-build-windows-arm64.yml
+++ b/.github/workflows/jan-tauri-build-windows-arm64.yml
@@ -1,12 +1,12 @@
 # Windows ARM64 desktop build.
 #
 # Standalone on purpose: it neither calls the x64 template nor edits any file
-# that build reads, so it cannot change an x64 artifact. Merging the two behind
-# an `arch` input is the eventual shape, once ARM64 has gone green.
+# that build reads, so it cannot change an x64 artifact. Folding the two behind
+# an `arch` input comes once ARM64 is green.
 #
-# Signing and updater artifacts match the x64 template. Publication does not:
-# no S3 sync, no release upload, and no `windows-aarch64` entry in latest.json,
-# so an ARM64 build cannot yet reach users through the updater.
+# Signing and updater artifacts match x64. Publication does not -- no S3, no
+# release upload, no `windows-aarch64` in latest.json -- so ARM64 builds cannot
+# yet reach users through the updater.
 name: Tauri Build Windows ARM64
 
 on:
@@ -37,9 +37,8 @@ on:
         required: false
         type: string
         default: '0'
-  # Pre-merge testing hook only. GitHub does not offer workflow_dispatch until
-  # the file is on the default branch, so without this there is no way to run
-  # this before merging. Drop it once that lands.
+  # Pre-merge hook: workflow_dispatch is not offered until the file is on the
+  # default branch. Drop this once it lands there.
   push:
     branches: ['feat/windows-arm64']
 
@@ -56,11 +55,10 @@ env:
   JAN_ENGINE_VARIANT: ${{ inputs.engine_variant || 'cuda13' }}
   JAN_ENGINE_VULKAN_FALLBACK: ${{ inputs.vulkan_fallback || '0' }}
   CUDA_SHORT: '13.4'
-  # Redistributable archives rather than the 3.8 GB local installer, which is
-  # how upstream llama.cpp provisions this same toolkit
-  # (.github/actions/windows-setup-cuda). A full silent install spends most of
-  # its time on the display driver and the Nsight profilers, none of which a
-  # build needs, and it hung past 38 minutes on a runner with no NVIDIA GPU.
+  # Redistributable archives, as upstream llama.cpp provisions this same
+  # toolkit (.github/actions/windows-setup-cuda). The 3.8 GB installer spends
+  # its time on the display driver and Nsight, neither of which a build needs,
+  # and hung past 38 minutes on a runner with no NVIDIA GPU.
   CUDA_POOL: 'https://packages.nvidia.com/bin-archive/pool/windows-arm64/5B515474-7E78-11F1-8656-C51E4F4B317F'
 
 jobs:
@@ -88,8 +86,8 @@ jobs:
       - name: Install ctoml
         run: cargo install ctoml
 
-      # build.rs reads VCToolsInstallDir to locate bin/Host*/arm64/cl.exe. The
-      # image does not export it outside a developer prompt.
+      # build.rs reads VCToolsInstallDir to find bin/Host*/arm64/cl.exe; the
+      # image only exports it inside a developer prompt.
       - name: Resolve the MSVC ARM64 toolset
         shell: pwsh
         run: |
@@ -106,15 +104,14 @@ jobs:
           if (-not $found) { throw "no arm64 cl.exe under $vcTools\bin\Host*\arm64" }
           "VCToolsInstallDir=$vcTools" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
 
-          # cmake links executables through `cmake -E vs_link_exe`, which shells
-          # out to `mt` to embed the manifest. mt.exe ships in the Windows SDK,
-          # not with LLVM, and cmake looks for that exact name -- so LLVM's
-          # llvm-mt.exe on PATH does not satisfy it. Without this, cmake reports
-          # CMAKE_MT as empty and every executable link dies on
-          # "no such file or directory", starting with its own compiler probe.
-          # mt.exe and signtool.exe are searched for separately: the ARM64 SDK
-          # bin ships a subset of the tools, so the two can live in different
-          # arch directories on the same image.
+          # Two Windows SDK tools, searched separately because the ARM64 bin
+          # ships a subset and they land in different arch directories:
+          #   mt       cmake shells out to it from vs_link_exe to embed the
+          #            manifest. It looks for that exact name, so LLVM's
+          #            llvm-mt.exe does not count; without it CMAKE_MT is empty
+          #            and every executable link fails.
+          #   signtool tauri needs it to *verify* existing signatures, which a
+          #            custom signCommand does not replace.
           $kits = "${env:ProgramFiles(x86)}\Windows Kits\10\bin"
           $versions = @()
           if (Test-Path $kits) {
@@ -122,7 +119,7 @@ jobs:
               Where-Object { $_.Name -as [version] } |
               Sort-Object { [version]$_.Name } -Descending
           }
-          # arm64 first so a native tool wins over the emulated x64 one.
+          # arm64 first: native beats emulated x64.
           function Find-SdkTool([string]$exe) {
             foreach ($ver in $versions) {
               foreach ($a in 'arm64', 'x64', 'x86') {
@@ -138,23 +135,20 @@ jobs:
           Write-Host "mt:       $mt"
           Split-Path $mt -Parent | Out-File $env:GITHUB_PATH -Append -Encoding utf8
 
-          # tauri-bundler resolves signtool itself, from the registry plus the
-          # *native* processor architecture -- so on this runner it only ever
-          # looks in the arm64 directory and fails when signtool is not there.
-          # TAURI_WINDOWS_SIGNTOOL_PATH short-circuits that lookup entirely.
+          # tauri derives the directory from the *native* processor arch, so
+          # here it only ever looks in arm64. This env var bypasses that.
           $signtool = Find-SdkTool 'signtool.exe'
           if (-not $signtool) { throw "no signtool.exe under $kits\<version>\{arm64,x64,x86}" }
           Write-Host "signtool: $signtool"
           "TAURI_WINDOWS_SIGNTOOL_PATH=$signtool" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
 
-      # Every archive is arm64: this is a native build, so nvcc itself is an
-      # ARM64 binary. Upstream cross-compiles instead and pairs x86_64 host
-      # tools with arm64 target libraries -- worth remembering as the fallback
-      # if a native nvcc misbehaves, though switching would also mean
-      # cross-compiling the Tauri app and relocating every output path.
+      # All arm64: this is a native build, so nvcc is an ARM64 binary too.
+      # Upstream instead cross-compiles, pairing x86_64 host tools with arm64
+      # target libs -- the fallback if a native nvcc misbehaves, though it would
+      # also mean cross-compiling the app and relocating every output path.
       #
-      # Versions are pinned. These live in a prerelease pool with no "latest"
-      # alias, so an unpinned URL is not merely unstable, it does not exist.
+      # Pinned because this prerelease pool has no "latest" alias: an unpinned
+      # URL does not just drift, it 404s.
       - name: Install the CUDA toolkit (ARM64)
         shell: pwsh
         run: |
@@ -183,8 +177,8 @@ jobs:
             Invoke-WebRequest -Uri "$env:CUDA_POOL/$a.zip" -OutFile $zip
             $total += (Get-Item $zip).Length
             Expand-Archive -Path $zip -DestinationPath $tmp -Force
-            # Each archive unpacks to <name>/{bin,lib,include}; merge them all
-            # into one toolkit root, which is what CUDA_PATH has to point at.
+            # Each unpacks to <name>/{bin,lib,include}; merge into one root,
+            # which is what CUDA_PATH must point at.
             Copy-Item -Path (Join-Path $tmp "$a\*") -Destination $root -Recurse -Force
           }
           Write-Host ("Fetched {0:N0} MB and unpacked in {1:N1} min" -f ($total / 1MB), $sw.Elapsed.TotalMinutes)
@@ -192,8 +186,7 @@ jobs:
           "CUDA_PATH=$root" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
           "$root\bin"       | Out-File $env:GITHUB_PATH -Append -Encoding utf8
 
-          # Layout differs between the installer and these archives, and between
-          # host and target arch, so print it rather than assume it.
+          # Layout differs from the installer's and by arch, so print it.
           foreach ($d in 'bin', 'lib', 'lib\arm64', 'lib\x64') {
             $path = Join-Path $root $d
             Write-Host "--- $path"
@@ -228,15 +221,15 @@ jobs:
       - name: Verify the engine toolchain
         shell: bash
         run: |
-          # mt is included because cmake needs it to link any executable, and
-          # its absence surfaces as an opaque failure inside a compiler probe.
+          # mt included: without it every executable link fails, and it
+          # surfaces opaquely inside cmake's own compiler probe.
           for tool in cmake ninja clang mt; do
             command -v "$tool" >/dev/null 2>&1 || { echo "::error::$tool is not on PATH"; exit 1; }
             echo "$tool -> $(command -v "$tool")"
           done
           nvcc --version
-          # Not on PATH -- tauri reads it from the environment. Checked here so
-          # a missing signtool fails in seconds rather than after the ~75
+          # Not on PATH; tauri reads it from the env. Checked here so a missing
+          # signtool fails in seconds rather than after the ~75
           # minutes of compiling that precede bundling.
           [ -x "$TAURI_WINDOWS_SIGNTOOL_PATH" ] || {
             echo "::error::TAURI_WINDOWS_SIGNTOOL_PATH is not an executable: ${TAURI_WINDOWS_SIGNTOOL_PATH:-<unset>}"; exit 1;

--- a/.github/workflows/jan-tauri-build-windows-arm64.yml
+++ b/.github/workflows/jan-tauri-build-windows-arm64.yml
@@ -112,24 +112,40 @@ jobs:
           # llvm-mt.exe on PATH does not satisfy it. Without this, cmake reports
           # CMAKE_MT as empty and every executable link dies on
           # "no such file or directory", starting with its own compiler probe.
-          $sdkBin = $null
+          # mt.exe and signtool.exe are searched for separately: the ARM64 SDK
+          # bin ships a subset of the tools, so the two can live in different
+          # arch directories on the same image.
           $kits = "${env:ProgramFiles(x86)}\Windows Kits\10\bin"
+          $versions = @()
           if (Test-Path $kits) {
             $versions = Get-ChildItem $kits -Directory |
               Where-Object { $_.Name -as [version] } |
               Sort-Object { [version]$_.Name } -Descending
-            foreach ($ver in $versions) {
-              # arm64 first so the native tool wins over the emulated x64 one.
-              foreach ($a in 'arm64', 'x64') {
-                $cand = Join-Path $ver.FullName $a
-                if (Test-Path (Join-Path $cand 'mt.exe')) { $sdkBin = $cand; break }
-              }
-              if ($sdkBin) { break }
-            }
           }
-          if (-not $sdkBin) { throw "no mt.exe under $kits\<version>\{arm64,x64}" }
-          Write-Host "Windows SDK bin: $sdkBin"
-          $sdkBin | Out-File $env:GITHUB_PATH -Append -Encoding utf8
+          # arm64 first so a native tool wins over the emulated x64 one.
+          function Find-SdkTool([string]$exe) {
+            foreach ($ver in $versions) {
+              foreach ($a in 'arm64', 'x64', 'x86') {
+                $p = Join-Path (Join-Path $ver.FullName $a) $exe
+                if (Test-Path $p) { return $p }
+              }
+            }
+            return $null
+          }
+
+          $mt = Find-SdkTool 'mt.exe'
+          if (-not $mt) { throw "no mt.exe under $kits\<version>\{arm64,x64,x86}" }
+          Write-Host "mt:       $mt"
+          Split-Path $mt -Parent | Out-File $env:GITHUB_PATH -Append -Encoding utf8
+
+          # tauri-bundler resolves signtool itself, from the registry plus the
+          # *native* processor architecture -- so on this runner it only ever
+          # looks in the arm64 directory and fails when signtool is not there.
+          # TAURI_WINDOWS_SIGNTOOL_PATH short-circuits that lookup entirely.
+          $signtool = Find-SdkTool 'signtool.exe'
+          if (-not $signtool) { throw "no signtool.exe under $kits\<version>\{arm64,x64,x86}" }
+          Write-Host "signtool: $signtool"
+          "TAURI_WINDOWS_SIGNTOOL_PATH=$signtool" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
 
       # Every archive is arm64: this is a native build, so nvcc itself is an
       # ARM64 binary. Upstream cross-compiles instead and pairs x86_64 host
@@ -219,6 +235,13 @@ jobs:
             echo "$tool -> $(command -v "$tool")"
           done
           nvcc --version
+          # Not on PATH -- tauri reads it from the environment. Checked here so
+          # a missing signtool fails in seconds rather than after the ~75
+          # minutes of compiling that precede bundling.
+          [ -x "$TAURI_WINDOWS_SIGNTOOL_PATH" ] || {
+            echo "::error::TAURI_WINDOWS_SIGNTOOL_PATH is not an executable: ${TAURI_WINDOWS_SIGNTOOL_PATH:-<unset>}"; exit 1;
+          }
+          echo "signtool -> $TAURI_WINDOWS_SIGNTOOL_PATH"
 
       - name: Update app version and product name
         shell: bash

--- a/.github/workflows/jan-tauri-build-windows-arm64.yml
+++ b/.github/workflows/jan-tauri-build-windows-arm64.yml
@@ -106,6 +106,15 @@ jobs:
       # ~3.8 GB with no network installer available, so this dominates the job.
       # Uncached deliberately: it would claim a third of the repo's 10 GB cache
       # budget and evict the cargo caches that matter more.
+      #
+      # Subpackages are enumerated rather than using a bare `-s`. A full silent
+      # install pulls all ~42 components plus Display.Driver, which on a runner
+      # with no NVIDIA GPU ran past 38 minutes with no output before being
+      # killed -- against a 3 minute download. Naming the packages skips the
+      # driver, all three Nsight profilers, documentation, sanitizer, opencl,
+      # the maths libraries ggml does not link (npp/cufft/curand/cusolver/
+      # cusparse/nvjpeg) and the Visual Studio integration we do not use with
+      # Ninja.
       - name: Install the CUDA toolkit (ARM64)
         shell: pwsh
         run: |
@@ -115,14 +124,34 @@ jobs:
           Invoke-WebRequest -Uri $env:CUDA_URL -OutFile $exe
           Write-Host ("Downloaded {0:N0} MB in {1:N1} min" -f ((Get-Item $exe).Length / 1MB), $sw.Elapsed.TotalMinutes)
 
+          $v = $env:CUDA_SHORT
+          $packages = @(
+            'nvcc', 'crt', 'nvvm', 'cudart',          # compiler + runtime
+            'cublas', 'cublas_dev',                   # the only maths library ggml links
+            'cuda_profiler_api', 'thrust', 'nvtx',    # headers ggml includes
+            'nvrtc', 'nvrtc_dev',
+            'nvjitlink', 'nvfatbin', 'nvptxcompiler', # device link time
+            'cuobjdump', 'nvdisasm', 'nvprune', 'cuxxfilt'
+          ) | ForEach-Object { '{0}_{1}' -f $_, $v }
+          Write-Host "Installing: $($packages -join ' ')"
+
           $sw.Restart()
-          Start-Process -FilePath $exe -ArgumentList '-s' -Wait -NoNewWindow
+          Start-Process -FilePath $exe -ArgumentList (@('-s') + $packages) -Wait -NoNewWindow
           Write-Host ("Installed in {0:N1} min" -f $sw.Elapsed.TotalMinutes)
 
-          $root = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$env:CUDA_SHORT"
+          $root = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$v"
           if (-not (Test-Path $root)) { throw "CUDA not installed at $root" }
           "CUDA_PATH=$root" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
           "$root\bin"       | Out-File $env:GITHUB_PATH -Append -Encoding utf8
+
+          # A named subpackage that the installer did not recognise is skipped
+          # silently, so list what actually landed instead of assuming.
+          Write-Host "--- $root\lib\arm64"
+          Get-ChildItem "$root\lib\arm64" -ErrorAction SilentlyContinue |
+            Select-Object -ExpandProperty Name
+          foreach ($need in 'cudart.lib', 'cublas.lib', 'cublasLt.lib') {
+            if (-not (Test-Path "$root\lib\arm64\$need")) { throw "missing $need" }
+          }
           & "$root\bin\nvcc.exe" --version
 
       # LunarG's Windows ARM64 SDK is platform code `warm`; `windows` is x64.

--- a/.github/workflows/jan-tauri-build-windows-arm64.yml
+++ b/.github/workflows/jan-tauri-build-windows-arm64.yml
@@ -105,6 +105,31 @@ jobs:
           if (-not $found) { throw "no arm64 cl.exe under $vcTools\bin\Host*\arm64" }
           "VCToolsInstallDir=$vcTools" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
 
+          # cmake links executables through `cmake -E vs_link_exe`, which shells
+          # out to `mt` to embed the manifest. mt.exe ships in the Windows SDK,
+          # not with LLVM, and cmake looks for that exact name -- so LLVM's
+          # llvm-mt.exe on PATH does not satisfy it. Without this, cmake reports
+          # CMAKE_MT as empty and every executable link dies on
+          # "no such file or directory", starting with its own compiler probe.
+          $sdkBin = $null
+          $kits = "${env:ProgramFiles(x86)}\Windows Kits\10\bin"
+          if (Test-Path $kits) {
+            $versions = Get-ChildItem $kits -Directory |
+              Where-Object { $_.Name -as [version] } |
+              Sort-Object { [version]$_.Name } -Descending
+            foreach ($ver in $versions) {
+              # arm64 first so the native tool wins over the emulated x64 one.
+              foreach ($a in 'arm64', 'x64') {
+                $cand = Join-Path $ver.FullName $a
+                if (Test-Path (Join-Path $cand 'mt.exe')) { $sdkBin = $cand; break }
+              }
+              if ($sdkBin) { break }
+            }
+          }
+          if (-not $sdkBin) { throw "no mt.exe under $kits\<version>\{arm64,x64}" }
+          Write-Host "Windows SDK bin: $sdkBin"
+          $sdkBin | Out-File $env:GITHUB_PATH -Append -Encoding utf8
+
       # Every archive is arm64: this is a native build, so nvcc itself is an
       # ARM64 binary. Upstream cross-compiles instead and pairs x86_64 host
       # tools with arm64 target libraries -- worth remembering as the fallback
@@ -186,7 +211,9 @@ jobs:
       - name: Verify the engine toolchain
         shell: bash
         run: |
-          for tool in cmake ninja clang; do
+          # mt is included because cmake needs it to link any executable, and
+          # its absence surfaces as an opaque failure inside a compiler probe.
+          for tool in cmake ninja clang mt; do
             command -v "$tool" >/dev/null 2>&1 || { echo "::error::$tool is not on PATH"; exit 1; }
             echo "$tool -> $(command -v "$tool")"
           done

--- a/.github/workflows/jan-tauri-build-windows-arm64.yml
+++ b/.github/workflows/jan-tauri-build-windows-arm64.yml
@@ -4,8 +4,9 @@
 # that build reads, so it cannot change an x64 artifact. Merging the two behind
 # an `arch` input is the eventual shape, once ARM64 has gone green.
 #
-# Unsigned, no updater artifacts, so it needs no secrets. Signing, the
-# `windows-aarch64` updater entry and publication come later.
+# Signing and updater artifacts match the x64 template. Publication does not:
+# no S3 sync, no release upload, and no `windows-aarch64` entry in latest.json,
+# so an ARM64 build cannot yet reach users through the updater.
 name: Tauri Build Windows ARM64
 
 on:
@@ -222,10 +223,14 @@ jobs:
       - name: Update app version and product name
         shell: bash
         run: |
-          jq --arg version "$NEW_VERSION" '.version = $version' ./src-tauri/tauri.conf.json > /tmp/c.json
+          jq --arg version "$NEW_VERSION" \
+             '.version = $version | .bundle.createUpdaterArtifacts = true' \
+             ./src-tauri/tauri.conf.json > /tmp/c.json
           mv /tmp/c.json ./src-tauri/tauri.conf.json
 
-          jq '.bundle.targets = ["nsis"] | .bundle.windows.nsis.template = "tauri.bundle.windows.nsis.template"' \
+          jq '.bundle.targets = ["nsis"]
+              | .bundle.windows.nsis.template = "tauri.bundle.windows.nsis.template"
+              | .bundle.windows.signCommand = "powershell -ExecutionPolicy Bypass -File ./sign.ps1 %1"' \
              ./src-tauri/tauri.windows.conf.json > /tmp/w.json
           mv /tmp/w.json ./src-tauri/tauri.windows.conf.json
 
@@ -289,6 +294,9 @@ jobs:
           Set-Content -Path $t -Value $c -NoNewline
           Select-String -Path $t -Pattern 'ARCH|aarch64|jan_' | Select-Object -First 12
 
+      - name: Install AzureSignTool
+        run: dotnet tool install --global --version 6.0.0 AzureSignTool
+
       - name: Config Yarn
         run: |
           corepack enable
@@ -298,6 +306,18 @@ jobs:
       - name: Build app
         shell: bash
         run: make build
+        env:
+          AZURE_KEY_VAULT_URI: ${{ secrets.AZURE_KEY_VAULT_URI }}
+          JAN_ENGINE_REQUIRE_SIGNING: '1'
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_CERT_NAME: ${{ secrets.AZURE_CERT_NAME }}
+          POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          JAN_SIGNING_KEY: ${{ secrets.JAN_SIGNING_KEY }}
 
       - name: Upload the engine build log
         if: failure()
@@ -345,5 +365,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: jan-windows-arm64-exe-${{ env.NEW_VERSION }}
-          path: ./src-tauri/target/release/bundle/nsis/*.exe
+          path: |
+            ./src-tauri/target/release/bundle/nsis/*.exe
+            ./src-tauri/target/release/bundle/nsis/*.sig
           if-no-files-found: error

--- a/.github/workflows/jan-tauri-build-windows-arm64.yml
+++ b/.github/workflows/jan-tauri-build-windows-arm64.yml
@@ -294,6 +294,22 @@ jobs:
           Set-Content -Path $t -Value $c -NoNewline
           Select-String -Path $t -Pattern 'ARCH|aarch64|jan_' | Select-Object -First 12
 
+      # Only src-tauri, which covers the two release compiles that follow the
+      # engine: `build:cli` and `tauri build`. The llamacpp plugin has its own
+      # target dir -- these are separate crates, not one workspace -- and it is
+      # deliberately left uncached: its OUT_DIR holds the whole cmake tree with
+      # ggml-cuda built for seven architectures, which would swallow the 10 GB
+      # per-repo cache budget on its own.
+      #
+      # Does nothing for a cold first run; the payoff is every run after it.
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          workspaces: src-tauri
+          # This job has failed in packaging after an hour of compiling more
+          # than once. Saving anyway keeps the next attempt cheap.
+          cache-on-failure: true
+
       - name: Install AzureSignTool
         run: dotnet tool install --global --version 6.0.0 AzureSignTool
 

--- a/.github/workflows/jan-tauri-build-windows-arm64.yml
+++ b/.github/workflows/jan-tauri-build-windows-arm64.yml
@@ -55,10 +55,12 @@ env:
   JAN_ENGINE_VARIANT: ${{ inputs.engine_variant || 'cuda13' }}
   JAN_ENGINE_VULKAN_FALLBACK: ${{ inputs.vulkan_fallback || '0' }}
   CUDA_SHORT: '13.4'
-  # 13.4 is the first release with Windows ARM64, and is a developer preview --
-  # hence packages.nvidia.com/prerelease; the usual compute/cuda path has no
-  # 13.4 entry.
-  CUDA_URL: 'https://packages.nvidia.com/prerelease/cuda/13.4.0/local_installers/cuda_13.4.0_windows_arm64.exe'
+  # Redistributable archives rather than the 3.8 GB local installer, which is
+  # how upstream llama.cpp provisions this same toolkit
+  # (.github/actions/windows-setup-cuda). A full silent install spends most of
+  # its time on the display driver and the Nsight profilers, none of which a
+  # build needs, and it hung past 38 minutes on a runner with no NVIDIA GPU.
+  CUDA_POOL: 'https://packages.nvidia.com/bin-archive/pool/windows-arm64/5B515474-7E78-11F1-8656-C51E4F4B317F'
 
 jobs:
   build-windows-arm64:
@@ -103,56 +105,71 @@ jobs:
           if (-not $found) { throw "no arm64 cl.exe under $vcTools\bin\Host*\arm64" }
           "VCToolsInstallDir=$vcTools" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
 
-      # ~3.8 GB with no network installer available, so this dominates the job.
-      # Uncached deliberately: it would claim a third of the repo's 10 GB cache
-      # budget and evict the cargo caches that matter more.
+      # Every archive is arm64: this is a native build, so nvcc itself is an
+      # ARM64 binary. Upstream cross-compiles instead and pairs x86_64 host
+      # tools with arm64 target libraries -- worth remembering as the fallback
+      # if a native nvcc misbehaves, though switching would also mean
+      # cross-compiling the Tauri app and relocating every output path.
       #
-      # Subpackages are enumerated rather than using a bare `-s`. A full silent
-      # install pulls all ~42 components plus Display.Driver, which on a runner
-      # with no NVIDIA GPU ran past 38 minutes with no output before being
-      # killed -- against a 3 minute download. Naming the packages skips the
-      # driver, all three Nsight profilers, documentation, sanitizer, opencl,
-      # the maths libraries ggml does not link (npp/cufft/curand/cusolver/
-      # cusparse/nvjpeg) and the Visual Studio integration we do not use with
-      # Ninja.
+      # Versions are pinned. These live in a prerelease pool with no "latest"
+      # alias, so an unpinned URL is not merely unstable, it does not exist.
       - name: Install the CUDA toolkit (ARM64)
         shell: pwsh
         run: |
+          $ErrorActionPreference = 'Stop'
           $ProgressPreference = 'SilentlyContinue'
-          $exe = Join-Path $env:RUNNER_TEMP 'cuda_arm64.exe'
+          $root = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$env:CUDA_SHORT"
+          New-Item -ItemType Directory -Force -Path $root | Out-Null
+
+          $archives = @(
+            'cuda_nvcc-windows-arm64-13.4.46-archive',
+            'cuda_crt-windows-arm64-13.4.46-archive',
+            'libnvvm-windows-arm64-13.4.46-archive',
+            'cuda_cudart-windows-arm64-13.4.46-archive',
+            'libcublas-windows-arm64-13.7.0.10-archive',
+            'cccl-windows-arm64-13.3.4.1.2-archive',
+            'cuda_nvtx-windows-arm64-13.4.46-archive',
+            'cuda_profiler_api-windows-arm64-13.4.46-archive'
+          )
+
           $sw = [Diagnostics.Stopwatch]::StartNew()
-          Invoke-WebRequest -Uri $env:CUDA_URL -OutFile $exe
-          Write-Host ("Downloaded {0:N0} MB in {1:N1} min" -f ((Get-Item $exe).Length / 1MB), $sw.Elapsed.TotalMinutes)
+          $tmp = Join-Path $env:RUNNER_TEMP 'cuda'
+          New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+          $total = 0
+          foreach ($a in $archives) {
+            $zip = Join-Path $tmp "$a.zip"
+            Invoke-WebRequest -Uri "$env:CUDA_POOL/$a.zip" -OutFile $zip
+            $total += (Get-Item $zip).Length
+            Expand-Archive -Path $zip -DestinationPath $tmp -Force
+            # Each archive unpacks to <name>/{bin,lib,include}; merge them all
+            # into one toolkit root, which is what CUDA_PATH has to point at.
+            Copy-Item -Path (Join-Path $tmp "$a\*") -Destination $root -Recurse -Force
+          }
+          Write-Host ("Fetched {0:N0} MB and unpacked in {1:N1} min" -f ($total / 1MB), $sw.Elapsed.TotalMinutes)
 
-          $v = $env:CUDA_SHORT
-          $packages = @(
-            'nvcc', 'crt', 'nvvm', 'cudart',          # compiler + runtime
-            'cublas', 'cublas_dev',                   # the only maths library ggml links
-            'cuda_profiler_api', 'thrust', 'nvtx',    # headers ggml includes
-            'nvrtc', 'nvrtc_dev',
-            'nvjitlink', 'nvfatbin', 'nvptxcompiler', # device link time
-            'cuobjdump', 'nvdisasm', 'nvprune', 'cuxxfilt'
-          ) | ForEach-Object { '{0}_{1}' -f $_, $v }
-          Write-Host "Installing: $($packages -join ' ')"
-
-          $sw.Restart()
-          Start-Process -FilePath $exe -ArgumentList (@('-s') + $packages) -Wait -NoNewWindow
-          Write-Host ("Installed in {0:N1} min" -f $sw.Elapsed.TotalMinutes)
-
-          $root = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$v"
-          if (-not (Test-Path $root)) { throw "CUDA not installed at $root" }
           "CUDA_PATH=$root" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
           "$root\bin"       | Out-File $env:GITHUB_PATH -Append -Encoding utf8
 
-          # A named subpackage that the installer did not recognise is skipped
-          # silently, so list what actually landed instead of assuming.
-          Write-Host "--- $root\lib\arm64"
-          Get-ChildItem "$root\lib\arm64" -ErrorAction SilentlyContinue |
-            Select-Object -ExpandProperty Name
-          foreach ($need in 'cudart.lib', 'cublas.lib', 'cublasLt.lib') {
-            if (-not (Test-Path "$root\lib\arm64\$need")) { throw "missing $need" }
+          # Layout differs between the installer and these archives, and between
+          # host and target arch, so print it rather than assume it.
+          foreach ($d in 'bin', 'lib', 'lib\arm64', 'lib\x64') {
+            $path = Join-Path $root $d
+            Write-Host "--- $path"
+            if (Test-Path $path) {
+              Get-ChildItem $path | Select-Object -ExpandProperty Name
+            } else { Write-Host '   (absent)' }
           }
-          & "$root\bin\nvcc.exe" --version
+
+          $nvcc = Get-ChildItem $root -Recurse -Filter 'nvcc.exe' | Select-Object -First 1
+          if (-not $nvcc) { throw 'nvcc.exe not found under the toolkit root' }
+          Write-Host "nvcc: $($nvcc.FullName)"
+          & $nvcc.FullName --version
+
+          foreach ($need in 'cudart.lib', 'cublas.lib', 'cublasLt.lib') {
+            if (-not (Get-ChildItem $root -Recurse -Filter $need -ErrorAction SilentlyContinue)) {
+              throw "missing $need -- the archive list is incomplete"
+            }
+          }
 
       # LunarG's Windows ARM64 SDK is platform code `warm`; `windows` is x64.
       - name: Provision the Vulkan SDK

--- a/.github/workflows/jan-tauri-build-windows-arm64.yml
+++ b/.github/workflows/jan-tauri-build-windows-arm64.yml
@@ -1,0 +1,276 @@
+# Windows ARM64 desktop build.
+#
+# Standalone on purpose: it neither calls the x64 template nor edits any file
+# that build reads, so it cannot change an x64 artifact. Merging the two behind
+# an `arch` input is the eventual shape, once ARM64 has gone green.
+#
+# Unsigned, no updater artifacts, so it needs no secrets. Signing, the
+# `windows-aarch64` updater entry and publication come later.
+name: Tauri Build Windows ARM64
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: 'stable / beta / nightly'
+        required: false
+        type: string
+        default: 'nightly'
+      new_version:
+        description: 'Version to stamp into the app'
+        required: false
+        type: string
+        default: '0.0.0'
+      engine_variant:
+        description: >
+          JAN_ENGINE_VARIANT. `cuda13` is the minimum that exercises CUDA;
+          `cuda13-vulkan` adds the fallback for GPUs with no CUDA runtime.
+        required: false
+        type: string
+        default: 'cuda13'
+      vulkan_fallback:
+        description: >
+          JAN_ENGINE_VULKAN_FALLBACK. Defaults to 1 in the Makefile, which adds
+          the vulkan feature -- and the SDK requirement -- to any vendor build
+          whether or not the variant named it. Set to 1 with cuda13-vulkan.
+        required: false
+        type: string
+        default: '0'
+  # Pre-merge testing hook only. GitHub does not offer workflow_dispatch until
+  # the file is on the default branch, so without this there is no way to run
+  # this before merging. Drop it once that lands.
+  push:
+    branches: ['feat/windows-arm64']
+
+concurrency:
+  group: tauri-win-arm64-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  CHANNEL: ${{ inputs.channel || 'nightly' }}
+  NEW_VERSION: ${{ inputs.new_version || '0.0.0' }}
+  JAN_ENGINE_VARIANT: ${{ inputs.engine_variant || 'cuda13' }}
+  JAN_ENGINE_VULKAN_FALLBACK: ${{ inputs.vulkan_fallback || '0' }}
+  CUDA_SHORT: '13.4'
+  # 13.4 is the first release with Windows ARM64, and is a developer preview --
+  # hence packages.nvidia.com/prerelease; the usual compute/cuda path has no
+  # 13.4 entry.
+  CUDA_URL: 'https://packages.nvidia.com/prerelease/cuda/13.4.0/local_installers/cuda_13.4.0_windows_arm64.exe'
+
+jobs:
+  build-windows-arm64:
+    runs-on: windows-11-arm
+    timeout-minutes: 180
+
+    steps:
+      - name: Getting the repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Replace Icons for Beta Build
+        if: env.CHANNEL != 'stable'
+        shell: bash
+        run: cp .github/scripts/icon-${CHANNEL}.png src-tauri/icons/icon.png
+
+      - name: Installing node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 20
+
+      - name: Install jq
+        uses: dcarbone/install-jq-action@b7ef57d46ece78760b4019dbc4080a1ba2a40b45 # v3.2.0
+
+      - name: Install ctoml
+        run: cargo install ctoml
+
+      # build.rs reads VCToolsInstallDir to locate bin/Host*/arm64/cl.exe. The
+      # image does not export it outside a developer prompt.
+      - name: Resolve the MSVC ARM64 toolset
+        shell: pwsh
+        run: |
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsRoot = & $vswhere -products * -latest -property installationPath | Select-Object -First 1
+          if (-not $vsRoot) { throw 'vswhere found no Visual Studio installation' }
+          $ver = (Get-Content "$vsRoot\VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt" -Raw).Trim()
+          $vcTools = "$vsRoot\VC\Tools\MSVC\$ver"
+          $found = $false
+          foreach ($host_ in 'Hostarm64', 'Hostx64') {
+            $cl = "$vcTools\bin\$host_\arm64\cl.exe"
+            if (Test-Path $cl) { Write-Host "ARM64 host compiler: $cl"; $found = $true; break }
+          }
+          if (-not $found) { throw "no arm64 cl.exe under $vcTools\bin\Host*\arm64" }
+          "VCToolsInstallDir=$vcTools" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+
+      # ~3.8 GB with no network installer available, so this dominates the job.
+      # Uncached deliberately: it would claim a third of the repo's 10 GB cache
+      # budget and evict the cargo caches that matter more.
+      - name: Install the CUDA toolkit (ARM64)
+        shell: pwsh
+        run: |
+          $ProgressPreference = 'SilentlyContinue'
+          $exe = Join-Path $env:RUNNER_TEMP 'cuda_arm64.exe'
+          $sw = [Diagnostics.Stopwatch]::StartNew()
+          Invoke-WebRequest -Uri $env:CUDA_URL -OutFile $exe
+          Write-Host ("Downloaded {0:N0} MB in {1:N1} min" -f ((Get-Item $exe).Length / 1MB), $sw.Elapsed.TotalMinutes)
+
+          $sw.Restart()
+          Start-Process -FilePath $exe -ArgumentList '-s' -Wait -NoNewWindow
+          Write-Host ("Installed in {0:N1} min" -f $sw.Elapsed.TotalMinutes)
+
+          $root = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$env:CUDA_SHORT"
+          if (-not (Test-Path $root)) { throw "CUDA not installed at $root" }
+          "CUDA_PATH=$root" | Out-File $env:GITHUB_ENV -Append -Encoding utf8
+          "$root\bin"       | Out-File $env:GITHUB_PATH -Append -Encoding utf8
+          & "$root\bin\nvcc.exe" --version
+
+      # LunarG's Windows ARM64 SDK is platform code `warm`; `windows` is x64.
+      - name: Provision the Vulkan SDK
+        if: contains(format('-{0}-', env.JAN_ENGINE_VARIANT), '-vulkan-') || env.JAN_ENGINE_VULKAN_FALLBACK == '1'
+        shell: bash
+        run: |
+          curl -fL -o "$RUNNER_TEMP/vulkan-sdk.exe" \
+            https://sdk.lunarg.com/sdk/download/latest/warm/vulkan_sdk.exe
+          "$RUNNER_TEMP/vulkan-sdk.exe" --root 'C:\VulkanSDK' \
+            --accept-licenses --default-answer --confirm-command install
+          echo 'VULKAN_SDK=C:\VulkanSDK' >> "$GITHUB_ENV"
+          echo 'C:\VulkanSDK\Bin' >> "$GITHUB_PATH"
+
+      - name: Verify the engine toolchain
+        shell: bash
+        run: |
+          for tool in cmake ninja clang; do
+            command -v "$tool" >/dev/null 2>&1 || { echo "::error::$tool is not on PATH"; exit 1; }
+            echo "$tool -> $(command -v "$tool")"
+          done
+          nvcc --version
+
+      - name: Update app version and product name
+        shell: bash
+        run: |
+          jq --arg version "$NEW_VERSION" '.version = $version' ./src-tauri/tauri.conf.json > /tmp/c.json
+          mv /tmp/c.json ./src-tauri/tauri.conf.json
+
+          jq '.bundle.targets = ["nsis"] | .bundle.windows.nsis.template = "tauri.bundle.windows.nsis.template"' \
+             ./src-tauri/tauri.windows.conf.json > /tmp/w.json
+          mv /tmp/w.json ./src-tauri/tauri.windows.conf.json
+
+          jq --arg version "$NEW_VERSION" '.version = $version' web-app/package.json > /tmp/p.json
+          mv /tmp/p.json web-app/package.json
+
+          for p in hardware llamacpp; do
+            jq --arg version "$NEW_VERSION" '.version = $version' \
+              "./src-tauri/plugins/tauri-plugin-$p/package.json" > /tmp/p.json
+            mv /tmp/p.json "./src-tauri/plugins/tauri-plugin-$p/package.json"
+            ctoml "./src-tauri/plugins/tauri-plugin-$p/Cargo.toml" package.version "$NEW_VERSION"
+          done
+          ctoml ./src-tauri/Cargo.toml package.version "$NEW_VERSION"
+
+          if [ "$CHANNEL" != "stable" ]; then
+            jq --arg name "Jan-$CHANNEL" '.productName = $name' ./src-tauri/tauri.conf.json > /tmp/c.json
+            mv /tmp/c.json ./src-tauri/tauri.conf.json
+            chmod +x .github/scripts/rename-tauri-app.sh .github/scripts/rename-workspace.sh
+            .github/scripts/rename-tauri-app.sh ./src-tauri/tauri.conf.json "$CHANNEL"
+            .github/scripts/rename-workspace.sh ./package.json "$CHANNEL"
+            ctoml ./src-tauri/Cargo.toml package.name "Jan-$CHANNEL"
+          fi
+
+      # The checked-in NSIS "template" is a rendered Handlebars dump: every
+      # value is literal, including the arch, the sidecar filenames and the
+      # workspace path of whatever machine generated it. Rewritten here rather
+      # than in the file, which the x64 build shares.
+      - name: Retarget the NSIS template for ARM64
+        shell: pwsh
+        run: |
+          $t = 'src-tauri/tauri.bundle.windows.nsis.template'
+          $c = Get-Content $t -Raw
+
+          # .Replace, not -replace: regex would eat the backslashes.
+          $c = $c.Replace('D:\a\jan\jan', $env:GITHUB_WORKSPACE)
+          $c = $c.Replace('!define ARCH "x64"', '!define ARCH "arm64"')
+          $c = $c.Replace('\nsis\x64\', '\nsis\arm64\')
+          # Sidecars are named by target triple, so they land as aarch64-*.
+          # Without this NSIS fails late with "could not find file".
+          $c = $c.Replace('x86_64-pc-windows-msvc', 'aarch64-pc-windows-msvc')
+
+          $base, $build = $env:NEW_VERSION, $env:NEW_VERSION
+          if ($env:NEW_VERSION -match '^([^-]+)-(?:rc(\d+)-beta|(.+))$') {
+            $base = $Matches[1]
+            $build = "$base." + $(if ($Matches[2]) { $Matches[2] } else { $Matches[3] })
+          } else {
+            $build = "$base.0"
+          }
+          $c = $c.Replace('jan_version', $base).Replace('jan_build', $build)
+
+          if ($env:CHANNEL -eq 'stable') {
+            $c = $c.Replace('jan_productname', 'Jan').
+                    Replace('jan_mainbinaryname', 'Jan-Desktop').
+                    Replace('jan_bundleid', 'jan.ai.app')
+          } else {
+            $c = $c.Replace('jan_productname', "Jan-$env:CHANNEL").
+                    Replace('jan_mainbinaryname', "Jan-Desktop-$env:CHANNEL").
+                    Replace('jan_bundleid', "jan-$env:CHANNEL.ai.app")
+          }
+
+          Set-Content -Path $t -Value $c -NoNewline
+          Select-String -Path $t -Pattern 'ARCH|aarch64|jan_' | Select-Object -First 12
+
+      - name: Config Yarn
+        run: |
+          corepack enable
+          corepack prepare yarn@4.5.3 --activate
+          yarn config set -H enableImmutableInstalls false
+
+      - name: Build app
+        shell: bash
+        run: make build
+
+      - name: Upload the engine build log
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: engine-build-log-windows-arm64
+          path: src-tauri/target/engine-build.log
+          if-no-files-found: ignore
+
+      # `make build` succeeding is not the same as having produced an ARM64
+      # binary with a CUDA backend beside it.
+      - name: Verify the artifacts
+        shell: pwsh
+        run: |
+          $bin = 'src-tauri/resources/bin'
+          $worker = Join-Path $bin 'jan-llama-worker.exe'
+          if (-not (Test-Path $worker)) { throw "$worker missing" }
+
+          $vc = $env:VCToolsInstallDir
+          $dumpbin = Join-Path $vc 'bin\Hostarm64\arm64\dumpbin.exe'
+          if (-not (Test-Path $dumpbin)) { $dumpbin = Join-Path $vc 'bin\Hostx64\x64\dumpbin.exe' }
+
+          $bad = @()
+          foreach ($f in @($worker) + @(Get-ChildItem $bin -Filter 'ggml*.dll')) {
+            $p = if ($f -is [string]) { $f } else { $f.FullName }
+            $h = & $dumpbin /headers $p 2>&1 | Out-String
+            $arm = $h -match 'AA64|ARM64'
+            Write-Host ("{0,-46} {1}" -f (Split-Path $p -Leaf), $(if ($arm) { 'ARM64' } else { 'NOT ARM64' }))
+            if (-not $arm) { $bad += (Split-Path $p -Leaf) }
+          }
+          if ($bad) { throw "not ARM64: $($bad -join ', ')" }
+
+          $backends = Get-ChildItem $bin -Filter 'ggml-*.dll' |
+            Where-Object { $_.Name -notmatch 'ggml-base' }
+          if (-not $backends) { throw 'no ggml backend modules staged' }
+          Write-Host "backends: $($backends.Name -join ', ')"
+          if (-not ($backends.Name -contains 'ggml-cuda.dll')) {
+            throw 'ggml-cuda.dll missing -- the CUDA backend did not build'
+          }
+
+          Get-ChildItem -Path src-tauri/target/release/bundle -Recurse -Include *.exe |
+            ForEach-Object { Write-Host "bundle: $($_.FullName)" }
+
+      - name: Upload NSIS Installer Artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: jan-windows-arm64-exe-${{ env.NEW_VERSION }}
+          path: ./src-tauri/target/release/bundle/nsis/*.exe
+          if-no-files-found: error

--- a/.github/workflows/jan-tauri-build-windows-arm64.yml
+++ b/.github/workflows/jan-tauri-build-windows-arm64.yml
@@ -271,9 +271,10 @@ jobs:
           fi
 
       # The checked-in NSIS "template" is a rendered Handlebars dump: every
-      # value is literal, including the arch, the sidecar filenames and the
-      # workspace path of whatever machine generated it. Rewritten here rather
-      # than in the file, which the x64 build shares.
+      # value is literal except the placeholders the x64 template substitutes
+      # (`jan_workspace` and the product names), so the arch and the sidecar
+      # filenames are rewritten here rather than in the file, which the x64
+      # build shares.
       - name: Retarget the NSIS template for ARM64
         shell: pwsh
         run: |
@@ -281,7 +282,7 @@ jobs:
           $c = Get-Content $t -Raw
 
           # .Replace, not -replace: regex would eat the backslashes.
-          $c = $c.Replace('D:\a\jan\jan', $env:GITHUB_WORKSPACE)
+          $c = $c.Replace('jan_workspace', $env:GITHUB_WORKSPACE)
           $c = $c.Replace('!define ARCH "x64"', '!define ARCH "arm64"')
           $c = $c.Replace('\nsis\x64\', '\nsis\arm64\')
           # Sidecars are named by target triple, so they land as aarch64-*.

--- a/.github/workflows/template-cli-build-windows-arm64.yml
+++ b/.github/workflows/template-cli-build-windows-arm64.yml
@@ -1,0 +1,106 @@
+# Builds the Jan Agent CLI binary for Windows aarch64.
+# Runs natively on GitHub's windows-11-arm runner; no Tauri bundler, no
+# frontend, and none of the CUDA/Vulkan/signtool provisioning the desktop
+# ARM64 build needs -- this is a plain `cargo build` against the host triple.
+name: cli-build-windows-arm64
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+        default: refs/heads/dev
+      new_version:
+        required: true
+        type: string
+        default: ''
+      channel:
+        required: true
+        type: string
+        default: agent-nightly
+    secrets:
+      DELTA_AWS_S3_BUCKET_NAME:
+        required: false
+      DELTA_AWS_ACCESS_KEY_ID:
+        required: false
+      DELTA_AWS_SECRET_ACCESS_KEY:
+        required: false
+      DELTA_AWS_REGION:
+        required: false
+      # Baked into the binary at compile time via option_env!; without it the
+      # released CLI falls back to the local-dev key and its signed requests
+      # are rejected.
+      JAN_SIGNING_KEY:
+        required: false
+    outputs:
+      FILE_NAME:
+        value: ${{ jobs.build-windows-arm64.outputs.FILE_NAME }}
+      SHA256:
+        value: ${{ jobs.build-windows-arm64.outputs.SHA256 }}
+
+jobs:
+  build-windows-arm64:
+    runs-on: windows-11-arm
+    outputs:
+      FILE_NAME: ${{ steps.package.outputs.FILE_NAME }}
+      SHA256: ${{ steps.package.outputs.SHA256 }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
+        with:
+          toolchain: stable
+
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+
+      - name: Build CLI binary
+        env:
+          JAN_CLI_UPDATE_CHANNEL: ${{ inputs.channel }}
+          JAN_CLI_BUILD_VERSION: ${{ inputs.new_version }}
+          JAN_SIGNING_KEY: ${{ secrets.JAN_SIGNING_KEY }}
+        run: |
+          cd src-tauri
+          cargo build --no-default-features --features cli --bin jan --release
+
+      # The binary must be ARM64: the runner can run x64 under emulation, so a
+      # toolchain mix-up would produce a working but emulated build that this
+      # job would otherwise publish under the aarch64 key.
+      - name: Verify the binary is ARM64
+        shell: pwsh
+        run: |
+          $exe = 'src-tauri/target/release/jan.exe'
+          if (-not (Test-Path $exe)) { throw "$exe missing" }
+          # PE machine type sits at the COFF header, 4 bytes past the offset
+          # stored at 0x3C. 0xAA64 is ARM64.
+          $b = [IO.File]::ReadAllBytes((Resolve-Path $exe))
+          $machine = [BitConverter]::ToUInt16($b, [BitConverter]::ToInt32($b, 0x3C) + 4)
+          Write-Host ("machine: 0x{0:X4}" -f $machine)
+          if ($machine -ne 0xAA64) { throw ("not ARM64: 0x{0:X4}" -f $machine) }
+
+      - name: Package zip
+        id: package
+        shell: bash
+        run: |
+          VERSION="${{ inputs.new_version }}"
+          FILE_NAME="jan-agent-windows-aarch64-$VERSION.zip"
+          # Compress-Archive rather than the x64 template's 7z: it ships with
+          # PowerShell, so it needs nothing from the runner image.
+          powershell -Command "Compress-Archive -Path './src-tauri/target/release/jan.exe' -DestinationPath '$FILE_NAME' -Force"
+          echo "FILE_NAME=$FILE_NAME" >> "$GITHUB_OUTPUT"
+          echo "SHA256=$(sha256sum "$FILE_NAME" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to S3
+        shell: bash
+        run: |
+          aws s3 cp "./${{ steps.package.outputs.FILE_NAME }}" \
+            "s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/${{ inputs.channel }}/${{ steps.package.outputs.FILE_NAME }}"
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.DELTA_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DELTA_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.DELTA_AWS_REGION }}
+          AWS_EC2_METADATA_DISABLED: 'true'

--- a/.github/workflows/template-cli-build-windows-arm64.yml
+++ b/.github/workflows/template-cli-build-windows-arm64.yml
@@ -64,8 +64,8 @@ jobs:
           JAN_CLI_BUILD_VERSION: ${{ inputs.new_version }}
           JAN_SIGNING_KEY: ${{ secrets.JAN_SIGNING_KEY }}
         run: |
-          cd src-tauri
-          cargo build --no-default-features --features cli --bin jan --release
+          cd src-tauri/jan-cli
+          cargo build --no-default-features --features cli --release
 
       # The binary must be ARM64: the runner can run x64 under emulation, so a
       # toolchain mix-up would produce a working but emulated build that this

--- a/.github/workflows/template-tauri-build-windows-arm64.yml
+++ b/.github/workflows/template-tauri-build-windows-arm64.yml
@@ -1,12 +1,10 @@
 # Windows ARM64 desktop build.
 #
-# Separate from the x64 template on purpose: the arm64 CUDA pool, the vswhere
-# MSVC resolution and the NSIS retarget below are ~200 lines x64 has no use for,
-# so folding the two behind an `arch` input would buy a conditional maze. That
-# merge waits until ARM64 has a few green releases behind it.
+# Kept separate from the x64 template: the CUDA pool, MSVC resolution and NSIS
+# retarget below are ~200 lines x64 has no use for. Merge once ARM64 is green.
 #
-# Publishes the same way x64 does -- release asset, S3, and the `windows-aarch64`
-# key its FILE_NAME/WIN_SIG outputs feed into latest.json.
+# Publishes like x64 -- release asset, S3, and the windows-aarch64 key its
+# FILE_NAME/WIN_SIG outputs feed into latest.json.
 name: tauri-build-windows-arm64
 
 on:
@@ -84,9 +82,8 @@ on:
       FILE_NAME:
         value: ${{ jobs.build-windows-arm64.outputs.FILE_NAME }}
 
-  # Standalone entry point, kept because a 3-hour build wants an iteration loop
-  # that is not a full nightly. `ref` and `public_provider` are deliberately not
-  # declared here: unset, checkout takes the dispatched branch and every publish
+  # Standalone loop for a 3-hour build. `ref` and `public_provider` are left
+  # undeclared: unset, checkout takes the dispatched branch and every publish
   # step's `if:` is false, so a manual run builds without publishing.
   workflow_dispatch:
     inputs:
@@ -122,12 +119,9 @@ on:
   push:
     branches: ['feat/windows-arm64']
 
-# Superseding a run supersedes its build: three hours of ARM runner is not worth
-# spending on a commit that has already been replaced, and two runs pulling the
-# CUDA pool at once is what got them throttled. Keyed on the caller's ref, so a
-# nightly on main and a push on a feature branch do not evict each other. The
-# x64 template has none of this because its caller already serialises it; this
-# one is also reachable by push.
+# Don't spend 3h of ARM runner on a superseded commit, and concurrent CUDA pulls
+# get throttled. Keyed on the caller's ref so nightly and a feature branch don't
+# evict each other. x64 needs none of this; only this one takes pushes.
 concurrency:
   group: tauri-win-arm64-${{ github.ref }}
   cancel-in-progress: true
@@ -259,14 +253,10 @@ jobs:
             'cuda_profiler_api-windows-arm64-13.4.46-archive'
           )
 
-          # curl.exe rather than Invoke-WebRequest, which has neither retry nor
-          # resume: three runs inside nine minutes saw two of them cut off about
-          # two seconds into the first archive with "the response ended
-          # prematurely", the pool throttling concurrent pulls. IWR turns that
-          # into a hard failure three minutes into a three-hour job. curl ships
-          # in System32, so this adds no dependency -- checked once here anyway,
-          # because a missing one would otherwise surface as a parse-time
-          # "command not found" rather than something legible.
+          # curl.exe over Invoke-WebRequest, which has no retry or resume: the pool
+          # throttles concurrent pulls and drops the connection mid-body, killing a
+          # 3h job at minute 3. curl is in System32; checked anyway so a missing one
+          # fails legibly.
           if (-not (Get-Command curl.exe -ErrorAction SilentlyContinue)) {
             throw 'curl.exe not found; it is expected in System32 on this image'
           }
@@ -277,8 +267,7 @@ jobs:
           $total = 0
           foreach ($a in $archives) {
             $zip = Join-Path $tmp "$a.zip"
-            # --retry-all-errors is what covers this: plain --retry ignores a
-            # connection dropped mid-body, which is the failure seen here.
+            # --retry-all-errors: plain --retry ignores a mid-body drop.
             curl.exe -sS --fail --location --retry 5 --retry-all-errors `
                      --retry-delay 5 --connect-timeout 30 --max-time 900 `
                      -o $zip "$env:CUDA_POOL/$a.zip"
@@ -349,10 +338,9 @@ jobs:
           }
           echo "signtool -> $TAURI_WINDOWS_SIGNTOOL_PATH"
 
-          # scripts/download-bin.mjs names the bun/uv sidecars from node's
-          # os.arch(), while the NSIS retarget below rewrites them to aarch64
-          # unconditionally. An emulated x64 node would name them x86_64-* and
-          # the mismatch would not surface until bundling, after the engine.
+          # download-bin.mjs names the sidecars from node's os.arch() while the NSIS
+          # retarget below assumes aarch64. An x64 node would mismatch, and not
+          # surface until bundling -- after the engine.
           node_arch=$(node -p 'process.arch')
           echo "node -> $node_arch"
           [ "$node_arch" = "arm64" ] || {
@@ -385,8 +373,8 @@ jobs:
           ctoml ./src-tauri/Cargo.toml package.version "$NEW_VERSION"
 
           if [ "$CHANNEL" != "stable" ]; then
-            # Without this an arm64 nightly keeps the stable endpoints baked into
-            # tauri.conf.json and checks the wrong manifest.
+            # Without this an arm64 nightly keeps tauri.conf.json's stable
+            # endpoints and checks the wrong manifest.
             if [ "$CHANNEL" = "nightly" ]; then
               jq --arg fallback "https://delta.jan.ai/$CHANNEL/latest.json" \
                  '.plugins.updater.endpoints = ["https://apps-nightly.jan.ai/update-check", $fallback]' \
@@ -428,13 +416,10 @@ jobs:
           # Left unpatched, an ARM64 install fetches and runs the x64 redist.
           $c = $c.Replace('vc_redist.x64.exe', 'vc_redist.arm64.exe')
 
-          # And the matching detection, which is the half that actually bites:
-          # the VC runtime registers per architecture, and an ARM64 machine
-          # almost always carries the x64 redist for emulated apps. Probing the
-          # x64 keys therefore finds it, concludes the runtime is present, and
-          # skips installing the ARM64 one the app links against. Guessing wrong
-          # the other way merely re-runs an idempotent installer -- it exits 1638
-          # and the script already treats that as success.
+          # And the detection, the half that bites: an ARM64 machine usually has
+          # the x64 redist, so probing x64 keys skips installing the ARM64 one the
+          # app links against. Guessing wrong the other way just re-runs an
+          # idempotent installer (exit 1638, already handled).
           $c = $c.Replace('\VC\Runtimes\x64', '\VC\Runtimes\arm64')
           $c = $c.Replace('VC_RuntimeMinimumVSU_amd64', 'VC_RuntimeMinimumVSU_arm64')
 

--- a/.github/workflows/template-tauri-build-windows-arm64.yml
+++ b/.github/workflows/template-tauri-build-windows-arm64.yml
@@ -116,11 +116,18 @@ on:
           the vulkan feature -- and the SDK requirement -- to any vendor build
           whether or not the variant named it. Set to 1 with cuda13-vulkan.
 
+  # Pre-merge hook: workflow_dispatch is not offered until the file is on the
+  # default branch, so until this merges a push is the only way to exercise it.
+  # Drop this once it lands there.
+  push:
+    branches: ['feat/windows-arm64']
+
 env:
-  CHANNEL: ${{ inputs.channel }}
-  NEW_VERSION: ${{ inputs.new_version }}
-  JAN_ENGINE_VARIANT: ${{ inputs.engine_variant }}
-  JAN_ENGINE_VULKAN_FALLBACK: ${{ inputs.vulkan_fallback }}
+  # `||` defaults because a push carries no inputs at all.
+  CHANNEL: ${{ inputs.channel || 'nightly' }}
+  NEW_VERSION: ${{ inputs.new_version || '0.0.0' }}
+  JAN_ENGINE_VARIANT: ${{ inputs.engine_variant || 'cuda13' }}
+  JAN_ENGINE_VULKAN_FALLBACK: ${{ inputs.vulkan_fallback || '0' }}
   CUDA_SHORT: '13.4'
   # Redistributable archives, as upstream llama.cpp provisions this same
   # toolkit (.github/actions/windows-setup-cuda). The 3.8 GB installer spends

--- a/.github/workflows/template-tauri-build-windows-arm64.yml
+++ b/.github/workflows/template-tauri-build-windows-arm64.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Replace Icons for Beta Build
         if: env.CHANNEL != 'stable'
         shell: bash
-        run: cp .github/scripts/icon-${CHANNEL}.png src-tauri/icons/icon.png
+        run: cp ".github/scripts/icon-${CHANNEL}.png" src-tauri/icons/icon.png
 
       - name: Installing node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
@@ -388,6 +388,16 @@ jobs:
           # VCREDIST_URL embeds the filename, so one replace covers both defines.
           # Left unpatched, an ARM64 install fetches and runs the x64 redist.
           $c = $c.Replace('vc_redist.x64.exe', 'vc_redist.arm64.exe')
+
+          # And the matching detection, which is the half that actually bites:
+          # the VC runtime registers per architecture, and an ARM64 machine
+          # almost always carries the x64 redist for emulated apps. Probing the
+          # x64 keys therefore finds it, concludes the runtime is present, and
+          # skips installing the ARM64 one the app links against. Guessing wrong
+          # the other way merely re-runs an idempotent installer -- it exits 1638
+          # and the script already treats that as success.
+          $c = $c.Replace('\VC\Runtimes\x64', '\VC\Runtimes\arm64')
+          $c = $c.Replace('VC_RuntimeMinimumVSU_amd64', 'VC_RuntimeMinimumVSU_arm64')
 
           $base, $build = $env:NEW_VERSION, $env:NEW_VERSION
           if ($env:NEW_VERSION -match '^([^-]+)-(?:rc(\d+)-beta|(.+))$') {

--- a/.github/workflows/template-tauri-build-windows-arm64.yml
+++ b/.github/workflows/template-tauri-build-windows-arm64.yml
@@ -249,13 +249,33 @@ jobs:
             'cuda_profiler_api-windows-arm64-13.4.46-archive'
           )
 
+          # curl.exe rather than Invoke-WebRequest, which has neither retry nor
+          # resume: three runs inside nine minutes saw two of them cut off about
+          # two seconds into the first archive with "the response ended
+          # prematurely", the pool throttling concurrent pulls. IWR turns that
+          # into a hard failure three minutes into a three-hour job. curl ships
+          # in System32, so this adds no dependency -- checked once here anyway,
+          # because a missing one would otherwise surface as a parse-time
+          # "command not found" rather than something legible.
+          if (-not (Get-Command curl.exe -ErrorAction SilentlyContinue)) {
+            throw 'curl.exe not found; it is expected in System32 on this image'
+          }
+
           $sw = [Diagnostics.Stopwatch]::StartNew()
           $tmp = Join-Path $env:RUNNER_TEMP 'cuda'
           New-Item -ItemType Directory -Force -Path $tmp | Out-Null
           $total = 0
           foreach ($a in $archives) {
             $zip = Join-Path $tmp "$a.zip"
-            Invoke-WebRequest -Uri "$env:CUDA_POOL/$a.zip" -OutFile $zip
+            # --retry-all-errors is what covers this: plain --retry ignores a
+            # connection dropped mid-body, which is the failure seen here.
+            curl.exe -sS --fail --location --retry 5 --retry-all-errors `
+                     --retry-delay 5 --connect-timeout 30 --max-time 900 `
+                     -o $zip "$env:CUDA_POOL/$a.zip"
+            # Native exes do not trip $ErrorActionPreference; check by hand.
+            if ($LASTEXITCODE -ne 0) {
+              throw "$a.zip failed after 5 retries (curl exit $LASTEXITCODE)"
+            }
             $total += (Get-Item $zip).Length
             Expand-Archive -Path $zip -DestinationPath $tmp -Force
             # Each unpacks to <name>/{bin,lib,include}; merge into one root,
@@ -292,7 +312,9 @@ jobs:
         if: contains(format('-{0}-', env.JAN_ENGINE_VARIANT), '-vulkan-') || env.JAN_ENGINE_VULKAN_FALLBACK == '1'
         shell: bash
         run: |
-          curl -fL -o "$RUNNER_TEMP/vulkan-sdk.exe" \
+          curl -fL --retry 5 --retry-all-errors --retry-delay 5 \
+            --connect-timeout 30 --max-time 900 \
+            -o "$RUNNER_TEMP/vulkan-sdk.exe" \
             https://sdk.lunarg.com/sdk/download/latest/warm/vulkan_sdk.exe
           "$RUNNER_TEMP/vulkan-sdk.exe" --root 'C:\VulkanSDK' \
             --accept-licenses --default-answer --confirm-command install

--- a/.github/workflows/template-tauri-build-windows-arm64.yml
+++ b/.github/workflows/template-tauri-build-windows-arm64.yml
@@ -122,6 +122,16 @@ on:
   push:
     branches: ['feat/windows-arm64']
 
+# Superseding a run supersedes its build: three hours of ARM runner is not worth
+# spending on a commit that has already been replaced, and two runs pulling the
+# CUDA pool at once is what got them throttled. Keyed on the caller's ref, so a
+# nightly on main and a push on a feature branch do not evict each other. The
+# x64 template has none of this because its caller already serialises it; this
+# one is also reachable by push.
+concurrency:
+  group: tauri-win-arm64-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   # `||` defaults because a push carries no inputs at all.
   CHANNEL: ${{ inputs.channel || 'nightly' }}

--- a/.github/workflows/template-tauri-build-windows-arm64.yml
+++ b/.github/workflows/template-tauri-build-windows-arm64.yml
@@ -310,6 +310,16 @@ jobs:
           }
           echo "signtool -> $TAURI_WINDOWS_SIGNTOOL_PATH"
 
+          # scripts/download-bin.mjs names the bun/uv sidecars from node's
+          # os.arch(), while the NSIS retarget below rewrites them to aarch64
+          # unconditionally. An emulated x64 node would name them x86_64-* and
+          # the mismatch would not surface until bundling, after the engine.
+          node_arch=$(node -p 'process.arch')
+          echo "node -> $node_arch"
+          [ "$node_arch" = "arm64" ] || {
+            echo "::error::node reports $node_arch, not arm64 -- the bun/uv sidecars would be named for the wrong target"; exit 1;
+          }
+
       - name: Update app version and product name
         shell: bash
         run: |

--- a/.github/workflows/template-tauri-build-windows-arm64.yml
+++ b/.github/workflows/template-tauri-build-windows-arm64.yml
@@ -1,15 +1,93 @@
 # Windows ARM64 desktop build.
 #
-# Standalone on purpose: it neither calls the x64 template nor edits any file
-# that build reads, so it cannot change an x64 artifact. Folding the two behind
-# an `arch` input comes once ARM64 is green.
+# Separate from the x64 template on purpose: the arm64 CUDA pool, the vswhere
+# MSVC resolution and the NSIS retarget below are ~200 lines x64 has no use for,
+# so folding the two behind an `arch` input would buy a conditional maze. That
+# merge waits until ARM64 has a few green releases behind it.
 #
-# Signing and updater artifacts match x64. Publication does not -- no S3, no
-# release upload, no `windows-aarch64` in latest.json -- so ARM64 builds cannot
-# yet reach users through the updater.
-name: Tauri Build Windows ARM64
+# Publishes the same way x64 does -- release asset, S3, and the `windows-aarch64`
+# key its FILE_NAME/WIN_SIG outputs feed into latest.json.
+name: tauri-build-windows-arm64
 
 on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+        default: 'refs/heads/main'
+      public_provider:
+        required: true
+        type: string
+        default: none
+        description: 'none: build only, github: build and publish to github, aws s3: build and publish to aws s3'
+      new_version:
+        required: true
+        type: string
+        default: ''
+      upload_url:
+        required: false
+        type: string
+        default: ''
+      channel:
+        required: true
+        type: string
+        default: 'nightly'
+        description: 'The channel to use for this job'
+      engine_variant:
+        required: false
+        type: string
+        default: 'cuda13'
+        description: >
+          JAN_ENGINE_VARIANT. `cuda13` is the minimum that exercises CUDA;
+          `cuda13-vulkan` adds the fallback for GPUs with no CUDA runtime.
+      vulkan_fallback:
+        required: false
+        type: string
+        default: '0'
+        description: >
+          JAN_ENGINE_VULKAN_FALLBACK. Defaults to 1 in the Makefile, which adds
+          the vulkan feature -- and the SDK requirement -- to any vendor build
+          whether or not the variant named it. Set to 1 with cuda13-vulkan.
+    secrets:
+      DELTA_AWS_S3_BUCKET_NAME:
+        required: false
+      DELTA_AWS_ACCESS_KEY_ID:
+        required: false
+      DELTA_AWS_SECRET_ACCESS_KEY:
+        required: false
+      DELTA_AWS_REGION:
+        required: false
+      AZURE_KEY_VAULT_URI:
+        required: false
+      AZURE_CLIENT_ID:
+        required: false
+      AZURE_TENANT_ID:
+        required: false
+      AZURE_CLIENT_SECRET:
+        required: false
+      AZURE_CERT_NAME:
+        required: false
+      TAURI_SIGNING_PRIVATE_KEY:
+        required: false
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD:
+        required: false
+      JAN_SIGNING_KEY:
+        required: false
+      POSTHOG_KEY:
+        required: false
+      POSTHOG_HOST:
+        required: false
+    outputs:
+      WIN_SIG:
+        value: ${{ jobs.build-windows-arm64.outputs.WIN_SIG }}
+      FILE_NAME:
+        value: ${{ jobs.build-windows-arm64.outputs.FILE_NAME }}
+
+  # Standalone entry point, kept because a 3-hour build wants an iteration loop
+  # that is not a full nightly. `ref` and `public_provider` are deliberately not
+  # declared here: unset, checkout takes the dispatched branch and every publish
+  # step's `if:` is false, so a manual run builds without publishing.
   workflow_dispatch:
     inputs:
       channel:
@@ -23,37 +101,26 @@ on:
         type: string
         default: '0.0.0'
       engine_variant:
-        description: >
-          JAN_ENGINE_VARIANT. `cuda13` is the minimum that exercises CUDA;
-          `cuda13-vulkan` adds the fallback for GPUs with no CUDA runtime.
         required: false
         type: string
         default: 'cuda13'
+        description: >
+          JAN_ENGINE_VARIANT. `cuda13` is the minimum that exercises CUDA;
+          `cuda13-vulkan` adds the fallback for GPUs with no CUDA runtime.
       vulkan_fallback:
+        required: false
+        type: string
+        default: '0'
         description: >
           JAN_ENGINE_VULKAN_FALLBACK. Defaults to 1 in the Makefile, which adds
           the vulkan feature -- and the SDK requirement -- to any vendor build
           whether or not the variant named it. Set to 1 with cuda13-vulkan.
-        required: false
-        type: string
-        default: '0'
-  # Pre-merge hook: workflow_dispatch is not offered until the file is on the
-  # default branch. Drop this once it lands there.
-  push:
-    branches: ['feat/windows-arm64']
-
-concurrency:
-  group: tauri-win-arm64-${{ github.ref }}
-  cancel-in-progress: true
-
-permissions:
-  contents: read
 
 env:
-  CHANNEL: ${{ inputs.channel || 'nightly' }}
-  NEW_VERSION: ${{ inputs.new_version || '0.0.0' }}
-  JAN_ENGINE_VARIANT: ${{ inputs.engine_variant || 'cuda13' }}
-  JAN_ENGINE_VULKAN_FALLBACK: ${{ inputs.vulkan_fallback || '0' }}
+  CHANNEL: ${{ inputs.channel }}
+  NEW_VERSION: ${{ inputs.new_version }}
+  JAN_ENGINE_VARIANT: ${{ inputs.engine_variant }}
+  JAN_ENGINE_VULKAN_FALLBACK: ${{ inputs.vulkan_fallback }}
   CUDA_SHORT: '13.4'
   # Redistributable archives, as upstream llama.cpp provisions this same
   # toolkit (.github/actions/windows-setup-cuda). The 3.8 GB installer spends
@@ -65,10 +132,17 @@ jobs:
   build-windows-arm64:
     runs-on: windows-11-arm
     timeout-minutes: 180
+    outputs:
+      WIN_SIG: ${{ steps.metadata.outputs.WIN_SIG }}
+      FILE_NAME: ${{ steps.metadata.outputs.FILE_NAME }}
+    permissions:
+      contents: write
 
     steps:
       - name: Getting the repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Replace Icons for Beta Build
         if: env.CHANNEL != 'stable'
@@ -262,6 +336,19 @@ jobs:
           ctoml ./src-tauri/Cargo.toml package.version "$NEW_VERSION"
 
           if [ "$CHANNEL" != "stable" ]; then
+            # Without this an arm64 nightly keeps the stable endpoints baked into
+            # tauri.conf.json and checks the wrong manifest.
+            if [ "$CHANNEL" = "nightly" ]; then
+              jq --arg fallback "https://delta.jan.ai/$CHANNEL/latest.json" \
+                 '.plugins.updater.endpoints = ["https://apps-nightly.jan.ai/update-check", $fallback]' \
+                 ./src-tauri/tauri.conf.json > /tmp/c.json
+            else
+              jq --arg fallback "https://delta.jan.ai/$CHANNEL/latest.json" \
+                 '.plugins.updater.endpoints = [$fallback]' \
+                 ./src-tauri/tauri.conf.json > /tmp/c.json
+            fi
+            mv /tmp/c.json ./src-tauri/tauri.conf.json
+
             jq --arg name "Jan-$CHANNEL" '.productName = $name' ./src-tauri/tauri.conf.json > /tmp/c.json
             mv /tmp/c.json ./src-tauri/tauri.conf.json
             chmod +x .github/scripts/rename-tauri-app.sh .github/scripts/rename-workspace.sh
@@ -288,6 +375,9 @@ jobs:
           # Sidecars are named by target triple, so they land as aarch64-*.
           # Without this NSIS fails late with "could not find file".
           $c = $c.Replace('x86_64-pc-windows-msvc', 'aarch64-pc-windows-msvc')
+          # VCREDIST_URL embeds the filename, so one replace covers both defines.
+          # Left unpatched, an ARM64 install fetches and runs the x64 redist.
+          $c = $c.Replace('vc_redist.x64.exe', 'vc_redist.arm64.exe')
 
           $base, $build = $env:NEW_VERSION, $env:NEW_VERSION
           if ($env:NEW_VERSION -match '^([^-]+)-(?:rc(\d+)-beta|(.+))$') {
@@ -394,6 +484,30 @@ jobs:
           Get-ChildItem -Path src-tauri/target/release/bundle -Recurse -Include *.exe |
             ForEach-Object { Write-Host "bundle: $($_.FullName)" }
 
+      # Reconstructed rather than globbed, because latest.json needs the exact
+      # name too. `arm64` is the bundler's own token for AArch64, so this is the
+      # x64 template's step with that one substitution.
+      - name: Set output filename for windows
+        id: metadata
+        shell: bash
+        run: |
+          cd ./src-tauri/target/release/bundle/nsis
+          if [ "$CHANNEL" != "stable" ]; then
+            FILE_NAME="Jan-${CHANNEL}_${NEW_VERSION}_arm64-setup.exe"
+          else
+            FILE_NAME="Jan_${NEW_VERSION}_arm64-setup.exe"
+          fi
+
+          # Fails here rather than in the updater, where a missing signature
+          # surfaces to users as a download error.
+          [ -f "$FILE_NAME" ]     || { echo "::error::$FILE_NAME not in $(pwd)"; ls -la; exit 1; }
+          [ -s "$FILE_NAME.sig" ] || { echo "::error::$FILE_NAME.sig missing or empty -- createUpdaterArtifacts or the signing key did not take"; exit 1; }
+
+          {
+            echo "FILE_NAME=$FILE_NAME"
+            echo "WIN_SIG=$(cat "$FILE_NAME.sig")"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Upload NSIS Installer Artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -402,3 +516,30 @@ jobs:
             ./src-tauri/target/release/bundle/nsis/*.exe
             ./src-tauri/target/release/bundle/nsis/*.sig
           if-no-files-found: error
+
+      ## Upload to s3 for nightly and beta
+      - name: upload to aws s3 if public provider is aws
+        shell: bash
+        if: inputs.public_provider == 'aws-s3' || inputs.channel == 'beta'
+        run: |
+          cd ./src-tauri/target/release/bundle/nsis
+
+          # Upload for tauri updater
+          aws s3 cp ./${{ steps.metadata.outputs.FILE_NAME }} s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/${{ steps.metadata.outputs.FILE_NAME }}
+          aws s3 cp ./${{ steps.metadata.outputs.FILE_NAME }}.sig s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/${{ steps.metadata.outputs.FILE_NAME }}.sig
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.DELTA_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DELTA_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.DELTA_AWS_REGION }}
+          AWS_EC2_METADATA_DISABLED: 'true'
+
+      - name: Upload release assert if public provider is github
+        if: inputs.public_provider == 'github'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/upload-release-asset@64e5e85fc528f162d7ba7ce2d15a3bb67efb3d80 # v1.0.1
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: ./src-tauri/target/release/bundle/nsis/${{ steps.metadata.outputs.FILE_NAME }}
+          asset_name: ${{ steps.metadata.outputs.FILE_NAME }}
+          asset_content_type: application/octet-stream

--- a/scripts/download-bin.mjs
+++ b/scripts/download-bin.mjs
@@ -142,8 +142,11 @@ function getPlatformArch() {
         ? 'aarch64-unknown-linux-gnu'
         : 'x86_64-unknown-linux-gnu'
   } else if (platform === 'win32') {
-    bunPlatform = 'windows-x64' // Bun has limited Windows support
-    uvPlatform = 'x86_64-pc-windows-msvc'
+    bunPlatform = arch === 'arm64' ? 'windows-aarch64' : 'windows-x64'
+    uvPlatform =
+      arch === 'arm64'
+        ? 'aarch64-pc-windows-msvc'
+        : 'x86_64-pc-windows-msvc'
   } else {
     throw new Error(`Unsupported platform: ${platform}`)
   }
@@ -248,7 +251,7 @@ async function main() {
     if (platform === 'win32') {
       copyFile(
         path.join(binDir, 'bun.exe'),
-        path.join(binDir, 'bun-x86_64-pc-windows-msvc.exe'),
+        path.join(binDir, `bun-${uvPlatform}.exe`),
         (err) => {
           if (err) {
             console.log('Error Found:', err)
@@ -322,7 +325,7 @@ async function main() {
     if (platform === 'win32') {
       copyFile(
         path.join(binDir, 'uv.exe'),
-        path.join(binDir, 'uv-x86_64-pc-windows-msvc.exe'),
+        path.join(binDir, `uv-${uvPlatform}.exe`),
         (err) => {
           if (err) {
             console.log('Error Found:', err)

--- a/scripts/download-bin.mjs
+++ b/scripts/download-bin.mjs
@@ -96,22 +96,34 @@ function matchSqliteVecAsset(assets, platform, arch) {
         : ['linux']
 
   const archHints = arch === 'arm64' ? ['arm64', 'aarch64'] : ['x86_64', 'x64', 'amd64']
+  // The two fallbacks below drop the arch hint, so without this an arch with no
+  // asset takes another one's: windows-arm64 has no sqlite-vec build, and would
+  // otherwise land the windows-x86_64 dll, which then fails to load at runtime
+  // and silently costs ANN acceleration. Skipping the extension entirely is the
+  // supported outcome -- the caller falls back to linear search.
+  const foreignArchHints =
+    arch === 'arm64'
+      ? ['x86_64', 'x64', 'amd64', 'i686']
+      : ['arm64', 'aarch64', 'armv7']
   const extHints = ['zip', 'tar.gz']
 
   const lc = (s) => s.toLowerCase()
   const candidates = assets
     .filter((a) => a && a.browser_download_url && a.name)
     .map((a) => ({ name: lc(a.name), url: a.browser_download_url }))
+    .filter((c) => !foreignArchHints.some((h) => c.name.includes(h)))
 
   // Prefer exact OS + arch matches
   let matches = candidates.filter((c) => osHints.some((o) => c.name.includes(o)) && archHints.some((h) => c.name.includes(h)) && extHints.some((e) => c.name.endsWith(e)))
   if (matches.length) return matches[0].url
-  // Fallback: OS only
+  // Fallback: OS only. Safe because foreign architectures are already filtered
+  // out above, so this can only relax the arch *spelling*, not the arch.
   matches = candidates.filter((c) => osHints.some((o) => c.name.includes(o)) && extHints.some((e) => c.name.endsWith(e)))
   if (matches.length) return matches[0].url
-  // Last resort: any asset with shared library extension inside is unknown here, so pick any zip/tar.gz
-  matches = candidates.filter((c) => extHints.some((e) => c.name.endsWith(e)))
-  return matches.length ? matches[0].url : null
+  // No OS-only-last-resort: it could fire solely when nothing matches this OS,
+  // which means there is no build for the platform, and any archive it picked
+  // would be for a different one. Returning null skips the optional extension.
+  return null
 }
 
 async function fetchLatestSqliteVecUrl(platform, arch) {

--- a/scripts/download-bin.mjs
+++ b/scripts/download-bin.mjs
@@ -96,10 +96,8 @@ function matchSqliteVecAsset(assets, platform, arch) {
         : ['linux']
 
   const archHints = arch === 'arm64' ? ['arm64', 'aarch64'] : ['x86_64', 'x64', 'amd64']
-  // The two fallbacks below drop the arch hint, so without this an arch with no
-  // asset takes another one's: windows-arm64 has no sqlite-vec build, and would
-  // otherwise land the windows-x86_64 dll, which then fails to load at runtime
-  // and silently costs ANN acceleration. Skipping the extension entirely is the
+  // The fallbacks below drop the arch hint: windows-arm64 has no sqlite-vec
+  // build and would take the x86_64 dll, which cannot load. Skipping is the
   // supported outcome -- the caller falls back to linear search.
   const foreignArchHints =
     arch === 'arm64'
@@ -116,13 +114,12 @@ function matchSqliteVecAsset(assets, platform, arch) {
   // Prefer exact OS + arch matches
   let matches = candidates.filter((c) => osHints.some((o) => c.name.includes(o)) && archHints.some((h) => c.name.includes(h)) && extHints.some((e) => c.name.endsWith(e)))
   if (matches.length) return matches[0].url
-  // Fallback: OS only. Safe because foreign architectures are already filtered
-  // out above, so this can only relax the arch *spelling*, not the arch.
+  // OS only. Safe: foreign arches are filtered above, so this relaxes the arch
+  // spelling, not the arch.
   matches = candidates.filter((c) => osHints.some((o) => c.name.includes(o)) && extHints.some((e) => c.name.endsWith(e)))
   if (matches.length) return matches[0].url
-  // No OS-only-last-resort: it could fire solely when nothing matches this OS,
-  // which means there is no build for the platform, and any archive it picked
-  // would be for a different one. Returning null skips the optional extension.
+  // No last resort: it would fire only when nothing matches this OS, so any
+  // archive it picked would be for another platform.
   return null
 }
 
@@ -263,9 +260,8 @@ async function main() {
     if (platform === 'win32') {
       copyFile(
         path.join(binDir, 'bun.exe'),
-        // uvPlatform, not bunPlatform: tauri resolves an externalBin by rust
-        // target triple, which is the spelling uv happens to use and bun does
-        // not (bun ships windows-aarch64, tauri wants aarch64-pc-windows-msvc).
+        // uvPlatform, not bunPlatform: tauri names externalBin by rust target
+        // triple, which is uv's spelling and not bun's.
         path.join(binDir, `bun-${uvPlatform}.exe`),
         (err) => {
           if (err) {

--- a/scripts/download-bin.mjs
+++ b/scripts/download-bin.mjs
@@ -263,6 +263,9 @@ async function main() {
     if (platform === 'win32') {
       copyFile(
         path.join(binDir, 'bun.exe'),
+        // uvPlatform, not bunPlatform: tauri resolves an externalBin by rust
+        // target triple, which is the spelling uv happens to use and bun does
+        // not (bun ships windows-aarch64, tauri wants aarch64-pc-windows-msvc).
         path.join(binDir, `bun-${uvPlatform}.exe`),
         (err) => {
           if (err) {

--- a/scripts/install-jan-agent.ps1
+++ b/scripts/install-jan-agent.ps1
@@ -33,7 +33,10 @@ $ErrorActionPreference = 'Stop'
 $ProgressPreference = 'SilentlyContinue'
 
 $BinaryName = 'jan.exe'
-$PlatformKey = 'windows-x86_64'
+# ARCHITEW6432 is what an emulated process sees; PROCESSOR_ARCHITECTURE alone
+# would report AMD64 for an x64 PowerShell on an ARM64 machine.
+$NativeArch = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
+$PlatformKey = if ($NativeArch -eq 'ARM64') { 'windows-aarch64' } else { 'windows-x86_64' }
 
 if (-not $Dir) {
   if ($env:JAN_INSTALL_DIR) {
@@ -45,9 +48,6 @@ if (-not $Dir) {
 
 if ([Environment]::Is64BitOperatingSystem -eq $false) {
   throw 'no published build for 32-bit Windows; use -Source'
-}
-if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') {
-  Write-Warning 'no native ARM64 build is published; the x86_64 build runs under emulation'
 }
 
 # PowerShell 5.1 defaults to TLS 1.0, which delta.jan.ai rejects.

--- a/scripts/install-jan-agent.ps1
+++ b/scripts/install-jan-agent.ps1
@@ -36,10 +36,8 @@ $BinaryName = 'jan.exe'
 # ARCHITEW6432 is what an emulated process sees; PROCESSOR_ARCHITECTURE alone
 # would report AMD64 for an x64 PowerShell on an ARM64 machine.
 $NativeArch = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
-# Native first, then x86_64 under emulation. ARM64 Windows runs the x64 build
-# fine, and it is all that any version predating ARM64 -- or any nightly whose
-# ARM leg failed -- has to offer. Hard-failing there would be a downgrade from
-# the emulated install these users already had.
+# Native first, then x86_64 under emulation: it is all that pre-ARM64 versions,
+# or a nightly whose ARM leg failed, have to offer.
 $PlatformKeys = if ($NativeArch -eq 'ARM64') { @('windows-aarch64', 'windows-x86_64') }
                 else { @('windows-x86_64') }
 

--- a/scripts/install-jan-agent.ps1
+++ b/scripts/install-jan-agent.ps1
@@ -36,7 +36,12 @@ $BinaryName = 'jan.exe'
 # ARCHITEW6432 is what an emulated process sees; PROCESSOR_ARCHITECTURE alone
 # would report AMD64 for an x64 PowerShell on an ARM64 machine.
 $NativeArch = if ($env:PROCESSOR_ARCHITEW6432) { $env:PROCESSOR_ARCHITEW6432 } else { $env:PROCESSOR_ARCHITECTURE }
-$PlatformKey = if ($NativeArch -eq 'ARM64') { 'windows-aarch64' } else { 'windows-x86_64' }
+# Native first, then x86_64 under emulation. ARM64 Windows runs the x64 build
+# fine, and it is all that any version predating ARM64 -- or any nightly whose
+# ARM leg failed -- has to offer. Hard-failing there would be a downgrade from
+# the emulated install these users already had.
+$PlatformKeys = if ($NativeArch -eq 'ARM64') { @('windows-aarch64', 'windows-x86_64') }
+                else { @('windows-x86_64') }
 
 if (-not $Dir) {
   if ($env:JAN_INSTALL_DIR) {
@@ -130,7 +135,16 @@ function Install-Published {
   $resolved = $Version
 
   if ($resolved) {
-    $url = "$base/jan-agent-$PlatformKey-$resolved.zip"
+    foreach ($k in $PlatformKeys) {
+      $candidate = "$base/jan-agent-$k-$resolved.zip"
+      try {
+        Invoke-WebRequest -Uri $candidate -Method Head -UseBasicParsing | Out-Null
+        $url = $candidate
+        if ($k -ne $PlatformKeys[0]) { Write-Warning "no $($PlatformKeys[0]) build of $resolved; using $k under emulation" }
+        break
+      } catch { }
+    }
+    if (-not $url) { throw "no $Channel build of $resolved for $($PlatformKeys -join ' or ')" }
   } else {
     Write-Host "resolving the latest $Channel build"
     try {
@@ -139,9 +153,17 @@ function Install-Published {
       throw "cannot fetch $base/manifest.json : $($_.Exception.Message)"
     }
     $resolved = $manifest.version
-    $entry = $manifest.platforms.$PlatformKey
-    if (-not $entry -or -not $entry.url) {
-      throw "the $Channel manifest has no build for $PlatformKey"
+    $entry = $null
+    foreach ($k in $PlatformKeys) {
+      $candidate = $manifest.platforms.$k
+      if ($candidate -and $candidate.url) {
+        $entry = $candidate
+        if ($k -ne $PlatformKeys[0]) { Write-Warning "no native $($PlatformKeys[0]) build published; using $k under emulation" }
+        break
+      }
+    }
+    if (-not $entry) {
+      throw "the $Channel manifest has no build for $($PlatformKeys -join ' or ')"
     }
     $url = $entry.url
     if ($entry.PSObject.Properties.Name -contains 'sha256') { $expected = $entry.sha256 }

--- a/src-tauri/build-utils/check-engine-toolchain.sh
+++ b/src-tauri/build-utils/check-engine-toolchain.sh
@@ -72,12 +72,37 @@ MINGW* | MSYS* | CYGWIN*)
     exit 1
   }
   if ! command -v cl >/dev/null 2>&1; then
-    if [ -n "$want" ]; then
+    # An ARM64 build never puts cl on PATH: the one nvcc needs is the arm64
+    # cross, which build.rs passes by full path as CMAKE_CUDA_HOST_COMPILER.
+    # So there it is VCToolsInstallDir that has to be right, not PATH; probed
+    # the same way build.rs probes it, since arm64 is hosted from either.
+    #
+    # rustc for the arch, not uname: Git for Windows on an ARM64 runner is the
+    # x86-64 build under emulation and reports x86_64. Backslashes to forward
+    # slashes because MSYS resolves a C:/... path and cygpath is not on every
+    # Git for Windows install.
+    host_cl=""
+    case "$(rustc -vV 2>/dev/null | sed -n 's/^host: //p')" in
+    aarch64-*)
+      root=$(printf '%s' "${VCToolsInstallDir:-}" | tr '\\' '/')
+      for h in Hostarm64 Hostx64; do
+        [ -n "$root" ] && [ -f "$root/bin/$h/arm64/cl.exe" ] || continue
+        host_cl="$root/bin/$h/arm64/cl.exe"
+        break
+      done
+      ;;
+    esac
+    if [ -n "$host_cl" ]; then
+      echo "engine toolchain: nvcc host compiler $host_cl"
+    elif [ -n "$want" ]; then
       echo "error: nvcc needs cl on PATH on Windows; run from a Visual Studio developer prompt" >&2
+      echo "       (on ARM64, set VCToolsInstallDir to an MSVC toolset with bin/Host*/arm64/cl.exe;" >&2
+      echo "        VCToolsInstallDir='${VCToolsInstallDir:-}')" >&2
       exit 1
+    else
+      echo "warning: cl is not on PATH; run from a Visual Studio developer prompt" >&2
+      echo "         if the build cannot find the MSVC headers and libraries." >&2
     fi
-    echo "warning: cl is not on PATH; run from a Visual Studio developer prompt" >&2
-    echo "         if the build cannot find the MSVC headers and libraries." >&2
   fi
   echo "engine toolchain: ninja and clang found"
   ;;

--- a/src-tauri/plugins/tauri-plugin-llamacpp/build.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/build.rs
@@ -110,10 +110,63 @@ mod engine {
             return;
         }
         cmd.args(["-G", WINDOWS_GENERATOR]);
+        // One per target arch, both clang. The arm64 file also pins
+        // `-march=armv8.7-a`, upstream's baseline for its own ARM64 releases.
+        let toolchain = if env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default() == "aarch64" {
+            "cmake/arm64-windows-llvm.cmake"
+        } else {
+            "cmake/x64-windows-llvm.cmake"
+        };
         cmd.arg(format!(
             "-DCMAKE_TOOLCHAIN_FILE={}",
-            cmake_path(&src.join("cmake/x64-windows-llvm.cmake"))
+            cmake_path(&src.join(toolchain))
         ));
+        windows_cuda_host_compiler(cmd);
+    }
+
+    /// nvcc needs a host compiler for the non-device half of every `.cu`, and
+    /// cmake infers it from the host arch -- wrong when the target is ARM64.
+    /// Upstream's `cmake/arm64-windows-msvc-cuda.cmake` fixes that but leaves
+    /// `CMAKE_C_COMPILER` unset, so C/C++ falls to `cl.exe`, which ggml-cpu
+    /// rejects for ARM. So the clang toolchain file stays authoritative and
+    /// only the CUDA host compiler is overridden here.
+    ///
+    /// `VCToolsInstallDir` is the arch-independent toolset root, set by any VS
+    /// developer environment. Left alone when absent, so cmake reports the
+    /// missing compiler rather than a path that does not exist.
+    fn windows_cuda_host_compiler(cmd: &mut Command) {
+        if env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default() != "aarch64" {
+            return;
+        }
+        if !feature_enabled("engine-cuda") {
+            return;
+        }
+        println!("cargo:rerun-if-env-changed=VCToolsInstallDir");
+        let Ok(tools) = env::var("VCToolsInstallDir") else {
+            println!(
+                "cargo:warning=VCToolsInstallDir is unset, so cmake will guess the CUDA host \
+                 compiler from the host arch; run from a Visual Studio developer prompt if the \
+                 CUDA configure fails"
+            );
+            return;
+        };
+        // Probed, not assumed: ARM64 is reachable from either host.
+        let root = PathBuf::from(tools);
+        for host in ["Hostarm64", "Hostx64"] {
+            let cl = root.join("bin").join(host).join("arm64").join("cl.exe");
+            if cl.is_file() {
+                cmd.arg(format!(
+                    "-DCMAKE_CUDA_HOST_COMPILER={}",
+                    cmake_path(&cl)
+                ));
+                return;
+            }
+        }
+        println!(
+            "cargo:warning=no arm64 cl.exe under {}/bin/Host*/arm64 -- install the MSVC ARM64 \
+             toolset (Microsoft.VisualStudio.Component.VC.Tools.ARM64)",
+            root.display()
+        );
     }
 
     /// cmake takes forward slashes on every platform and treats a backslash as
@@ -677,11 +730,20 @@ mod engine {
     /// `GGML_CPU_ALL_VARIANTS` hard-errors on architectures it has no variant
     /// table for (ggml/src/CMakeLists.txt:581), so it is opt-in per arch rather
     /// than unconditional.
+    ///
+    /// The table is keyed on (arch, OS), not arch alone: the ARM branch covers
+    /// Linux, Android and Apple only, so Windows hits the `FATAL_ERROR`.
+    /// Opting out there is safe, not just quieter -- `GGML_BACKEND_DL` still
+    /// yields one CPU backend as a loadable MODULE, which is what
+    /// stage-engine.sh asserts. Cost is that one backend at the toolchain
+    /// file's armv8.7-a baseline instead of a runtime-scored set.
     fn cpu_all_variants_supported() -> bool {
-        matches!(
-            env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default().as_str(),
-            "x86_64" | "aarch64" | "riscv64"
-        )
+        let arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+        let os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+        if arch == "aarch64" && os == "windows" {
+            return false;
+        }
+        matches!(arch.as_str(), "x86_64" | "aarch64" | "riscv64")
     }
 
     /// `JAN_LLAMA_CPP_DIR` overrides the vendored clone, which is what a

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/engine/worker.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/engine/worker.rs
@@ -318,9 +318,9 @@ impl WorkerHandle {
 
         #[cfg(unix)]
         crate::process::graceful_terminate_process(&mut self.child).await;
-        #[cfg(all(windows, target_arch = "x86_64"))]
+        #[cfg(windows)]
         crate::process::force_terminate_process(&mut self.child).await;
-        #[cfg(not(any(unix, all(windows, target_arch = "x86_64"))))]
+        #[cfg(not(any(unix, windows)))]
         {
             let _ = self.child.kill().await;
         }

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/process.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/process.rs
@@ -25,7 +25,7 @@ pub async fn graceful_terminate_process(child: &mut tokio::process::Child) {
     }
 }
 
-#[cfg(all(windows, target_arch = "x86_64"))]
+#[cfg(windows)]
 pub async fn force_terminate_process(child: &mut tokio::process::Child) {
     // Graceful shutdown is not implemented on Windows: llama-server's console
     // handler only reacts to CTRL_C_EVENT (server.cpp), and

--- a/src-tauri/src/core/cli/updater.rs
+++ b/src-tauri/src/core/cli/updater.rs
@@ -79,6 +79,7 @@ fn platform_key() -> Option<&'static str> {
         ("linux", "aarch64") => Some("linux-aarch64"),
         ("macos", _) => Some("darwin-universal"),
         ("windows", "x86_64") => Some("windows-x86_64"),
+        ("windows", "aarch64") => Some("windows-aarch64"),
         _ => None,
     }
 }

--- a/src-tauri/utils/src/system.rs
+++ b/src-tauri/utils/src/system.rs
@@ -587,13 +587,13 @@ fn collect_flatpak_gl_paths(cuda_lib_paths: &mut std::collections::HashSet<Strin
 }
 
 pub fn setup_windows_process_flags(command: &mut tokio::process::Command) {
-    #[cfg(all(windows, target_arch = "x86_64"))]
+    #[cfg(windows)]
     {
         const CREATE_NO_WINDOW: u32 = 0x0800_0000;
         const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
         command.creation_flags(CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP);
     }
-    #[cfg(not(all(windows, target_arch = "x86_64")))]
+    #[cfg(not(windows))]
     {
         let _ = command; // Silence unused parameter warning on non-Windows platforms
     }


### PR DESCRIPTION
## Describe Your Changes

This pull request adds full Windows ARM64 (aarch64) support for both the Jan Agent CLI and desktop builds, including CI/CD pipeline updates, installer improvements, and supporting script changes. The workflows now build and publish native Windows ARM64 binaries, and the installer and supporting scripts are updated to prefer native binaries where available, falling back to x64 under emulation only if necessary. Additional improvements ensure the correct binaries are selected and handled throughout the build and installation process.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
