### PR TITLE
fix(cowork): restore sessions across surface tabs

### DIFF
--- a/web-app/src/components/left-sidebar/NavTabs.tsx
+++ b/web-app/src/components/left-sidebar/NavTabs.tsx
@@ -1,11 +1,10 @@
 import { useRef } from 'react'
-import { Link, useLocation } from '@tanstack/react-router'
+import { Link } from '@tanstack/react-router'
 import { Handshake, HomeIcon, type LucideIcon } from 'lucide-react'
 import { route, isCoworkRoute } from '@/constants/routes'
 import { cn } from '@/lib/utils'
 import { useTranslation } from '@/i18n/react-i18next-compat'
-import { startNewSession } from '@/hooks/useCoworkSessions'
-import { useCoworkRun } from '@/hooks/useCoworkRun'
+import { useThreads } from '@/hooks/useThreads'
 import {
   AnimatedLucideIcon,
   type AnimatedLucideIconHandle,
@@ -18,13 +17,7 @@ type TabItem = {
   icon: LucideIcon
   preset: AnimatedLucidePreset
   isActive: boolean
-  onClick?: () => void
 }
-
-// The tab is the start page, like Home: it opens a fresh session rather than
-// landing on whichever one was viewed last. Sessions are picked from the list.
-const openCoworkStart = () =>
-  startNewSession(Object.keys(useCoworkRun.getState().runId))
 
 function NavTab({ tab }: { tab: TabItem }) {
   const iconRef = useRef<AnimatedLucideIconHandle>(null)
@@ -32,7 +25,6 @@ function NavTab({ tab }: { tab: TabItem }) {
   return (
     <Link
       to={tab.to}
-      onClick={tab.onClick}
       aria-current={tab.isActive ? 'page' : undefined}
       className={cn(
         'flex flex-1 items-center justify-center gap-1.5 rounded-md px-2 py-1 text-sm font-medium transition-colors',
@@ -58,7 +50,7 @@ function NavTab({ tab }: { tab: TabItem }) {
 
 export function NavTabs({ surfacePath }: { surfacePath: string }) {
   const { t } = useTranslation()
-  const { pathname } = useLocation()
+  const lastHomePath = useRef<string>(route.home)
 
   const isCowork = isCoworkRoute(surfacePath)
   // Home owns the chat surfaces (new chat, threads, projects); Cowork owns /cowork.
@@ -66,11 +58,19 @@ export function NavTabs({ surfacePath }: { surfacePath: string }) {
     surfacePath === route.home ||
     surfacePath.startsWith('/threads') ||
     surfacePath.startsWith('/project')
+  if (isHome) lastHomePath.current = surfacePath
+  const homePath = isHome ? surfacePath : lastHomePath.current
+  const threadId = homePath.startsWith('/threads/')
+    ? homePath.slice('/threads/'.length)
+    : undefined
+  const threadExists = useThreads(
+    (s) => !threadId || Boolean(s.threads[threadId])
+  )
 
   const tabs: TabItem[] = [
     {
       label: t('common:home'),
-      to: route.home,
+      to: threadExists ? homePath : route.home,
       icon: HomeIcon,
       preset: 'home',
       isActive: isHome,
@@ -81,10 +81,6 @@ export function NavTabs({ surfacePath }: { surfacePath: string }) {
       icon: Handshake,
       preset: 'handshake',
       isActive: isCowork,
-      onClick:
-        isCowork && pathname.startsWith('/settings')
-          ? undefined
-          : openCoworkStart,
     },
   ]
 

--- a/web-app/src/components/left-sidebar/__tests__/settingsNavigation.test.tsx
+++ b/web-app/src/components/left-sidebar/__tests__/settingsNavigation.test.tsx
@@ -35,14 +35,6 @@ vi.mock('@tanstack/react-router', () => ({
 vi.mock('@/i18n/react-i18next-compat', () => ({
   useTranslation: () => ({ t: (key: string) => key }),
 }))
-vi.mock('@/hooks/useCoworkSessions', () => ({
-  startNewSession: () => {
-    navigation.session = 'new-session'
-  },
-}))
-vi.mock('@/hooks/useCoworkRun', () => ({
-  useCoworkRun: { getState: () => ({ runId: {} }) },
-}))
 vi.mock('@/hooks/useLeftPanel', () => ({
   useLeftPanel: () => ({ open: true }),
 }))
@@ -92,7 +84,7 @@ it('keeps Cowork navigation across Settings pages and returns without starting a
   expect(navigation.session).toBe('existing-session')
 })
 
-it('keeps Home navigation for Settings opened from a chat', () => {
+it('keeps the current Cowork session when switching from a chat', () => {
   navigation.pathname = '/threads/chat-1'
   const view = render(<LeftSidebar />)
   navigation.pathname = '/settings/general'
@@ -103,5 +95,5 @@ it('keeps Home navigation for Settings opened from a chat', () => {
     'page'
   )
   fireEvent.click(screen.getByRole('link', { name: 'common:cowork' }))
-  expect(navigation.session).toBe('new-session')
+  expect(navigation.session).toBe('existing-session')
 })

--- a/web-app/src/components/left-sidebar/__tests__/tabRestoration.test.tsx
+++ b/web-app/src/components/left-sidebar/__tests__/tabRestoration.test.tsx
@@ -1,0 +1,158 @@
+import '@testing-library/jest-dom/vitest'
+import type { ReactNode } from 'react'
+import { beforeEach, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+const navigation = vi.hoisted(() => ({
+  pathname: '/threads/chat-a',
+  threads: {} as Record<string, { id: string }>,
+  running: {} as Record<string, string>,
+}))
+vi.mock('@tanstack/react-router', () => ({
+  useLocation: () => ({ pathname: navigation.pathname }),
+  Link: ({
+    to,
+    onClick,
+    children,
+    ...props
+  }: {
+    to: string
+    onClick?: () => void
+    children: ReactNode
+  }) => (
+    <a
+      {...props}
+      href={to}
+      onClick={(event) => {
+        event.preventDefault()
+        onClick?.()
+        navigation.pathname = to
+      }}
+    >
+      {children}
+    </a>
+  ),
+}))
+vi.mock('@/i18n/react-i18next-compat', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+vi.mock('@/hooks/useThreads', () => ({
+  useThreads: (
+    selector: (state: { threads: typeof navigation.threads }) => unknown
+  ) => selector({ threads: navigation.threads }),
+}))
+vi.mock('@/hooks/useCoworkRun', () => ({
+  useCoworkRun: { getState: () => ({ runId: navigation.running }) },
+}))
+vi.mock('@/lib/backendStorage', () => ({
+  backendStorage: {
+    getItem: vi.fn().mockResolvedValue(null),
+    setItem: vi.fn().mockResolvedValue(undefined),
+    removeItem: vi.fn().mockResolvedValue(undefined),
+  },
+}))
+
+import { NavTabs } from '../NavTabs'
+import { startNewSession, useCoworkSessions } from '../../../hooks/useCoworkSessions'
+
+beforeEach(() => {
+  navigation.pathname = '/threads/chat-a'
+  navigation.threads = { 'chat-a': { id: 'chat-a' } }
+  navigation.running = {}
+  useCoworkSessions.setState({ sessions: [], currentId: null })
+})
+
+function tabs() {
+  const view = render(<NavTabs surfacePath={navigation.pathname} />)
+  const refresh = () =>
+    view.rerender(<NavTabs surfacePath={navigation.pathname} />)
+  return {
+    visit: (pathname: string) => {
+      navigation.pathname = pathname
+      refresh()
+    },
+    click: (tab: 'home' | 'cowork') => {
+      fireEvent.click(screen.getByRole('link', { name: `common:${tab}` }))
+      refresh()
+    },
+  }
+}
+
+it('returns to the previously viewed chat and Cowork conversation in both directions', () => {
+  const store = useCoworkSessions.getState()
+  const session = store.createSession()
+  store.commitTurns(
+    session,
+    [{ role: 'user', content: 'Remember this conversation' }],
+    [],
+    []
+  )
+  const view = tabs()
+  view.click('cowork')
+  expect(useCoworkSessions.getState().currentId).toBe(session)
+  view.click('home')
+  expect(navigation.pathname).toBe('/threads/chat-a')
+  view.click('cowork')
+  expect(useCoworkSessions.getState().currentId).toBe(session)
+  expect(useCoworkSessions.getState().sessions).toHaveLength(1)
+})
+
+it('restores chat independently of Cowork selection', () => {
+  const view = tabs()
+  view.click('cowork')
+  view.click('home')
+  expect(navigation.pathname).toBe('/threads/chat-a')
+})
+
+it('keeps an explicitly opened blank chat instead of restoring an older thread', () => {
+  const view = tabs()
+  view.visit('/')
+  view.click('cowork')
+  view.click('home')
+  expect(navigation.pathname).toBe('/')
+})
+
+it('falls back to a blank chat if the remembered thread was deleted', () => {
+  const view = tabs()
+  view.click('cowork')
+  navigation.threads = {}
+  view.visit('/cowork')
+  view.click('home')
+  expect(navigation.pathname).toBe('/')
+})
+
+it('opens blank chat when Cowork was the first surface visited', () => {
+  navigation.pathname = '/cowork'
+  const view = tabs()
+  view.click('home')
+  expect(navigation.pathname).toBe('/')
+})
+
+it('keeps the first streaming Cowork session when switching or clicking the active tab', () => {
+  const session = useCoworkSessions.getState().createSession()
+  navigation.running = { [session]: 'active-run' }
+  const view = tabs()
+  view.click('cowork')
+  expect(useCoworkSessions.getState().currentId).toBe(session)
+  view.click('cowork')
+  expect(useCoworkSessions.getState().currentId).toBe(session)
+})
+
+it('retains an explicit new Cowork session and the existing deletion fallback', () => {
+  const store = useCoworkSessions.getState()
+  const previous = store.createSession()
+  store.commitTurns(
+    previous,
+    [{ role: 'user', content: 'Existing conversation' }],
+    [],
+    []
+  )
+  const fresh = startNewSession([])
+  const view = tabs()
+  view.click('cowork')
+  expect(useCoworkSessions.getState().currentId).toBe(fresh)
+  view.click('home')
+  store.deleteSession(fresh)
+  view.click('cowork')
+  expect(useCoworkSessions.getState().currentId).toBe(previous)
+})


### PR DESCRIPTION
## Summary
- Switching between Chat and Cowork now restores the last conversation on each surface instead of opening a new session.
- Explicit New Chat and New Cowork Session actions remain unchanged.

## Verification
- `yarn test:web src/components/left-sidebar/__tests__/tabRestoration.test.tsx src/components/left-sidebar/__tests__/settingsNavigation.test.tsx src/hooks/__tests__/useCoworkSessions.test.ts` - 32 passed.
- `yarn workspace @janhq/web-app lint` - passed.
- `yarn workspace @janhq/web-app build` - passed.
- `yarn test:web` - failed in 17 unrelated files because the test environment exposed a non-functional localStorage stub; 186 tests failed and 3,767 passed.