### PR TITLE
fix(cowork): expose full artifact titles

### DIFF
--- a/web-app/src/containers/CoworkArtifactCard.tsx
+++ b/web-app/src/containers/CoworkArtifactCard.tsx
@@ -92,7 +92,10 @@ export function CoworkArtifactCard({
         )}
         {/* min-w-0 on a block box: `truncate` is inert otherwise. */}
         <span className="min-w-0 flex-1">
-          <span className="block truncate text-sm font-medium">
+          <span
+            className="block truncate text-sm font-medium"
+            title={artifact.title}
+          >
             {artifact.title}
           </span>
           <span className="mt-0.5 flex items-center gap-1.5 text-xs text-muted-foreground">

--- a/web-app/src/containers/__tests__/CoworkArtifactCard.test.tsx
+++ b/web-app/src/containers/__tests__/CoworkArtifactCard.test.tsx
@@ -1,0 +1,30 @@
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/i18n/react-i18next-compat', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}))
+
+import { CoworkArtifactCard } from '../CoworkArtifactCard'
+import type { CoworkArtifact } from '@/lib/coworkArtifacts'
+
+const artifact: CoworkArtifact = {
+  path: 'reports/customer-research-summary.html',
+  title: 'customer-research-summary',
+  group: 'Code',
+  label: 'HTML',
+}
+
+describe('CoworkArtifactCard', () => {
+  it('exposes the complete artifact title when the card truncates it', () => {
+    render(
+      <CoworkArtifactCard artifact={artifact} roots={[]} onPreview={vi.fn()} />
+    )
+
+    expect(screen.getByText(artifact.title)).toHaveAttribute(
+      'title',
+      artifact.title
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Cowork artifact cards now expose full artifact filenames on hover when titles are truncated.
- Existing preview and external-open actions remain unchanged.

## Verification
- `yarn test:web src/containers/__tests__/CoworkArtifactCard.test.tsx` - 1 passed
- `yarn workspace @janhq/web-app lint` - passed
- `yarn workspace @janhq/web-app build` - passed