### PR TITLE
vector-db-extension: surface real embedding probe errors

### DIFF
--- a/extensions/vector-db-extension/src/index.test.ts
+++ b/extensions/vector-db-extension/src/index.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import * as vecdb from '@janhq/tauri-plugin-vector-db-api'
 import * as ragApi from '@janhq/tauri-plugin-rag-api'
-import VectorDBExt from './index'
+import VectorDBExt, { formatUnknownError } from './index'
 
 const mockVecdb = vecdb as unknown as Record<string, ReturnType<typeof vi.fn>>
 const mockRag = ragApi as unknown as Record<string, ReturnType<typeof vi.fn>>
@@ -28,6 +28,28 @@ beforeEach(() => {
   mockVecdb.chunkText.mockResolvedValue([])
   mockRag.parseDocument.mockResolvedValue('')
   ext = new VectorDBExt()
+})
+
+describe('formatUnknownError', () => {
+  it('reads Error.message', () => {
+    expect(formatUnknownError(new Error('boom'))).toBe('boom')
+  })
+
+  it('reads message/error fields from plain objects', () => {
+    expect(formatUnknownError({ message: 'from message' })).toBe('from message')
+    expect(formatUnknownError({ error: 'from error' })).toBe('from error')
+  })
+
+  it('JSON-stringifies objects without a message field', () => {
+    expect(formatUnknownError({ code: 42, reason: 'nope' })).toBe(
+      '{"code":42,"reason":"nope"}'
+    )
+  })
+
+  it('does not collapse objects to [object Object]', () => {
+    expect(formatUnknownError({ message: 'real cause' })).not.toBe('[object Object]')
+    expect(formatUnknownError({ nested: true })).not.toBe('[object Object]')
+  })
 })
 
 describe('lifecycle + passthrough', () => {
@@ -146,6 +168,27 @@ describe('chunk sizing against embedding context', () => {
     )
   })
 
+  it('clampToEmbeddingContext surfaces plain-object probe failures instead of [object Object]', async () => {
+    getByName.mockReturnValue(
+      makeEngine({
+        getEmbeddingContextSize: vi
+          .fn()
+          .mockRejectedValue({ message: 'embedding model failed to load' }),
+      })
+    )
+    const error = await (ext as any)
+      .clampToEmbeddingContext(4000, 100)
+      .then(() => {
+        throw new Error('expected clampToEmbeddingContext to reject')
+      })
+      .catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toMatch(
+      /embedding context size.*embedding model failed to load/i
+    )
+    expect((error as Error).message).not.toContain('[object Object]')
+  })
+
   it('ensureChunksFitEmbeddingContext propagates a failing ctx-size probe', async () => {
     getByName.mockReturnValue(
       makeEngine({
@@ -166,6 +209,23 @@ describe('chunk sizing against embedding context', () => {
     await expect((ext as any).splitChunkToFit('text', 10, llm)).rejects.toThrow(
       /count embedding tokens.*tokenize 500/i
     )
+  })
+
+  it('splitChunkToFit surfaces plain-object token-count failures instead of [object Object]', async () => {
+    const llm = {
+      countEmbeddingTokens: vi.fn().mockRejectedValue({ error: 'tokenizer unavailable' }),
+    }
+    const error = await (ext as any)
+      .splitChunkToFit('text', 10, llm)
+      .then(() => {
+        throw new Error('expected splitChunkToFit to reject')
+      })
+      .catch((e: unknown) => e)
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toMatch(
+      /count embedding tokens.*tokenizer unavailable/i
+    )
+    expect((error as Error).message).not.toContain('[object Object]')
   })
 })
 

--- a/extensions/vector-db-extension/src/index.ts
+++ b/extensions/vector-db-extension/src/index.ts
@@ -11,6 +11,33 @@ const MIN_CHUNK_SIZE_CHARS = 64
 // Reserves room for BOS/special tokens the tokenizer adds beyond raw content.
 const EMBEDDING_CONTEXT_SAFETY_TOKENS = 8
 
+/**
+ * Tauri / IPC failures often reject with plain objects (`{ message }`,
+ * `{ error }`) rather than `Error`. `String(obj)` becomes `[object Object]`,
+ * which is what users see in the UI toast — hide the real cause.
+ */
+export function formatUnknownError(error: unknown): string {
+  if (error instanceof Error) return error.message || error.name
+  if (typeof error === 'string') return error
+  if (typeof error === 'number' || typeof error === 'boolean' || typeof error === 'bigint') {
+    return String(error)
+  }
+  if (error && typeof error === 'object') {
+    const record = error as Record<string, unknown>
+    for (const key of ['message', 'error', 'msg', 'detail'] as const) {
+      const value = record[key]
+      if (typeof value === 'string' && value.trim()) return value
+      if (value instanceof Error) return value.message || value.name
+    }
+    try {
+      return JSON.stringify(error)
+    } catch {
+      // circular / non-serializable
+    }
+  }
+  return String(error)
+}
+
 export default class VectorDBExt extends VectorDBExtension {
   async onLoad(): Promise<void> {
     // no-op
@@ -209,7 +236,7 @@ export default class VectorDBExt extends VectorDBExtension {
       return await llm.getEmbeddingContextSize()
     } catch (e) {
       throw new Error(
-        `Failed to determine embedding context size: ${e instanceof Error ? e.message : String(e)}`
+        `Failed to determine embedding context size: ${formatUnknownError(e)}`
       )
     }
   }
@@ -225,7 +252,7 @@ export default class VectorDBExt extends VectorDBExtension {
       ;[count] = await llm.countEmbeddingTokens([text])
     } catch (e) {
       throw new Error(
-        `Failed to count embedding tokens: ${e instanceof Error ? e.message : String(e)}`
+        `Failed to count embedding tokens: ${formatUnknownError(e)}`
       )
     }
     if (count <= budget || text.length <= MIN_CHUNK_SIZE_CHARS) return [text]


### PR DESCRIPTION
## Describe Your Changes

Fixes #8784.

When probing the embedding context size (or counting embedding tokens), failures that reject with a plain object were wrapped using `String(e)`, which becomes `[object Object]` in the UI toast and hides the real cause.

This adds `formatUnknownError()` so we prefer `Error.message`, then common object fields (`message` / `error` / …), then `JSON.stringify`, and uses it in both catch paths.

## Self Checklist

- [x] I have tested this change locally
- [x] Related docs / comments updated if needed (N/A)
- [x] Tests added/updated for this change

## How to test

```bash
yarn workspace @janhq/vector-db-extension test
```

(Requires building `@janhq/tauri-plugin-vector-db-api` / `@janhq/tauri-plugin-rag-api` guest JS if `dist-js` is missing.)

New coverage asserts plain-object rejections no longer surface as `[object Object]`.

## Notes

This fixes the reported toast serialization. The underlying embedding engine/model failure may still need a separate fix (e.g. re-download / unhealthy embedder), but users should now see the real error text.

Made with [Cursor](https://cursor.com)